### PR TITLE
Sécurité : journalisation des accès (connexions à l'application)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 
 ### Securite
 - Authentification par login/mot de passe
+- Journal des acces consultable par la direction (Administration > Securite) : connexions reussies, echecs de connexion, demandes de reinitialisation et changements de mot de passe (consultation directe ou export CSV)
 - Migration automatique des anciens hash SHA256 vers werkzeug (bcrypt)
 - Cle secrete chargee depuis variable d'environnement (generee automatiquement au premier demarrage)
 - Protection contre le path traversal sur les sauvegardes
@@ -183,6 +184,7 @@ CS-PILOT/
 │   ├── exportation.py         # Export ecritures comptables (TXT)
 │   ├── admin.py               # Gestion des utilisateurs
 │   ├── administration.py      # Administration systeme
+│   ├── securite.py            # Journal des acces (securite)
 │   ├── backup.py              # Sauvegardes
 │   ├── absences.py            # Gestion des absences
 │   ├── variables_paie.py      # Variables de paie

--- a/access_log.py
+++ b/access_log.py
@@ -1,0 +1,69 @@
+"""
+Journalisation des acces a l'application (securite).
+
+Enregistre les evenements lies aux connexions : connexions reussies, echecs de
+connexion, demandes de reinitialisation et modifications de mot de passe. Le
+journal est consultable par la direction via le menu Administration > Securite.
+
+La journalisation est concue pour ne JAMAIS interrompre le parcours
+utilisateur : toute erreur lors de l'enregistrement est tracee dans les logs
+applicatifs mais reste silencieuse vis-a-vis de l'appelant.
+"""
+import logging
+
+from database import get_db
+
+logger = logging.getLogger(__name__)
+
+# Types d'evenements journalises
+EVT_CONNEXION_REUSSIE = 'connexion_reussie'
+EVT_ECHEC_CONNEXION = 'echec_connexion'
+EVT_REINITIALISATION_DEMANDEE = 'reinitialisation_demandee'
+EVT_MOT_DE_PASSE_MODIFIE = 'mot_de_passe_modifie'
+
+# Libelles lisibles pour l'affichage et l'export
+EVENEMENTS_LABELS = {
+    EVT_CONNEXION_REUSSIE: 'Connexion réussie',
+    EVT_ECHEC_CONNEXION: 'Échec de connexion',
+    EVT_REINITIALISATION_DEMANDEE: 'Réinitialisation demandée',
+    EVT_MOT_DE_PASSE_MODIFIE: 'Mot de passe modifié',
+}
+
+
+def _adresse_ip():
+    """Retourne l'adresse IP du client courant si un contexte requete existe."""
+    try:
+        from flask import request, has_request_context
+        if has_request_context():
+            return request.remote_addr
+    except Exception:
+        pass
+    return None
+
+
+def enregistrer_acces(evenement, login_saisi=None, user_id=None, adresse_ip=None):
+    """Enregistre un evenement d'acces dans le journal.
+
+    Args:
+        evenement: un des EVT_* (type d'evenement).
+        login_saisi: identifiant saisi dans le formulaire (peut etre inconnu).
+        user_id: identifiant de l'utilisateur concerne s'il est connu.
+        adresse_ip: adresse IP du client (detectee automatiquement si absente).
+    """
+    if adresse_ip is None:
+        adresse_ip = _adresse_ip()
+
+    conn = None
+    try:
+        conn = get_db()
+        conn.execute(
+            'INSERT INTO journal_acces (login_saisi, user_id, evenement, adresse_ip) '
+            'VALUES (?, ?, ?, ?)',
+            (login_saisi, user_id, evenement, adresse_ip)
+        )
+        conn.commit()
+    except Exception:
+        logger.exception("Impossible d'enregistrer l'evenement d'acces %s", evenement)
+    finally:
+        if conn:
+            conn.close()

--- a/app.py
+++ b/app.py
@@ -166,6 +166,7 @@ from blueprints.api_keys import api_keys_bp
 from blueprints.assistant_rh import assistant_rh_bp
 from blueprints.backup import backup_bp
 from blueprints.administration import administration_bp
+from blueprints.securite import securite_bp
 from blueprints.absences import absences_bp
 from blueprints.variables_paie import variables_paie_bp
 from blueprints.infos_salaries import infos_salaries_bp
@@ -217,6 +218,7 @@ app.register_blueprint(api_keys_bp)
 app.register_blueprint(assistant_rh_bp)
 app.register_blueprint(backup_bp)
 app.register_blueprint(administration_bp)
+app.register_blueprint(securite_bp)
 app.register_blueprint(absences_bp)
 app.register_blueprint(variables_paie_bp)
 app.register_blueprint(infos_salaries_bp)

--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -9,6 +9,13 @@ import string
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from access_log import (
+    EVT_CONNEXION_REUSSIE,
+    EVT_ECHEC_CONNEXION,
+    EVT_MOT_DE_PASSE_MODIFIE,
+    EVT_REINITIALISATION_DEMANDEE,
+    enregistrer_acces,
+)
 from database import get_db
 from email_service import envoyer_email, is_email_configured
 from extensions import limiter
@@ -128,12 +135,14 @@ def login():
 
         if password_ok:
             _populate_session(user)
+            enregistrer_acces(EVT_CONNEXION_REUSSIE, login_saisi=login_val, user_id=user['id'])
             flash(f'Bienvenue {user["prenom"]} {user["nom"]} !', 'success')
             if user['force_password_change']:
                 flash('Votre mot de passe temporaire doit être remplacé avant de continuer.', 'warning')
                 return redirect(url_for('auth.changer_mot_de_passe'))
             return _redirect_after_login(user['profil'])
 
+        enregistrer_acces(EVT_ECHEC_CONNEXION, login_saisi=login_val)
         flash('Identifiants incorrects', 'error')
 
     return render_template('login.html')
@@ -203,7 +212,7 @@ def changer_mot_de_passe():
     conn = get_db()
     try:
         user = conn.execute(
-            'SELECT id, nom, prenom, profil, password, force_password_change '
+            'SELECT id, nom, prenom, profil, password, force_password_change, login '
             'FROM users WHERE id = ? AND actif = 1',
             (session['user_id'],)
         ).fetchone()
@@ -240,6 +249,11 @@ def changer_mot_de_passe():
             )
             conn.commit()
             session['force_password_change'] = False
+            enregistrer_acces(
+                EVT_MOT_DE_PASSE_MODIFIE,
+                login_saisi=user['login'],
+                user_id=user['id'],
+            )
             flash('Votre mot de passe a été mis à jour.', 'success')
             return _redirect_after_login(user['profil'])
     finally:
@@ -303,6 +317,11 @@ def mot_de_passe_oublie():
             )
             if ok:
                 conn.commit()
+                enregistrer_acces(
+                    EVT_REINITIALISATION_DEMANDEE,
+                    login_saisi=user['login'],
+                    user_id=user['id'],
+                )
                 flash(generic_message, 'info')
                 return redirect(url_for('auth.login'))
 

--- a/blueprints/securite.py
+++ b/blueprints/securite.py
@@ -42,17 +42,36 @@ def _lire_filtres():
     }
 
 
-def _construire_requete(filtres, limite):
-    """Construit la requete du journal et le dictionnaire de parametres.
+# Requete du journal : chaine CONSTANTE (jamais derivee d'une saisie
+# utilisateur). Les filtres sont optionnels et appliques via des parametres
+# nommes (:nom) ; une valeur vide neutralise le filtre correspondant.
+# limite = -1 retourne toutes les lignes (illimite en SQLite).
+_JOURNAL_QUERY = '''
+    SELECT j.id, j.date_heure, j.login_saisi, j.evenement, j.adresse_ip,
+           u.nom AS nom, u.prenom AS prenom
+    FROM journal_acces j
+    LEFT JOIN users u ON j.user_id = u.id
+    WHERE (:evenement = '' OR j.evenement = :evenement)
+      AND (:date_debut = '' OR date(j.date_heure) >= date(:date_debut))
+      AND (:date_fin = '' OR date(j.date_heure) <= date(:date_fin))
+      AND (:recherche = ''
+           OR j.login_saisi LIKE :recherche_like
+           OR u.nom LIKE :recherche_like
+           OR u.prenom LIKE :recherche_like)
+    ORDER BY j.date_heure DESC, j.id DESC
+    LIMIT :limite
+'''
 
-    La chaine SQL est CONSTANTE : aucune donnee saisie par l'utilisateur n'y
-    est concatenee. Tous les filtres sont optionnels et exprimes via des
-    parametres nommes (`:nom`) ; une valeur vide neutralise le filtre
-    correspondant. `limite` = -1 retourne toutes les lignes (illimite SQLite).
+
+def _params_filtres(filtres, limite):
+    """Construit le dictionnaire de parametres nommes pour `_JOURNAL_QUERY`.
+
+    Les valeurs saisies par l'utilisateur ne transitent QUE par ces parametres
+    (lies par le moteur SQL) ; elles ne sont jamais concatenees a la requete.
     """
     evenement = filtres['evenement'] if filtres['evenement'] in EVENEMENTS_LABELS else ''
     recherche = filtres['recherche']
-    params = {
+    return {
         'evenement': evenement,
         'date_debut': filtres['date_debut'],
         'date_fin': filtres['date_fin'],
@@ -60,22 +79,6 @@ def _construire_requete(filtres, limite):
         'recherche_like': f'%{recherche}%',
         'limite': limite,
     }
-    query = '''
-        SELECT j.id, j.date_heure, j.login_saisi, j.evenement, j.adresse_ip,
-               u.nom AS nom, u.prenom AS prenom
-        FROM journal_acces j
-        LEFT JOIN users u ON j.user_id = u.id
-        WHERE (:evenement = '' OR j.evenement = :evenement)
-          AND (:date_debut = '' OR date(j.date_heure) >= date(:date_debut))
-          AND (:date_fin = '' OR date(j.date_heure) <= date(:date_fin))
-          AND (:recherche = ''
-               OR j.login_saisi LIKE :recherche_like
-               OR u.nom LIKE :recherche_like
-               OR u.prenom LIKE :recherche_like)
-        ORDER BY j.date_heure DESC, j.id DESC
-        LIMIT :limite
-    '''
-    return query, params
 
 
 @securite_bp.route('/securite/journal-acces')
@@ -87,11 +90,10 @@ def journal_acces():
         return redirect(url_for('dashboard_bp.dashboard'))
 
     filtres = _lire_filtres()
-    query, params = _construire_requete(filtres, LIMITE_AFFICHAGE)
 
     conn = get_db()
     try:
-        entrees = conn.execute(query, params).fetchall()
+        entrees = conn.execute(_JOURNAL_QUERY, _params_filtres(filtres, LIMITE_AFFICHAGE)).fetchall()
     finally:
         conn.close()
 
@@ -113,12 +115,11 @@ def export_journal_acces():
         return redirect(url_for('dashboard_bp.dashboard'))
 
     filtres = _lire_filtres()
-    # limite = -1 : export complet (pas de plafond d'affichage)
-    query, params = _construire_requete(filtres, -1)
 
     conn = get_db()
     try:
-        entrees = conn.execute(query, params).fetchall()
+        # limite = -1 : export complet (pas de plafond d'affichage)
+        entrees = conn.execute(_JOURNAL_QUERY, _params_filtres(filtres, -1)).fetchall()
     finally:
         conn.close()
 

--- a/blueprints/securite.py
+++ b/blueprints/securite.py
@@ -42,31 +42,39 @@ def _lire_filtres():
     }
 
 
-def _construire_requete(filtres):
-    """Construit la requete SQL filtree et la liste de parametres associee."""
+def _construire_requete(filtres, limite):
+    """Construit la requete du journal et le dictionnaire de parametres.
+
+    La chaine SQL est CONSTANTE : aucune donnee saisie par l'utilisateur n'y
+    est concatenee. Tous les filtres sont optionnels et exprimes via des
+    parametres nommes (`:nom`) ; une valeur vide neutralise le filtre
+    correspondant. `limite` = -1 retourne toutes les lignes (illimite SQLite).
+    """
+    evenement = filtres['evenement'] if filtres['evenement'] in EVENEMENTS_LABELS else ''
+    recherche = filtres['recherche']
+    params = {
+        'evenement': evenement,
+        'date_debut': filtres['date_debut'],
+        'date_fin': filtres['date_fin'],
+        'recherche': recherche,
+        'recherche_like': f'%{recherche}%',
+        'limite': limite,
+    }
     query = '''
         SELECT j.id, j.date_heure, j.login_saisi, j.evenement, j.adresse_ip,
                u.nom AS nom, u.prenom AS prenom
         FROM journal_acces j
         LEFT JOIN users u ON j.user_id = u.id
-        WHERE 1=1
+        WHERE (:evenement = '' OR j.evenement = :evenement)
+          AND (:date_debut = '' OR date(j.date_heure) >= date(:date_debut))
+          AND (:date_fin = '' OR date(j.date_heure) <= date(:date_fin))
+          AND (:recherche = ''
+               OR j.login_saisi LIKE :recherche_like
+               OR u.nom LIKE :recherche_like
+               OR u.prenom LIKE :recherche_like)
+        ORDER BY j.date_heure DESC, j.id DESC
+        LIMIT :limite
     '''
-    params = []
-
-    if filtres['evenement'] and filtres['evenement'] in EVENEMENTS_LABELS:
-        query += ' AND j.evenement = ?'
-        params.append(filtres['evenement'])
-    if filtres['date_debut']:
-        query += ' AND date(j.date_heure) >= date(?)'
-        params.append(filtres['date_debut'])
-    if filtres['date_fin']:
-        query += ' AND date(j.date_heure) <= date(?)'
-        params.append(filtres['date_fin'])
-    if filtres['recherche']:
-        like = f"%{filtres['recherche']}%"
-        query += ' AND (j.login_saisi LIKE ? OR u.nom LIKE ? OR u.prenom LIKE ?)'
-        params.extend([like, like, like])
-
     return query, params
 
 
@@ -79,9 +87,7 @@ def journal_acces():
         return redirect(url_for('dashboard_bp.dashboard'))
 
     filtres = _lire_filtres()
-    query, params = _construire_requete(filtres)
-    query += ' ORDER BY j.date_heure DESC, j.id DESC LIMIT ?'
-    params.append(LIMITE_AFFICHAGE)
+    query, params = _construire_requete(filtres, LIMITE_AFFICHAGE)
 
     conn = get_db()
     try:
@@ -107,8 +113,8 @@ def export_journal_acces():
         return redirect(url_for('dashboard_bp.dashboard'))
 
     filtres = _lire_filtres()
-    query, params = _construire_requete(filtres)
-    query += ' ORDER BY j.date_heure DESC, j.id DESC'
+    # limite = -1 : export complet (pas de plafond d'affichage)
+    query, params = _construire_requete(filtres, -1)
 
     conn = get_db()
     try:

--- a/blueprints/securite.py
+++ b/blueprints/securite.py
@@ -1,0 +1,139 @@
+"""
+Blueprint securite_bp - Journal des acces (securite).
+
+Permet a la direction de consulter le journal des connexions a l'application :
+connexions reussies, echecs de connexion, demandes de reinitialisation et
+modifications de mot de passe. Le journal peut etre consulte directement dans
+l'interface ou telecharge au format CSV.
+
+Accessible uniquement aux directeurs (la direction).
+"""
+import csv
+import io
+from datetime import datetime
+
+from flask import (
+    Blueprint, render_template, request, redirect, url_for, session, flash,
+    Response
+)
+
+from access_log import EVENEMENTS_LABELS
+from database import get_db
+from utils import login_required
+
+securite_bp = Blueprint('securite_bp', __name__)
+
+# Nombre maximal d'entrees affichees a l'ecran (l'export CSV n'est pas limite)
+LIMITE_AFFICHAGE = 500
+
+
+def _check_direction():
+    """Verifie que l'utilisateur connecte fait partie de la direction."""
+    return session.get('profil') == 'directeur'
+
+
+def _lire_filtres():
+    """Recupere les filtres communs depuis la requete."""
+    return {
+        'evenement': request.args.get('evenement') or '',
+        'date_debut': request.args.get('date_debut') or '',
+        'date_fin': request.args.get('date_fin') or '',
+        'recherche': (request.args.get('recherche') or '').strip(),
+    }
+
+
+def _construire_requete(filtres):
+    """Construit la requete SQL filtree et la liste de parametres associee."""
+    query = '''
+        SELECT j.id, j.date_heure, j.login_saisi, j.evenement, j.adresse_ip,
+               u.nom AS nom, u.prenom AS prenom
+        FROM journal_acces j
+        LEFT JOIN users u ON j.user_id = u.id
+        WHERE 1=1
+    '''
+    params = []
+
+    if filtres['evenement'] and filtres['evenement'] in EVENEMENTS_LABELS:
+        query += ' AND j.evenement = ?'
+        params.append(filtres['evenement'])
+    if filtres['date_debut']:
+        query += ' AND date(j.date_heure) >= date(?)'
+        params.append(filtres['date_debut'])
+    if filtres['date_fin']:
+        query += ' AND date(j.date_heure) <= date(?)'
+        params.append(filtres['date_fin'])
+    if filtres['recherche']:
+        like = f"%{filtres['recherche']}%"
+        query += ' AND (j.login_saisi LIKE ? OR u.nom LIKE ? OR u.prenom LIKE ?)'
+        params.extend([like, like, like])
+
+    return query, params
+
+
+@securite_bp.route('/securite/journal-acces')
+@login_required
+def journal_acces():
+    """Affiche le journal des acces (direction uniquement)."""
+    if not _check_direction():
+        flash('Accès non autorisé', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    filtres = _lire_filtres()
+    query, params = _construire_requete(filtres)
+    query += ' ORDER BY j.date_heure DESC, j.id DESC LIMIT ?'
+    params.append(LIMITE_AFFICHAGE)
+
+    conn = get_db()
+    try:
+        entrees = conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+    return render_template(
+        'journal_acces.html',
+        entrees=entrees,
+        evenements_labels=EVENEMENTS_LABELS,
+        limite=LIMITE_AFFICHAGE,
+        **filtres,
+    )
+
+
+@securite_bp.route('/securite/journal-acces/export')
+@login_required
+def export_journal_acces():
+    """Telecharge le journal des acces (filtre applique) au format CSV."""
+    if not _check_direction():
+        flash('Accès non autorisé', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    filtres = _lire_filtres()
+    query, params = _construire_requete(filtres)
+    query += ' ORDER BY j.date_heure DESC, j.id DESC'
+
+    conn = get_db()
+    try:
+        entrees = conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+    output = io.StringIO()
+    writer = csv.writer(output, delimiter=';')
+    writer.writerow(['Date et heure', 'Identifiant saisi', 'Utilisateur', 'Événement', 'Adresse IP'])
+    for e in entrees:
+        nom_complet = f"{e['prenom'] or ''} {e['nom'] or ''}".strip()
+        writer.writerow([
+            e['date_heure'] or '',
+            e['login_saisi'] or '',
+            nom_complet,
+            EVENEMENTS_LABELS.get(e['evenement'], e['evenement']),
+            e['adresse_ip'] or '',
+        ])
+
+    nom_fichier = f"journal_acces_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
+    # Encodage utf-8-sig : ajoute un BOM pour un affichage correct des accents
+    # a l'ouverture du CSV dans Excel.
+    return Response(
+        output.getvalue().encode('utf-8-sig'),
+        mimetype='text/csv; charset=utf-8',
+        headers={'Content-Disposition': f'attachment; filename={nom_fichier}'},
+    )

--- a/database.py
+++ b/database.py
@@ -74,6 +74,7 @@ ALL_MIGRATION_VERSIONS = [
     ('0034', 'Prevention sante au travail'),
     ('0035', 'Recuperation partielle'),
     ('0036', 'Horaires forfait jour'),
+    ('0037', 'Journal des acces'),
 ]
 
 # Postes de depense par defaut (migration 0012)
@@ -279,6 +280,22 @@ def init_db():
             FOREIGN KEY (modifie_par) REFERENCES users(id)
         )
     ''')
+
+    # ===== Journal des acces (securite, migration 0037) =====
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS journal_acces (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date_heure TEXT DEFAULT CURRENT_TIMESTAMP,
+            login_saisi TEXT,
+            user_id INTEGER,
+            evenement TEXT NOT NULL,
+            adresse_ip TEXT,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    ''')
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_journal_acces_date ON journal_acces(date_heure)"
+    )
 
     # ===== Table des demandes de recuperation =====
     cursor.execute('''

--- a/migrations/0037_journal_acces.py
+++ b/migrations/0037_journal_acces.py
@@ -1,0 +1,43 @@
+"""
+Migration 0037 : Journal des acces (securite).
+
+Ajoute la table journal_acces pour la journalisation des connexions a
+l'application : connexions reussies, echecs de connexion, demandes de
+reinitialisation et modifications de mot de passe. Le journal est consultable
+par la direction via le menu Administration > Securite.
+"""
+
+NOM = "Journal des acces"
+DESCRIPTION = (
+    "Ajoute la table journal_acces pour tracer les connexions a l'application "
+    "(connexions reussies, echecs, reinitialisations et changements de mot de passe)."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS journal_acces (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date_heure TEXT DEFAULT CURRENT_TIMESTAMP,
+            login_saisi TEXT,
+            user_id INTEGER,
+            evenement TEXT NOT NULL,
+            adresse_ip TEXT,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+        """
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_journal_acces_date ON journal_acces(date_heure)"
+    )
+    conn.commit()
+
+
+def downgrade(conn):
+    """Annule la migration."""
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS journal_acces")
+    conn.commit()

--- a/templates/base.html
+++ b/templates/base.html
@@ -121,6 +121,7 @@
                 </button>
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('admin_bp.gestion_users') }}">👤 Utilisateurs</a>
+                    <a href="{{ url_for('securite_bp.journal_acces') }}">🔒 Sécurité</a>
                     <a href="{{ url_for('admin_bp.gestion_vacances') }}">🗓️ Vacances scolaires</a>
                     <a href="{{ url_for('admin_bp.gestion_jours_feries') }}">🎌 Jours fériés</a>
                     <a href="{{ url_for('api_keys_bp.gestion_cles_api') }}">🔑 Clés API</a>

--- a/templates/journal_acces.html
+++ b/templates/journal_acces.html
@@ -1,0 +1,166 @@
+{% extends "base.html" %}
+
+{% block title %}Sécurité — Journal des accès{% endblock %}
+
+{% block content %}
+<style>
+    .journal-page { max-width: 1100px; margin: 0 auto; }
+    .journal-filtres {
+        background: var(--white);
+        border: 1px solid var(--gray-200);
+        border-radius: 12px;
+        padding: 18px;
+        margin: 20px 0;
+        box-shadow: var(--shadow-sm);
+    }
+    .journal-filtres-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+        gap: 14px;
+        align-items: end;
+    }
+    .journal-filtres .form-group { margin: 0; }
+    .journal-actions { margin-top: 14px; display: flex; gap: 10px; flex-wrap: wrap; }
+    .journal-table-wrap {
+        background: var(--white);
+        border: 1px solid var(--gray-200);
+        border-radius: 12px;
+        padding: 8px;
+        box-shadow: var(--shadow-sm);
+        overflow-x: auto;
+    }
+    .journal-user-login { font-weight: 600; color: var(--gray-900); }
+    .journal-user-nom { font-size: 0.82rem; color: var(--gray-500); }
+    .journal-ip { font-family: monospace; color: var(--gray-500); font-size: 0.85rem; }
+    .journal-date small { color: var(--gray-500); }
+</style>
+
+{% set badges = {
+    'connexion_reussie': ('badge-success', '✅'),
+    'echec_connexion': ('badge-danger', '⛔'),
+    'reinitialisation_demandee': ('badge-info', '🔑'),
+    'mot_de_passe_modifie': ('badge-warning', '🔒')
+} %}
+
+<div class="journal-page">
+    <h1>🔒 Journal des accès</h1>
+    <p class="subtitle">
+        Traçabilité des connexions à l'application — affichage des {{ limite }} entrées les plus récentes.
+    </p>
+
+    <!-- Statistiques rapides (sur les entrées affichées) -->
+    <div class="stats-grid" style="grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));">
+        <div class="stat-card">
+            <div class="stat-icon">✅</div>
+            <div class="stat-content">
+                <h3>Connexions réussies</h3>
+                <p class="stat-value">{{ entrees|selectattr('evenement', 'equalto', 'connexion_reussie')|list|length }}</p>
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon">⛔</div>
+            <div class="stat-content">
+                <h3>Échecs de connexion</h3>
+                <p class="stat-value">{{ entrees|selectattr('evenement', 'equalto', 'echec_connexion')|list|length }}</p>
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon">🔑</div>
+            <div class="stat-content">
+                <h3>Réinitialisations</h3>
+                <p class="stat-value">{{ entrees|selectattr('evenement', 'equalto', 'reinitialisation_demandee')|list|length }}</p>
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon">🔒</div>
+            <div class="stat-content">
+                <h3>Mots de passe modifiés</h3>
+                <p class="stat-value">{{ entrees|selectattr('evenement', 'equalto', 'mot_de_passe_modifie')|list|length }}</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Filtres -->
+    <div class="journal-filtres">
+        <form method="GET" action="{{ url_for('securite_bp.journal_acces') }}">
+            <div class="journal-filtres-grid">
+                <div class="form-group">
+                    <label for="evenement">Événement</label>
+                    <select id="evenement" name="evenement">
+                        <option value="">-- Tous les événements --</option>
+                        {% for cle, libelle in evenements_labels.items() %}
+                        <option value="{{ cle }}" {% if evenement == cle %}selected{% endif %}>{{ libelle }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="recherche">Utilisateur / identifiant</label>
+                    <input type="text" id="recherche" name="recherche" value="{{ recherche }}" placeholder="Nom ou identifiant…">
+                </div>
+                <div class="form-group">
+                    <label for="date_debut">Date début</label>
+                    <input type="date" id="date_debut" name="date_debut" value="{{ date_debut }}">
+                </div>
+                <div class="form-group">
+                    <label for="date_fin">Date fin</label>
+                    <input type="date" id="date_fin" name="date_fin" value="{{ date_fin }}">
+                </div>
+            </div>
+            <div class="journal-actions">
+                <button type="submit" class="btn btn-primary">🔍 Filtrer</button>
+                <a href="{{ url_for('securite_bp.journal_acces') }}" class="btn btn-secondary">↻ Réinitialiser</a>
+                <a href="{{ url_for('securite_bp.export_journal_acces', evenement=evenement, recherche=recherche, date_debut=date_debut, date_fin=date_fin) }}" class="btn btn-secondary">⬇️ Télécharger (CSV)</a>
+            </div>
+        </form>
+    </div>
+
+    <!-- Tableau du journal -->
+    <div class="journal-table-wrap">
+        {% if entrees %}
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Date et heure</th>
+                    <th>Utilisateur</th>
+                    <th>Événement</th>
+                    <th>Adresse IP</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for e in entrees %}
+                {% set b = badges.get(e.evenement, ('badge-inactive', '•')) %}
+                <tr>
+                    <td class="journal-date" style="white-space: nowrap;">
+                        {% set parts = (e.date_heure or '').split(' ') %}
+                        <strong>{{ parts[0] }}</strong>
+                        {% if parts|length > 1 %}<br><small>{{ parts[1] }}</small>{% endif %}
+                    </td>
+                    <td>
+                        <span class="journal-user-login">{{ e.login_saisi or '—' }}</span>
+                        {% if e.prenom or e.nom %}
+                        <br><span class="journal-user-nom">{{ e.prenom }} {{ e.nom }}</span>
+                        {% endif %}
+                    </td>
+                    <td><span class="badge {{ b[0] }}">{{ b[1] }} {{ evenements_labels.get(e.evenement, e.evenement) }}</span></td>
+                    <td><span class="journal-ip">{{ e.adresse_ip or '—' }}</span></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="no-data">Aucun accès enregistré pour ces critères.</p>
+        {% endif %}
+    </div>
+
+    <div class="help-box" style="margin-top: 1.5rem;">
+        <h4>ℹ️ À propos du journal des accès</h4>
+        <ul>
+            <li><strong>✅ Connexion réussie</strong> : authentification réussie d'un utilisateur.</li>
+            <li><strong>⛔ Échec de connexion</strong> : identifiant ou mot de passe incorrect.</li>
+            <li><strong>🔑 Réinitialisation demandée</strong> : envoi d'un mot de passe temporaire par email.</li>
+            <li><strong>🔒 Mot de passe modifié</strong> : un utilisateur a défini un nouveau mot de passe.</li>
+        </ul>
+        <p><strong>Confidentialité :</strong> cette page est réservée à la direction. Les heures sont enregistrées au format du serveur.</p>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -28,7 +28,7 @@ class TestInitDb:
         'historique_modifications', 'demandes_recup', 'jours_feries',
         'planning_enfance_config', 'absences', 'app_settings',
         'presence_forfait_jour', 'validation_forfait_jour', 'schema_migrations',
-        'prevention_dismissals',
+        'prevention_dismissals', 'journal_acces',
         # Tables ajoutées par les migrations, maintenant dans le schéma initial
         'variables_paie_defauts', 'variables_paie', 'contrats',
         'documents_salaries', 'prepa_paie_statut', 'conges_cloture_mensuelle',

--- a/tests/test_securite.py
+++ b/tests/test_securite.py
@@ -1,0 +1,153 @@
+"""
+Tests du module securite :
+- Journalisation des evenements d'acces (connexion reussie/echouee,
+  reinitialisation demandee, mot de passe modifie)
+- Page de consultation du journal (reservee a la direction)
+- Export CSV
+- Presence du menu "Securite" dans l'administration du directeur
+"""
+
+
+def _derniere_entree(db, evenement):
+    """Retourne la derniere entree du journal pour un evenement donne."""
+    return db.execute(
+        "SELECT * FROM journal_acces WHERE evenement = ? ORDER BY id DESC LIMIT 1",
+        (evenement,)
+    ).fetchone()
+
+
+class TestJournalisationAcces:
+    """Verifie que les evenements d'acces sont enregistres dans le journal."""
+
+    def test_connexion_reussie_journalisee(self, client, app, db, sample_users):
+        client.post('/login', data={'login': 'admin', 'password': 'Admin1234'})
+        with app.app_context():
+            entry = _derniere_entree(db, 'connexion_reussie')
+        assert entry is not None
+        assert entry['login_saisi'] == 'admin'
+        assert entry['user_id'] == sample_users['directeur_id']
+
+    def test_echec_connexion_journalise(self, client, app, db, sample_users):
+        client.post('/login', data={'login': 'admin', 'password': 'mauvais_mdp'})
+        with app.app_context():
+            entry = _derniere_entree(db, 'echec_connexion')
+        assert entry is not None
+        assert entry['login_saisi'] == 'admin'
+        assert entry['user_id'] is None
+
+    def test_echec_connexion_utilisateur_inconnu_journalise(self, client, app, db, sample_users):
+        client.post('/login', data={'login': 'inconnu', 'password': 'peu_importe'})
+        with app.app_context():
+            entry = _derniere_entree(db, 'echec_connexion')
+        assert entry is not None
+        assert entry['login_saisi'] == 'inconnu'
+
+    def test_changement_mot_de_passe_journalise(self, client, app, db, sample_users):
+        from werkzeug.security import generate_password_hash
+
+        with app.app_context():
+            db.execute(
+                "INSERT INTO users (nom, prenom, login, password, profil, force_password_change) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ('Temp', 'User', 'temp_user', generate_password_hash('Temporaire!'), 'salarie', 1)
+            )
+            db.commit()
+
+        client.post('/login', data={'login': 'temp_user', 'password': 'Temporaire!'})
+        client.post('/changer_mot_de_passe', data={
+            'current_password': 'Temporaire!',
+            'new_password': 'Nouveau!Pass',
+            'password_confirm': 'Nouveau!Pass',
+        })
+
+        with app.app_context():
+            entry = _derniere_entree(db, 'mot_de_passe_modifie')
+        assert entry is not None
+        assert entry['login_saisi'] == 'temp_user'
+
+    def test_reinitialisation_demandee_journalisee(self, client, app, db, sample_users, monkeypatch):
+        with app.app_context():
+            db.execute(
+                "UPDATE users SET email = ? WHERE login = ?",
+                ('salarie@example.com', 'salarie_test')
+            )
+            db.commit()
+
+        monkeypatch.setattr('blueprints.auth.is_email_configured', lambda: True)
+        monkeypatch.setattr('blueprints.auth.envoyer_email', lambda *a, **k: (True, 'ok'))
+
+        client.post('/mot-de-passe-oublie', data={'login': 'salarie_test'})
+
+        with app.app_context():
+            entry = _derniere_entree(db, 'reinitialisation_demandee')
+        assert entry is not None
+        assert entry['login_saisi'] == 'salarie_test'
+
+
+class TestPageJournalAcces:
+    """Verifie le controle d'acces et l'affichage de la page du journal."""
+
+    def test_acces_directeur_ok(self, admin_client):
+        response = admin_client.get('/securite/journal-acces')
+        assert response.status_code == 200
+        assert 'Journal des accès' in response.get_data(as_text=True)
+
+    def test_acces_refuse_salarie(self, auth_client):
+        response = auth_client.get('/securite/journal-acces', follow_redirects=False)
+        assert response.status_code == 302
+
+    def test_acces_refuse_comptable(self, comptable_client):
+        response = comptable_client.get('/securite/journal-acces', follow_redirects=False)
+        assert response.status_code == 302
+
+    def test_acces_refuse_non_connecte(self, client, sample_users):
+        response = client.get('/securite/journal-acces', follow_redirects=False)
+        assert response.status_code == 302
+        assert '/login' in response.headers['Location']
+
+    def test_affiche_connexion_reussie(self, admin_client):
+        # admin_client s'est connecte : une entree "connexion reussie" existe
+        response = admin_client.get('/securite/journal-acces')
+        html = response.get_data(as_text=True)
+        assert 'Connexion réussie' in html
+        assert 'admin' in html
+
+    def test_filtre_par_evenement(self, admin_client):
+        response = admin_client.get('/securite/journal-acces?evenement=echec_connexion')
+        assert response.status_code == 200
+
+
+class TestExportJournalAcces:
+    """Verifie l'export CSV du journal."""
+
+    def test_export_directeur_ok(self, admin_client):
+        response = admin_client.get('/securite/journal-acces/export')
+        assert response.status_code == 200
+        assert 'text/csv' in response.content_type
+        disposition = response.headers.get('Content-Disposition', '')
+        assert 'attachment' in disposition
+        assert '.csv' in disposition
+        body = response.get_data(as_text=True)
+        assert 'Date et heure' in body
+
+    def test_export_refuse_salarie(self, auth_client):
+        response = auth_client.get('/securite/journal-acces/export', follow_redirects=False)
+        assert response.status_code == 302
+
+
+class TestMenuSecurite:
+    """Verifie la presence du menu Securite selon le profil."""
+
+    def test_lien_present_pour_directeur(self, admin_client):
+        html = admin_client.get('/securite/journal-acces').get_data(as_text=True)
+        assert '🔒 Sécurité' in html
+        assert url_securite() in html
+
+    def test_lien_absent_pour_comptable(self, comptable_client):
+        html = comptable_client.get('/dashboard_comptable').get_data(as_text=True)
+        assert '🔒 Sécurité' not in html
+
+
+def url_securite():
+    """URL de la page du journal des acces (pour les assertions de menu)."""
+    return '/securite/journal-acces'

--- a/tests/test_securite.py
+++ b/tests/test_securite.py
@@ -117,6 +117,40 @@ class TestPageJournalAcces:
         assert response.status_code == 200
 
 
+class TestFiltrageJournal:
+    """Verifie que les filtres du journal fonctionnent (requete parametree)."""
+
+    def _seed(self, app, db):
+        with app.app_context():
+            db.execute(
+                "INSERT INTO journal_acces (login_saisi, evenement, adresse_ip) VALUES (?, ?, ?)",
+                ('alice_login', 'connexion_reussie', '10.0.0.1')
+            )
+            db.execute(
+                "INSERT INTO journal_acces (login_saisi, evenement, adresse_ip) VALUES (?, ?, ?)",
+                ('bob_login', 'echec_connexion', '10.0.0.2')
+            )
+            db.commit()
+
+    def test_filtre_par_evenement_isole_le_bon_type(self, admin_client, app, db):
+        self._seed(app, db)
+        html = admin_client.get('/securite/journal-acces?evenement=echec_connexion').get_data(as_text=True)
+        assert 'bob_login' in html
+        assert 'alice_login' not in html
+
+    def test_filtre_recherche_par_login(self, admin_client, app, db):
+        self._seed(app, db)
+        html = admin_client.get('/securite/journal-acces?recherche=alice').get_data(as_text=True)
+        assert 'alice_login' in html
+        assert 'bob_login' not in html
+
+    def test_export_respecte_le_filtre(self, admin_client, app, db):
+        self._seed(app, db)
+        body = admin_client.get('/securite/journal-acces/export?evenement=connexion_reussie').get_data(as_text=True)
+        assert 'alice_login' in body
+        assert 'bob_login' not in body
+
+
 class TestExportJournalAcces:
     """Verifie l'export CSV du journal."""
 


### PR DESCRIPTION
## Objectif

Mettre en place une **journalisation des accès** à l'application, consultable par la direction, avec un nouveau menu **« 🔒 Sécurité »** dans Administration.

Dans un premier temps, seules les **connexions à l'application** sont tracées (comme demandé).

## Événements journalisés

| Événement | Déclencheur |
|---|---|
| ✅ Connexion réussie | Authentification réussie |
| ⛔ Échec de connexion | Identifiant / mot de passe incorrect |
| 🔑 Réinitialisation demandée | Envoi d'un mot de passe temporaire par email |
| 🔒 Mot de passe modifié | Un utilisateur définit un nouveau mot de passe |

Chaque entrée enregistre : **date et heure**, **identifiant saisi pour se connecter**, utilisateur concerné (si connu) et **adresse IP**.

## Consultation (réservée à la direction)

`Administration > Sécurité` (`/securite/journal-acces`), accessible au profil **directeur** uniquement (« visualisé par la direction ») :

- **Consultation directe** dans l'interface (le plus simple), avec filtres par événement, date et utilisateur/identifiant ;
- **Export CSV** (téléchargement, encodage UTF-8 compatible Excel) en bonus.

## Détails techniques

- **`access_log.py`** : helper d'enregistrement robuste — toute erreur d'écriture est tracée mais n'interrompt jamais le parcours de connexion.
- **`blueprints/securite.py`** : page de consultation + export CSV (réservés au directeur).
- **Migration `0037`** + table `journal_acces` ajoutée à `init_db()` (même convention que les tables existantes).
- **`blueprints/auth.py`** : instrumentation des 4 événements.
- Menu ajouté uniquement dans la section Administration du **directeur** (pas du comptable, qui n'y a pas accès).

## Tests

- Nouveau fichier **`tests/test_securite.py`** (15 tests) : enregistrement des 4 événements, contrôle d'accès (directeur OK / salarié / comptable / non connecté refusés), export CSV, présence/absence du menu selon le profil.
- Suite complète : **407 tests passent** (aucune régression).

## Point d'attention (choix retenu)

L'accès au journal est restreint au profil **directeur** (interprétation de « visualisé par la direction »). Le menu Administration est partagé avec le comptable, mais le lien « Sécurité » n'apparaît que pour le directeur. Si vous souhaitez aussi l'ouvrir au comptable, c'est une modification triviale.

https://claude.ai/code/session_01QQUCf3KztJauP4AsfV3cXz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQUCf3KztJauP4AsfV3cXz)_