### PR TITLE
Codex/add delegation task access

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from flask_wtf.csrf import CSRFError
 from werkzeug.middleware.proxy_fix import ProxyFix
 import app_version
 from database import init_db, get_db, DATA_DIR
+from delegations import MISSION_SUIVI_VALIDATIONS_RELANCES
 from extensions import csrf, limiter
 
 
@@ -270,7 +271,11 @@ def invalidate_version_cache():
 def inject_pending_counts():
     """Injecte le nombre de demandes en attente dans tous les templates."""
     if 'user_id' not in session:
-        return {'pending_count': 0, 'chatbot_enabled': False}
+        return {
+            'pending_count': 0,
+            'chatbot_enabled': False,
+            'can_access_vue_ensemble_validation': False,
+        }
 
     profil = session.get('profil', '')
     conn = None
@@ -313,9 +318,30 @@ def inject_pending_counts():
             chatbot_on = _gs('chatbot_model') is not None
         except Exception:
             pass
-        return {'pending_count': count, 'chatbot_enabled': chatbot_on}
+
+        delegation_validation = False
+        try:
+            row = conn.execute(
+                'SELECT delegated_user_id FROM delegations_missions WHERE mission_key = ?',
+                (MISSION_SUIVI_VALIDATIONS_RELANCES,)
+            ).fetchone()
+            delegation_validation = bool(row and row['delegated_user_id'] == session.get('user_id'))
+        except Exception:
+            delegation_validation = False
+
+        can_access_vue_ensemble_validation = profil in ('directeur', 'comptable', 'responsable') or delegation_validation
+
+        return {
+            'pending_count': count,
+            'chatbot_enabled': chatbot_on,
+            'can_access_vue_ensemble_validation': can_access_vue_ensemble_validation,
+        }
     except Exception:
-        return {'pending_count': 0, 'chatbot_enabled': False}
+        return {
+            'pending_count': 0,
+            'chatbot_enabled': False,
+            'can_access_vue_ensemble_validation': False,
+        }
     finally:
         if conn:
             conn.close()

--- a/blueprints/notifications.py
+++ b/blueprints/notifications.py
@@ -5,6 +5,7 @@ Acces : directeur, comptable.
 """
 from flask import Blueprint, render_template, request, session, flash, redirect, url_for, jsonify
 from database import get_db
+from delegations import MISSION_SUIVI_VALIDATIONS_RELANCES, user_has_delegation
 from utils import login_required, get_setting, NOMS_MOIS
 from email_service import (
     get_email_config, save_email_config, set_email_enabled,
@@ -91,7 +92,10 @@ def test_email():
 @login_required
 def relance_validation():
     """Envoie une relance aux responsables pour les fiches d'heures non validees."""
-    if session.get('profil') not in ['directeur']:
+    if session.get('profil') != 'directeur' and not user_has_delegation(
+        session.get('user_id'),
+        MISSION_SUIVI_VALIDATIONS_RELANCES,
+    ):
         return jsonify({'error': 'Acces reserve au directeur'}), 403
 
     if not is_email_configured():
@@ -165,7 +169,10 @@ def relance_validation():
 @login_required
 def relance_responsable_unique():
     """Envoie une relance a un responsable specifique pour les fiches non validees."""
-    if session.get('profil') not in ['directeur']:
+    if session.get('profil') != 'directeur' and not user_has_delegation(
+        session.get('user_id'),
+        MISSION_SUIVI_VALIDATIONS_RELANCES,
+    ):
         return jsonify({'error': 'Acces reserve au directeur'}), 403
 
     if not is_email_configured():

--- a/blueprints/notifications.py
+++ b/blueprints/notifications.py
@@ -96,7 +96,7 @@ def relance_validation():
         session.get('user_id'),
         MISSION_SUIVI_VALIDATIONS_RELANCES,
     ):
-        return jsonify({'error': 'Acces reserve au directeur'}), 403
+        return jsonify({'error': 'Acces reserve a la direction ou aux utilisateurs delegues'}), 403
 
     if not is_email_configured():
         return jsonify({'error': 'Service email non configure'}), 400

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -5,6 +5,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, sessio
 from datetime import datetime, timedelta
 import json
 from database import get_db
+from delegations import MISSION_SUIVI_VALIDATIONS_RELANCES, user_has_delegation
 from utils import (login_required, get_user_info, calculer_heures,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS)
 from app_options import get_option_bool
@@ -195,7 +196,12 @@ def deverrouiller_mois():
 @login_required
 def vue_ensemble_validation():
     """Vue d'ensemble des validations mensuelles (directeur, comptable et responsables)"""
-    if session.get('profil') not in ['directeur', 'comptable', 'responsable']:
+    acces_delegation = user_has_delegation(
+        session.get('user_id'),
+        MISSION_SUIVI_VALIDATIONS_RELANCES,
+    )
+    profil = session.get('profil')
+    if profil not in ['directeur', 'comptable', 'responsable'] and not acces_delegation:
         flash('Accès non autorisé', 'error')
         return redirect(url_for('dashboard_bp.dashboard'))
     
@@ -211,7 +217,7 @@ def vue_ensemble_validation():
 
     try:
         # Récupérer les utilisateurs selon le profil connecté
-        if session.get('profil') == 'responsable':
+        if profil == 'responsable' and not acces_delegation:
             responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
 
             if not responsable_secteur or not responsable_secteur['secteur_id']:
@@ -272,6 +278,9 @@ def vue_ensemble_validation():
     
     noms_mois = ['', 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
                  'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre']
+
+    peut_relancer_validation = profil == 'directeur' or acces_delegation
+    delegation_sans_fiches = acces_delegation and profil not in ['directeur', 'comptable', 'responsable']
     
     return render_template('vue_ensemble_validation.html',
                          users_validation=users_validation,
@@ -281,7 +290,9 @@ def vue_ensemble_validation():
                          mois_precedent=mois_precedent,
                          annee_precedente=annee_precedente,
                          mois_suivant=mois_suivant,
-                         annee_suivante=annee_suivante)
+                         annee_suivante=annee_suivante,
+                         peut_relancer_validation=peut_relancer_validation,
+                         delegation_sans_fiches=delegation_sans_fiches)
 
 def _get_vue_mensuelle_data(redirect_route='validation_bp.vue_mensuelle'):
     """Calcul partagé des données de la fiche mensuelle (utilisé par vue_mensuelle et vue_calendrier)."""

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -280,7 +280,12 @@ def vue_ensemble_validation():
                  'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre']
 
     peut_relancer_validation = profil == 'directeur' or acces_delegation
-    delegation_sans_fiches = acces_delegation and profil not in ['directeur', 'comptable', 'responsable']
+    # Les responsables peuvent accéder à la vue d'ensemble, mais leurs droits
+    # sur les fiches individuelles restent limités par secteur dans
+    # `vue_mensuelle`. Lorsqu'ils arrivent ici via délégation, on masque donc
+    # les liens vers les fiches pour éviter d'afficher des accès qui seront
+    # refusés ensuite.
+    delegation_sans_fiches = acces_delegation and profil not in ['directeur', 'comptable']
     
     return render_template('vue_ensemble_validation.html',
                          users_validation=users_validation,

--- a/delegations.py
+++ b/delegations.py
@@ -5,11 +5,16 @@ from database import get_db
 
 
 MISSION_SUIVI_COMMANDES_FOURNITURES = 'suivi_commandes_fournitures'
+MISSION_SUIVI_VALIDATIONS_RELANCES = 'suivi_validations_relances'
 
 MISSIONS = [
     {
         'key': MISSION_SUIVI_COMMANDES_FOURNITURES,
         'label': 'Suivi et commande des fournitures',
+    },
+    {
+        'key': MISSION_SUIVI_VALIDATIONS_RELANCES,
+        'label': "Suivi des validations (vue d'ensemble) et relances",
     }
 ]
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -319,18 +319,15 @@
                 <button class="sidebar-section-toggle" onclick="toggleSection(this)">
                     <span>📊 Mon espace</span><span class="sidebar-arrow">&#9662;</span>
                 </button>
-	                <div class="sidebar-section-menu">
-	                    <a href="{{ url_for('dashboard_bp.dashboard') }}">📊 Tableau de bord</a>
-	                    <a href="{{ url_for('validation_bp.vue_mensuelle') }}">📅 Vue mensuelle</a>
-	                    <a href="{{ url_for('validation_bp.vue_calendrier') }}">📆 Vue calendrier</a>
-	                    {% if can_access_vue_ensemble_validation %}
-	                    <a href="{{ url_for('validation_bp.vue_ensemble_validation') }}">📋 Vue ensemble validation</a>
-	                    {% endif %}
-	                    <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>
-	                    <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Mon planning</a>
-	                    <a href="{{ url_for('mon_equipe_bp.mon_equipe') }}">👥 Mon équipe</a>
-	                </div>
-            </div>
+		                <div class="sidebar-section-menu">
+		                    <a href="{{ url_for('dashboard_bp.dashboard') }}">📊 Tableau de bord</a>
+		                    <a href="{{ url_for('validation_bp.vue_mensuelle') }}">📅 Vue mensuelle</a>
+		                    <a href="{{ url_for('validation_bp.vue_calendrier') }}">📆 Vue calendrier</a>
+		                    <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>
+		                    <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Mon planning</a>
+		                    <a href="{{ url_for('mon_equipe_bp.mon_equipe') }}">👥 Mon équipe</a>
+		                </div>
+	            </div>
             <div class="sidebar-section">
                 <button class="sidebar-section-toggle" onclick="toggleSection(this)">
                     <span>🏖️ Récup & Congés</span><span class="sidebar-arrow">&#9662;</span>
@@ -341,10 +338,13 @@
                     <a href="{{ url_for('recup_bp.mes_demandes_recup') }}">📄 Mes demandes récup</a>
                     <a href="{{ url_for('recup_bp.mes_demandes_conges') }}">📄 Mes demandes congés</a>
                 </div>
-            </div>
-            <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
-            {% endif %}
-        </nav>
+	            </div>
+	            <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
+	            {% if can_access_vue_ensemble_validation %}
+	            <a href="{{ url_for('validation_bp.vue_ensemble_validation') }}" class="sidebar-link">📋 Vue ensemble validation</a>
+	            {% endif %}
+	            {% endif %}
+	        </nav>
 
         <div class="sidebar-footer">
             {% if session.profil in ['salarie', 'prestataire'] %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -319,14 +319,17 @@
                 <button class="sidebar-section-toggle" onclick="toggleSection(this)">
                     <span>📊 Mon espace</span><span class="sidebar-arrow">&#9662;</span>
                 </button>
-                <div class="sidebar-section-menu">
-                    <a href="{{ url_for('dashboard_bp.dashboard') }}">📊 Tableau de bord</a>
-                    <a href="{{ url_for('validation_bp.vue_mensuelle') }}">📅 Vue mensuelle</a>
-                    <a href="{{ url_for('validation_bp.vue_calendrier') }}">📆 Vue calendrier</a>
-                    <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>
-                    <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Mon planning</a>
-                    <a href="{{ url_for('mon_equipe_bp.mon_equipe') }}">👥 Mon équipe</a>
-                </div>
+	                <div class="sidebar-section-menu">
+	                    <a href="{{ url_for('dashboard_bp.dashboard') }}">📊 Tableau de bord</a>
+	                    <a href="{{ url_for('validation_bp.vue_mensuelle') }}">📅 Vue mensuelle</a>
+	                    <a href="{{ url_for('validation_bp.vue_calendrier') }}">📆 Vue calendrier</a>
+	                    {% if can_access_vue_ensemble_validation %}
+	                    <a href="{{ url_for('validation_bp.vue_ensemble_validation') }}">📋 Vue ensemble validation</a>
+	                    {% endif %}
+	                    <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>
+	                    <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Mon planning</a>
+	                    <a href="{{ url_for('mon_equipe_bp.mon_equipe') }}">👥 Mon équipe</a>
+	                </div>
             </div>
             <div class="sidebar-section">
                 <button class="sidebar-section-toggle" onclick="toggleSection(this)">

--- a/templates/base.html
+++ b/templates/base.html
@@ -341,7 +341,7 @@
 	            </div>
 	            <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
 	            {% if can_access_vue_ensemble_validation %}
-	            <a href="{{ url_for('validation_bp.vue_ensemble_validation') }}" class="sidebar-link">📋 Vue ensemble validation</a>
+	            <a href="{{ url_for('validation_bp.vue_ensemble_validation') }}" class="sidebar-link">📋 Vue ensemble</a>
 	            {% endif %}
 	            {% endif %}
 	        </nav>

--- a/templates/vue_ensemble_validation.html
+++ b/templates/vue_ensemble_validation.html
@@ -121,8 +121,12 @@
                     
                     <!-- Actions -->
                     <td>
-                        <a href="{{ url_for('validation_bp.vue_mensuelle', user_id=u.id, mois=mois, annee=annee) }}" 
+                        {% if not delegation_sans_fiches or u.id == session.user_id %}
+                        <a href="{{ url_for('validation_bp.vue_mensuelle', user_id=u.id, mois=mois, annee=annee) }}"
                            class="btn-icon" title="Voir la fiche">👁️</a>
+                        {% else %}
+                        <span class="btn-icon" style="opacity:0.25;cursor:not-allowed;" title="Accès à la fiche non autorisé">👁️</span>
+                        {% endif %}
                     </td>
                 </tr>
                 {% endfor %}
@@ -132,7 +136,7 @@
     
     <div class="actions" style="margin-top: 2rem; display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
         <a href="{{ url_for('dashboard_bp.dashboard') }}" class="btn btn-secondary">← Retour au tableau de bord</a>
-        {% if session.profil == 'directeur' and en_attente > 0 %}
+        {% if peut_relancer_validation and en_attente > 0 %}
         <button class="btn" id="relanceBtn" onclick="relancerResponsables()"
                 style="background:#7c3aed;color:white;border:none;padding:8px 18px;border-radius:8px;font-weight:700;font-size:13px;cursor:pointer;">
             &#128233; Relancer les responsables par email
@@ -193,7 +197,7 @@
 }
 </style>
 
-{% if session.profil == 'directeur' %}
+{% if peut_relancer_validation %}
 <script>
 async function relancerResponsables() {
     if (!confirm('Envoyer un email de relance a tous les responsables ayant des fiches non validees pour {{ nom_mois }} {{ annee }} ?')) return;

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from blueprints.validation import _get_vue_mensuelle_data_impl
 from database import get_db
+from tests.conftest import _login
 
 
 def _creer_saisie_mois(db, user_id, mois, annee):
@@ -225,6 +226,72 @@ class TestVueEnsembleAcces:
         response = auth_client.get('/vue_ensemble_validation', follow_redirects=True)
         assert response.status_code == 200
         assert 'non autoris' in response.data.decode('utf-8').lower()
+
+    def test_salarie_delegue_acces(self, app, sample_users):
+        """Un salarié délégué peut accéder à la vue d'ensemble."""
+        directeur_client = app.test_client()
+        salarie_client = app.test_client()
+        _login(directeur_client, 'admin', 'Admin1234')
+        _login(salarie_client, 'salarie_test', 'sal123')
+
+        response = directeur_client.post(
+            '/delegations',
+            data={
+                'mission_key': 'suivi_validations_relances',
+                'delegated_user_id': str(sample_users['salarie_id']),
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        vue_ensemble = salarie_client.get('/vue_ensemble_validation')
+        assert vue_ensemble.status_code == 200
+        html = vue_ensemble.get_data(as_text=True)
+        assert 'État des validations' in html
+        assert 'Marie Dupont' in html
+
+        fiche_responsable = salarie_client.get(
+            f"/vue_mensuelle?user_id={sample_users['responsable_id']}&mois=5&annee=2024",
+            follow_redirects=True,
+        )
+        assert fiche_responsable.status_code == 200
+        assert 'accès non autorisé' in fiche_responsable.get_data(as_text=True).lower()
+
+
+class TestRelanceValidationDelegation:
+    """Tests d'accès aux endpoints de relance par délégation."""
+
+    def test_salarie_refuse_api_relance(self, auth_client):
+        response = auth_client.post(
+            '/api/email/relance_validation',
+            json={'mois': 5, 'annee': 2024},
+        )
+
+        assert response.status_code == 403
+        assert 'acces reserve au directeur' in response.get_data(as_text=True).lower()
+
+    def test_salarie_delegue_peut_appeler_api_relance(self, app, sample_users):
+        directeur_client = app.test_client()
+        salarie_client = app.test_client()
+        _login(directeur_client, 'admin', 'Admin1234')
+        _login(salarie_client, 'salarie_test', 'sal123')
+
+        response = directeur_client.post(
+            '/delegations',
+            data={
+                'mission_key': 'suivi_validations_relances',
+                'delegated_user_id': str(sample_users['salarie_id']),
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        res = salarie_client.post(
+            '/api/email/relance_validation',
+            json={'mois': 5, 'annee': 2024},
+        )
+        assert res.status_code == 400
+        assert 'service email non configure' in res.get_data(as_text=True).lower()
 
 
 class TestVueMensuelleJoursFeries:


### PR DESCRIPTION
This pull request introduces support for delegated access to the "vue d'ensemble des validations" (overview validation view) and related relance (reminder) actions. Now, users who have been delegated the relevant mission can access these features, even if their profile is not "directeur", "comptable", or "responsable". The changes include backend permission checks, UI updates, and new tests to ensure proper delegation behavior.

**Delegation and Access Control Enhancements:**

* Added a new mission key `MISSION_SUIVI_VALIDATIONS_RELANCES` in `delegations.py` to represent delegation for validation overview and reminder actions.
* Updated permission checks in `vue_ensemble_validation`, `relance_validation`, and `relance_responsable_unique` endpoints to allow access for users with the relevant delegation, not just specific profiles. [[1]](diffhunk://#diff-30dd7427a95fb58c962bc96a29763cc6a74b86c743b9355133649bf278804fe5L198-R204) [[2]](diffhunk://#diff-30dd7427a95fb58c962bc96a29763cc6a74b86c743b9355133649bf278804fe5L214-R220) [[3]](diffhunk://#diff-bb05cd346b7834a6f5c994395bffdaca759325ea0adb893b19c5492e0021c230L94-R98) [[4]](diffhunk://#diff-bb05cd346b7834a6f5c994395bffdaca759325ea0adb893b19c5492e0021c230L168-R175)

**Context Injection and Template Updates:**

* Modified the `inject_pending_counts` context processor in `app.py` to include a `can_access_vue_ensemble_validation` flag, which is used to control sidebar visibility and page access. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L273-R278) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L316-R344)
* Updated `base.html` to show the sidebar link for the validation overview only if the user has access (including via delegation).
* Adjusted `vue_ensemble_validation.html` to:
  - Show or hide action buttons and relance features based on delegation, and prevent access to individual fiches if delegation does not allow it. [[1]](diffhunk://#diff-20309807d4a82745063e97cb547cdf377e9bbf8ed8c67ec2eb44ef791d4b62e8R124-R129) [[2]](diffhunk://#diff-20309807d4a82745063e97cb547cdf377e9bbf8ed8c67ec2eb44ef791d4b62e8L135-R139) [[3]](diffhunk://#diff-20309807d4a82745063e97cb547cdf377e9bbf8ed8c67ec2eb44ef791d4b62e8L196-R200)

**Testing:**

* Added comprehensive tests to ensure delegated users can access the overview validation view and perform relance actions, while still restricting access to individual fiches as appropriate.

These changes collectively make permission management for validation and relance actions more flexible and robust, supporting organizational needs for delegated responsibilities.