### PR TITLE
Refonte graphique de la page Alertes surcharge

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3469,3 +3469,177 @@ a.btn-icon:-webkit-any-link {
         display: block;
     }
 }
+
+/* === ALERTES SURCHARGE (cartes) === */
+.surcharge-list {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    animation: fadeIn var(--transition-slow) both;
+}
+
+.surcharge-card {
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--gray-200);
+    transition: background var(--transition-fast);
+}
+
+.surcharge-card:last-child {
+    border-bottom: none;
+}
+
+/* Alternance clair / foncé pour bien séparer les salariés */
+.surcharge-card:nth-child(odd) {
+    background: var(--white);
+}
+
+.surcharge-card:nth-child(even) {
+    background: var(--gray-50);
+}
+
+.surcharge-card:hover {
+    background: var(--gray-100);
+}
+
+/* Ligne principale : infos salarié + indicateurs + action */
+.surcharge-card-main {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+.surcharge-identity {
+    flex: 1 1 200px;
+    min-width: 180px;
+}
+
+.surcharge-identity .surcharge-name {
+    font-weight: 700;
+    color: var(--gray-900);
+    font-size: 1.02rem;
+}
+
+.surcharge-identity .surcharge-sector {
+    color: var(--gray-500);
+    font-size: 0.85rem;
+}
+
+.surcharge-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.surcharge-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 70px;
+}
+
+.surcharge-metric .surcharge-metric-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--gray-500);
+    font-weight: 600;
+}
+
+.surcharge-metric .surcharge-metric-value {
+    font-weight: 700;
+    color: var(--gray-900);
+    font-size: 1.05rem;
+}
+
+.surcharge-category-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.surcharge-action {
+    margin-left: auto;
+}
+
+/* Détail du score : pleine largeur sous la ligne principale */
+.surcharge-breakdown {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px dashed var(--gray-200);
+}
+
+.surcharge-breakdown-title {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--gray-500);
+    font-weight: 700;
+    margin-bottom: 0.6rem;
+}
+
+.surcharge-breakdown-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 0.6rem;
+}
+
+.surcharge-breakdown-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.6rem 0.75rem;
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-sm);
+}
+
+.surcharge-card:nth-child(even) .surcharge-breakdown-item {
+    background: var(--white);
+}
+
+.surcharge-breakdown-points {
+    flex: 0 0 auto;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: var(--gray-900);
+    background: var(--gray-200);
+    border-radius: 999px;
+    padding: 0.15rem 0.55rem;
+    white-space: nowrap;
+}
+
+.surcharge-breakdown-text .surcharge-breakdown-label {
+    font-weight: 600;
+    color: var(--gray-700);
+    font-size: 0.88rem;
+}
+
+.surcharge-breakdown-text .surcharge-breakdown-detail {
+    color: var(--gray-500);
+    font-size: 0.82rem;
+    margin-top: 0.1rem;
+}
+
+@media (max-width: 768px) {
+    .surcharge-card {
+        padding: 1rem;
+    }
+
+    .surcharge-action {
+        margin-left: 0;
+        width: 100%;
+    }
+
+    .surcharge-action .btn {
+        width: 100%;
+        justify-content: center;
+    }
+}

--- a/templates/alertes_surcharge.html
+++ b/templates/alertes_surcharge.html
@@ -49,51 +49,40 @@
     <div class="section">
         <h2>Liste des alertes</h2>
         {% if alertes %}
-        <div style="overflow-x: auto;">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Salarié</th>
-                        <th>Catégorie</th>
-                        <th>Score</th>
-                        <th>Solde actuel</th>
-                        <th>Solde dernier mois</th>
-                        <th>Détail du score</th>
-                        <th>Évolution 60 jours</th>
-                        <th>Action</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for alerte in alertes %}
-                    <tr>
-                        <td>
-                            <strong>{{ alerte.nom_complet }}</strong><br>
-                            <span style="color: var(--gray-500); font-size: 0.9rem;">{{ alerte.secteur_nom }}</span>
-                        </td>
-                        <td>
-                            <span style="display:inline-flex;align-items:center;justify-content:center;padding:0.35rem 0.75rem;border-radius:999px;font-weight:700;background:{{ alerte.category.color }}22;color:{{ alerte.category.text_color }};border:1px solid {{ alerte.category.color }}55;">
-                                {{ alerte.category.label }}
+        <div class="surcharge-list">
+            {% for alerte in alertes %}
+            <div class="surcharge-card">
+                <div class="surcharge-card-main">
+                    <div class="surcharge-identity">
+                        <div class="surcharge-name">{{ alerte.nom_complet }}</div>
+                        <div class="surcharge-sector">{{ alerte.secteur_nom }}</div>
+                    </div>
+
+                    <div class="surcharge-metrics">
+                        <span class="surcharge-category-badge"
+                              style="background:{{ alerte.category.color }}22;color:{{ alerte.category.text_color }};border:1px solid {{ alerte.category.color }}55;">
+                            {{ alerte.category.label }}
+                        </span>
+
+                        <div class="surcharge-metric">
+                            <span class="surcharge-metric-label">Score</span>
+                            <span class="surcharge-metric-value">{{ alerte.score }}/100</span>
+                        </div>
+
+                        <div class="surcharge-metric">
+                            <span class="surcharge-metric-label">Solde actuel</span>
+                            <span class="surcharge-metric-value">{{ "%.1f"|format(alerte.solde_actuel) }}h</span>
+                        </div>
+
+                        <div class="surcharge-metric">
+                            <span class="surcharge-metric-label">Dernier mois</span>
+                            <span class="surcharge-metric-value">
+                                {% if alerte.solde_dernier_mois >= 0 %}+{% endif %}{{ "%.1f"|format(alerte.solde_dernier_mois) }}h
                             </span>
-                        </td>
-                        <td style="font-weight: 700; font-size: 1.05rem;">{{ alerte.score }}/100</td>
-                        <td>
-                            <strong>{{ "%.1f"|format(alerte.solde_actuel) }}h</strong>
-                        </td>
-                        <td>
-                            {% if alerte.solde_dernier_mois >= 0 %}
-                            +{{ "%.1f"|format(alerte.solde_dernier_mois) }}h
-                            {% else %}
-                            {{ "%.1f"|format(alerte.solde_dernier_mois) }}h
-                            {% endif %}
-                        </td>
-                        <td>
-                            <ul style="margin: 0; padding-left: 1rem;">
-                                {% for ligne in alerte.breakdown if ligne.points > 0 %}
-                                <li><strong>{{ ligne.points }} pts</strong> — {{ ligne.label }}<br><span style="color: var(--gray-500); font-size: 0.85rem;">{{ ligne.detail }}</span></li>
-                                {% endfor %}
-                            </ul>
-                        </td>
-                        <td style="min-width: 150px;">
+                        </div>
+
+                        <div class="surcharge-metric">
+                            <span class="surcharge-metric-label">Évolution 60 j</span>
                             <canvas
                                 class="surcharge-sparkline"
                                 width="140"
@@ -103,16 +92,35 @@
                                 data-color="{{ alerte.category.color }}"
                                 aria-label="Évolution du solde d'heures supplémentaires sur 60 jours pour {{ alerte.nom_complet }}">
                             </canvas>
-                        </td>
-                        <td>
-                            <a href="{{ url_for('validation_bp.vue_mensuelle', user_id=alerte.user_id, mois=mois, annee=annee) }}" class="btn btn-primary">
-                                📅 Vue mensuelle
-                            </a>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                        </div>
+                    </div>
+
+                    <div class="surcharge-action">
+                        <a href="{{ url_for('validation_bp.vue_mensuelle', user_id=alerte.user_id, mois=mois, annee=annee) }}" class="btn btn-primary">
+                            📅 Vue mensuelle
+                        </a>
+                    </div>
+                </div>
+
+                {% set lignes_score = alerte.breakdown|selectattr('points', 'gt', 0)|list %}
+                {% if lignes_score %}
+                <div class="surcharge-breakdown">
+                    <div class="surcharge-breakdown-title">Détail du score</div>
+                    <div class="surcharge-breakdown-grid">
+                        {% for ligne in lignes_score %}
+                        <div class="surcharge-breakdown-item">
+                            <span class="surcharge-breakdown-points">{{ ligne.points }} pts</span>
+                            <div class="surcharge-breakdown-text">
+                                <div class="surcharge-breakdown-label">{{ ligne.label }}</div>
+                                <div class="surcharge-breakdown-detail">{{ ligne.detail }}</div>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+            {% endfor %}
         </div>
         {% else %}
         <div class="direction-empty">


### PR DESCRIPTION
## Contexte

Sur un écran réduit (petit PC portable), la colonne **Détail du score** du tableau était trop étroite : le texte long s'étalait verticalement sur 20+ lignes, et les salariés n'étaient distingués qu'au survol de la souris (peu lisible).

## Changements

- **Passage du tableau à 8 colonnes vers une liste de cartes** : chaque salarié occupe sa propre carte.
- **Détail du score en pleine largeur** : affiché en dessous des indicateurs principaux, sous forme de grille responsive (`auto-fill, minmax(280px, 1fr)`) au lieu d'une colonne étroite. Fini l'empilement vertical illisible.
- **Alternance clair/foncé** des cartes pour bien séparer visuellement les salariés (au lieu d'un simple effet au survol), avec adaptation au thème sombre.
- **Indicateurs principaux** (catégorie, score, soldes, sparkline, action) regroupés sur une ligne flexible qui se réorganise selon la largeur disponible.
- Adapté aux petits écrans portables ; reste utilisable jusqu'au mobile (bouton d'action pleine largeur sous 768px).

## Tests

- `tests/test_alertes_surcharge.py` : 7 passés
- Suite complète : **361 passés**

Les chaînes vérifiées par les tests (détail du score, soldes) restent rendues à l'identique car elles proviennent du calcul serveur (`ligne.detail`).

https://claude.ai/code/session_01RGu5UKA1uAYtdcAthXshYq

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGu5UKA1uAYtdcAthXshYq)_