### PR TITLE
Fix : planning alterné bloqué après suppression des plannings

### DIFF
--- a/blueprints/planning.py
+++ b/blueprints/planning.py
@@ -171,6 +171,16 @@ def supprimer_planning(planning_id):
             return redirect(url_for('planning_bp.planning_theorique'))
 
         conn.execute('DELETE FROM planning_theorique WHERE id = ?', (planning_id,))
+
+        # Nettoyer alternance_reference si plus aucun planning alterné ne reste
+        restants = conn.execute(
+            "SELECT COUNT(*) as nb FROM planning_theorique "
+            "WHERE user_id = ? AND type_alternance IN ('semaine_1', 'semaine_2')",
+            (session['user_id'],)
+        ).fetchone()
+        if restants['nb'] == 0:
+            conn.execute('DELETE FROM alternance_reference WHERE user_id = ?', (session['user_id'],))
+
         conn.commit()
         flash(f'Planning du {planning["date_debut_validite"]} supprimé.', 'success')
     except Exception as e:

--- a/blueprints/worktime_metrics.py
+++ b/blueprints/worktime_metrics.py
@@ -96,7 +96,7 @@ def get_planning_cached(conn, user_id: int, date_str: str, planning_cache: dict,
                 (user_id, type_periode_recherche, date_str),
             ).fetchone()
 
-        return conn.execute(
+        planning = conn.execute(
             """
             SELECT *
             FROM planning_theorique
@@ -109,6 +109,24 @@ def get_planning_cached(conn, user_id: int, date_str: str, planning_cache: dict,
             """,
             (user_id, type_periode_recherche, semaine_type, date_str),
         ).fetchone()
+
+        # Fallback : si aucun planning alterné pour ce type_periode, utiliser le planning fixe
+        if not planning:
+            planning = conn.execute(
+                """
+                SELECT *
+                FROM planning_theorique
+                WHERE user_id = ?
+                  AND type_periode = ?
+                  AND (type_alternance IS NULL OR type_alternance = 'fixe')
+                  AND date_debut_validite <= ?
+                ORDER BY date_debut_validite DESC
+                LIMIT 1
+                """,
+                (user_id, type_periode_recherche, date_str),
+            ).fetchone()
+
+        return planning
 
     planning = _chercher_planning(type_periode)
     if not planning and type_periode == "vacances":

--- a/blueprints/worktime_metrics.py
+++ b/blueprints/worktime_metrics.py
@@ -45,6 +45,27 @@ def _get_semaine_alternance(conn, user_id: int, date_str: str) -> str:
     if not ref:
         return "fixe"
 
+    still_alternating = conn.execute(
+        """
+        SELECT 1 FROM planning_theorique p
+        WHERE p.user_id = ?
+          AND p.type_alternance IN ('semaine_1', 'semaine_2')
+          AND p.date_debut_validite <= ?
+          AND NOT EXISTS (
+              SELECT 1 FROM planning_theorique p2
+              WHERE p2.user_id = p.user_id
+                AND p2.type_periode = p.type_periode
+                AND p2.type_alternance = 'fixe'
+                AND p2.date_debut_validite > p.date_debut_validite
+                AND p2.date_debut_validite <= ?
+          )
+        LIMIT 1
+        """,
+        (user_id, date_str, date_str),
+    ).fetchone()
+    if not still_alternating:
+        return "fixe"
+
     date_ref = datetime.strptime(ref["date_reference"], "%Y-%m-%d")
     date_actuelle = datetime.strptime(date_str, "%Y-%m-%d")
     semaines_ecoulees = (date_actuelle - date_ref).days // 7

--- a/utils.py
+++ b/utils.py
@@ -185,9 +185,32 @@ def get_semaine_alternance(user_id, date_str):
         LIMIT 1
     ''', (user_id, date_str)).fetchone()
 
+    if not ref:
+        conn.close()
+        return 'fixe'
+
+    # Vérifier qu'au moins un planning alterné est encore actif (non supersédé par un planning fixe
+    # plus récent pour le même type_periode) — évite de bloquer les heures théoriques si tous les
+    # plannings alternés ont été supprimés ou remplacés par des plannings fixes.
+    still_alternating = conn.execute('''
+        SELECT 1 FROM planning_theorique p
+        WHERE p.user_id = ?
+          AND p.type_alternance IN ('semaine_1', 'semaine_2')
+          AND p.date_debut_validite <= ?
+          AND NOT EXISTS (
+              SELECT 1 FROM planning_theorique p2
+              WHERE p2.user_id = p.user_id
+                AND p2.type_periode = p.type_periode
+                AND p2.type_alternance = 'fixe'
+                AND p2.date_debut_validite > p.date_debut_validite
+                AND p2.date_debut_validite <= ?
+          )
+        LIMIT 1
+    ''', (user_id, date_str, date_str)).fetchone()
+
     conn.close()
 
-    if not ref:
+    if not still_alternating:
         return 'fixe'
 
     date_ref = datetime.strptime(ref['date_reference'], '%Y-%m-%d')

--- a/utils.py
+++ b/utils.py
@@ -243,7 +243,7 @@ def get_planning_valide_a_date(user_id, type_periode, date_str):
                 LIMIT 1
             ''', (user_id, type_periode_recherche, date_str)).fetchone()
 
-        return conn.execute('''
+        planning = conn.execute('''
             SELECT * FROM planning_theorique
             WHERE user_id = ?
             AND type_periode = ?
@@ -252,6 +252,20 @@ def get_planning_valide_a_date(user_id, type_periode, date_str):
             ORDER BY date_debut_validite DESC
             LIMIT 1
         ''', (user_id, type_periode_recherche, semaine_type, date_str)).fetchone()
+
+        # Fallback : si aucun planning alterné pour ce type_periode, utiliser le planning fixe
+        if not planning:
+            planning = conn.execute('''
+                SELECT * FROM planning_theorique
+                WHERE user_id = ?
+                AND type_periode = ?
+                AND (type_alternance IS NULL OR type_alternance = 'fixe')
+                AND date_debut_validite <= ?
+                ORDER BY date_debut_validite DESC
+                LIMIT 1
+            ''', (user_id, type_periode_recherche, date_str)).fetchone()
+
+        return planning
 
     planning = _chercher_planning_pour_type(type_periode)
 


### PR DESCRIPTION
## Problème

Quand une responsable configurait par erreur un planning en mode « semaine alternée », il était impossible de revenir en mode normal. Même en supprimant tous les plannings, le mode alterné restait actif et retournait 0h théoriques (car le système cherchait des plannings `semaine_1`/`semaine_2` qui n'existaient plus).

**Cause racine** : la table `alternance_reference` n'était jamais nettoyée lors de la suppression de plannings. `get_semaine_alternance()` trouvait ces enregistrements orphelins et continuait à retourner `semaine_1`/`semaine_2`.

## Corrections

### 1. Nettoyage lors de la suppression (`blueprints/planning.py`)
Après `DELETE FROM planning_theorique`, on vérifie s'il reste des plannings alternés pour ce salarié. Si aucun ne reste, les enregistrements `alternance_reference` sont supprimés automatiquement.

### 2. Vérification défensive dans `get_semaine_alternance()` (`utils.py` + `worktime_metrics.py`)
Avant de retourner `semaine_1`/`semaine_2`, la fonction vérifie qu'il existe au moins un planning alterné **non supersédé** par un planning fixe plus récent pour le même `type_periode`. Si tous les plannings alternés ont été remplacés par des plannings fixes, retourne `fixe`.

## Cas couverts

| Scénario | Comportement avant | Comportement après |
|---|---|---|
| Suppression de tous les plannings | 0h théoriques (mode alterné bloqué) | Mode alterné désactivé, heures théoriques correctes |
| Ajout d'un planning fixe qui remplace les plannings alternés | Anciens plannings alternés toujours utilisés | Planning fixe utilisé dès sa date de validité |
| Planning alterné normal | Inchangé ✓ | Inchangé ✓ |

## Tests
24/24 tests existants passent sans modification.

https://claude.ai/code/session_012KzBbvqswMBcnaPB7w7PZH

---
_Generated by [Claude Code](https://claude.ai/code/session_012KzBbvqswMBcnaPB7w7PZH)_