### PR TITLE
Sécurité : accès comptable au journal + enregistrement de l'IP client réelle

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 
 ### Securite
 - Authentification par login/mot de passe
-- Journal des acces consultable par la direction (Administration > Securite) : connexions reussies, echecs de connexion, demandes de reinitialisation et changements de mot de passe (consultation directe ou export CSV)
+- Journal des acces consultable par la direction et la comptabilite (Administration > Securite) : connexions reussies, echecs de connexion, demandes de reinitialisation et changements de mot de passe (consultation directe ou export CSV)
 - Migration automatique des anciens hash SHA256 vers werkzeug (bcrypt)
 - Cle secrete chargee depuis variable d'environnement (generee automatiquement au premier demarrage)
 - Protection contre le path traversal sur les sauvegardes

--- a/access_log.py
+++ b/access_log.py
@@ -31,14 +31,30 @@ EVENEMENTS_LABELS = {
 
 
 def _adresse_ip():
-    """Retourne l'adresse IP du client courant si un contexte requete existe."""
+    """Retourne l'adresse IP du client (et non celle du serveur/proxy).
+
+    Derriere un proxy ou un tunnel (ngrok, Cloudflare, reverse proxy...),
+    request.remote_addr vaut l'adresse du proxy local et serait donc toujours
+    identique. On privilegie l'en-tete X-Forwarded-For (la premiere adresse de
+    la liste correspond au client d'origine), puis X-Real-IP, avec repli sur
+    request.remote_addr lorsqu'aucun en-tete n'est present.
+    """
     try:
         from flask import request, has_request_context
-        if has_request_context():
-            return request.remote_addr
+        if not has_request_context():
+            return None
+        forwarded = request.headers.get('X-Forwarded-For', '')
+        if forwarded:
+            # Format "client, proxy1, proxy2" : la 1re adresse = client d'origine
+            client = forwarded.split(',')[0].strip()
+            if client:
+                return client
+        real_ip = (request.headers.get('X-Real-IP') or '').strip()
+        if real_ip:
+            return real_ip
+        return request.remote_addr
     except Exception:
-        pass
-    return None
+        return None
 
 
 def enregistrer_acces(evenement, login_saisi=None, user_id=None, adresse_ip=None):

--- a/blueprints/securite.py
+++ b/blueprints/securite.py
@@ -6,7 +6,7 @@ connexions reussies, echecs de connexion, demandes de reinitialisation et
 modifications de mot de passe. Le journal peut etre consulte directement dans
 l'interface ou telecharge au format CSV.
 
-Accessible uniquement aux directeurs (la direction).
+Accessible aux profils de direction et de comptabilite (directeur, comptable).
 """
 import csv
 import io
@@ -27,9 +27,13 @@ securite_bp = Blueprint('securite_bp', __name__)
 LIMITE_AFFICHAGE = 500
 
 
-def _check_direction():
-    """Verifie que l'utilisateur connecte fait partie de la direction."""
-    return session.get('profil') == 'directeur'
+def _check_acces():
+    """Verifie que l'utilisateur peut consulter le journal (direction/comptable).
+
+    Pour l'instant le comptable dispose des memes acces que la direction ;
+    ce perimetre pourra etre restreint ulterieurement si besoin.
+    """
+    return session.get('profil') in ('directeur', 'comptable')
 
 
 def _lire_filtres():
@@ -84,8 +88,8 @@ def _params_filtres(filtres, limite):
 @securite_bp.route('/securite/journal-acces')
 @login_required
 def journal_acces():
-    """Affiche le journal des acces (direction uniquement)."""
-    if not _check_direction():
+    """Affiche le journal des acces (direction et comptabilite)."""
+    if not _check_acces():
         flash('Accès non autorisé', 'error')
         return redirect(url_for('dashboard_bp.dashboard'))
 
@@ -110,7 +114,7 @@ def journal_acces():
 @login_required
 def export_journal_acces():
     """Telecharge le journal des acces (filtre applique) au format CSV."""
-    if not _check_direction():
+    if not _check_acces():
         flash('Accès non autorisé', 'error')
         return redirect(url_for('dashboard_bp.dashboard'))
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -237,6 +237,7 @@
                 </button>
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('admin_bp.gestion_users') }}">👤 Utilisateurs</a>
+                    <a href="{{ url_for('securite_bp.journal_acces') }}">🔒 Sécurité</a>
                     <a href="{{ url_for('admin_bp.gestion_vacances') }}">🗓️ Vacances scolaires</a>
                     <a href="{{ url_for('admin_bp.gestion_jours_feries') }}">🎌 Jours fériés</a>
                     <a href="{{ url_for('api_keys_bp.gestion_cles_api') }}">🔑 Clés API</a>

--- a/templates/journal_acces.html
+++ b/templates/journal_acces.html
@@ -160,7 +160,7 @@
             <li><strong>🔑 Réinitialisation demandée</strong> : envoi d'un mot de passe temporaire par email.</li>
             <li><strong>🔒 Mot de passe modifié</strong> : un utilisateur a défini un nouveau mot de passe.</li>
         </ul>
-        <p><strong>Confidentialité :</strong> cette page est réservée à la direction. Les heures sont enregistrées au format du serveur.</p>
+        <p><strong>Confidentialité :</strong> cette page est réservée à la direction et à la comptabilité. Les heures sont enregistrées au format du serveur.</p>
     </div>
 </div>
 {% endblock %}

--- a/tests/test_securite.py
+++ b/tests/test_securite.py
@@ -35,6 +35,19 @@ class TestJournalisationAcces:
         assert entry['login_saisi'] == 'admin'
         assert entry['user_id'] is None
 
+    def test_adresse_ip_client_via_x_forwarded_for(self, client, app, db, sample_users):
+        """L'IP enregistree doit etre celle du client (1er X-Forwarded-For),
+        et non celle du serveur/proxy."""
+        client.post(
+            '/login',
+            data={'login': 'admin', 'password': 'Admin1234'},
+            headers={'X-Forwarded-For': '203.0.113.7, 10.0.0.1'},
+        )
+        with app.app_context():
+            entry = _derniere_entree(db, 'connexion_reussie')
+        assert entry is not None
+        assert entry['adresse_ip'] == '203.0.113.7'
+
     def test_echec_connexion_utilisateur_inconnu_journalise(self, client, app, db, sample_users):
         client.post('/login', data={'login': 'inconnu', 'password': 'peu_importe'})
         with app.app_context():
@@ -96,9 +109,10 @@ class TestPageJournalAcces:
         response = auth_client.get('/securite/journal-acces', follow_redirects=False)
         assert response.status_code == 302
 
-    def test_acces_refuse_comptable(self, comptable_client):
-        response = comptable_client.get('/securite/journal-acces', follow_redirects=False)
-        assert response.status_code == 302
+    def test_acces_autorise_comptable(self, comptable_client):
+        response = comptable_client.get('/securite/journal-acces')
+        assert response.status_code == 200
+        assert 'Journal des accès' in response.get_data(as_text=True)
 
     def test_acces_refuse_non_connecte(self, client, sample_users):
         response = client.get('/securite/journal-acces', follow_redirects=False)
@@ -164,6 +178,11 @@ class TestExportJournalAcces:
         body = response.get_data(as_text=True)
         assert 'Date et heure' in body
 
+    def test_export_comptable_ok(self, comptable_client):
+        response = comptable_client.get('/securite/journal-acces/export')
+        assert response.status_code == 200
+        assert 'text/csv' in response.content_type
+
     def test_export_refuse_salarie(self, auth_client):
         response = auth_client.get('/securite/journal-acces/export', follow_redirects=False)
         assert response.status_code == 302
@@ -177,8 +196,13 @@ class TestMenuSecurite:
         assert '🔒 Sécurité' in html
         assert url_securite() in html
 
-    def test_lien_absent_pour_comptable(self, comptable_client):
+    def test_lien_present_pour_comptable(self, comptable_client):
         html = comptable_client.get('/dashboard_comptable').get_data(as_text=True)
+        assert '🔒 Sécurité' in html
+        assert url_securite() in html
+
+    def test_lien_absent_pour_salarie(self, auth_client):
+        html = auth_client.get('/dashboard').get_data(as_text=True)
         assert '🔒 Sécurité' not in html
 
 


### PR DESCRIPTION
## Objectif

Deux ajustements au **journal des accès** (suite de la PR #141, déjà mergée) :

1. **Accès comptable** — le journal est désormais consultable par le profil **comptable** en plus du **directeur**. Pour l'instant le comptable a les mêmes accès que la direction ; le périmètre pourra être restreint plus tard.
2. **Adresse IP réelle du client** — derrière un proxy/tunnel, `request.remote_addr` valait l'IP du serveur (toujours identique, donc inutile). On enregistre maintenant l'IP du client.

## Détails

### Accès comptable
- `blueprints/securite.py` : `_check_acces()` autorise `directeur` **et** `comptable` (mirroir de `_check_admin` dans `administration.py`).
- `templates/base.html` : lien « 🔒 Sécurité » ajouté au menu Administration du comptable (il y était déjà pour le directeur).

### Adresse IP
- `access_log.py` : `_adresse_ip()` lit `X-Forwarded-For` (1ʳᵉ adresse = client d'origine), puis `X-Real-IP`, avec repli sur `request.remote_addr`. Fonctionne que `BEHIND_PROXY` soit activé ou non.

> ℹ️ Pour une journalisation informative, on retient la 1ʳᵉ adresse de `X-Forwarded-For` (le client final). Cet en-tête est en théorie falsifiable côté client ; c'est un compromis standard et acceptable pour un journal d'accès (et non pour du contrôle d'accès).

## Tests
- `tests/test_securite.py` : accès comptable autorisé (page + export), lien de menu présent pour le comptable / absent pour le salarié, et nouveau test vérifiant que l'IP enregistrée provient de `X-Forwarded-For`.
- Suite complète : **413 tests passent**, aucune régression.

https://claude.ai/code/session_01QQUCf3KztJauP4AsfV3cXz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQUCf3KztJauP4AsfV3cXz)_