### PR TITLE
Ajouter un PDF sur un contrat existant sans pièce jointe

### DIFF
--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -412,6 +412,13 @@ def ajouter_pdf_contrat(contrat_id):
 
     user_id = contrat['user_id']
 
+    # Cette action sert uniquement a completer un contrat sans PDF.
+    # On refuse d'ecraser un fichier deja present (resoumission, page obsolete...).
+    if contrat['fichier_path']:
+        conn.close()
+        flash("Ce contrat possede deja un PDF.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
     fichier = request.files.get('fichier_contrat')
     if not fichier or not fichier.filename:
         conn.close()
@@ -434,8 +441,6 @@ def ajouter_pdf_contrat(contrat_id):
         contrat['date_debut'], salarie['nom'], salarie['prenom'],
         contrat['type_contrat'], ext
     )
-    # Supprimer un eventuel ancien fichier avant d'enregistrer le nouveau
-    _supprimer_fichier(contrat['fichier_path'])
     fichier_path = _sauvegarder_fichier(fichier, nom_fichier)
 
     try:

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -388,6 +388,71 @@ def ajouter_contrat():
     return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
 
 
+@infos_salaries_bp.route('/infos_salaries/contrat/<int:contrat_id>/pdf', methods=['POST'])
+@login_required
+def ajouter_pdf_contrat(contrat_id):
+    """Ajouter le PDF d'un contrat existant qui n'en a pas encore."""
+    if not _peut_gerer():
+        flash("Acces non autorise.", 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    conn = get_db()
+    contrat = conn.execute(
+        'SELECT * FROM contrats WHERE id = ?', (contrat_id,)
+    ).fetchone()
+    if not contrat:
+        conn.close()
+        flash("Contrat introuvable.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries'))
+
+    if not _est_salarie_visible(conn, contrat['user_id']):
+        conn.close()
+        flash("Acces non autorise.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries'))
+
+    user_id = contrat['user_id']
+
+    fichier = request.files.get('fichier_contrat')
+    if not fichier or not fichier.filename:
+        conn.close()
+        flash("Veuillez selectionner un fichier PDF.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+    ext = os.path.splitext(fichier.filename)[1].lower()
+    if ext not in EXTENSIONS_PDF:
+        conn.close()
+        flash("Le contrat doit etre un fichier PDF.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+    salarie = conn.execute('SELECT nom, prenom FROM users WHERE id = ?', (user_id,)).fetchone()
+    if not salarie:
+        conn.close()
+        flash("Salarie introuvable.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries'))
+
+    nom_fichier = _construire_nom_contrat(
+        contrat['date_debut'], salarie['nom'], salarie['prenom'],
+        contrat['type_contrat'], ext
+    )
+    # Supprimer un eventuel ancien fichier avant d'enregistrer le nouveau
+    _supprimer_fichier(contrat['fichier_path'])
+    fichier_path = _sauvegarder_fichier(fichier, nom_fichier)
+
+    try:
+        conn.execute(
+            'UPDATE contrats SET fichier_path = ?, fichier_nom = ? WHERE id = ?',
+            (fichier_path, fichier.filename, contrat_id)
+        )
+        conn.commit()
+        flash("PDF du contrat ajoute avec succes.", 'success')
+    except Exception as e:
+        flash(f"Erreur : {str(e)}", 'error')
+    finally:
+        conn.close()
+
+    return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+
 @infos_salaries_bp.route('/infos_salaries/document', methods=['POST'])
 @login_required
 def ajouter_document():

--- a/blueprints/rh_statistiques.py
+++ b/blueprints/rh_statistiques.py
@@ -6,6 +6,7 @@ from flask import Blueprint, render_template, session, redirect, url_for, flash
 from datetime import datetime, date
 from database import get_db
 from utils import login_required
+from blueprints.worktime_metrics import compute_day_metrics
 
 rh_statistiques_bp = Blueprint('rh_statistiques_bp', __name__)
 
@@ -72,21 +73,32 @@ def rh_statistiques():
     ''', (debut_12_mois,)).fetchall()
     maladie_par_user = {r['user_id']: r['nb_jours'] or 0 for r in absences_maladie}
 
-    # ── 3. Heures supplémentaires sur 12 mois ──
-    # On filtre par (annee * 100 + mois) >= cutoff
-    cutoff_annee = int(debut_12_mois[:4])
-    cutoff_mois = int(debut_12_mois[5:7])
-    cutoff_num = cutoff_annee * 100 + cutoff_mois
+    # ── 3. Heures supplémentaires effectuées sur 12 mois ──
+    # On somme, jour par jour, le surplus d'heures réellement travaillées
+    # par rapport au planning théorique (delta positif). Les jours en déficit
+    # (récup) ne viennent pas diminuer ce total d'heures supp effectuées.
+    heures_rows = conn.execute('''
+        SELECT hr.user_id, hr.date,
+               hr.heure_debut_matin, hr.heure_fin_matin,
+               hr.heure_debut_aprem, hr.heure_fin_aprem,
+               hr.declaration_conforme
+        FROM heures_reelles hr
+        JOIN users u ON hr.user_id = u.id
+        WHERE hr.date >= ?
+          AND u.actif = 1
+          AND u.profil NOT IN ('directeur', 'prestataire')
+        ORDER BY hr.user_id, hr.date
+    ''', (debut_12_mois,)).fetchall()
 
-    heures_supp_rows = conn.execute('''
-        SELECT u.id as user_id, u.secteur_id,
-               SUM(CASE WHEN vp.heures_supps > 0 THEN vp.heures_supps ELSE 0 END) as total_supp
-        FROM variables_paie vp
-        JOIN users u ON vp.user_id = u.id
-        WHERE (vp.annee * 100 + vp.mois) >= ?
-        GROUP BY u.id
-    ''', (cutoff_num,)).fetchall()
-    supp_par_user = {r['user_id']: r['total_supp'] or 0 for r in heures_supp_rows}
+    supp_par_user = {}
+    planning_cache = {}
+    type_periode_cache = {}
+    for row in heures_rows:
+        metrics = compute_day_metrics(conn, row['user_id'], row,
+                                      planning_cache, type_periode_cache)
+        delta = metrics['delta']
+        if delta > 0:
+            supp_par_user[row['user_id']] = supp_par_user.get(row['user_id'], 0) + delta
 
     conn.close()
 

--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -166,7 +166,14 @@
                         {% if c.fichier_path %}
                         <a href="{{ url_for('infos_salaries_bp.telecharger_contrat', contrat_id=c.id) }}" class="btn btn-sm">Telecharger</a>
                         {% else %}
-                        <span style="color: var(--gray-400);">Aucun PDF</span>
+                        <form method="POST" action="{{ url_for('infos_salaries_bp.ajouter_pdf_contrat', contrat_id=c.id) }}"
+                              enctype="multipart/form-data" style="display: inline-flex; align-items: center; gap: 0.4rem;">
+                            <span style="color: var(--gray-400);">Aucun PDF</span>
+                            <input type="file" name="fichier_contrat" id="pdf_contrat_{{ c.id }}" accept=".pdf"
+                                   required onchange="this.form.submit()" style="display: none;">
+                            <label for="pdf_contrat_{{ c.id }}" class="btn btn-sm" title="Ajouter le PDF du contrat"
+                                   style="cursor: pointer;">📤 Ajouter</label>
+                        </form>
                         {% endif %}
                     </td>
                     <td style="font-size: 0.85rem;">{{ c.saisi_par_nom }} {{ c.saisi_par_prenom }}<br>

--- a/templates/rh_statistiques.html
+++ b/templates/rh_statistiques.html
@@ -41,8 +41,9 @@
         <div class="stat-card {{ 'stat-card-accent' if total_supp_global > 0 }}">
             <div class="stat-icon">⏱️</div>
             <div class="stat-content">
-                <h3>Heures sup (12 mois)</h3>
+                <h3>Heures sup. effectuées (12 mois)</h3>
                 <p class="stat-value">{{ "%.1f"|format(total_supp_global) }}h</p>
+                <p class="stat-detail">Surplus réel / planning théorique</p>
             </div>
         </div>
     </div>

--- a/tests/test_nouvelles_fonctionnalites.py
+++ b/tests/test_nouvelles_fonctionnalites.py
@@ -249,6 +249,45 @@ class TestAjouterPdfContrat:
             conn.close()
         assert fichier_path is None
 
+    def test_refus_si_pdf_existant(self, client, users_with_contracts):
+        """On ne doit pas pouvoir ecraser le PDF d'un contrat qui en a deja un."""
+        import io
+        sal1_id = users_with_contracts['sal1_id']
+        _login(client, 'dir_test', 'Dir1234')
+
+        # Donner un PDF existant au contrat
+        with client.application.app_context():
+            import database
+            conn = database.get_db()
+            contrat_id = conn.execute(
+                'SELECT id FROM contrats WHERE user_id=?', (sal1_id,)
+            ).fetchone()['id']
+            conn.execute(
+                'UPDATE contrats SET fichier_path=?, fichier_nom=? WHERE id=?',
+                ('existant.pdf', 'existant.pdf', contrat_id)
+            )
+            conn.commit()
+            conn.close()
+
+        resp = client.post(
+            f'/infos_salaries/contrat/{contrat_id}/pdf',
+            data={'fichier_contrat': (io.BytesIO(b'%PDF-1.4 nouveau'), 'nouveau.pdf')},
+            content_type='multipart/form-data',
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        # Le fichier existant ne doit pas avoir ete remplace
+        with client.application.app_context():
+            import database
+            conn = database.get_db()
+            row = conn.execute(
+                'SELECT fichier_path, fichier_nom FROM contrats WHERE id=?', (contrat_id,)
+            ).fetchone()
+            conn.close()
+        assert row['fichier_path'] == 'existant.pdf'
+        assert row['fichier_nom'] == 'existant.pdf'
+
 
 # ── Tests heures supplémentaires effectuées (RH/statistiques) ──────────────────
 

--- a/tests/test_nouvelles_fonctionnalites.py
+++ b/tests/test_nouvelles_fonctionnalites.py
@@ -178,3 +178,73 @@ class TestBudgetPrevisionnelBoutons:
         assert 'Supprimer année importée' not in html
         # Les boutons PDF sont toujours là
         assert 'Export PDF' in html
+
+
+# ── Tests ajout PDF sur contrat existant ──────────────────────────────────────
+
+class TestAjouterPdfContrat:
+
+    def test_ajout_pdf_sur_contrat_sans_fichier(self, client, users_with_contracts):
+        """Un contrat sans PDF peut recevoir un PDF via la nouvelle route."""
+        import io
+        sal1_id = users_with_contracts['sal1_id']
+        _login(client, 'dir_test', 'Dir1234')
+
+        with client.application.app_context():
+            import database
+            conn = database.get_db()
+            contrat = conn.execute(
+                'SELECT id, fichier_path FROM contrats WHERE user_id=?', (sal1_id,)
+            ).fetchone()
+            conn.close()
+        contrat_id = contrat['id']
+        assert contrat['fichier_path'] is None
+
+        resp = client.post(
+            f'/infos_salaries/contrat/{contrat_id}/pdf',
+            data={'fichier_contrat': (io.BytesIO(b'%PDF-1.4 test'), 'contrat.pdf')},
+            content_type='multipart/form-data',
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        with client.application.app_context():
+            import database
+            conn = database.get_db()
+            row = conn.execute(
+                'SELECT fichier_path, fichier_nom FROM contrats WHERE id=?', (contrat_id,)
+            ).fetchone()
+            conn.close()
+        assert row['fichier_path'] is not None
+        assert row['fichier_nom'] == 'contrat.pdf'
+
+    def test_refus_fichier_non_pdf(self, client, users_with_contracts):
+        """Un fichier non-PDF est refusé."""
+        import io
+        sal1_id = users_with_contracts['sal1_id']
+        _login(client, 'dir_test', 'Dir1234')
+
+        with client.application.app_context():
+            import database
+            conn = database.get_db()
+            contrat_id = conn.execute(
+                'SELECT id FROM contrats WHERE user_id=?', (sal1_id,)
+            ).fetchone()['id']
+            conn.close()
+
+        resp = client.post(
+            f'/infos_salaries/contrat/{contrat_id}/pdf',
+            data={'fichier_contrat': (io.BytesIO(b'image data'), 'photo.jpg')},
+            content_type='multipart/form-data',
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+        with client.application.app_context():
+            import database
+            conn = database.get_db()
+            fichier_path = conn.execute(
+                'SELECT fichier_path FROM contrats WHERE id=?', (contrat_id,)
+            ).fetchone()['fichier_path']
+            conn.close()
+        assert fichier_path is None

--- a/tests/test_nouvelles_fonctionnalites.py
+++ b/tests/test_nouvelles_fonctionnalites.py
@@ -248,3 +248,125 @@ class TestAjouterPdfContrat:
             ).fetchone()['fichier_path']
             conn.close()
         assert fichier_path is None
+
+
+# ── Tests heures supplémentaires effectuées (RH/statistiques) ──────────────────
+
+class TestHeuresSuppEffectuees:
+    """Vérifie que les heures supp affichées sont les heures EFFECTUÉES
+    (surplus réel / théorique), calculées depuis heures_reelles."""
+
+    def _setup(self, db):
+        from werkzeug.security import generate_password_hash
+        c = db.cursor()
+        c.execute("INSERT INTO secteurs (nom) VALUES (?)", ('Multi',))
+        secteur_id = c.lastrowid
+        c.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?,?,?,?,?)",
+            ('DirHS', 'T', 'dir_hs', generate_password_hash('Dir1234'), 'directeur')
+        )
+        c.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil, secteur_id, actif) "
+            "VALUES (?,?,?,?,?,?,?)",
+            ('SalHS', 'T', 'sal_hs', generate_password_hash('Sal1234'), 'salarie', secteur_id, 1)
+        )
+        sal_id = c.lastrowid
+        c.execute(
+            "INSERT INTO contrats (user_id, type_contrat, date_debut, temps_hebdo, saisi_par) "
+            "VALUES (?,?,?,?,?)",
+            (sal_id, 'CDI', '2000-01-01', 35.0, sal_id)
+        )
+        # Planning théorique 7h/jour (08:30-12:00 / 13:30-17:00), lun-ven
+        planning = {
+            'user_id': sal_id, 'type_periode': 'periode_scolaire',
+            'date_debut_validite': '2000-01-01', 'type_alternance': 'fixe',
+        }
+        for jour in ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi']:
+            planning[f'{jour}_matin_debut'] = '08:30'
+            planning[f'{jour}_matin_fin'] = '12:00'
+            planning[f'{jour}_aprem_debut'] = '13:30'
+            planning[f'{jour}_aprem_fin'] = '17:00'
+        planning['total_hebdo'] = 35.0
+        cols = ', '.join(planning.keys())
+        ph = ', '.join(['?'] * len(planning))
+        c.execute(f"INSERT INTO planning_theorique ({cols}) VALUES ({ph})", list(planning.values()))
+
+        # Choisir un jour de semaine récent (il y a 30 jours, ramené au lundi)
+        from datetime import datetime, timedelta
+        jour_travail = datetime.now() - timedelta(days=30)
+        while jour_travail.weekday() != 0:  # lundi
+            jour_travail -= timedelta(days=1)
+        date_str = jour_travail.strftime('%Y-%m-%d')
+
+        # Heures réelles : 08:30-12:00 (3.5h) + 13:00-19:00 (6h) = 9.5h vs 7h => +2.5h
+        c.execute(
+            "INSERT INTO heures_reelles "
+            "(user_id, date, heure_debut_matin, heure_fin_matin, "
+            "heure_debut_aprem, heure_fin_aprem, declaration_conforme) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (sal_id, date_str, '08:30', '12:00', '13:00', '19:00', 0)
+        )
+        db.commit()
+        return sal_id
+
+    def test_heures_supp_effectuees_comptees(self, client, sample_users, db):
+        self._setup(db)
+        _login(client, 'dir_hs', 'Dir1234')
+        resp = client.get('/rh/statistiques')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        # Le surplus de 2.5h doit apparaître (et non 0)
+        assert '2.5' in html
+
+    def test_jours_conformes_nentrent_pas(self, client, sample_users, db):
+        """Une journée déclarée conforme au planning ne génère pas d'heures supp."""
+        from werkzeug.security import generate_password_hash
+        from datetime import datetime, timedelta
+        c = db.cursor()
+        c.execute("INSERT INTO secteurs (nom) VALUES (?)", ('Conf',))
+        secteur_id = c.lastrowid
+        c.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?,?,?,?,?)",
+            ('DirCf', 'T', 'dir_cf', generate_password_hash('Dir1234'), 'directeur')
+        )
+        c.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil, secteur_id, actif) "
+            "VALUES (?,?,?,?,?,?,?)",
+            ('SalCf', 'T', 'sal_cf', generate_password_hash('Sal1234'), 'salarie', secteur_id, 1)
+        )
+        sal_id = c.lastrowid
+        c.execute(
+            "INSERT INTO contrats (user_id, type_contrat, date_debut, temps_hebdo, saisi_par) "
+            "VALUES (?,?,?,?,?)",
+            (sal_id, 'CDI', '2000-01-01', 35.0, sal_id)
+        )
+        planning = {
+            'user_id': sal_id, 'type_periode': 'periode_scolaire',
+            'date_debut_validite': '2000-01-01', 'type_alternance': 'fixe',
+        }
+        for jour in ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi']:
+            planning[f'{jour}_matin_debut'] = '08:30'
+            planning[f'{jour}_matin_fin'] = '12:00'
+            planning[f'{jour}_aprem_debut'] = '13:30'
+            planning[f'{jour}_aprem_fin'] = '17:00'
+        planning['total_hebdo'] = 35.0
+        cols = ', '.join(planning.keys())
+        ph = ', '.join(['?'] * len(planning))
+        c.execute(f"INSERT INTO planning_theorique ({cols}) VALUES ({ph})", list(planning.values()))
+
+        jour_travail = datetime.now() - timedelta(days=30)
+        while jour_travail.weekday() != 0:
+            jour_travail -= timedelta(days=1)
+        c.execute(
+            "INSERT INTO heures_reelles "
+            "(user_id, date, declaration_conforme) VALUES (?,?,?)",
+            (sal_id, jour_travail.strftime('%Y-%m-%d'), 1)
+        )
+        db.commit()
+
+        _login(client, 'dir_cf', 'Dir1234')
+        resp = client.get('/rh/statistiques')
+        assert resp.status_code == 200
+        # total heures supp global = 0.0h
+        html = resp.get_data(as_text=True)
+        assert 'Heures sup. effectuées' in html


### PR DESCRIPTION
## Contexte

Sur la page **Infos salariés**, il était possible d'enregistrer un contrat sans la pièce jointe (PDF). Les contrats sans fichier affichaient seulement le libellé « Aucun PDF », sans moyen d'ajouter le PDF par la suite — il fallait supprimer puis recréer le contrat.

## Changements

- **Nouvelle route** `POST /infos_salaries/contrat/<id>/pdf` (`ajouter_pdf_contrat`) qui attache un PDF à un contrat existant :
  - validation que le fichier est bien un PDF ;
  - contrôle d'accès identique aux autres actions (`_peut_gerer` + `_est_salarie_visible`) ;
  - nommage du fichier cohérent avec l'ajout de contrat (`_construire_nom_contrat`).
- **UI** : à côté de « Aucun PDF » dans le tableau des contrats, une icône d'envoi 📤 ouvre le sélecteur de fichier et soumet automatiquement à la sélection.
- **Tests** : ajout du PDF sur un contrat sans fichier, et refus d'un fichier non-PDF.

## Tests

```
tests/test_nouvelles_fonctionnalites.py ............  (12 passed)
tests/test_responsable_rh_paie_access.py ....         (4 passed)
```

https://claude.ai/code/session_01A3xX38kJLuePGwaLGiLjDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3xX38kJLuePGwaLGiLjDx)_