### PR TITLE
Procédure de migration VPS → VPS (base + documents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 ## Documentation
 
 - **[Guide de démarrage rapide](docs/quick-start.md)** — installation, premier lancement, configuration initiale, création des salariés et de leur fiche RH.
-- **[Migration d'un VPS à un autre](docs/migration-vps.md)** — transférer une installation (base de données + documents) vers un nouveau serveur, avec scripts d'export/import et reconstruction du service systemd + Nginx.
+- **[Migration d'un VPS à un autre](docs/migration-vps.md)** — transférer une installation complète (base de données, documents, factures, contrats et paramètres chiffrés) vers un nouveau serveur, avec scripts d'export/import (re-chiffrement automatique des paramètres) et reconstruction du service systemd + Nginx.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 ## Documentation
 
 - **[Guide de démarrage rapide](docs/quick-start.md)** — installation, premier lancement, configuration initiale, création des salariés et de leur fiche RH.
+- **[Migration d'un VPS à un autre](docs/migration-vps.md)** — transférer une installation (base de données + documents) vers un nouveau serveur, avec scripts d'export/import et reconstruction du service systemd + Nginx.
 
 ## Installation
 

--- a/docs/migration-vps.md
+++ b/docs/migration-vps.md
@@ -1,0 +1,241 @@
+# Migration de CS-PILOT d'un VPS à un autre
+
+Ce guide décrit la procédure complète pour déplacer une installation CS-PILOT
+d'un serveur (VPS source — ex. le serveur de test actuel) vers un nouveau
+serveur (VPS cible — ex. celui du centre), **avec toutes les données** : base
+de données et documents uploadés.
+
+L'application est mono-instance : un fichier SQLite (`cspilot.db`) + un dossier
+`documents/`. La migration consiste donc à transférer ces deux éléments puis à
+remonter le service. Deux scripts automatisent l'export/import des données ;
+la reconstruction du service systemd et du reverse proxy Nginx est décrite
+ci-dessous (à faire à la main sur le nouveau serveur).
+
+> **Note sur le `SECRET_KEY`** : cette procédure **génère une nouvelle clé** sur
+> le serveur cible. Le `.env` de la source n'est volontairement pas copié. Les
+> sessions actives de l'ancien serveur seront donc invalidées : les utilisateurs
+> devront simplement se reconnecter. C'est sans impact sur les données.
+
+---
+
+## Vue d'ensemble
+
+| Étape | Où | Commande / Action |
+|------|-----|-------------------|
+| 1 | Cible | Préparer le VPS (Python, git, dépendances) |
+| 2 | Source | Exporter les données → archive `.tar.gz` |
+| 3 | — | Transférer l'archive (scp/rsync) + vérifier le SHA-256 |
+| 4 | Cible | Importer les données |
+| 5 | Cible | Reconstruire le service systemd |
+| 6 | Cible | Reconstruire Nginx + HTTPS |
+| 7 | Cible | Vérifier la migration |
+| 8 | — | Basculer le DNS, puis rollback possible |
+
+---
+
+## 1. Préparer le VPS cible
+
+Pré-requis à installer :
+
+```bash
+sudo apt update
+sudo apt install -y python3 python3-venv python3-pip git sqlite3 rsync
+```
+
+Récupérer le code et préparer l'environnement :
+
+```bash
+cd /opt                       # ou le répertoire de déploiement de votre choix
+sudo git clone https://github.com/cyril-cb/cs-pilot.git
+sudo chown -R "$USER" cs-pilot
+cd cs-pilot
+./lancer.sh                   # crée venv/ + installe les dépendances + génère un .env
+```
+
+Au premier lancement, `lancer.sh` crée le `venv`, installe les dépendances et
+**génère automatiquement un `.env` avec un nouveau `SECRET_KEY`**. Une fois que
+l'application affiche qu'elle écoute sur le port 5000, arrêtez-la avec `Ctrl+C` :
+les données seront importées à l'étape 4.
+
+---
+
+## 2. Exporter les données depuis le VPS source
+
+Sur le serveur **actuel**, depuis le dossier du projet :
+
+```bash
+cd /chemin/vers/cs-pilot
+./scripts/migration/export-data.sh
+```
+
+Le script :
+- effectue une **copie cohérente** de la base (API backup SQLite — indispensable
+  car la base tourne en mode WAL, un simple `cp` n'est pas fiable) ;
+- copie l'intégralité du dossier `documents/` ;
+- produit `cspilot-migration-AAAAMMJJ-HHMMSS.tar.gz` et affiche sa taille et son
+  empreinte **SHA-256**.
+
+Option pour un instantané parfaitement figé (courte interruption de service) :
+
+```bash
+./scripts/migration/export-data.sh --stop-service
+```
+
+Cette option arrête le service `cspilot` le temps de la copie puis le relance.
+
+---
+
+## 3. Transférer l'archive
+
+Depuis le VPS source (ou votre poste) :
+
+```bash
+scp cspilot-migration-*.tar.gz user@NOUVEAU_VPS:~/
+```
+
+Vérifier que l'empreinte est identique des deux côtés :
+
+```bash
+# Sur la source
+sha256sum cspilot-migration-*.tar.gz
+# Sur la cible
+sha256sum ~/cspilot-migration-*.tar.gz
+```
+
+Les deux empreintes doivent correspondre avant de continuer.
+
+---
+
+## 4. Importer les données sur le VPS cible
+
+```bash
+cd /opt/cs-pilot
+./scripts/migration/import-data.sh ~/cspilot-migration-AAAAMMJJ-HHMMSS.tar.gz
+```
+
+Le script :
+- **sauvegarde** toute base/documents déjà présents (dans `backups/`, horodaté) ;
+- restaure `cspilot.db` et `documents/` ;
+- conserve le `.env` (et son nouveau `SECRET_KEY`) déjà généré à l'étape 1 ;
+- **rejoue les migrations de schéma en attente** si le code de la cible est plus
+  récent que celui de la source, puis affiche la version du schéma.
+
+---
+
+## 5. Reconstruire le service systemd
+
+Le code attend un service nommé **`cspilot`** (utilisé notamment par la mise à
+jour automatique : `blueprints/mise_a_jour.py` lance `systemctl restart cspilot`).
+Créez `/etc/systemd/system/cspilot.service` :
+
+```ini
+[Unit]
+Description=CS-PILOT (gestion du temps de travail)
+After=network.target
+
+[Service]
+Type=simple
+User=cspilot
+WorkingDirectory=/opt/cs-pilot
+ExecStart=/opt/cs-pilot/venv/bin/python /opt/cs-pilot/app.py
+Restart=always
+RestartSec=3
+# Le port et les autres réglages sont lus depuis .env (chargé par app.py).
+EnvironmentFile=-/opt/cs-pilot/.env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+> Adaptez `User=` et `WorkingDirectory=` à votre déploiement. Créez au besoin un
+> utilisateur dédié : `sudo useradd -r -s /usr/sbin/nologin cspilot` puis
+> `sudo chown -R cspilot /opt/cs-pilot`.
+
+Activer et démarrer :
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now cspilot
+sudo systemctl status cspilot
+```
+
+---
+
+## 6. Reconstruire Nginx + HTTPS
+
+L'application écoute en local sur `127.0.0.1:5000` (Waitress). Placez Nginx en
+reverse proxy. `/etc/nginx/sites-available/cspilot` :
+
+```nginx
+server {
+    listen 80;
+    server_name cspilot.votre-domaine.fr;
+
+    client_max_body_size 50M;   # marge pour l'upload de documents
+
+    location / {
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+```bash
+sudo ln -s /etc/nginx/sites-available/cspilot /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+Comme l'application tourne derrière un reverse proxy, activez le mode proxy
+dans `.env` (cf. `app.py`, gestion de `BEHIND_PROXY` / `ProxyFix` et des cookies
+sécurisés) :
+
+```bash
+echo "BEHIND_PROXY=true" >> /opt/cs-pilot/.env
+sudo systemctl restart cspilot
+```
+
+Certificat TLS via Let's Encrypt :
+
+```bash
+sudo apt install -y certbot python3-certbot-nginx
+sudo certbot --nginx -d cspilot.votre-domaine.fr
+```
+
+---
+
+## 7. Vérifier la migration
+
+- **Connexion** : ouvrez l'application et connectez-vous (les comptes existants
+  fonctionnent ; seules les sessions sont à refaire à cause du nouveau `SECRET_KEY`).
+- **Documents** : ouvrez quelques justificatifs / factures / pièces de subvention
+  pour confirmer que les fichiers sont bien présents.
+- **Schéma** : dans le panneau **Administration**, vérifiez qu'aucune migration
+  n'est en attente et que la version du schéma correspond à la source.
+- **Comptage** (optionnel) — comparer la source et la cible :
+
+  ```bash
+  sqlite3 cspilot.db "SELECT name FROM sqlite_master WHERE type='table';"
+  sqlite3 cspilot.db "SELECT COUNT(*) FROM utilisateurs;"
+  ```
+
+---
+
+## 8. Bascule DNS et rollback
+
+1. Une fois la cible validée, faites pointer le nom de domaine vers l'IP du
+   nouveau VPS (ou mettez à jour le tunnel/reverse proxy en amont).
+2. **Conservez l'archive de migration et l'ancien VPS** quelques jours : en cas
+   de problème, il suffit de re-basculer le DNS vers l'ancien serveur.
+3. Quand tout est confirmé, vous pouvez décommissionner l'ancien VPS.
+
+---
+
+## Hors périmètre
+
+- **Secrets / SMTP** : les éventuels réglages de notification e-mail sont à
+  reconfigurer manuellement sur la cible.
+- **Zéro interruption / haute dispo** : non couvert (architecture mono-instance
+  SQLite — une courte coupure pendant la bascule est normale).

--- a/docs/migration-vps.md
+++ b/docs/migration-vps.md
@@ -5,16 +5,35 @@ d'un serveur (VPS source — ex. le serveur de test actuel) vers un nouveau
 serveur (VPS cible — ex. celui du centre), **avec toutes les données** : base
 de données et documents uploadés.
 
-L'application est mono-instance : un fichier SQLite (`cspilot.db`) + un dossier
-`documents/`. La migration consiste donc à transférer ces deux éléments puis à
-remonter le service. Deux scripts automatisent l'export/import des données ;
-la reconstruction du service systemd et du reverse proxy Nginx est décrite
-ci-dessous (à faire à la main sur le nouveau serveur).
+L'application est mono-instance : un fichier SQLite (`cspilot.db`) + des dossiers
+de données sur disque. La migration transfère **toutes** les données puis remonte
+le service. Deux scripts automatisent l'export/import ; la reconstruction du
+service systemd et du reverse proxy Nginx est décrite ci-dessous (à faire à la
+main sur le nouveau serveur).
 
-> **Note sur le `SECRET_KEY`** : cette procédure **génère une nouvelle clé** sur
-> le serveur cible. Le `.env` de la source n'est volontairement pas copié. Les
-> sessions actives de l'ancien serveur seront donc invalidées : les utilisateurs
-> devront simplement se reconnecter. C'est sans impact sur les données.
+Ce qui est transféré :
+
+- **`cspilot.db`** — toute la base (utilisateurs, saisies, absences, factures, etc.) ;
+- les **dossiers de données** : `documents/`, `factures/`, `modeles_contrats/`,
+  `contrats_generes/`, `exports/` (ceux présents) ;
+- les **paramètres** stockés dans la table `app_settings` (config SMTP/notifications,
+  clés API OpenAI/Anthropic/Groq, tarifs ALSH, salaire socle, options d'affichage).
+
+> **`SECRET_KEY` et paramètres chiffrés.** Les paramètres de `app_settings` sont
+> chiffrés avec une clé dérivée du `SECRET_KEY` (`utils.py`). Cette procédure
+> **génère un nouveau `SECRET_KEY`** sur la cible : le `.env` source n'est pas
+> réutilisé. Pour ne rien perdre, le script d'export embarque la **clé d'origine
+> de façon transitoire** dans l'archive, et le script d'import **re-chiffre**
+> automatiquement tous les paramètres avec la nouvelle clé
+> (`scripts/migration/reencrypt_settings.py`). Résultat : rien à reconfigurer,
+> et le serveur cible tourne ensuite avec une clé neuve.
+>
+> Les sessions actives de l'ancien serveur sont invalidées (nouveau `SECRET_KEY`) :
+> les utilisateurs se reconnectent simplement.
+
+> ⚠️ **L'archive de migration est sensible** : elle contient toute la base **et** la
+> clé d'origine. Le script la crée en permissions `600`. Transférez-la uniquement
+> via SSH (scp) et **supprimez-la des deux côtés** une fois la migration validée.
 
 ---
 
@@ -114,11 +133,22 @@ cd /opt/cs-pilot
 ```
 
 Le script :
-- **sauvegarde** toute base/documents déjà présents (dans `backups/`, horodaté) ;
-- restaure `cspilot.db` et `documents/` ;
+- **sauvegarde** toute base/dossiers déjà présents (dans `backups/`, horodaté) ;
+- restaure `cspilot.db` et les dossiers de données (`documents/`, `factures/`,
+  `modeles_contrats/`, `contrats_generes/`, `exports/`) ;
 - conserve le `.env` (et son nouveau `SECRET_KEY`) déjà généré à l'étape 1 ;
+- **re-chiffre tous les paramètres** de `app_settings` (SMTP, clés API, tarifs
+  ALSH...) avec la nouvelle clé, à partir de la clé d'origine de l'archive →
+  aucune reconfiguration manuelle nécessaire ;
 - **rejoue les migrations de schéma en attente** si le code de la cible est plus
   récent que celui de la source, puis affiche la version du schéma.
+
+Après import, supprimez l'archive (elle contient la clé d'origine) :
+
+```bash
+rm -f ~/cspilot-migration-AAAAMMJJ-HHMMSS.tar.gz   # sur la cible
+# et sur la source aussi
+```
 
 ---
 
@@ -210,15 +240,19 @@ sudo certbot --nginx -d cspilot.votre-domaine.fr
 
 - **Connexion** : ouvrez l'application et connectez-vous (les comptes existants
   fonctionnent ; seules les sessions sont à refaire à cause du nouveau `SECRET_KEY`).
-- **Documents** : ouvrez quelques justificatifs / factures / pièces de subvention
-  pour confirmer que les fichiers sont bien présents.
+- **Documents et fichiers** : ouvrez quelques justificatifs, factures et contrats
+  pour confirmer que les fichiers (`documents/`, `factures/`, `modeles_contrats/`...)
+  sont bien présents.
+- **Paramètres re-chiffrés** : vérifiez que la **configuration e-mail** et les
+  **clés API** sont toujours renseignées (pages *Configuration email* et *Gestion
+  des clés API*). Faites un envoi d'e-mail de test si possible.
 - **Schéma** : dans le panneau **Administration**, vérifiez qu'aucune migration
   n'est en attente et que la version du schéma correspond à la source.
 - **Comptage** (optionnel) — comparer la source et la cible :
 
   ```bash
   sqlite3 cspilot.db "SELECT name FROM sqlite_master WHERE type='table';"
-  sqlite3 cspilot.db "SELECT COUNT(*) FROM utilisateurs;"
+  sqlite3 cspilot.db "SELECT COUNT(*) FROM users;"
   ```
 
 ---
@@ -235,7 +269,5 @@ sudo certbot --nginx -d cspilot.votre-domaine.fr
 
 ## Hors périmètre
 
-- **Secrets / SMTP** : les éventuels réglages de notification e-mail sont à
-  reconfigurer manuellement sur la cible.
 - **Zéro interruption / haute dispo** : non couvert (architecture mono-instance
   SQLite — une courte coupure pendant la bascule est normale).

--- a/scripts/migration/export-data.sh
+++ b/scripts/migration/export-data.sh
@@ -4,12 +4,17 @@
 # ========================================================
 #
 # A lancer sur le VPS SOURCE (le serveur actuel).
-# Produit une archive .tar.gz unique contenant la base de donnees (copie
-# coherente) et tous les documents uploades, prete a etre transferee vers
-# le nouveau VPS.
+# Produit une archive .tar.gz unique contenant :
+#   - la base de donnees (copie coherente via l'API backup SQLite),
+#   - les dossiers de donnees sur disque (documents, factures, modeles de
+#     contrats, contrats generes, exports),
+#   - le SECRET_KEY d'origine (de maniere TRANSITOIRE), uniquement pour
+#     permettre le re-chiffrement des parametres (SMTP, cles API, tarifs ALSH,
+#     etc.) sur la cible avec une nouvelle cle. Cette cle est jetee apres import.
 #
-# Le fichier .env (donc le SECRET_KEY) n'est PAS inclus : une nouvelle cle
-# sera generee sur le serveur cible lors de l'import.
+# /!\ L'archive contient des donnees sensibles (base + cle d'origine).
+#     Elle est creee avec des permissions restreintes (600). Transferez-la de
+#     facon securisee (scp/ssh) et supprimez-la des deux cotes apres migration.
 #
 # Usage :
 #   ./scripts/migration/export-data.sh [--stop-service] [--output DOSSIER]
@@ -34,7 +39,8 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DATA_DIR="$PROJECT_DIR"   # mode script : DATA_DIR == dossier du projet (cf. database.py)
 
 DB_FILE="$DATA_DIR/cspilot.db"
-DOCS_DIR="$DATA_DIR/documents"
+# Dossiers de donnees sur disque a transferer (cf. blueprints/*.py).
+DATA_FOLDERS=(documents factures modeles_contrats contrats_generes exports)
 
 # --- Options ---
 STOP_SERVICE=0
@@ -60,6 +66,20 @@ if [ ! -f "$DB_FILE" ]; then
     exit 1
 fi
 info "Base de donnees detectee : $DB_FILE ($(du -h "$DB_FILE" | cut -f1))"
+
+# --- Recuperation du SECRET_KEY d'origine (pour re-chiffrement sur la cible) ---
+OLD_KEY=""
+if [ -f "$DATA_DIR/.env" ]; then
+    OLD_KEY="$(grep -E '^[[:space:]]*SECRET_KEY=' "$DATA_DIR/.env" | head -1 | cut -d= -f2- | tr -d ' \r\"')"
+fi
+[ -z "$OLD_KEY" ] && OLD_KEY="${SECRET_KEY:-}"
+if [ -z "$OLD_KEY" ]; then
+    warn "SECRET_KEY d'origine introuvable (.env absent ?)."
+    warn "Les parametres chiffres (SMTP, cles API...) devront etre reconfigures"
+    warn "manuellement sur la cible. La migration des donnees se poursuit."
+else
+    info "SECRET_KEY d'origine recupere (pour re-chiffrement automatique)."
+fi
 
 # --- Arret optionnel du service ---
 SERVICE_WAS_STOPPED=0
@@ -101,23 +121,34 @@ else
     info "Base copiee via backup_db.py."
 fi
 
-# --- Copie des documents ---
-if [ -d "$DOCS_DIR" ]; then
-    DOC_COUNT="$(find "$DOCS_DIR" -type f | wc -l | tr -d ' ')"
-    warn "Copie des documents ($DOC_COUNT fichiers)..."
-    cp -a "$DOCS_DIR" "$STAGE_DIR/documents"
-    info "Documents copies."
-else
-    warn "Aucun dossier 'documents' : export de la base seule."
-    mkdir -p "$STAGE_DIR/documents"
+# --- Copie des dossiers de donnees presents ---
+TAR_ITEMS=(cspilot.db)
+for folder in "${DATA_FOLDERS[@]}"; do
+    src="$DATA_DIR/$folder"
+    if [ -d "$src" ] && [ -n "$(ls -A "$src" 2>/dev/null)" ]; then
+        n="$(find "$src" -type f | wc -l | tr -d ' ')"
+        cp -a "$src" "$STAGE_DIR/$folder"
+        TAR_ITEMS+=("$folder")
+        info "Dossier '$folder' copie ($n fichiers)."
+    fi
+done
+
+# --- Metadonnees de migration (SECRET_KEY d'origine) ---
+if [ -n "$OLD_KEY" ]; then
+    META_DIR="$STAGE_DIR/_migration"
+    mkdir -p "$META_DIR"
+    printf '%s' "$OLD_KEY" > "$META_DIR/old_secret_key"
+    chmod 600 "$META_DIR/old_secret_key"
+    TAR_ITEMS+=(_migration)
 fi
 
-# --- Creation de l'archive ---
+# --- Creation de l'archive (permissions restreintes) ---
 mkdir -p "$OUTPUT_DIR"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 ARCHIVE="$OUTPUT_DIR/cspilot-migration-$TIMESTAMP.tar.gz"
 warn "Creation de l'archive..."
-tar -czf "$ARCHIVE" -C "$STAGE_DIR" cspilot.db documents
+( umask 077 && tar -czf "$ARCHIVE" -C "$STAGE_DIR" "${TAR_ITEMS[@]}" )
+chmod 600 "$ARCHIVE"
 
 echo ""
 echo "============================================================"
@@ -126,6 +157,9 @@ echo "  Archive   : $ARCHIVE"
 echo "  Taille    : $(du -h "$ARCHIVE" | cut -f1)"
 echo "  SHA-256   : $(sha256sum "$ARCHIVE" | cut -d' ' -f1)"
 echo "============================================================"
+echo ""
+echo "/!\\ Archive sensible (donnees + cle d'origine). A transferer en SSH"
+echo "    et a supprimer des deux cotes une fois la migration validee."
 echo ""
 echo "Etapes suivantes :"
 echo "  1. Transferer l'archive vers le nouveau VPS :"

--- a/scripts/migration/export-data.sh
+++ b/scripts/migration/export-data.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# CS-PILOT - Export des donnees pour migration VPS -> VPS
+# ========================================================
+#
+# A lancer sur le VPS SOURCE (le serveur actuel).
+# Produit une archive .tar.gz unique contenant la base de donnees (copie
+# coherente) et tous les documents uploades, prete a etre transferee vers
+# le nouveau VPS.
+#
+# Le fichier .env (donc le SECRET_KEY) n'est PAS inclus : une nouvelle cle
+# sera generee sur le serveur cible lors de l'import.
+#
+# Usage :
+#   ./scripts/migration/export-data.sh [--stop-service] [--output DOSSIER]
+#
+#   --stop-service   Arrete le service systemd "cspilot" pendant l'export
+#                    pour un instantane parfaitement propre, puis le relance.
+#                    (Optionnel : la copie via l'API backup SQLite est deja
+#                    coherente meme si l'application tourne.)
+#   --output DOSSIER Dossier ou ecrire l'archive (defaut : dossier courant).
+#
+set -euo pipefail
+
+# --- Couleurs ---
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[OK]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[INFO]${NC} $*"; }
+err()   { echo -e "${RED}[ERREUR]${NC} $*" >&2; }
+
+# --- Racine du projet (deux niveaux au-dessus de ce script) ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DATA_DIR="$PROJECT_DIR"   # mode script : DATA_DIR == dossier du projet (cf. database.py)
+
+DB_FILE="$DATA_DIR/cspilot.db"
+DOCS_DIR="$DATA_DIR/documents"
+
+# --- Options ---
+STOP_SERVICE=0
+OUTPUT_DIR="$(pwd)"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --stop-service) STOP_SERVICE=1; shift ;;
+        --output) OUTPUT_DIR="$2"; shift 2 ;;
+        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) err "Option inconnue : $1"; exit 1 ;;
+    esac
+done
+
+echo "============================================================"
+echo "   CS-PILOT - EXPORT DES DONNEES (migration)"
+echo "============================================================"
+echo ""
+
+# --- Verifications ---
+if [ ! -f "$DB_FILE" ]; then
+    err "Base de donnees introuvable : $DB_FILE"
+    err "Lancez ce script depuis le dossier du projet CS-PILOT."
+    exit 1
+fi
+info "Base de donnees detectee : $DB_FILE ($(du -h "$DB_FILE" | cut -f1))"
+
+# --- Arret optionnel du service ---
+SERVICE_WAS_STOPPED=0
+if [ "$STOP_SERVICE" -eq 1 ]; then
+    if systemctl is-active --quiet cspilot 2>/dev/null; then
+        warn "Arret du service cspilot pour un instantane propre..."
+        sudo systemctl stop cspilot
+        SERVICE_WAS_STOPPED=1
+        info "Service cspilot arrete."
+    else
+        warn "Service cspilot non actif : rien a arreter."
+    fi
+fi
+
+# --- Dossier temporaire ---
+TMP_DIR="$(mktemp -d)"
+STAGE_DIR="$TMP_DIR/cspilot-data"
+mkdir -p "$STAGE_DIR"
+cleanup() {
+    rm -rf "$TMP_DIR"
+    if [ "$SERVICE_WAS_STOPPED" -eq 1 ]; then
+        warn "Redemarrage du service cspilot..."
+        sudo systemctl start cspilot && info "Service cspilot redemarre."
+    fi
+}
+trap cleanup EXIT
+
+# --- Copie coherente de la base (SQLite est en mode WAL) ---
+warn "Copie coherente de la base de donnees..."
+if command -v sqlite3 &> /dev/null; then
+    sqlite3 "$DB_FILE" ".backup '$STAGE_DIR/cspilot.db'"
+    info "Base copiee via l'API backup SQLite (sqlite3)."
+else
+    warn "sqlite3 absent : utilisation de backup_db.py (API backup Python)."
+    PY="python3"; [ -x "$PROJECT_DIR/venv/bin/python" ] && PY="$PROJECT_DIR/venv/bin/python"
+    BK_PATH="$( cd "$PROJECT_DIR" && "$PY" -c "import backup_db; path,erreur=backup_db.creer_sauvegarde(label='migration'); import sys; sys.stderr.write((erreur or '')+'\n'); print(path or '')" )"
+    [ -z "$BK_PATH" ] || [ ! -f "$BK_PATH" ] && { err "Echec de la sauvegarde de la base."; exit 1; }
+    cp "$BK_PATH" "$STAGE_DIR/cspilot.db"
+    info "Base copiee via backup_db.py."
+fi
+
+# --- Copie des documents ---
+if [ -d "$DOCS_DIR" ]; then
+    DOC_COUNT="$(find "$DOCS_DIR" -type f | wc -l | tr -d ' ')"
+    warn "Copie des documents ($DOC_COUNT fichiers)..."
+    cp -a "$DOCS_DIR" "$STAGE_DIR/documents"
+    info "Documents copies."
+else
+    warn "Aucun dossier 'documents' : export de la base seule."
+    mkdir -p "$STAGE_DIR/documents"
+fi
+
+# --- Creation de l'archive ---
+mkdir -p "$OUTPUT_DIR"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+ARCHIVE="$OUTPUT_DIR/cspilot-migration-$TIMESTAMP.tar.gz"
+warn "Creation de l'archive..."
+tar -czf "$ARCHIVE" -C "$STAGE_DIR" cspilot.db documents
+
+echo ""
+echo "============================================================"
+info "Export termine."
+echo "  Archive   : $ARCHIVE"
+echo "  Taille    : $(du -h "$ARCHIVE" | cut -f1)"
+echo "  SHA-256   : $(sha256sum "$ARCHIVE" | cut -d' ' -f1)"
+echo "============================================================"
+echo ""
+echo "Etapes suivantes :"
+echo "  1. Transferer l'archive vers le nouveau VPS :"
+echo "       scp \"$ARCHIVE\" user@NOUVEAU_VPS:~/"
+echo "  2. Verifier le SHA-256 apres transfert (doit etre identique)."
+echo "  3. Sur le nouveau VPS, lancer :"
+echo "       ./scripts/migration/import-data.sh ~/$(basename "$ARCHIVE")"
+echo ""

--- a/scripts/migration/import-data.sh
+++ b/scripts/migration/import-data.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# CS-PILOT - Import des donnees pour migration VPS -> VPS
+# ========================================================
+#
+# A lancer sur le VPS CIBLE (le nouveau serveur), APRES avoir clone le depot
+# et installe les dependances (ex. via ./lancer.sh une premiere fois).
+#
+# Restaure la base de donnees et les documents depuis l'archive produite par
+# export-data.sh. Un .env neuf (avec un nouveau SECRET_KEY) est genere s'il
+# n'existe pas encore. Toute donnee existante est sauvegardee avant ecrasement.
+#
+# Usage :
+#   ./scripts/migration/import-data.sh cspilot-migration-AAAAMMJJ-HHMMSS.tar.gz
+#
+set -euo pipefail
+
+# --- Couleurs ---
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[OK]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[INFO]${NC} $*"; }
+err()   { echo -e "${RED}[ERREUR]${NC} $*" >&2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DATA_DIR="$PROJECT_DIR"   # mode script : DATA_DIR == dossier du projet (cf. database.py)
+
+ARCHIVE="${1:-}"
+if [ -z "$ARCHIVE" ]; then
+    err "Archive manquante."
+    echo "Usage : $0 cspilot-migration-AAAAMMJJ-HHMMSS.tar.gz"
+    exit 1
+fi
+if [ ! -f "$ARCHIVE" ]; then
+    err "Archive introuvable : $ARCHIVE"
+    exit 1
+fi
+
+echo "============================================================"
+echo "   CS-PILOT - IMPORT DES DONNEES (migration)"
+echo "============================================================"
+echo ""
+
+# --- Verifier que le code et les dependances sont en place ---
+PY="python3"
+if [ -x "$PROJECT_DIR/venv/bin/python" ]; then
+    PY="$PROJECT_DIR/venv/bin/python"
+else
+    warn "venv introuvable. Lancez d'abord ./lancer.sh pour creer l'environnement,"
+    warn "ou installez les dependances avant de poursuivre."
+fi
+if ! "$PY" -c "import flask" &> /dev/null; then
+    err "Flask n'est pas installe dans cet environnement."
+    err "Executez ./lancer.sh une premiere fois, puis Ctrl+C, avant l'import."
+    exit 1
+fi
+info "Environnement Python pret ($PY)."
+
+# --- Arreter le service si actif ---
+SERVICE_WAS_RUNNING=0
+if systemctl is-active --quiet cspilot 2>/dev/null; then
+    warn "Arret du service cspilot..."
+    sudo systemctl stop cspilot
+    SERVICE_WAS_RUNNING=1
+    info "Service cspilot arrete."
+fi
+
+# --- Sauvegarde de securite de l'existant ---
+BACKUP_DIR="$DATA_DIR/backups"
+mkdir -p "$BACKUP_DIR"
+TS="$(date +%Y%m%d-%H%M%S)"
+if [ -f "$DATA_DIR/cspilot.db" ]; then
+    warn "Base existante detectee : sauvegarde avant ecrasement."
+    cp "$DATA_DIR/cspilot.db" "$BACKUP_DIR/cspilot-pre-import-$TS.db"
+    info "Sauvegarde : backups/cspilot-pre-import-$TS.db"
+fi
+if [ -d "$DATA_DIR/documents" ] && [ -n "$(ls -A "$DATA_DIR/documents" 2>/dev/null)" ]; then
+    warn "Documents existants detectes : archivage avant ecrasement."
+    tar -czf "$BACKUP_DIR/documents-pre-import-$TS.tar.gz" -C "$DATA_DIR" documents
+    info "Archive : backups/documents-pre-import-$TS.tar.gz"
+fi
+
+# --- Extraction de l'archive ---
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+warn "Extraction de l'archive..."
+tar -xzf "$ARCHIVE" -C "$TMP_DIR"
+[ -f "$TMP_DIR/cspilot.db" ] || { err "Archive invalide : cspilot.db absent."; exit 1; }
+
+# --- Mise en place de la base ---
+# On retire d'eventuels fichiers WAL/SHM orphelins avant de poser la nouvelle base.
+rm -f "$DATA_DIR/cspilot.db-wal" "$DATA_DIR/cspilot.db-shm"
+cp "$TMP_DIR/cspilot.db" "$DATA_DIR/cspilot.db"
+info "Base de donnees restauree ($(du -h "$DATA_DIR/cspilot.db" | cut -f1))."
+
+# --- Mise en place des documents ---
+if [ -d "$TMP_DIR/documents" ]; then
+    rm -rf "$DATA_DIR/documents"
+    cp -a "$TMP_DIR/documents" "$DATA_DIR/documents"
+    DOC_COUNT="$(find "$DATA_DIR/documents" -type f | wc -l | tr -d ' ')"
+    info "Documents restaures ($DOC_COUNT fichiers)."
+fi
+
+# --- Generation d'un .env neuf (nouveau SECRET_KEY) ---
+ENV_FILE="$DATA_DIR/.env"
+if [ -f "$ENV_FILE" ]; then
+    info ".env deja present : SECRET_KEY existant conserve."
+else
+    warn "Generation d'un nouveau .env avec SECRET_KEY aleatoire..."
+    NEW_KEY="$("$PY" -c "import secrets; print(secrets.token_hex(32))")"
+    cat > "$ENV_FILE" <<EOF
+# Genere automatiquement lors de la migration ($TS)
+# Pour regenerer une cle : python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=$NEW_KEY
+
+# Decommentez si l'application est derriere un reverse proxy / HTTPS (Nginx, Cloudflare...)
+# BEHIND_PROXY=true
+EOF
+    info ".env cree avec un nouveau SECRET_KEY."
+fi
+
+# --- Application des migrations de schema en attente ---
+warn "Application des migrations de schema en attente (si le code est plus recent)..."
+( cd "$PROJECT_DIR" && "$PY" -c "
+from migration_manager import appliquer_toutes_en_attente, get_version_actuelle
+res = appliquer_toutes_en_attente(appliquee_par='migration')
+print('Migrations appliquees :', res if res else 'aucune (schema deja a jour)')
+print('Version du schema :', get_version_actuelle())
+" )
+
+echo ""
+echo "============================================================"
+info "Import termine."
+echo "============================================================"
+echo ""
+echo "Etapes suivantes :"
+if [ "$SERVICE_WAS_RUNNING" -eq 1 ]; then
+    echo "  - Redemarrer le service :  sudo systemctl start cspilot"
+else
+    echo "  - Demarrer l'application :  sudo systemctl start cspilot"
+    echo "    (ou ./lancer.sh pour un test manuel)"
+fi
+echo "  - Se connecter et verifier : donnees, documents, version du schema"
+echo "    (panneau Administration)."
+echo ""
+echo "Note : le SECRET_KEY ayant change, les sessions de l'ancien serveur sont"
+echo "       invalidees. Les utilisateurs devront se reconnecter (normal)."
+echo ""

--- a/scripts/migration/import-data.sh
+++ b/scripts/migration/import-data.sh
@@ -6,9 +6,15 @@
 # A lancer sur le VPS CIBLE (le nouveau serveur), APRES avoir clone le depot
 # et installe les dependances (ex. via ./lancer.sh une premiere fois).
 #
-# Restaure la base de donnees et les documents depuis l'archive produite par
-# export-data.sh. Un .env neuf (avec un nouveau SECRET_KEY) est genere s'il
-# n'existe pas encore. Toute donnee existante est sauvegardee avant ecrasement.
+# Restaure depuis l'archive produite par export-data.sh :
+#   - la base de donnees,
+#   - les dossiers de donnees (documents, factures, modeles_contrats,
+#     contrats_generes, exports).
+# Un .env neuf (nouveau SECRET_KEY) est genere s'il n'existe pas, puis tous les
+# parametres chiffres de app_settings (SMTP, cles API, tarifs ALSH...) sont
+# RE-CHIFFRES avec cette nouvelle cle a partir de la cle d'origine transmise
+# dans l'archive : rien a reconfigurer manuellement.
+# Toute donnee existante est sauvegardee avant ecrasement.
 #
 # Usage :
 #   ./scripts/migration/import-data.sh cspilot-migration-AAAAMMJJ-HHMMSS.tar.gz
@@ -24,6 +30,7 @@ err()   { echo -e "${RED}[ERREUR]${NC} $*" >&2; }
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DATA_DIR="$PROJECT_DIR"   # mode script : DATA_DIR == dossier du projet (cf. database.py)
+DATA_FOLDERS=(documents factures modeles_contrats contrats_generes exports)
 
 ARCHIVE="${1:-}"
 if [ -z "$ARCHIVE" ]; then
@@ -74,11 +81,12 @@ if [ -f "$DATA_DIR/cspilot.db" ]; then
     cp "$DATA_DIR/cspilot.db" "$BACKUP_DIR/cspilot-pre-import-$TS.db"
     info "Sauvegarde : backups/cspilot-pre-import-$TS.db"
 fi
-if [ -d "$DATA_DIR/documents" ] && [ -n "$(ls -A "$DATA_DIR/documents" 2>/dev/null)" ]; then
-    warn "Documents existants detectes : archivage avant ecrasement."
-    tar -czf "$BACKUP_DIR/documents-pre-import-$TS.tar.gz" -C "$DATA_DIR" documents
-    info "Archive : backups/documents-pre-import-$TS.tar.gz"
-fi
+for folder in "${DATA_FOLDERS[@]}"; do
+    if [ -d "$DATA_DIR/$folder" ] && [ -n "$(ls -A "$DATA_DIR/$folder" 2>/dev/null)" ]; then
+        warn "Dossier '$folder' existant : archivage avant ecrasement."
+        tar -czf "$BACKUP_DIR/$folder-pre-import-$TS.tar.gz" -C "$DATA_DIR" "$folder"
+    fi
+done
 
 # --- Extraction de l'archive ---
 TMP_DIR="$(mktemp -d)"
@@ -93,30 +101,45 @@ rm -f "$DATA_DIR/cspilot.db-wal" "$DATA_DIR/cspilot.db-shm"
 cp "$TMP_DIR/cspilot.db" "$DATA_DIR/cspilot.db"
 info "Base de donnees restauree ($(du -h "$DATA_DIR/cspilot.db" | cut -f1))."
 
-# --- Mise en place des documents ---
-if [ -d "$TMP_DIR/documents" ]; then
-    rm -rf "$DATA_DIR/documents"
-    cp -a "$TMP_DIR/documents" "$DATA_DIR/documents"
-    DOC_COUNT="$(find "$DATA_DIR/documents" -type f | wc -l | tr -d ' ')"
-    info "Documents restaures ($DOC_COUNT fichiers)."
-fi
+# --- Mise en place des dossiers de donnees ---
+for folder in "${DATA_FOLDERS[@]}"; do
+    if [ -d "$TMP_DIR/$folder" ]; then
+        rm -rf "$DATA_DIR/$folder"
+        cp -a "$TMP_DIR/$folder" "$DATA_DIR/$folder"
+        n="$(find "$DATA_DIR/$folder" -type f | wc -l | tr -d ' ')"
+        info "Dossier '$folder' restaure ($n fichiers)."
+    fi
+done
 
-# --- Generation d'un .env neuf (nouveau SECRET_KEY) ---
+# --- .env / SECRET_KEY (genere si absent) + recuperation de la NOUVELLE cle ---
 ENV_FILE="$DATA_DIR/.env"
 if [ -f "$ENV_FILE" ]; then
     info ".env deja present : SECRET_KEY existant conserve."
 else
     warn "Generation d'un nouveau .env avec SECRET_KEY aleatoire..."
-    NEW_KEY="$("$PY" -c "import secrets; print(secrets.token_hex(32))")"
+    GEN_KEY="$("$PY" -c "import secrets; print(secrets.token_hex(32))")"
     cat > "$ENV_FILE" <<EOF
 # Genere automatiquement lors de la migration ($TS)
 # Pour regenerer une cle : python -c "import secrets; print(secrets.token_hex(32))"
-SECRET_KEY=$NEW_KEY
+SECRET_KEY=$GEN_KEY
 
 # Decommentez si l'application est derriere un reverse proxy / HTTPS (Nginx, Cloudflare...)
 # BEHIND_PROXY=true
 EOF
+    chmod 600 "$ENV_FILE"
     info ".env cree avec un nouveau SECRET_KEY."
+fi
+NEW_KEY="$(grep -E '^[[:space:]]*SECRET_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d ' \r\"')"
+
+# --- Re-chiffrement des parametres avec la nouvelle cle ---
+OLD_KEY_FILE="$TMP_DIR/_migration/old_secret_key"
+if [ -f "$OLD_KEY_FILE" ]; then
+    OLD_KEY="$(cat "$OLD_KEY_FILE")"
+    warn "Re-chiffrement des parametres (SMTP, cles API, tarifs ALSH...) avec la nouvelle cle..."
+    "$PY" "$SCRIPT_DIR/reencrypt_settings.py" "$OLD_KEY" "$NEW_KEY" "$DATA_DIR/cspilot.db"
+else
+    warn "Cle d'origine absente de l'archive : pas de re-chiffrement automatique."
+    warn "Les parametres chiffres (SMTP, cles API...) devront etre reconfigures via l'UI."
 fi
 
 # --- Application des migrations de schema en attente ---
@@ -140,8 +163,9 @@ else
     echo "  - Demarrer l'application :  sudo systemctl start cspilot"
     echo "    (ou ./lancer.sh pour un test manuel)"
 fi
-echo "  - Se connecter et verifier : donnees, documents, version du schema"
-echo "    (panneau Administration)."
+echo "  - Se connecter et verifier : donnees, documents, parametres (SMTP, cles API)."
+echo "  - Supprimer l'archive de migration (contient la cle d'origine) :"
+echo "       rm -f \"$ARCHIVE\""
 echo ""
 echo "Note : le SECRET_KEY ayant change, les sessions de l'ancien serveur sont"
 echo "       invalidees. Les utilisateurs devront se reconnecter (normal)."

--- a/scripts/migration/reencrypt_settings.py
+++ b/scripts/migration/reencrypt_settings.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Re-chiffrement des parametres de app_settings lors d'une migration VPS.
+
+Les valeurs de la table `app_settings` (SMTP, cles API, tarifs ALSH, salaire
+socle, options d'affichage...) sont chiffrees avec une cle Fernet derivee du
+SECRET_KEY (cf. utils._get_fernet : Fernet(base64(sha256(SECRET_KEY)))).
+
+Quand on regenere le SECRET_KEY sur le serveur cible, ces valeurs deviennent
+indechiffrables. Ce script dechiffre chaque valeur avec l'ANCIENNE cle puis la
+re-chiffre avec la NOUVELLE, de sorte que tous les parametres restent
+utilisables sans reconfiguration manuelle.
+
+Usage :
+    python reencrypt_settings.py <ancienne_cle> <nouvelle_cle> <chemin_cspilot.db>
+"""
+import base64
+import hashlib
+import sqlite3
+import sys
+
+from cryptography.fernet import Fernet
+
+
+def fernet_for(secret_key: str) -> Fernet:
+    """Reproduit utils._get_fernet sans dependre du contexte Flask."""
+    digest = hashlib.sha256(secret_key.encode()).digest()
+    return Fernet(base64.urlsafe_b64encode(digest))
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(__doc__)
+        return 2
+
+    old_key, new_key, db_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    if not old_key:
+        print("[ignore] Ancienne cle absente : aucun re-chiffrement possible.")
+        return 0
+    if old_key == new_key:
+        print("[ok] Ancienne et nouvelle cle identiques : rien a re-chiffrer.")
+        return 0
+
+    f_old = fernet_for(old_key)
+    f_new = fernet_for(new_key)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT key, value FROM app_settings").fetchall()
+    except sqlite3.OperationalError:
+        # Table absente : rien a faire (base sans parametres).
+        print("[ok] Table app_settings absente : rien a re-chiffrer.")
+        conn.close()
+        return 0
+
+    migres, deja_ok, ignores = 0, 0, 0
+    for row in rows:
+        cle, valeur = row["key"], row["value"]
+        try:
+            clair = f_old.decrypt(valeur.encode())
+        except Exception:
+            # Pas dechiffrable avec l'ancienne cle : peut-etre deja chiffre avec
+            # la nouvelle (re-execution), ou valeur non standard -> on laisse tel quel.
+            try:
+                f_new.decrypt(valeur.encode())
+                deja_ok += 1
+            except Exception:
+                print(f"  [ignore] '{cle}' indechiffrable, laisse tel quel.")
+                ignores += 1
+            continue
+        conn.execute(
+            "UPDATE app_settings SET value = ? WHERE key = ?",
+            (f_new.encrypt(clair).decode(), cle),
+        )
+        migres += 1
+
+    conn.commit()
+    conn.close()
+    print(f"[ok] Parametres re-chiffres : {migres} | deja a jour : {deja_ok} | ignores : {ignores}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Contexte

L'application est aujourd'hui testée sur le serveur de test ; le centre prendra ensuite son propre VPS. Il fallait une procédure reproductible pour transférer **l'intégralité d'une installation de production** vers un nouveau serveur. Jusqu'ici il n'existait aucune procédure documentée ni script dédié.

## Ce qui est migré

- **`cspilot.db`** — copie cohérente via l'API backup SQLite (indispensable, base en mode WAL).
- **Dossiers de données sur disque** : `documents/`, `factures/`, `modeles_contrats/`, `contrats_generes/`, `exports/`.
- **Paramètres** de la table `app_settings` : config SMTP/notifications, clés API (OpenAI/Anthropic/Groq), tarifs ALSH, salaire socle, options d'affichage.

## Point clé : paramètres chiffrés + nouveau SECRET_KEY

Les valeurs de `app_settings` sont chiffrées (Fernet) avec une clé dérivée du `SECRET_KEY`. Comme la cible reçoit un **nouveau** `SECRET_KEY`, ces valeurs deviendraient illisibles. La solution retenue :

- l'export embarque la **clé d'origine de façon transitoire** dans l'archive ;
- l'import **re-chiffre** automatiquement tous les paramètres avec la nouvelle clé (`scripts/migration/reencrypt_settings.py`) ;
- résultat : **rien à reconfigurer**, et la cible tourne ensuite avec une clé neuve (la clé d'origine est jetée).

L'archive (base + clé) est créée en permissions `600` ; le script rappelle de la supprimer des deux côtés après migration.

## Fichiers

- **`scripts/migration/export-data.sh`** (VPS source) — copie cohérente de la base + dossiers présents + clé d'origine, archive `.tar.gz` (SHA-256 affiché), option `--stop-service`.
- **`scripts/migration/import-data.sh`** (VPS cible) — sauvegarde de sécurité de tout existant, restauration base + dossiers, génération `.env`/SECRET_KEY si absent, **re-chiffrement** des paramètres, application des migrations de schéma.
- **`scripts/migration/reencrypt_settings.py`** — re-chiffrement autonome (sans contexte Flask) des valeurs `app_settings` de l'ancienne vers la nouvelle clé.
- **`docs/migration-vps.md`** — guide pas-à-pas : pré-requis, transfert (scp + vérif SHA-256), import, reconstruction **systemd** `cspilot` + **Nginx + HTTPS** (certbot), vérification, rollback.
- **`README.md`** — lien vers le guide.

## Choix de conception

- Réutilise l'existant : `backup_db.py` (copie cohérente) et `migration_manager.py` (schéma) ; `reencrypt_settings.py` réplique `utils._get_fernet`.
- Régénération du `SECRET_KEY` validée en amont, sans perte de paramètres grâce au re-chiffrement.

## Tests effectués (migration « à blanc », 2 dossiers = 2 VPS)

- Source : schéma v0034 (73 tables), 5 dossiers de données peuplés, 3 paramètres chiffrés (`email_password`, `email_smtp_server`, `anthropic_api_key`) avec une clé connue.
- Export → archive valide, contenu vérifié, clé d'origine capturée, permissions 600.
- Import sur cible avec une **clé différente** → base + 5 dossiers restaurés ; **les 3 paramètres se déchiffrent correctement avec la nouvelle clé** ; schéma v0034, 0 migration en attente.
- Sauvegarde de sécurité auto de chaque dossier au ré-import ; re-chiffrement idempotent.
- `bash -n` OK sur les 2 scripts, `py_compile` OK sur le script Python.

https://claude.ai/code/session_01Rgf2WkjyUY564jBCBDRCsC