### PR TITLE
Fix : validation responsable jamais posée quand le directeur est aussi responsable

### DIFF
--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -48,24 +48,33 @@ def valider_mois():
 
     try:
         # Vérifier les droits
-        peut_valider = False
-        type_validation = None
+        # Un même utilisateur peut cumuler plusieurs rôles de validation.
+        # Cas notable : un directeur qui est aussi responsable du secteur du
+        # salarié doit poser à la fois la validation responsable ET directeur,
+        # sinon la fiche ne se verrouille jamais (cf. verrouillage plus bas).
+        types_validation = []
+        profil = session.get('profil')
 
         if user_id == session['user_id']:
-            peut_valider = True
-            type_validation = 'salarie'
-        elif session.get('profil') == 'responsable':
-            user_to_validate = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (user_id,)).fetchone()
-            responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
+            types_validation.append('salarie')
+        else:
+            # Validation responsable : le valideur est responsable du secteur
+            # du salarié (un directeur ayant un secteur assigné agit aussi
+            # comme responsable de ce secteur).
+            if profil in ('responsable', 'directeur'):
+                user_to_validate = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (user_id,)).fetchone()
+                valideur_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
 
-            if user_to_validate and responsable_secteur and user_to_validate['secteur_id'] == responsable_secteur['secteur_id']:
-                peut_valider = True
-                type_validation = 'responsable'
-        elif session.get('profil') == 'directeur':
-            peut_valider = True
-            type_validation = 'directeur'
+                if (user_to_validate and valideur_secteur
+                        and valideur_secteur['secteur_id'] is not None
+                        and user_to_validate['secteur_id'] == valideur_secteur['secteur_id']):
+                    types_validation.append('responsable')
 
-        if not peut_valider:
+            # Validation directeur : un directeur peut valider toute fiche.
+            if profil == 'directeur':
+                types_validation.append('directeur')
+
+        if not types_validation:
             flash('Vous n\'avez pas le droit de valider cette fiche', 'error')
             return redirect(url_for('validation_bp.vue_mensuelle'))
 
@@ -78,41 +87,35 @@ def valider_mois():
         user_info = get_user_info(session['user_id'])
         validation_nom = f"{user_info['prenom']} {user_info['nom']}"
 
+        # Champs (colonne validation, colonne date) par type de validation.
+        # Les noms de colonnes proviennent de ce mapping fixe, pas d'une saisie
+        # utilisateur : aucun risque d'injection SQL.
+        champs_validation = {
+            'salarie': ('validation_salarie', 'date_salarie'),
+            'responsable': ('validation_responsable', 'date_responsable'),
+            'directeur': ('validation_directeur', 'date_directeur'),
+        }
+
         if not validation:
-            if type_validation == 'salarie':
-                conn.execute('''
-                    INSERT INTO validations (user_id, mois, annee, validation_salarie, date_salarie)
-                    VALUES (?, ?, ?, ?, ?)
-                ''', (user_id, mois, annee, validation_nom, now))
-            elif type_validation == 'responsable':
-                conn.execute('''
-                    INSERT INTO validations (user_id, mois, annee, validation_responsable, date_responsable)
-                    VALUES (?, ?, ?, ?, ?)
-                ''', (user_id, mois, annee, validation_nom, now))
-            elif type_validation == 'directeur':
-                conn.execute('''
-                    INSERT INTO validations (user_id, mois, annee, validation_directeur, date_directeur)
-                    VALUES (?, ?, ?, ?, ?)
-                ''', (user_id, mois, annee, validation_nom, now))
-        else:
-            if type_validation == 'salarie':
-                conn.execute('''
-                    UPDATE validations
-                    SET validation_salarie = ?, date_salarie = ?
-                    WHERE user_id = ? AND mois = ? AND annee = ?
-                ''', (validation_nom, now, user_id, mois, annee))
-            elif type_validation == 'responsable':
-                conn.execute('''
-                    UPDATE validations
-                    SET validation_responsable = ?, date_responsable = ?
-                    WHERE user_id = ? AND mois = ? AND annee = ?
-                ''', (validation_nom, now, user_id, mois, annee))
-            elif type_validation == 'directeur':
-                conn.execute('''
-                    UPDATE validations
-                    SET validation_directeur = ?, date_directeur = ?
-                    WHERE user_id = ? AND mois = ? AND annee = ?
-                ''', (validation_nom, now, user_id, mois, annee))
+            conn.execute('''
+                INSERT INTO validations (user_id, mois, annee)
+                VALUES (?, ?, ?)
+            ''', (user_id, mois, annee))
+
+        set_clauses = []
+        params = []
+        for type_validation in types_validation:
+            col_validation, col_date = champs_validation[type_validation]
+            set_clauses.append(f'{col_validation} = ?')
+            set_clauses.append(f'{col_date} = ?')
+            params.extend([validation_nom, now])
+
+        params.extend([user_id, mois, annee])
+        conn.execute(f'''
+            UPDATE validations
+            SET {', '.join(set_clauses)}
+            WHERE user_id = ? AND mois = ? AND annee = ?
+        ''', params)
 
         # Vérifier si la fiche doit être verrouillée (responsable + directeur validés)
         validation_updated = conn.execute('''

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -123,6 +123,42 @@ class TestValidationMois:
             assert validation is not None
             assert validation['bloque'] == 1  # Verrouillé !
 
+    def test_directeur_responsable_valide_les_deux_roles(self, app, db, sample_users):
+        """Un directeur responsable du secteur pose les validations responsable
+        ET directeur en une seule action, et la fiche est verrouillée.
+
+        Régression : auparavant la chaîne if/elif ne posait que la validation
+        directeur, donc validation_responsable restait vide et la fiche ne se
+        verrouillait jamais.
+        """
+        mois, annee = 6, 2024
+        with app.app_context():
+            # Le directeur (admin) devient aussi responsable du secteur du salarié
+            db.execute(
+                "UPDATE users SET secteur_id = ? WHERE id = ?",
+                (sample_users['secteur_id'], sample_users['directeur_id'])
+            )
+            db.commit()
+
+            _creer_saisie_mois(db, sample_users['salarie_id'], mois, annee)
+
+            client_dir = app.test_client()
+            client_dir.post('/login', data={'login': 'admin', 'password': 'Admin1234'})
+            client_dir.post('/valider_mois', data={
+                'user_id': sample_users['salarie_id'],
+                'mois': mois,
+                'annee': annee,
+            }, follow_redirects=True)
+
+            validation = db.execute(
+                "SELECT * FROM validations WHERE user_id = ? AND mois = ? AND annee = ?",
+                (sample_users['salarie_id'], mois, annee)
+            ).fetchone()
+            assert validation is not None
+            assert validation['validation_responsable'] is not None
+            assert validation['validation_directeur'] is not None
+            assert validation['bloque'] == 1  # Verrouillé en une seule validation
+
     def test_refus_validation_mois_en_cours(self, auth_client, app, db, sample_users):
         """On ne peut pas valider le mois en cours."""
         now = datetime.now()


### PR DESCRIPTION
## Problème

Lorsqu'un directeur est **aussi responsable du secteur** d'un salarié, la validation de la fiche d'heures par ce directeur ne posait jamais la **validation responsable**. La fiche restait donc indéfiniment non finalisée.

## Cause

Dans `valider_mois()` (`blueprints/validation.py`), les droits étaient déterminés par une chaîne `if / elif / elif` **mutuellement exclusive** :

```python
if user_id == session['user_id']:
    type_validation = 'salarie'
elif session.get('profil') == 'responsable':
    ...
    type_validation = 'responsable'
elif session.get('profil') == 'directeur':   # capte tout directeur
    type_validation = 'directeur'
```

Pour un directeur, c'est toujours la branche `directeur` qui s'exécutait — la branche `responsable` était inatteignable. Or le verrouillage de la fiche exige **les deux** :

```python
if validation['validation_responsable'] and validation['validation_directeur']:
    # bloque = 1
```

Résultat : `validation_responsable` restait `NULL`, la fiche n'était jamais verrouillée.

## Correctif

La logique calcule désormais **l'ensemble** des validations applicables au valideur, et les pose toutes en une seule action :

- Un **directeur responsable du secteur** du salarié pose à la fois `validation_responsable` **et** `validation_directeur` → la fiche se verrouille en une étape.
- Un directeur sans secteur (ou d'un autre secteur) ne pose que `validation_directeur`, comme avant.
- Le comportement pour les salariés et les responsables « classiques » est inchangé.

Le bloc d'écriture a été factorisé : un INSERT minimal si besoin, puis un UPDATE construit à partir d'un mapping fixe de colonnes (pas de saisie utilisateur → pas d'injection SQL).

## Tests

- Nouveau test de régression `test_directeur_responsable_valide_les_deux_roles` : un directeur affecté au secteur du salarié verrouille la fiche en une seule validation.
- Suite complète : **348 tests passent**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhDanSjGgnnusAm27zEZNC)_