### PR TITLE
feat: bilan-secteurs accessible aux responsables (lecture seule, secteur restreint)

### DIFF
--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -41,6 +41,7 @@ def _populate_session(user):
     session['nom'] = user['nom']
     session['prenom'] = user['prenom']
     session['profil'] = user['profil']
+    session['secteur_id'] = user['secteur_id']
     session['force_password_change'] = bool(user['force_password_change'])
 
 
@@ -114,7 +115,7 @@ def login():
         conn = get_db()
         try:
             user = conn.execute(
-                'SELECT id, nom, prenom, profil, password, force_password_change '
+                'SELECT id, nom, prenom, profil, password, force_password_change, secteur_id '
                 'FROM users WHERE login = ? AND actif = 1',
                 (login_val,)
             ).fetchone()

--- a/blueprints/bilan_secteurs.py
+++ b/blueprints/bilan_secteurs.py
@@ -12,7 +12,8 @@ Fonctionnalites :
 - Taux de logistique (site1, site2, global) par annee avec selection
 - Calcul du resultat avec et sans logistique
 - Export PDF du bilan
-- Accessible aux profils directeur et comptable
+- Accessible aux profils directeur, comptable et responsable
+  (les responsables ne voient que leur secteur et ne peuvent pas importer/modifier)
 """
 import csv
 import io
@@ -29,7 +30,17 @@ NOMS_MOIS = ['', 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin',
 
 
 def _peut_acceder():
+    """Lecture autorisée pour directeur, comptable et responsable."""
+    return session.get('profil') in ('directeur', 'comptable', 'responsable')
+
+
+def _peut_modifier():
+    """Import, suppression et modification des taux réservés aux directeurs/comptables."""
     return session.get('profil') in ('directeur', 'comptable')
+
+
+def _est_responsable():
+    return session.get('profil') == 'responsable'
 
 
 def _get_libelles_pcg(conn):
@@ -52,9 +63,23 @@ def bilan_secteurs():
     annee_courante = now.year
     annees = list(range(annee_courante - 3, annee_courante + 2))
 
+    est_resp = _est_responsable()
+    secteur_resp_id = session.get('secteur_id') if est_resp else None
+
+    if est_resp and not secteur_resp_id:
+        flash('Aucun secteur n\'est assigné à votre compte. Contactez un administrateur.', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
     conn = get_db()
     try:
-        secteurs = conn.execute('SELECT id, nom FROM secteurs ORDER BY nom').fetchall()
+        if est_resp:
+            secteurs = conn.execute(
+                'SELECT id, nom FROM secteurs WHERE id = ? ORDER BY nom',
+                (secteur_resp_id,)
+            ).fetchall()
+        else:
+            secteurs = conn.execute('SELECT id, nom FROM secteurs ORDER BY nom').fetchall()
+
         actions = conn.execute('SELECT id, nom FROM comptabilite_actions ORDER BY nom').fetchall()
 
         # Annees ayant des donnees importees
@@ -65,7 +90,9 @@ def bilan_secteurs():
         return render_template('bilan_secteurs.html',
                                annees=annees, annee_courante=annee_courante,
                                secteurs=secteurs, actions=actions,
-                               annees_importees=[r['annee'] for r in annees_importees])
+                               annees_importees=[r['annee'] for r in annees_importees],
+                               est_responsable=est_resp,
+                               secteur_responsable_id=secteur_resp_id)
     finally:
         conn.close()
 
@@ -108,7 +135,7 @@ def api_import_bi():
     Montant Débit | Montant Crédit | Mode de règlement | Date d'échéance |
     Type d'écriture | Compte analytique | Lettrage
     """
-    if not _peut_acceder():
+    if not _peut_modifier():
         return jsonify({'error': 'Accès non autorisé'}), 403
 
     fichier = request.files.get('fichier')
@@ -262,7 +289,7 @@ def api_import_bi():
 @login_required
 def api_supprimer_annee(annee):
     """Supprime toutes les donnees FEC d'une annee."""
-    if not _peut_acceder():
+    if not _peut_modifier():
         return jsonify({'error': 'Accès non autorisé'}), 403
 
     conn = get_db()
@@ -295,6 +322,13 @@ def api_bilan_donnees():
     annee = request.args.get('annee', type=int)
     secteur_id = request.args.get('secteur_id', type=int)
     action_id = request.args.get('action_id', type=int)
+
+    # Restriction responsable : forcer leur secteur assigné, quelle que soit la requête
+    if _est_responsable():
+        secteur_resp = session.get('secteur_id')
+        if not secteur_resp:
+            return jsonify({'error': 'Aucun secteur assigné à votre compte.'}), 403
+        secteur_id = secteur_resp
 
     if not annee:
         return jsonify({'error': 'Année requise.'}), 400
@@ -430,6 +464,13 @@ def api_detail_compte():
     secteur_id = request.args.get('secteur_id', type=int)
     action_id = request.args.get('action_id', type=int)
 
+    # Restriction responsable : forcer leur secteur assigné
+    if _est_responsable():
+        secteur_resp = session.get('secteur_id')
+        if not secteur_resp:
+            return jsonify({'error': 'Aucun secteur assigné à votre compte.'}), 403
+        secteur_id = secteur_resp
+
     if not annee or not compte_num:
         return jsonify({'error': 'Paramètres manquants.'}), 400
 
@@ -487,7 +528,7 @@ def api_detail_compte():
 @login_required
 def api_save_taux_logistique():
     """Sauvegarde les taux de logistique pour une annee."""
-    if not _peut_acceder():
+    if not _peut_modifier():
         return jsonify({'error': 'Accès non autorisé'}), 403
 
     data = request.get_json() or {}
@@ -559,6 +600,14 @@ def api_export_pdf():
     secteur_id = request.args.get('secteur_id', type=int)
     action_id = request.args.get('action_id', type=int)
     taux_selectionne = request.args.get('taux_selectionne', 'global')
+
+    # Restriction responsable : forcer leur secteur assigné
+    if _est_responsable():
+        secteur_resp = session.get('secteur_id')
+        if not secteur_resp:
+            flash('Aucun secteur assigné à votre compte.', 'error')
+            return redirect(url_for('bilan_secteurs_bp.bilan_secteurs'))
+        secteur_id = secteur_resp
 
     if not annee:
         flash('Année requise.', 'error')

--- a/templates/base.html
+++ b/templates/base.html
@@ -291,6 +291,7 @@
                     <a href="{{ url_for('budget_bp.budget_previsionnel') }}">📘 Budget prévisionnel</a>
                     {% endif %}
                     <a href="{{ url_for('subventions_bp.gestion_subventions') }}">📋 Subventions</a>
+                    <a href="{{ url_for('bilan_secteurs_bp.bilan_secteurs') }}">📊 Bilan secteur</a>
                 </div>
             </div>
             <div class="sidebar-section">

--- a/templates/bilan_secteurs.html
+++ b/templates/bilan_secteurs.html
@@ -5,7 +5,9 @@
 <div class="page-header" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:10px;">
     <h2>📊 Bilan secteurs / actions</h2>
     <div style="display:flex;gap:8px;flex-wrap:wrap;">
+        {% if not est_responsable %}
         <a href="{{ url_for('import_bi_bp.import_bi') }}" class="btn btn-secondary">📥 Importer BI</a>
+        {% endif %}
         <button class="btn btn-secondary" id="btnExportPdf" style="display:none;" onclick="exporterPdf()">📄 Export PDF</button>
     </div>
 </div>
@@ -21,11 +23,13 @@
         </select>
     </div>
     <div class="form-group" style="margin:0;">
-        <label>Secteur <small>(facultatif)</small></label>
-        <select id="filtreSecteur" class="form-select" onchange="chargerBilan()">
+        <label>Secteur {% if not est_responsable %}<small>(facultatif)</small>{% endif %}</label>
+        <select id="filtreSecteur" class="form-select" onchange="chargerBilan()" {% if est_responsable %}disabled{% endif %}>
+            {% if not est_responsable %}
             <option value="">— Tous —</option>
+            {% endif %}
             {% for s in secteurs %}
-            <option value="{{ s.id }}">{{ s.nom }}</option>
+            <option value="{{ s.id }}" {% if est_responsable %}selected{% endif %}>{{ s.nom }}</option>
             {% endfor %}
         </select>
     </div>
@@ -67,19 +71,19 @@
 
     {# ── Taux de logistique ── #}
     <div style="margin-top:32px;padding:20px;background:var(--bg-secondary, #f8f9fa);border-radius:12px;">
-        <h3>🏗️ Taux de logistique</h3>
+        <h3>🏗️ Taux de logistique{% if est_responsable %} <small style="font-size:0.7em;font-weight:normal;color:var(--text-muted);">(lecture seule)</small>{% endif %}</h3>
         <div style="display:flex;gap:24px;flex-wrap:wrap;align-items:flex-end;margin-top:12px;">
             <div class="form-group" style="margin:0;">
-                <label><input type="radio" name="tauxSel" value="site1" onchange="saveTaux()"> Site 1</label>
-                <input type="text" id="tauxSite1" class="form-control" placeholder="0,00" style="width:120px;" onchange="saveTaux()">
+                <label><input type="radio" name="tauxSel" value="site1" {% if est_responsable %}disabled{% else %}onchange="saveTaux()"{% endif %}> Site 1</label>
+                <input type="text" id="tauxSite1" class="form-control" placeholder="0,00" style="width:120px;" {% if est_responsable %}readonly{% else %}onchange="saveTaux()"{% endif %}>
             </div>
             <div class="form-group" style="margin:0;">
-                <label><input type="radio" name="tauxSel" value="site2" onchange="saveTaux()"> Site 2</label>
-                <input type="text" id="tauxSite2" class="form-control" placeholder="0,00" style="width:120px;" onchange="saveTaux()">
+                <label><input type="radio" name="tauxSel" value="site2" {% if est_responsable %}disabled{% else %}onchange="saveTaux()"{% endif %}> Site 2</label>
+                <input type="text" id="tauxSite2" class="form-control" placeholder="0,00" style="width:120px;" {% if est_responsable %}readonly{% else %}onchange="saveTaux()"{% endif %}>
             </div>
             <div class="form-group" style="margin:0;">
-                <label><input type="radio" name="tauxSel" value="global" checked onchange="saveTaux()"> Global</label>
-                <input type="text" id="tauxGlobal" class="form-control" placeholder="0,00" style="width:120px;" onchange="saveTaux()">
+                <label><input type="radio" name="tauxSel" value="global" checked {% if not est_responsable %}onchange="saveTaux()"{% endif %}> Global</label>
+                <input type="text" id="tauxGlobal" class="form-control" placeholder="0,00" style="width:120px;" {% if est_responsable %}readonly{% else %}onchange="saveTaux()"{% endif %}>
             </div>
         </div>
         <div id="logistiqueCalc" style="margin-top:16px;font-size:1.05em;"></div>
@@ -106,6 +110,8 @@
 </div>
 
 <script>
+var EST_RESPONSABLE = {{ 'true' if est_responsable else 'false' }};
+
 var NOMS_CATEGORIES = {
     '60': 'Achats', '61': 'Services extérieurs', '62': 'Autres services ext.',
     '63': 'Impôts et taxes', '64': 'Charges de personnel', '65': 'Autres charges de gestion',
@@ -238,6 +244,10 @@ function voirDetail(compteNum) {
 
 // Taux de logistique
 function saveTaux() {
+    if (EST_RESPONSABLE) {
+        if (bilanData) calculerResultat(bilanData);
+        return;
+    }
     var annee = document.getElementById('filtreAnnee').value;
     var sel = document.querySelector('input[name="tauxSel"]:checked');
     var data = {
@@ -286,6 +296,13 @@ function calculerResultat(data) {
     resHtml += ' <small>(Produits ' + fmt(totalProduits) + ' − Charges ' + fmt(totalCharges) + ' − Logistique ' + fmt(logistique) + ')</small></div>';
 
     document.getElementById('resultatDisplay').innerHTML = resHtml;
+}
+
+// Pour les responsables, le secteur est pré-sélectionné : charger automatiquement
+if (EST_RESPONSABLE) {
+    document.addEventListener('DOMContentLoaded', function() {
+        chargerBilan();
+    });
 }
 
 // Export PDF


### PR DESCRIPTION
$(cat <<'EOF'
## Résumé

- Rend la page **Bilan secteurs/actions** accessible aux responsables, avec leur secteur verrouillé
- Le bouton **Importer BI** n'apparaît pas pour les responsables
- Les taux de logistique sont affichés en **lecture seule** pour les responsables
- Sécurisation côté serveur sur tous les endpoints API

## Détail des changements

### `auth.py`
- Ajout de `secteur_id` dans la session à la connexion (SELECT + `_populate_session`)

### `bilan_secteurs.py`
- `_peut_acceder()` → inclut désormais `responsable` (lecture)
- `_peut_modifier()` (nouveau) → réservé à `directeur` et `comptable` (import BI, suppression année, modification taux)
- Route `/bilan-secteurs` → filtre la liste des secteurs au seul secteur du responsable ; redirige si aucun secteur assigné
- API `/api/bilan/donnees`, `/api/bilan/detail-compte`, `/api/bilan/export-pdf` → forcent `secteur_id` au secteur de session du responsable, quelle que soit la valeur transmise en paramètre
- API `/api/bilan/import-bi`, `/api/bilan/annee/<annee>`, `/api/bilan/taux-logistique` → utilisent `_peut_modifier()` (403 pour les responsables)

### `templates/bilan_secteurs.html`
- Bouton "📥 Importer BI" conditionnel (`{% if not est_responsable %}`)
- Dropdown secteur : désactivé (`disabled`) et pré-sélectionné pour les responsables
- Champs taux logistique : `readonly` + radio buttons `disabled` pour les responsables
- Variable JS `EST_RESPONSABLE` + `saveTaux()` protégé + chargement automatique du bilan au chargement de la page

### `templates/base.html`
- Ajout du lien "📊 Bilan secteur" dans la section Financier du menu responsable

## Plan de test

- [ ] Connexion en tant que responsable avec un secteur assigné → accès à la page, secteur pré-sélectionné, bilan chargé automatiquement
- [ ] Vérifier l'absence du bouton "Importer BI" pour le responsable
- [ ] Vérifier que les taux sont affichés mais non modifiables (champs grisés)
- [ ] Tenter un appel direct à `/api/bilan/donnees?annee=2024&secteur_id=99` en tant que responsable → retourne les données de son secteur uniquement (secteur_id forcé)
- [ ] Tenter un appel à `/api/bilan/import-bi` en tant que responsable → 403
- [ ] Tenter un appel à `/api/bilan/taux-logistique` en tant que responsable → 403
- [ ] Connexion en tant que responsable sans secteur assigné → redirection avec message d'erreur
- [ ] Directeur et comptable : comportement inchangé, bouton "Importer BI" toujours présent

https://claude.ai/code/session_0171s8QQiJRhJSSppTtjVbS7
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0171s8QQiJRhJSSppTtjVbS7)_