### PR TITLE
Saisie du planning d'un salarié par la direction, le comptable et les responsables

### DIFF
--- a/blueprints/planning.py
+++ b/blueprints/planning.py
@@ -9,70 +9,167 @@ from utils import login_required, calculer_heures, get_semaine_alternance
 planning_bp = Blueprint('planning_bp', __name__)
 
 
+def _peut_gerer_plannings():
+    """Profils autorisés à saisir le planning d'autres salariés."""
+    return session.get('profil') in ('comptable', 'directeur', 'responsable')
+
+
+def _salarie_accessible(conn, user_id):
+    """Indique si l'utilisateur connecté peut saisir le planning de user_id.
+
+    - Chacun peut gérer son propre planning.
+    - Direction et comptable : tous les salariés actifs (hors prestataire).
+    - Responsable : uniquement les salariés de son secteur.
+    """
+    if user_id == session.get('user_id'):
+        return True
+
+    profil = session.get('profil')
+    if profil in ('comptable', 'directeur'):
+        return conn.execute(
+            "SELECT 1 FROM users WHERE id = ? AND actif = 1 AND profil != 'prestataire'",
+            (user_id,)
+        ).fetchone() is not None
+
+    if profil == 'responsable':
+        resp = conn.execute(
+            'SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)
+        ).fetchone()
+        secteur_id = resp['secteur_id'] if resp else None
+        if not secteur_id:
+            return False
+        return conn.execute('''
+            SELECT 1 FROM users
+            WHERE id = ? AND actif = 1 AND profil != 'prestataire' AND secteur_id = ?
+        ''', (user_id, secteur_id)).fetchone() is not None
+
+    return False
+
+
+def _liste_salaries(conn):
+    """Liste des salariés dont l'utilisateur peut gérer le planning (sélecteur)."""
+    profil = session.get('profil')
+    if profil in ('comptable', 'directeur'):
+        return conn.execute('''
+            SELECT u.id, u.nom, u.prenom, COALESCE(s.nom, '') AS secteur_nom
+            FROM users u
+            LEFT JOIN secteurs s ON u.secteur_id = s.id
+            WHERE u.actif = 1 AND u.profil != 'prestataire'
+            ORDER BY u.nom, u.prenom
+        ''').fetchall()
+
+    if profil == 'responsable':
+        resp = conn.execute(
+            'SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)
+        ).fetchone()
+        secteur_id = resp['secteur_id'] if resp else None
+        if secteur_id:
+            return conn.execute('''
+                SELECT u.id, u.nom, u.prenom, COALESCE(s.nom, '') AS secteur_nom
+                FROM users u
+                LEFT JOIN secteurs s ON u.secteur_id = s.id
+                WHERE u.actif = 1 AND u.profil != 'prestataire'
+                  AND (u.secteur_id = ? OR u.id = ?)
+                ORDER BY u.nom, u.prenom
+            ''', (secteur_id, session['user_id'])).fetchall()
+        return conn.execute('''
+            SELECT u.id, u.nom, u.prenom, COALESCE(s.nom, '') AS secteur_nom
+            FROM users u
+            LEFT JOIN secteurs s ON u.secteur_id = s.id
+            WHERE u.id = ?
+        ''', (session['user_id'],)).fetchall()
+
+    return []
+
+
+def _redirect_planning(user_id_cible):
+    """Redirige vers le planning en conservant le salarié cible (si ce n'est pas soi-même)."""
+    if user_id_cible and user_id_cible != session['user_id']:
+        return redirect(url_for('planning_bp.planning_theorique', user_id=user_id_cible))
+    return redirect(url_for('planning_bp.planning_theorique'))
+
+
 @planning_bp.route('/planning_theorique', methods=['GET', 'POST'])
 @login_required
 def planning_theorique():
-    """Gestion du planning théorique avec historisation et alternance"""
+    """Gestion du planning théorique avec historisation et alternance.
+
+    Par défaut, on saisit son propre planning. La direction, le comptable et
+    les responsables (pour leur équipe uniquement) peuvent saisir le planning
+    d'un autre salarié via le paramètre ``user_id``.
+    """
+    user_id_param = (request.args.get('user_id', type=int) if request.method == 'GET'
+                     else request.form.get('user_id', type=int))
+    user_id_cible = user_id_param if user_id_param else session['user_id']
+
+    # Contrôle d'accès au salarié cible
+    conn = get_db()
+    autorise = _salarie_accessible(conn, user_id_cible)
+    conn.close()
+    if not autorise:
+        flash("Vous n'avez pas le droit de saisir ce planning", 'error')
+        return redirect(url_for('planning_bp.planning_theorique'))
+
     if request.method == 'POST':
         type_periode = request.form.get('type_periode')
         date_debut_validite = request.form.get('date_debut_validite')
         type_alternance = request.form.get('type_alternance', 'fixe')
         date_reference = request.form.get('date_reference')
-        
+
         if not date_debut_validite:
             flash('Vous devez spécifier une date de début de validité', 'error')
-            return redirect(url_for('planning_bp.planning_theorique'))
-        
+            return _redirect_planning(user_id_cible)
+
         # Vérifier la cohérence alternance
         if type_alternance in ['semaine_1', 'semaine_2'] and not date_reference:
             flash('Vous devez spécifier une date de référence pour l\'alternance', 'error')
-            return redirect(url_for('planning_bp.planning_theorique'))
-        
+            return _redirect_planning(user_id_cible)
+
         # Vérifier que la date de référence est un lundi
         if date_reference:
             date_ref_obj = datetime.strptime(date_reference, '%Y-%m-%d')
             if date_ref_obj.weekday() != 0:  # 0 = lundi
                 flash('⚠️ La date de référence doit être un lundi', 'error')
-                return redirect(url_for('planning_bp.planning_theorique'))
-        
+                return _redirect_planning(user_id_cible)
+
         # Vérifier si date dans le passé → warning
         date_validite_obj = datetime.strptime(date_debut_validite, '%Y-%m-%d')
         aujourdhui = datetime.now().date()
-        
+
         if date_validite_obj.date() < aujourdhui:
             # Vérifier s'il y a des heures saisies après cette date
             conn = get_db()
             heures_apres = conn.execute('''
-                SELECT COUNT(*) as nb FROM heures_reelles 
+                SELECT COUNT(*) as nb FROM heures_reelles
                 WHERE user_id = ? AND date >= ?
-            ''', (session['user_id'], date_debut_validite)).fetchone()
-            
+            ''', (user_id_cible, date_debut_validite)).fetchone()
+
             if heures_apres and heures_apres['nb'] > 0:
                 flash(f'⚠️ ATTENTION : {heures_apres["nb"]} jour(s) avec des heures saisies après le {date_debut_validite}. Les calculs de solde seront recalculés avec ce nouveau planning !', 'warning')
             conn.close()
-        
+
         # Récupérer tous les horaires des 5 jours
         jours = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi']
         horaires = {}
         total_hebdo = 0
-        
+
         for jour in jours:
             matin_debut = request.form.get(f'{jour}_matin_debut') or None
             matin_fin = request.form.get(f'{jour}_matin_fin') or None
             aprem_debut = request.form.get(f'{jour}_aprem_debut') or None
             aprem_fin = request.form.get(f'{jour}_aprem_fin') or None
-            
+
             horaires[f'{jour}_matin_debut'] = matin_debut
             horaires[f'{jour}_matin_fin'] = matin_fin
             horaires[f'{jour}_aprem_debut'] = aprem_debut
             horaires[f'{jour}_aprem_fin'] = aprem_fin
-            
+
             # Calculer les heures du jour
             if matin_debut and matin_fin:
                 total_hebdo += calculer_heures(matin_debut, matin_fin)
             if aprem_debut and aprem_fin:
                 total_hebdo += calculer_heures(aprem_debut, aprem_fin)
-        
+
         conn = get_db()
         try:
             # CRÉER un nouveau planning (historisation) avec type_alternance
@@ -86,8 +183,8 @@ def planning_theorique():
                  vendredi_matin_debut, vendredi_matin_fin, vendredi_aprem_debut, vendredi_aprem_fin,
                  total_hebdo)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (session['user_id'], type_periode, date_debut_validite, type_alternance,
-                  horaires['lundi_matin_debut'], horaires['lundi_matin_fin'], 
+            ''', (user_id_cible, type_periode, date_debut_validite, type_alternance,
+                  horaires['lundi_matin_debut'], horaires['lundi_matin_fin'],
                   horaires['lundi_aprem_debut'], horaires['lundi_aprem_fin'],
                   horaires['mardi_matin_debut'], horaires['mardi_matin_fin'],
                   horaires['mardi_aprem_debut'], horaires['mardi_aprem_fin'],
@@ -98,23 +195,23 @@ def planning_theorique():
                   horaires['vendredi_matin_debut'], horaires['vendredi_matin_fin'],
                   horaires['vendredi_aprem_debut'], horaires['vendredi_aprem_fin'],
                   total_hebdo))
-            
+
             # Si alternance, enregistrer la date de référence
             if type_alternance in ['semaine_1', 'semaine_2'] and date_reference:
                 # Vérifier si on a déjà une référence pour cette date
                 ref_existante = conn.execute('''
                     SELECT id FROM alternance_reference
                     WHERE user_id = ? AND date_debut_validite = ?
-                ''', (session['user_id'], date_debut_validite)).fetchone()
-                
+                ''', (user_id_cible, date_debut_validite)).fetchone()
+
                 if not ref_existante:
                     conn.execute('''
                         INSERT INTO alternance_reference (user_id, date_reference, date_debut_validite)
                         VALUES (?, ?, ?)
-                    ''', (session['user_id'], date_reference, date_debut_validite))
-            
+                    ''', (user_id_cible, date_reference, date_debut_validite))
+
             conn.commit()
-            
+
             if type_alternance == 'fixe':
                 flash(f'✅ Nouveau planning {type_periode} créé ({total_hebdo:.2f}h/semaine), valable à partir du {date_debut_validite}', 'success')
             else:
@@ -123,36 +220,47 @@ def planning_theorique():
             flash(f'Erreur: {str(e)}', 'error')
         finally:
             conn.close()
-        
-        return redirect(url_for('planning_bp.planning_theorique'))
+
+        return _redirect_planning(user_id_cible)
 
     # GET: afficher tous les plannings (historique complet) + infos alternance
     conn = get_db()
     plannings = conn.execute('''
-        SELECT * FROM planning_theorique 
+        SELECT * FROM planning_theorique
         WHERE user_id = ?
         ORDER BY type_alternance, type_periode, date_debut_validite DESC
-    ''', (session['user_id'],)).fetchall()
-    
+    ''', (user_id_cible,)).fetchall()
+
     # Récupérer les dates de référence alternance
     references = conn.execute('''
         SELECT * FROM alternance_reference
         WHERE user_id = ?
         ORDER BY date_debut_validite DESC
-    ''', (session['user_id'],)).fetchall()
-    
+    ''', (user_id_cible,)).fetchall()
+
     # Calculer la semaine actuelle si alternance configurée
     semaine_actuelle = None
     if references:
-        semaine_actuelle = get_semaine_alternance(session['user_id'], datetime.now().strftime('%Y-%m-%d'))
-    
+        semaine_actuelle = get_semaine_alternance(user_id_cible, datetime.now().strftime('%Y-%m-%d'))
+
+    # Salarié cible + liste des salariés gérables (pour le sélecteur)
+    user_cible = conn.execute(
+        'SELECT id, nom, prenom FROM users WHERE id = ?', (user_id_cible,)
+    ).fetchone()
+    peut_gerer = _peut_gerer_plannings()
+    salaries = _liste_salaries(conn) if peut_gerer else []
+
     conn.close()
-    
+
     return render_template('planning_theorique.html',
                          plannings=plannings,
                          references=references,
                          semaine_actuelle=semaine_actuelle,
-                         date_actuelle=datetime.now().strftime('%Y-%m-%d'))
+                         date_actuelle=datetime.now().strftime('%Y-%m-%d'),
+                         user_cible=dict(user_cible) if user_cible else None,
+                         user_id_cible=user_id_cible,
+                         salaries=salaries,
+                         peut_gerer=peut_gerer)
 
 
 @planning_bp.route('/planning_theorique/supprimer/<int:planning_id>', methods=['POST'])
@@ -160,26 +268,28 @@ def planning_theorique():
 def supprimer_planning(planning_id):
     """Suppression d'un planning - uniquement en cas d'erreur de saisie"""
     conn = get_db()
+    redirect_user = session['user_id']
     try:
         planning = conn.execute(
-            'SELECT id, date_debut_validite FROM planning_theorique WHERE id = ? AND user_id = ?',
-            (planning_id, session['user_id'])
+            'SELECT id, user_id, date_debut_validite FROM planning_theorique WHERE id = ?',
+            (planning_id,)
         ).fetchone()
 
-        if not planning:
+        if not planning or not _salarie_accessible(conn, planning['user_id']):
             flash('Planning introuvable ou accès refusé', 'error')
             return redirect(url_for('planning_bp.planning_theorique'))
 
+        redirect_user = planning['user_id']
         conn.execute('DELETE FROM planning_theorique WHERE id = ?', (planning_id,))
 
         # Nettoyer alternance_reference si plus aucun planning alterné ne reste
         restants = conn.execute(
             "SELECT COUNT(*) as nb FROM planning_theorique "
             "WHERE user_id = ? AND type_alternance IN ('semaine_1', 'semaine_2')",
-            (session['user_id'],)
+            (redirect_user,)
         ).fetchone()
         if restants['nb'] == 0:
-            conn.execute('DELETE FROM alternance_reference WHERE user_id = ?', (session['user_id'],))
+            conn.execute('DELETE FROM alternance_reference WHERE user_id = ?', (redirect_user,))
 
         conn.commit()
         flash(f'Planning du {planning["date_debut_validite"]} supprimé.', 'success')
@@ -188,4 +298,4 @@ def supprimer_planning(planning_id):
     finally:
         conn.close()
 
-    return redirect(url_for('planning_bp.planning_theorique'))
+    return _redirect_planning(redirect_user)

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,7 @@
                 </button>
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}">📁 Infos Salariés</a>
+                    <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
                     <a href="{{ url_for('rh_statistiques_bp.rh_statistiques') }}">📊 Statistiques RH</a>
@@ -177,6 +178,7 @@
                 </button>
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}">📁 Infos Salariés</a>
+                    <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
                     <a href="{{ url_for('rh_statistiques_bp.rh_statistiques') }}">📊 Statistiques RH</a>
@@ -300,6 +302,7 @@
                 </button>
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}">📁 Infos Salariés</a>
+                    <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     {% if generation_contrats_responsable_autorise %}
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
                     {% endif %}

--- a/templates/planning_theorique.html
+++ b/templates/planning_theorique.html
@@ -4,9 +4,30 @@
 
 {% block content %}
 <div class="form-container">
+    {% if user_cible and user_cible.id != session.user_id %}
+    <h1>Planning théorique — {{ user_cible.prenom }} {{ user_cible.nom }}</h1>
+    <p class="subtitle">Définissez les horaires habituels de ce salarié selon les périodes (par jour de la semaine)</p>
+    {% else %}
     <h1>Planning théorique</h1>
     <p class="subtitle">Définissez vos horaires habituels selon les périodes (par jour de la semaine)</p>
-    
+    {% endif %}
+
+    {% if peut_gerer and salaries %}
+    <div class="section" style="margin-bottom: 1.5rem;">
+        <div class="form-group">
+            <label for="select-salarie"><strong>👤 Salarié</strong></label>
+            <select id="select-salarie" onchange="changerSalarie(this.value)">
+                {% for s in salaries %}
+                <option value="{{ s.id }}" {% if s.id == user_id_cible %}selected{% endif %}>
+                    {{ s.nom }} {{ s.prenom }}{% if s.secteur_nom %} — {{ s.secteur_nom }}{% endif %}{% if s.id == session.user_id %} (moi){% endif %}
+                </option>
+                {% endfor %}
+            </select>
+            <p class="help-text">Sélectionnez le salarié dont vous souhaitez saisir le planning théorique.</p>
+        </div>
+    </div>
+    {% endif %}
+
     {% if semaine_actuelle and semaine_actuelle != 'fixe' %}
     <div class="planning-alternance-banner">
         <h3 style="color: var(--primary-dark); margin-bottom: 0.5rem;">
@@ -169,6 +190,7 @@
         <h2>{% if plannings %}Modifier{% else %}Créer{% endif %} un planning</h2>
         
         <form method="POST" action="{{ url_for('planning_bp.planning_theorique') }}">
+            <input type="hidden" name="user_id" value="{{ user_id_cible }}">
             <div class="form-group">
                 <label for="type_periode">Type de période *</label>
                 <select id="type_periode" name="type_periode" required>
@@ -414,6 +436,13 @@
 </div>
 
 <script>
+// Changement de salarié cible (sélecteur direction / comptable / responsable)
+function changerSalarie(userId) {
+    if (userId) {
+        window.location.href = "{{ url_for('planning_bp.planning_theorique') }}?user_id=" + userId;
+    }
+}
+
 function ouvrirModaleSuppression(planningId, datePlanning) {
     document.getElementById('modal-date-planning').textContent = datePlanning;
     document.getElementById('form-suppression').action = '/planning_theorique/supprimer/' + planningId;

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,224 @@
+"""
+Tests pour le module planning.py :
+- Saisie du planning théorique (pour soi-même)
+- Saisie du planning d'un autre salarié par la direction, le comptable
+  et les responsables (équipe uniquement)
+- Contrôles d'accès
+- Suppression d'un planning
+"""
+
+
+def _planning_data(user_id, date_debut='2025-01-06'):
+    """Construit un jeu de données POST minimal et valide pour un planning fixe."""
+    return {
+        'user_id': user_id,
+        'type_periode': 'periode_scolaire',
+        'date_debut_validite': date_debut,
+        'type_alternance': 'fixe',
+        'lundi_matin_debut': '09:00',
+        'lundi_matin_fin': '12:00',
+        'lundi_aprem_debut': '14:00',
+        'lundi_aprem_fin': '17:00',
+    }
+
+
+def _creer_salarie_autre_secteur(db):
+    """Crée un secteur et un salarié distincts (hors équipe du responsable de test)."""
+    from werkzeug.security import generate_password_hash
+
+    cursor = db.cursor()
+    cursor.execute(
+        "INSERT INTO secteurs (nom, description) VALUES (?, ?)",
+        ('Autre Secteur', 'Secteur distinct pour les tests')
+    )
+    autre_secteur_id = cursor.lastrowid
+    cursor.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil, secteur_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ('Petit', 'Luc', 'autre_salarie', generate_password_hash('autre123'),
+         'salarie', autre_secteur_id)
+    )
+    autre_salarie_id = cursor.lastrowid
+    db.commit()
+    return autre_salarie_id
+
+
+class TestPlanningAcces:
+    """Tests d'accès à la page de planning."""
+
+    def test_acces_planning_salarie(self, auth_client):
+        """Un salarié peut accéder à son propre planning."""
+        response = auth_client.get('/planning_theorique')
+        assert response.status_code == 200
+
+    def test_acces_planning_non_connecte(self, client):
+        """Non connecté => redirigé vers login."""
+        response = client.get('/planning_theorique', follow_redirects=False)
+        assert response.status_code == 302
+        assert '/login' in response.headers['Location']
+
+    def test_salarie_pas_de_selecteur(self, auth_client):
+        """Un salarié ne voit pas le sélecteur de salarié."""
+        response = auth_client.get('/planning_theorique')
+        assert b'select-salarie' not in response.data
+
+    def test_directeur_voit_selecteur_et_nom(self, admin_client, sample_users):
+        """Le directeur voit le sélecteur et le nom du salarié ciblé."""
+        response = admin_client.get(
+            f"/planning_theorique?user_id={sample_users['salarie_id']}"
+        )
+        assert response.status_code == 200
+        assert b'select-salarie' in response.data
+        assert b'Martin' in response.data  # nom du salarié de test
+
+
+class TestPlanningCreation:
+    """Tests de création de planning pour soi-même."""
+
+    def test_salarie_cree_son_planning(self, auth_client, app, db, sample_users):
+        """Un salarié peut créer son propre planning théorique."""
+        with app.app_context():
+            response = auth_client.post(
+                '/planning_theorique',
+                data=_planning_data(sample_users['salarie_id']),
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE user_id = ? AND date_debut_validite = ?",
+                (sample_users['salarie_id'], '2025-01-06')
+            ).fetchone()
+            assert row is not None
+            assert row['lundi_matin_debut'] == '09:00'
+
+
+class TestPlanningDroits:
+    """Contrôles d'accès pour la saisie du planning d'un autre salarié."""
+
+    def test_directeur_cree_planning_salarie(self, admin_client, app, db, sample_users):
+        """Le directeur peut saisir le planning de n'importe quel salarié."""
+        with app.app_context():
+            response = admin_client.post(
+                '/planning_theorique',
+                data=_planning_data(sample_users['salarie_id']),
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE user_id = ? AND date_debut_validite = ?",
+                (sample_users['salarie_id'], '2025-01-06')
+            ).fetchone()
+            assert row is not None
+
+    def test_comptable_cree_planning_salarie(self, comptable_client, app, db, sample_users):
+        """Le comptable peut saisir le planning de n'importe quel salarié."""
+        with app.app_context():
+            response = comptable_client.post(
+                '/planning_theorique',
+                data=_planning_data(sample_users['salarie_id']),
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE user_id = ? AND date_debut_validite = ?",
+                (sample_users['salarie_id'], '2025-01-06')
+            ).fetchone()
+            assert row is not None
+
+    def test_responsable_cree_planning_de_son_equipe(self, resp_client, app, db, sample_users):
+        """Le responsable peut saisir le planning d'un salarié de son secteur."""
+        with app.app_context():
+            response = resp_client.post(
+                '/planning_theorique',
+                data=_planning_data(sample_users['salarie_id']),
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE user_id = ? AND date_debut_validite = ?",
+                (sample_users['salarie_id'], '2025-01-06')
+            ).fetchone()
+            assert row is not None
+
+    def test_responsable_ne_peut_pas_saisir_hors_equipe(self, resp_client, app, db, sample_users):
+        """Le responsable ne peut PAS saisir le planning d'un salarié d'un autre secteur."""
+        with app.app_context():
+            autre_salarie_id = _creer_salarie_autre_secteur(db)
+
+            response = resp_client.post(
+                '/planning_theorique',
+                data=_planning_data(autre_salarie_id),
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE user_id = ?",
+                (autre_salarie_id,)
+            ).fetchone()
+            assert row is None
+
+    def test_salarie_ne_peut_pas_saisir_pour_autrui(self, auth_client, app, db, sample_users):
+        """Un salarié ne peut PAS saisir le planning d'un autre salarié."""
+        with app.app_context():
+            response = auth_client.post(
+                '/planning_theorique',
+                data=_planning_data(sample_users['responsable_id']),
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE user_id = ?",
+                (sample_users['responsable_id'],)
+            ).fetchone()
+            assert row is None
+
+
+class TestPlanningSuppression:
+    """Tests de suppression de planning."""
+
+    def test_directeur_supprime_planning_salarie(self, admin_client, app, db, sample_users, sample_planning):
+        """Le directeur peut supprimer le planning d'un salarié."""
+        planning_id = sample_planning['planning_id']
+
+        with app.app_context():
+            response = admin_client.post(
+                f'/planning_theorique/supprimer/{planning_id}',
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE id = ?", (planning_id,)
+            ).fetchone()
+            assert row is None
+
+    def test_salarie_ne_peut_pas_supprimer_planning_autrui(self, auth_client, app, db, sample_users):
+        """Un salarié ne peut PAS supprimer le planning d'un autre salarié."""
+        with app.app_context():
+            # Créer un planning appartenant au responsable
+            cursor = db.cursor()
+            cursor.execute(
+                "INSERT INTO planning_theorique (user_id, type_periode, date_debut_validite, type_alternance, total_hebdo) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (sample_users['responsable_id'], 'periode_scolaire', '2025-01-06', 'fixe', 35.0)
+            )
+            planning_id = cursor.lastrowid
+            db.commit()
+
+            response = auth_client.post(
+                f'/planning_theorique/supprimer/{planning_id}',
+                follow_redirects=True,
+            )
+            assert response.status_code == 200
+
+            # Le planning ne doit PAS avoir été supprimé
+            row = db.execute(
+                "SELECT * FROM planning_theorique WHERE id = ?", (planning_id,)
+            ).fetchone()
+            assert row is not None


### PR DESCRIPTION
## Objectif

Permettre à la **direction**, au **comptable** et aux **responsables** (leur équipe uniquement) de saisir le planning théorique d'un salarié, en plus de leur propre planning.

## Modifications

### `blueprints/planning.py`
- La route `planning_theorique` (GET/POST) accepte désormais un paramètre `user_id` (cible), avec retour à soi-même par défaut — même pattern que `saisie.py`.
- Nouvelles fonctions de contrôle d'accès, alignées sur `infos_salaries.py` :
  - **direction / comptable** : tous les salariés actifs (hors prestataire) ;
  - **responsable** : uniquement les salariés de son secteur ;
  - **chaque utilisateur** continue de gérer son propre planning.
- Le contrôle d'accès s'applique à la **création** comme à la **suppression** (la suppression vérifie le propriétaire réel du planning).
- `_liste_salaries()` fournit la liste filtrée pour le sélecteur.

### `templates/planning_theorique.html`
- Sélecteur de salarié (visible uniquement par les profils gestionnaires) qui recharge la page sur le salarié choisi.
- Titre/sous-titre adaptés (« Planning théorique — Prénom Nom » lorsqu'on édite un autre salarié).
- Champ caché `user_id` transmis dans le formulaire (token CSRF injecté automatiquement par `base.html`).

### `templates/base.html`
- Lien **🗓️ Plannings salariés** ajouté dans la section « RH & Paie » des profils directeur, comptable et responsable.

### `tests/test_planning.py` (nouveau)
12 tests couvrant l'accès, la création pour soi et pour autrui, les refus (responsable hors secteur, salarié pour autrui) et la suppression.

## Tests

`python -m pytest` → **373 passés** (dont 12 nouveaux), aucune régression.

https://claude.ai/code/session_011B3MDSneSKnhDANe7RuicX

---
_Generated by [Claude Code](https://claude.ai/code/session_011B3MDSneSKnhDANe7RuicX)_