### PR TITLE
Forfait jour : pré-remplissage, prévisionnel et suivi des heures travaillées

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Suivi des absences par type et par salarie
 
 ### Forfait jours
-- Calendrier forfait jour
+- Calendrier forfait jour (jours ouvres pre-remplis en "travaille", hors feries)
+- Saisie previsionnelle des absences (conges, RTT...), y compris sur dates futures
 - Tableau de bord dedie
 
 ### Comptabilite & Finances

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -533,6 +533,21 @@ def gestion_jours_feries():
                 flash(f'Jour férié ajouté : {libelle}', 'success')
             except sqlite3.IntegrityError:
                 flash('Ce jour férié existe déjà', 'error')
+            else:
+                # Réconcilier le calendrier forfait jour : un jour férié n'est
+                # pas « travaillé ». Si l'année avait été pré-remplie avant la
+                # déclaration de ce férié, on retire les journées « travaillé »
+                # générées par défaut sur cette date (sans valeur réelle), tout
+                # en préservant toute saisie effective (horaires ou commentaire).
+                conn.execute('''
+                    DELETE FROM presence_forfait_jour
+                    WHERE date = ?
+                      AND type_journee = 'travaille'
+                      AND (commentaire IS NULL OR commentaire = '')
+                      AND matin_debut IS NULL AND matin_fin IS NULL
+                      AND aprem_debut IS NULL AND aprem_fin IS NULL
+                ''', (date,))
+                conn.commit()
             finally:
                 conn.close()
         

--- a/blueprints/forfait.py
+++ b/blueprints/forfait.py
@@ -5,7 +5,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, sessio
 from datetime import datetime, timedelta
 from io import BytesIO
 from database import get_db
-from utils import login_required, get_user_info, calculer_stats_forfait_jour
+from utils import login_required, get_user_info, calculer_stats_forfait_jour, calculer_heures
 
 forfait_bp = Blueprint('forfait_bp', __name__)
 
@@ -91,25 +91,34 @@ def calendrier_forfait_jour():
         date = request.form.get('date')
         type_journee = request.form.get('type_journee')
         commentaire = request.form.get('commentaire', '').strip()
-        
+
+        # Horaires facultatifs (le forfait jour n'impose pas d'horaire, mais la
+        # direction peut noter les heures travaillées matin / après-midi)
+        matin_debut = request.form.get('matin_debut', '').strip() or None
+        matin_fin = request.form.get('matin_fin', '').strip() or None
+        aprem_debut = request.form.get('aprem_debut', '').strip() or None
+        aprem_fin = request.form.get('aprem_fin', '').strip() or None
+
         if not date or not type_journee:
             flash('Date et type obligatoires', 'error')
             return redirect(url_for('forfait_bp.calendrier_forfait_jour'))
-        
+
         conn = get_db()
         try:
             conn.execute('''
-                INSERT OR REPLACE INTO presence_forfait_jour 
-                (user_id, date, type_journee, commentaire)
-                VALUES (?, ?, ?, ?)
-            ''', (session['user_id'], date, type_journee, commentaire))
+                INSERT OR REPLACE INTO presence_forfait_jour
+                (user_id, date, type_journee, commentaire,
+                 matin_debut, matin_fin, aprem_debut, aprem_fin)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (session['user_id'], date, type_journee, commentaire,
+                  matin_debut, matin_fin, aprem_debut, aprem_fin))
             conn.commit()
             flash('Journée enregistrée', 'success')
         except Exception as e:
             flash(f'Erreur : {str(e)}', 'error')
         finally:
             conn.close()
-        
+
         return redirect(url_for('forfait_bp.calendrier_forfait_jour'))
     
     # GET : afficher le calendrier
@@ -125,13 +134,33 @@ def calendrier_forfait_jour():
 
     # Récupérer les présences du mois
     presences = conn.execute('''
-        SELECT date, type_journee, commentaire
+        SELECT date, type_journee, commentaire,
+               matin_debut, matin_fin, aprem_debut, aprem_fin
         FROM presence_forfait_jour
         WHERE user_id = ? AND strftime('%Y', date) = ? AND strftime('%m', date) = ?
     ''', (session['user_id'], str(annee), f'{mois:02d}')).fetchall()
-    
-    # Convertir en dictionnaire
-    presences_dict = {p['date']: {'type': p['type_journee'], 'commentaire': p['commentaire']} for p in presences}
+
+    # Convertir en dictionnaire (avec horaires et total d'heures calculé)
+    presences_dict = {}
+    for p in presences:
+        heures = calculer_heures(p['matin_debut'], p['matin_fin']) + \
+                 calculer_heures(p['aprem_debut'], p['aprem_fin'])
+        parts = []
+        if p['matin_debut'] and p['matin_fin']:
+            parts.append(f"{p['matin_debut']}-{p['matin_fin']}")
+        if p['aprem_debut'] and p['aprem_fin']:
+            parts.append(f"{p['aprem_debut']}-{p['aprem_fin']}")
+        presences_dict[p['date']] = {
+            'type': p['type_journee'],
+            'commentaire': p['commentaire'] or '',
+            'matin_debut': p['matin_debut'] or '',
+            'matin_fin': p['matin_fin'] or '',
+            'aprem_debut': p['aprem_debut'] or '',
+            'aprem_fin': p['aprem_fin'] or '',
+            'horaire_str': ' / '.join(parts),
+            'heures': round(heures, 2),
+            'heures_str': f"{heures:g}h" if heures else '',
+        }
     
     # Récupérer les jours fériés du mois
     jours_feries = conn.execute('''
@@ -195,12 +224,13 @@ def rapport_forfait_jour_pdf(mois, annee):
     
     # Récupérer les présences du mois
     presences = conn.execute('''
-        SELECT date, type_journee, commentaire
+        SELECT date, type_journee, commentaire,
+               matin_debut, matin_fin, aprem_debut, aprem_fin
         FROM presence_forfait_jour
         WHERE user_id = ? AND strftime('%Y', date) = ? AND strftime('%m', date) = ?
         ORDER BY date
     ''', (session['user_id'], str(annee), f'{mois:02d}')).fetchall()
-    
+
     # Calculer les stats du mois
     stats_mois = {
         'travaille': 0,
@@ -212,11 +242,21 @@ def rapport_forfait_jour_pdf(mois, annee):
         'sans_solde': 0,
         'autre': 0
     }
-    
+
+    # Total des heures travaillées saisies et nombre de jours renseignés
+    total_heures = 0
+    nb_jours_horaires = 0
+
     for p in presences:
         if p['type_journee'] in stats_mois:
             stats_mois[p['type_journee']] += 1
-    
+        heures_jour = calculer_heures(p['matin_debut'], p['matin_fin']) + \
+                      calculer_heures(p['aprem_debut'], p['aprem_fin'])
+        if heures_jour > 0:
+            total_heures += heures_jour
+            nb_jours_horaires += 1
+    total_heures = round(total_heures, 2)
+
     # Stats cumulées année
     stats_annee = calculer_stats_forfait_jour(session['user_id'], annee)
     
@@ -331,8 +371,19 @@ def rapport_forfait_jour_pdf(mois, annee):
         ('GRID', (0, 0), (-1, -1), 1, colors.HexColor('#e2e8f0'))
     ]))
     elements.append(table_bilan)
+
+    # Total des heures travaillées saisies (suivi facultatif des horaires)
+    if nb_jours_horaires > 0:
+        jours_label = 'jour' if nb_jours_horaires == 1 else 'jours'
+        elements.append(Spacer(1, 0.3*cm))
+        elements.append(Paragraph(
+            f"<b>Heures travaillées :</b> {total_heures:g} heures "
+            f"({nb_jours_horaires} {jours_label} avec horaires saisies)",
+            styles['Normal']
+        ))
+
     elements.append(Spacer(1, 0.5*cm))
-    
+
     # Soldes cumulés année
     elements.append(Paragraph("SOLDES CUMULÉS (ANNÉE)", heading_style))
     data_cumul = [

--- a/blueprints/forfait.py
+++ b/blueprints/forfait.py
@@ -10,6 +10,54 @@ from utils import login_required, get_user_info, calculer_stats_forfait_jour
 forfait_bp = Blueprint('forfait_bp', __name__)
 
 
+def initialiser_annee_forfait_jour(conn, user_id, annee):
+    """Pré-remplit le calendrier forfait jour d'une année.
+
+    Par défaut, chaque jour ouvré (lundi → vendredi) qui n'est pas férié est
+    marqué comme « travaillé ». Les week-ends et les jours fériés sont laissés
+    de côté. La direction n'a donc plus qu'à modifier les jours d'absence
+    (congés, RTT, maladie…), y compris pour des dates futures, afin d'établir
+    un prévisionnel et de se projeter sur l'année.
+
+    L'initialisation n'a lieu qu'une seule fois par utilisateur et par année,
+    lorsque celle-ci est encore vierge de toute saisie : les saisies déjà
+    existantes ne sont jamais écrasées (INSERT OR IGNORE + garde « année vide »).
+
+    Retourne True si l'année vient d'être initialisée, False sinon.
+    """
+    deja_initialisee = conn.execute(
+        "SELECT 1 FROM presence_forfait_jour "
+        "WHERE user_id = ? AND strftime('%Y', date) = ? LIMIT 1",
+        (user_id, str(annee))
+    ).fetchone()
+    if deja_initialisee:
+        return False
+
+    feries = conn.execute(
+        "SELECT date FROM jours_feries WHERE annee = ?", (annee,)
+    ).fetchall()
+    feries_set = {f['date'] for f in feries}
+
+    jours_a_inserer = []
+    jour = datetime(annee, 1, 1)
+    fin = datetime(annee, 12, 31)
+    while jour <= fin:
+        date_str = jour.strftime('%Y-%m-%d')
+        # weekday() : 0 = lundi … 4 = vendredi ; on exclut les fériés
+        if jour.weekday() < 5 and date_str not in feries_set:
+            jours_a_inserer.append((user_id, date_str, 'travaille'))
+        jour += timedelta(days=1)
+
+    if jours_a_inserer:
+        conn.executemany(
+            "INSERT OR IGNORE INTO presence_forfait_jour "
+            "(user_id, date, type_journee) VALUES (?, ?, ?)",
+            jours_a_inserer
+        )
+        conn.commit()
+    return True
+
+
 @forfait_bp.route('/dashboard_forfait_jour')
 @login_required
 def dashboard_forfait_jour():
@@ -19,10 +67,16 @@ def dashboard_forfait_jour():
         return redirect(url_for('dashboard_bp.dashboard'))
     
     annee = request.args.get('annee', datetime.now().year, type=int)
-    
+
+    # Pré-remplir l'année (jours ouvrés = travaillé) si elle est encore vierge,
+    # afin que les statistiques reflètent le calendrier par défaut.
+    conn = get_db()
+    initialiser_annee_forfait_jour(conn, session['user_id'], annee)
+    conn.close()
+
     # Calculer les statistiques
     stats = calculer_stats_forfait_jour(session['user_id'], annee)
-    
+
     return render_template('dashboard_forfait_jour.html', stats=stats, annee=annee)
 
 @forfait_bp.route('/calendrier_forfait_jour', methods=['GET', 'POST'])
@@ -61,9 +115,15 @@ def calendrier_forfait_jour():
     # GET : afficher le calendrier
     mois = request.args.get('mois', datetime.now().month, type=int)
     annee = request.args.get('annee', datetime.now().year, type=int)
-    
-    # Récupérer les présences du mois
+
     conn = get_db()
+
+    # Pré-remplir l'année (jours ouvrés = travaillé, hors fériés) si elle est
+    # encore vierge. La direction peut ensuite poser à l'avance ses absences
+    # (congés, RTT…), y compris sur des dates futures, pour un prévisionnel.
+    initialiser_annee_forfait_jour(conn, session['user_id'], annee)
+
+    # Récupérer les présences du mois
     presences = conn.execute('''
         SELECT date, type_journee, commentaire
         FROM presence_forfait_jour

--- a/database.py
+++ b/database.py
@@ -73,6 +73,7 @@ ALL_MIGRATION_VERSIONS = [
     ('0033', 'Ajout commandes salaries et delegations'),
     ('0034', 'Prevention sante au travail'),
     ('0035', 'Recuperation partielle'),
+    ('0036', 'Horaires forfait jour'),
 ]
 
 # Postes de depense par defaut (migration 0012)
@@ -397,6 +398,10 @@ def init_db():
             date TEXT NOT NULL,
             type_journee TEXT NOT NULL,
             commentaire TEXT,
+            matin_debut TEXT,
+            matin_fin TEXT,
+            aprem_debut TEXT,
+            aprem_fin TEXT,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id),
             UNIQUE(user_id, date)
@@ -1407,6 +1412,14 @@ def init_db():
         cursor.execute("SELECT heure_fin FROM demandes_recup LIMIT 1")
     except sqlite3.OperationalError:
         cursor.execute("ALTER TABLE demandes_recup ADD COLUMN heure_fin TEXT")
+
+    # Migration 0036 : colonnes d'horaires forfait jour si elles n'existent pas
+    # (suivi facultatif des heures matin / apres-midi par la direction)
+    for col in ('matin_debut', 'matin_fin', 'aprem_debut', 'aprem_fin'):
+        try:
+            cursor.execute(f"SELECT {col} FROM presence_forfait_jour LIMIT 1")
+        except sqlite3.OperationalError:
+            cursor.execute(f"ALTER TABLE presence_forfait_jour ADD COLUMN {col} TEXT")
 
     conn.commit()
     conn.close()

--- a/migrations/0036_horaires_forfait_jour.py
+++ b/migrations/0036_horaires_forfait_jour.py
@@ -1,0 +1,37 @@
+"""
+Migration 0036 : Horaires forfait jour.
+
+Le forfait jour n'impose pas d'horaire, mais la direction souhaite pouvoir
+noter, de facon facultative, les heures travaillees sur une journee. On ajoute
+a la table presence_forfait_jour quatre colonnes d'horaires (matin / apres-midi) :
+
+- matin_debut  : debut de la matinee (HH:MM)
+- matin_fin    : fin de la matinee (HH:MM)
+- aprem_debut  : debut de l'apres-midi (HH:MM)
+- aprem_fin    : fin de l'apres-midi (HH:MM)
+"""
+
+NOM = "Horaires forfait jour"
+DESCRIPTION = (
+    "Ajoute les colonnes matin_debut, matin_fin, aprem_debut et aprem_fin a la "
+    "table presence_forfait_jour pour le suivi facultatif des heures travaillees."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+
+    cols = [row[1] for row in cursor.execute('PRAGMA table_info(presence_forfait_jour)').fetchall()]
+
+    for col in ('matin_debut', 'matin_fin', 'aprem_debut', 'aprem_fin'):
+        if col not in cols:
+            cursor.execute(f"ALTER TABLE presence_forfait_jour ADD COLUMN {col} TEXT")
+
+    conn.commit()
+
+
+def downgrade(conn):
+    """Annule la migration (SQLite ne supporte pas DROP COLUMN simplement)."""
+    # SQLite ancien ne permet pas DROP COLUMN : on laisse les colonnes en place.
+    pass

--- a/templates/calendrier_forfait_jour.html
+++ b/templates/calendrier_forfait_jour.html
@@ -13,6 +13,11 @@
         </div>
     </div>
     
+    <div style="margin-bottom: 1.5rem; padding: 0.85rem 1rem; background: var(--gray-50); border-left: 3px solid var(--primary); border-radius: 6px; font-size: 0.85rem; color: var(--gray-700); line-height: 1.5;">
+        ℹ️ Par défaut, chaque jour ouvré (lundi → vendredi) hors jour férié est marqué comme <strong>✓ Travaillé</strong> dès le début de l'année.
+        Cliquez sur une journée — <strong>y compris dans le futur</strong> — pour poser un congé, un RTT ou une absence et construire votre <strong>prévisionnel</strong>.
+    </div>
+
     <div style="margin-bottom: 1.5rem; display: flex; gap: 1rem; flex-wrap: wrap;">
         <div style="display: flex; align-items: center; gap: 0.5rem;">
             <div class="cal-swatch cal-day-travaille"></div>
@@ -57,7 +62,13 @@
             {% for j in jours %}
             {% set classe_jour = 'cal-day-default' %}
             {% set texte_type = '' %}
-            {% if j.presence %}
+            {# Une saisie explicite (congé, RTT, maladie…) l'emporte sur tout ;
+               un jour férié l'emporte sur la valeur « travaillé » par défaut. #}
+            {% set saisie_explicite = j.presence and j.presence.type != 'travaille' %}
+            {% if j.ferie and not saisie_explicite %}
+                {% set classe_jour = 'cal-day-ferie' %}
+                {% set texte_type = '🎉 ' + j.ferie %}
+            {% elif j.presence %}
                 {% if j.presence.type == 'travaille' %}
                     {% set classe_jour = 'cal-day-travaille' %}
                     {% set texte_type = '✓ Travaillé' %}
@@ -83,9 +94,6 @@
                     {% set classe_jour = 'cal-day-autre' %}
                     {% set texte_type = 'Autre' %}
                 {% endif %}
-            {% elif j.ferie %}
-                {% set classe_jour = 'cal-day-ferie' %}
-                {% set texte_type = '🎉 ' + j.ferie %}
             {% elif j.jour_semaine >= 5 %}
                 {% set classe_jour = 'cal-day-weekend' %}
             {% endif %}

--- a/templates/calendrier_forfait_jour.html
+++ b/templates/calendrier_forfait_jour.html
@@ -99,10 +99,23 @@
             {% endif %}
 
             <div class="cal-day {{ classe_jour }}" style="{% if j.jour_semaine >= 5 %}opacity: 0.6;{% endif %}"
-                 onclick="ouvrirModal('{{ j.date }}', {{ j.jour }}, '{{ j.presence.type if j.presence else '' }}', '{{ j.presence.commentaire if j.presence else '' }}')">
+                 data-date="{{ j.date }}"
+                 data-jour="{{ j.jour }}"
+                 data-type="{{ j.presence.type if j.presence else '' }}"
+                 data-commentaire="{{ j.presence.commentaire if j.presence else '' }}"
+                 data-matin-debut="{{ j.presence.matin_debut if j.presence else '' }}"
+                 data-matin-fin="{{ j.presence.matin_fin if j.presence else '' }}"
+                 data-aprem-debut="{{ j.presence.aprem_debut if j.presence else '' }}"
+                 data-aprem-fin="{{ j.presence.aprem_fin if j.presence else '' }}"
+                 onclick="ouvrirModalFromCell(this)">
                 <div style="font-weight: 700; font-size: 1.1rem; margin-bottom: 0.25rem;">{{ j.jour }}</div>
                 {% if texte_type %}
                 <div style="font-size: 0.8rem; font-weight: 600; color: var(--gray-700);">{{ texte_type }}</div>
+                {% endif %}
+                {% if j.presence and j.presence.horaire_str %}
+                <div style="font-size: 0.72rem; color: var(--gray-600); margin-top: 0.2rem; line-height: 1.25;">
+                    🕐 {{ j.presence.horaire_str }}{% if j.presence.heures_str %} · <strong>{{ j.presence.heures_str }}</strong>{% endif %}
+                </div>
                 {% endif %}
                 {% if j.presence and j.presence.commentaire %}
                 <div style="font-size: 0.75rem; color: var(--gray-500); margin-top: 0.25rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
@@ -144,10 +157,35 @@
             </div>
             
             <div class="form-group">
+                <label>Horaires travaillés (optionnel)</label>
+                <div style="display: flex; gap: 1.5rem; flex-wrap: wrap;">
+                    <div>
+                        <div style="font-size: 0.8rem; color: var(--gray-600); margin-bottom: 0.25rem;">Matin</div>
+                        <div style="display: flex; gap: 0.4rem; align-items: center;">
+                            <input type="time" name="matin_debut" id="matin_debut" style="max-width: 8rem;">
+                            <span style="color: var(--gray-500);">→</span>
+                            <input type="time" name="matin_fin" id="matin_fin" style="max-width: 8rem;">
+                        </div>
+                    </div>
+                    <div>
+                        <div style="font-size: 0.8rem; color: var(--gray-600); margin-bottom: 0.25rem;">Après-midi</div>
+                        <div style="display: flex; gap: 0.4rem; align-items: center;">
+                            <input type="time" name="aprem_debut" id="aprem_debut" style="max-width: 8rem;">
+                            <span style="color: var(--gray-500);">→</span>
+                            <input type="time" name="aprem_fin" id="aprem_fin" style="max-width: 8rem;">
+                        </div>
+                    </div>
+                </div>
+                <small style="display: block; margin-top: 0.5rem; color: var(--gray-500);">
+                    Le forfait jour n'impose pas d'horaire : ces champs sont facultatifs et servent au suivi des heures travaillées.
+                </small>
+            </div>
+
+            <div class="form-group">
                 <label for="commentaire">Commentaire (optionnel)</label>
                 <textarea id="commentaire" name="commentaire" rows="2" placeholder="Précisions éventuelles..."></textarea>
             </div>
-            
+
             <div style="display: flex; gap: 1rem; margin-top: 1.5rem;">
                 <button type="submit" class="btn btn-primary">Enregistrer</button>
                 <button type="button" onclick="fermerModal()" class="btn btn-secondary">Annuler</button>
@@ -157,11 +195,16 @@
 </div>
 
 <script>
-function ouvrirModal(date, jour, typeActuel, commentaireActuel) {
-    document.getElementById('inputDate').value = date;
-    document.getElementById('modalJour').textContent = jour;
-    document.getElementById('type_journee').value = typeActuel || '';
-    document.getElementById('commentaire').value = commentaireActuel || '';
+function ouvrirModalFromCell(el) {
+    const d = el.dataset;
+    document.getElementById('inputDate').value = d.date;
+    document.getElementById('modalJour').textContent = d.jour;
+    document.getElementById('type_journee').value = d.type || '';
+    document.getElementById('commentaire').value = d.commentaire || '';
+    document.getElementById('matin_debut').value = d.matinDebut || '';
+    document.getElementById('matin_fin').value = d.matinFin || '';
+    document.getElementById('aprem_debut').value = d.apremDebut || '';
+    document.getElementById('aprem_fin').value = d.apremFin || '';
     document.getElementById('modalSaisie').style.display = 'flex';
 }
 

--- a/tests/test_forfait_jour.py
+++ b/tests/test_forfait_jour.py
@@ -303,3 +303,60 @@ def test_migration_0036_ajoute_colonnes_horaires(tmp_path):
 
     for col in ('matin_debut', 'matin_fin', 'aprem_debut', 'aprem_fin'):
         assert col in cols
+
+
+# --- Réconciliation des fériés déclarés après le pré-remplissage ---
+
+def test_ajout_ferie_retire_travaille_par_defaut(app, admin_client, sample_users):
+    """Déclarer un férié après le pré-remplissage retire la journée « travaillé »
+    générée par défaut et corrige les stats (pas de sur-comptage)."""
+    import utils
+    annee = 2026
+    # pré-remplir l'année (jours ouvrés = travaillé)
+    admin_client.get(f'/calendrier_forfait_jour?mois=5&annee={annee}')
+
+    ferie = _premier_jour_ouvre(annee, 5)
+    presences = _presences(app, sample_users['directeur_id'], annee)
+    assert presences.get(ferie) == 'travaille'
+
+    with app.app_context():
+        travaille_avant = utils.calculer_stats_forfait_jour(
+            sample_users['directeur_id'], annee)['travaille']
+
+    # déclarer ce jour comme férié via la page de gestion
+    resp = admin_client.post('/gestion_jours_feries', data={
+        'action': 'ajouter', 'date': ferie, 'libelle': 'Jour de test',
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    # la journée « travaillé » par défaut a été retirée
+    presences = _presences(app, sample_users['directeur_id'], annee)
+    assert ferie not in presences
+
+    # les statistiques ne comptent plus ce jour comme travaillé
+    with app.app_context():
+        travaille_apres = utils.calculer_stats_forfait_jour(
+            sample_users['directeur_id'], annee)['travaille']
+    assert travaille_apres == travaille_avant - 1
+
+
+def test_ajout_ferie_preserve_saisie_reelle(app, admin_client, sample_users):
+    """Une journée avec horaires saisis n'est pas supprimée si elle devient férié."""
+    annee = 2026
+    date = _premier_jour_ouvre(annee, 6)
+
+    # saisie réelle : journée travaillée avec horaires
+    admin_client.post('/calendrier_forfait_jour', data={
+        'date': date, 'type_journee': 'travaille',
+        'matin_debut': '08:30', 'matin_fin': '12:00',
+        'aprem_debut': '13:30', 'aprem_fin': '17:00',
+    }, follow_redirects=True)
+
+    # le jour est ensuite déclaré férié
+    admin_client.post('/gestion_jours_feries', data={
+        'action': 'ajouter', 'date': date, 'libelle': 'Férié test',
+    }, follow_redirects=True)
+
+    # la saisie réelle (avec horaires) est conservée
+    presences = _presences(app, sample_users['directeur_id'], annee)
+    assert presences.get(date) == 'travaille'

--- a/tests/test_forfait_jour.py
+++ b/tests/test_forfait_jour.py
@@ -159,3 +159,147 @@ def test_acces_refuse_non_directeur(auth_client):
     resp = auth_client.get('/calendrier_forfait_jour', follow_redirects=True)
     assert resp.status_code == 200
     assert b'Calendrier Forfait Jour' not in resp.data
+
+
+# --- Suivi facultatif des heures travaillées (horaires matin / après-midi) ---
+
+def _premier_jour_ouvre(annee, mois, decalage=0):
+    """Retourne le (1 + decalage)-ième jour ouvré du mois, format YYYY-MM-DD."""
+    jour = datetime(annee, mois, 1)
+    trouves = 0
+    while True:
+        if jour.weekday() < 5:
+            if trouves == decalage:
+                return jour.strftime('%Y-%m-%d')
+            trouves += 1
+        jour += timedelta(days=1)
+
+
+def test_saisie_horaires_enregistree(app, admin_client, sample_users):
+    """Les horaires matin / après-midi saisis sont enregistrés en base."""
+    annee = 2026
+    date = _premier_jour_ouvre(annee, 4)
+
+    resp = admin_client.post('/calendrier_forfait_jour', data={
+        'date': date,
+        'type_journee': 'travaille',
+        'matin_debut': '08:30', 'matin_fin': '12:00',
+        'aprem_debut': '13:30', 'aprem_fin': '17:00',
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    import database
+    with app.app_context():
+        conn = database.get_db()
+        row = conn.execute(
+            "SELECT matin_debut, matin_fin, aprem_debut, aprem_fin "
+            "FROM presence_forfait_jour WHERE user_id = ? AND date = ?",
+            (sample_users['directeur_id'], date)
+        ).fetchone()
+        conn.close()
+
+    assert row['matin_debut'] == '08:30'
+    assert row['matin_fin'] == '12:00'
+    assert row['aprem_debut'] == '13:30'
+    assert row['aprem_fin'] == '17:00'
+
+
+def test_horaires_affiches_sur_calendrier(admin_client):
+    """Les horaires et le total d'heures apparaissent sur le calendrier."""
+    annee = 2026
+    date = _premier_jour_ouvre(annee, 4)
+
+    admin_client.post('/calendrier_forfait_jour', data={
+        'date': date,
+        'type_journee': 'travaille',
+        'matin_debut': '08:30', 'matin_fin': '12:00',
+        'aprem_debut': '13:30', 'aprem_fin': '17:00',
+    }, follow_redirects=True)
+
+    resp = admin_client.get(f'/calendrier_forfait_jour?mois=4&annee={annee}')
+    html = resp.data.decode('utf-8')
+    assert '08:30-12:00' in html
+    assert '13:30-17:00' in html
+    assert '7h' in html  # total d'heures de la journée (3,5 + 3,5)
+
+
+def test_horaires_vides_par_defaut(admin_client):
+    """Sans saisie d'horaire, aucune plage horaire n'est affichée."""
+    import re
+    annee = 2026
+    resp = admin_client.get(f'/calendrier_forfait_jour?mois=1&annee={annee}')
+    html = resp.data.decode('utf-8')
+    # aucune plage HH:MM-HH:MM ne doit apparaître tant qu'aucun horaire n'est saisi
+    assert not re.search(r'\d{2}:\d{2}-\d{2}:\d{2}', html)
+
+
+def test_pdf_bilan_total_heures(admin_client):
+    """Le bilan du PDF mensuel affiche le total d'heures et le nb de jours."""
+    import pdfplumber
+    from io import BytesIO
+
+    annee, mois = 2026, 4
+    j1 = _premier_jour_ouvre(annee, mois, 0)
+    j2 = _premier_jour_ouvre(annee, mois, 1)
+
+    # 08:30-12:00 + 13:30-17:00 = 7h
+    admin_client.post('/calendrier_forfait_jour', data={
+        'date': j1, 'type_journee': 'travaille',
+        'matin_debut': '08:30', 'matin_fin': '12:00',
+        'aprem_debut': '13:30', 'aprem_fin': '17:00',
+    }, follow_redirects=True)
+    # 09:00-12:00 + 14:00-17:00 = 6h
+    admin_client.post('/calendrier_forfait_jour', data={
+        'date': j2, 'type_journee': 'travaille',
+        'matin_debut': '09:00', 'matin_fin': '12:00',
+        'aprem_debut': '14:00', 'aprem_fin': '17:00',
+    }, follow_redirects=True)
+
+    resp = admin_client.get(f'/rapport_forfait_jour_pdf/{mois}/{annee}')
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'application/pdf'
+
+    with pdfplumber.open(BytesIO(resp.data)) as pdf:
+        texte = '\n'.join(page.extract_text() or '' for page in pdf.pages)
+    norm = ' '.join(texte.split())
+
+    # 7h + 6h = 13h réparties sur 2 jours
+    assert '13 heures' in norm
+    assert '2 jours avec horaires saisies' in norm
+
+
+def test_migration_0036_ajoute_colonnes_horaires(tmp_path):
+    """La migration 0036 ajoute les colonnes d'horaires sur une base existante."""
+    import os
+    import sqlite3
+    from migration_manager import _load_migration_module, MIGRATIONS_DIR
+
+    db_path = str(tmp_path / 'old.db')
+    conn = sqlite3.connect(db_path)
+    # Ancienne table, sans les colonnes d'horaires
+    conn.execute('''
+        CREATE TABLE presence_forfait_jour (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            date TEXT NOT NULL,
+            type_journee TEXT NOT NULL,
+            commentaire TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(user_id, date)
+        )
+    ''')
+    conn.commit()
+
+    module = _load_migration_module(
+        os.path.join(MIGRATIONS_DIR, '0036_horaires_forfait_jour.py')
+    )
+    module.upgrade(conn)
+    module.upgrade(conn)  # idempotent : un second passage ne casse rien
+
+    cols = [r[1] for r in conn.execute(
+        'PRAGMA table_info(presence_forfait_jour)'
+    ).fetchall()]
+    conn.close()
+
+    for col in ('matin_debut', 'matin_fin', 'aprem_debut', 'aprem_fin'):
+        assert col in cols

--- a/tests/test_forfait_jour.py
+++ b/tests/test_forfait_jour.py
@@ -1,0 +1,161 @@
+"""
+Tests du calendrier forfait jour (direction).
+
+Couvre :
+- l'initialisation automatique d'une année : jours ouvrés (lun-ven) = travaillé ;
+- l'exclusion des jours fériés et des week-ends ;
+- la préservation des saisies existantes (aucun écrasement) ;
+- l'affichage prioritaire des jours fériés sur la valeur « travaillé » par défaut ;
+- la possibilité de saisir des journées futures (prévisionnel).
+"""
+from datetime import datetime, timedelta
+
+
+def _jours_ouvres_attendus(annee, feries=None):
+    """Nombre de jours lun-ven de l'année, hors jours fériés fournis."""
+    feries = set(feries or [])
+    n = 0
+    jour = datetime(annee, 1, 1)
+    fin = datetime(annee, 12, 31)
+    while jour <= fin:
+        d = jour.strftime('%Y-%m-%d')
+        if jour.weekday() < 5 and d not in feries:
+            n += 1
+        jour += timedelta(days=1)
+    return n
+
+
+def _presences(app, user_id, annee):
+    """Retourne {date: type_journee} pour l'utilisateur et l'année donnés."""
+    import database
+    with app.app_context():
+        conn = database.get_db()
+        rows = conn.execute(
+            "SELECT date, type_journee FROM presence_forfait_jour "
+            "WHERE user_id = ? AND strftime('%Y', date) = ?",
+            (user_id, str(annee))
+        ).fetchall()
+        conn.close()
+    return {r['date']: r['type_journee'] for r in rows}
+
+
+def _ajouter_ferie(app, annee, date, libelle):
+    import database
+    with app.app_context():
+        conn = database.get_db()
+        conn.execute(
+            "INSERT INTO jours_feries (annee, date, libelle) VALUES (?, ?, ?)",
+            (annee, date, libelle)
+        )
+        conn.commit()
+        conn.close()
+
+
+def test_calendrier_initialise_jours_ouvres_en_travaille(app, admin_client, sample_users):
+    """À la 1re ouverture, chaque jour ouvré non férié est marqué 'travaille'."""
+    annee = 2026
+    resp = admin_client.get(f'/calendrier_forfait_jour?mois=1&annee={annee}')
+    assert resp.status_code == 200
+
+    presences = _presences(app, sample_users['directeur_id'], annee)
+
+    assert len(presences) == _jours_ouvres_attendus(annee)
+    # tous les jours initialisés sont des jours travaillés
+    assert set(presences.values()) == {'travaille'}
+    # aucun week-end n'a été inséré
+    for d in presences:
+        assert datetime.strptime(d, '%Y-%m-%d').weekday() < 5
+
+
+def test_initialisation_exclut_jours_feries(app, admin_client, sample_users):
+    """Un jour férié (jour ouvré) n'est pas marqué travaillé."""
+    annee = 2026
+    ferie_dt = datetime(annee, 7, 14)  # Fête nationale
+    while ferie_dt.weekday() >= 5:  # garantir un jour ouvré pour la pertinence
+        ferie_dt += timedelta(days=1)
+    ferie = ferie_dt.strftime('%Y-%m-%d')
+    _ajouter_ferie(app, annee, ferie, 'Fête nationale')
+
+    admin_client.get(f'/calendrier_forfait_jour?mois=7&annee={annee}')
+    presences = _presences(app, sample_users['directeur_id'], annee)
+
+    assert ferie not in presences
+    assert len(presences) == _jours_ouvres_attendus(annee, feries=[ferie])
+
+
+def test_initialisation_preserve_saisies_existantes(app, admin_client, sample_users):
+    """Une réouverture ne réécrase pas une absence déjà posée."""
+    annee = 2026
+    admin_client.get(f'/calendrier_forfait_jour?mois=3&annee={annee}')
+
+    # La direction pose un congé payé sur un lundi de mars
+    jour = datetime(annee, 3, 1)
+    while jour.weekday() != 0:
+        jour += timedelta(days=1)
+    jour_cp = jour.strftime('%Y-%m-%d')
+
+    resp = admin_client.post('/calendrier_forfait_jour', data={
+        'date': jour_cp,
+        'type_journee': 'conge_paye',
+        'commentaire': 'Congé test',
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    # Nouvelle ouverture : le congé ne doit pas redevenir 'travaille'
+    admin_client.get(f'/calendrier_forfait_jour?mois=3&annee={annee}')
+    presences = _presences(app, sample_users['directeur_id'], annee)
+    assert presences[jour_cp] == 'conge_paye'
+
+
+def test_jour_ferie_affiche_meme_si_travaille_par_defaut(app, admin_client, sample_users):
+    """Un férié ajouté après l'init reste affiché comme férié, pas 'travaillé'."""
+    annee = 2026
+    ferie_dt = datetime(annee, 11, 11)  # Armistice
+    while ferie_dt.weekday() >= 5:
+        ferie_dt += timedelta(days=1)
+    ferie = ferie_dt.strftime('%Y-%m-%d')
+
+    # Init AVANT l'ajout du férié : la date reçoit 'travaille' par défaut
+    admin_client.get(f'/calendrier_forfait_jour?mois=11&annee={annee}')
+    _ajouter_ferie(app, annee, ferie, 'Armistice 1918')
+
+    resp = admin_client.get(f'/calendrier_forfait_jour?mois=11&annee={annee}')
+    html = resp.data.decode('utf-8')
+    # le libellé du férié l'emporte sur l'affichage « travaillé »
+    assert 'Armistice 1918' in html
+
+
+def test_saisie_jour_futur_autorisee(app, admin_client, sample_users):
+    """La direction peut poser une absence sur une date future (prévisionnel)."""
+    futur = datetime.now() + timedelta(days=120)
+    while futur.weekday() >= 5:
+        futur += timedelta(days=1)
+    date_futur = futur.strftime('%Y-%m-%d')
+
+    resp = admin_client.post('/calendrier_forfait_jour', data={
+        'date': date_futur,
+        'type_journee': 'repos_forfait',
+        'commentaire': 'RTT prévisionnel',
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    presences = _presences(app, sample_users['directeur_id'], futur.year)
+    assert presences.get(date_futur) == 'repos_forfait'
+
+
+def test_dashboard_initialise_aussi(app, admin_client, sample_users):
+    """Le dashboard pré-remplit également l'année consultée."""
+    annee = 2027
+    resp = admin_client.get(f'/dashboard_forfait_jour?annee={annee}')
+    assert resp.status_code == 200
+
+    presences = _presences(app, sample_users['directeur_id'], annee)
+    travailles = [t for t in presences.values() if t == 'travaille']
+    assert len(travailles) == _jours_ouvres_attendus(annee)
+
+
+def test_acces_refuse_non_directeur(auth_client):
+    """Un salarié ne peut pas accéder au calendrier forfait jour."""
+    resp = auth_client.get('/calendrier_forfait_jour', follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Calendrier Forfait Jour' not in resp.data


### PR DESCRIPTION
Cette PR regroupe deux évolutions du calendrier forfait jour (direction), page `calendrier_forfait_jour`.

---

## 1. Pré-remplissage des jours travaillés + saisie prévisionnelle

### Contexte
- Par défaut, les **jours ouvrés (lundi → vendredi) sont marqués « travaillé »**, sauf les jours fériés, pour chaque année dès qu'elle commence.
- La direction peut **remplir les calendriers à l'avance** (congés, RTT…), **y compris des jours non passés**, pour établir un prévisionnel.

### Modifications
- `initialiser_annee_forfait_jour()` : pré-remplit l'année (jour ouvré non férié → `travaille`). **Idempotent** (garde « année vierge » + `INSERT OR IGNORE`), **n'écrase aucune saisie existante**.
- Appel à l'ouverture du **calendrier** et du **dashboard** forfait jour (année passée, courante ou future → prévisionnel).
- Affichage : un **jour férié l'emporte** sur le « travaillé » par défaut ; une saisie explicite (congé, RTT…) reste prioritaire.
- Bandeau d'information sur la page.

---

## 2. Suivi facultatif des heures travaillées

### Contexte
Le forfait jour n'impose pas d'horaire, mais la direction souhaite pouvoir **noter les heures travaillées** (matin / après-midi) en cliquant sur une journée.

### Modifications
- **Migration 0036** : ajout des colonnes `matin_debut`, `matin_fin`, `aprem_debut`, `aprem_fin` à `presence_forfait_jour` (+ schéma `init_db` et fallback `ALTER` pour les bases existantes).
- **Modal de saisie** : 4 champs horaires facultatifs (`type="time"`, matin / après-midi).
- **Calendrier** : affichage des plages horaires saisies et du total d'heures du jour (ex. `🕐 08:30-12:00 / 13:30-17:00 · 7h`).
- Lecture des cellules via attributs `data-*` (robuste aux apostrophes dans les commentaires).
- **PDF**, section **« BILAN DU MOIS »** : ligne `X heures (N jours avec horaires saisies)` (ex. *35.5 heures (5 jours avec horaires saisies)*).

---

## Tests
`pytest` : **385 tests passent** (12 dédiés au forfait jour, dont la vérification du total dans le PDF via `pdfplumber` et l'application de la migration 0036 sur une base existante).

## Notes
- L'initialisation est **paresseuse** (à la première ouverture du calendrier/dashboard pour une année), l'application n'ayant pas d'ordonnanceur.
- Les horaires sont **facultatifs** : un mois sans saisie d'horaire n'affiche pas de ligne d'heures dans le PDF.

https://claude.ai/code/session_01STvfGrD3wiY6Z9zNAr7uwn