### PR TITLE
Variables de paie : navigation figée + correctif cases mutuelle

### DIFF
--- a/blueprints/prepa_paie.py
+++ b/blueprints/prepa_paie.py
@@ -117,7 +117,9 @@ def _get_donnees_prepa(conn, salaries, mois, annee, date_debut_mois, date_fin_mo
             'secteur': sal['secteur_nom'],
             'traite': statuts.get(uid, 0),
             'contrats': [dict(c) for c in contrats],
-            'mutuelle': vp.get('mutuelle', 0),
+            # int() : sur les bases anterieures a la migration 0038, la
+            # colonne TEXT renvoie '0'/'1' et '0' serait affiche "Oui".
+            'mutuelle': int(vp.get('mutuelle') or 0),
             'nb_enfants': vp.get('nb_enfants', 0),
             'heures_reelles': vp.get('heures_reelles'),
             'heures_supps': vp.get('heures_supps'),

--- a/blueprints/variables_paie.py
+++ b/blueprints/variables_paie.py
@@ -94,6 +94,10 @@ def variables_paie():
                 'autres_regularisation': 0,
                 'commentaire': '',
             }
+        # Normaliser en entier : sur les bases anterieures a la migration
+        # 0038, la colonne TEXT renvoie '0'/'1' et '0' serait considere
+        # comme coche par le template.
+        d['mutuelle'] = int(d.get('mutuelle') or 0)
         grille.append({
             'user_id': uid,
             'nom': sal['nom'],

--- a/database.py
+++ b/database.py
@@ -75,6 +75,7 @@ ALL_MIGRATION_VERSIONS = [
     ('0035', 'Recuperation partielle'),
     ('0036', 'Horaires forfait jour'),
     ('0037', 'Journal des acces'),
+    ('0038', 'Correctif types variables paie'),
 ]
 
 # Postes de depense par defaut (migration 0012)
@@ -93,6 +94,101 @@ _POSTES_DEPENSE_DEFAUT = [
     ('Fournitures de bureau', ['administratif']),
     ("Produit d'entretien", ['administratif', 'entretien']),
 ]
+
+
+def _affinite_colonne(cursor, table, colonne):
+    """Retourne le type declare d'une colonne (PRAGMA table_info), ou None."""
+    for row in cursor.execute(f'PRAGMA table_info({table})'):  # noqa: S608 - nom de table en dur
+        if row[1] == colonne:
+            return (row[2] or '').strip().upper()
+    return None
+
+
+def _corriger_types_variables_paie(cursor):
+    """Corrige l'affinite des colonnes numeriques de variables_paie et
+    variables_paie_defauts creees en TEXT par d'anciennes versions du schema.
+
+    SQLite stockait alors 0/1 sous forme de texte ('0'), valeur consideree
+    comme vraie cote Python/Jinja : toutes les cases mutuelle apparaissaient
+    cochees apres enregistrement. Reconstruit les tables avec les types
+    INTEGER/REAL (schema des migrations 0004 et 0010) et convertit les
+    donnees existantes. Idempotent : ne fait rien si les types sont corrects.
+    """
+    def _reconstruire(table, schema_corrige, cibles, conversions):
+        anciennes = {row[1] for row in cursor.execute(f'PRAGMA table_info({table})')}  # noqa: S608
+        cursor.execute(f'DROP TABLE IF EXISTS {table}_corrige')  # noqa: S608
+        cursor.execute(schema_corrige)
+        cols = [c for c in cibles if c in anciennes]
+        exprs = [conversions.get(c, c) for c in cols]
+        # Noms de colonnes et expressions definis en dur ci-dessous, jamais
+        # issus de donnees utilisateur.
+        cursor.execute(  # noqa: S608
+            f"INSERT INTO {table}_corrige ({', '.join(cols)}) "
+            f"SELECT {', '.join(exprs)} FROM {table}"
+        )
+        cursor.execute(f'DROP TABLE {table}')  # noqa: S608
+        cursor.execute(f'ALTER TABLE {table}_corrige RENAME TO {table}')  # noqa: S608
+
+    if _affinite_colonne(cursor, 'variables_paie', 'mutuelle') not in (None, 'INTEGER'):
+        _reconstruire(
+            'variables_paie',
+            '''CREATE TABLE variables_paie_corrige (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                mois INTEGER NOT NULL,
+                annee INTEGER NOT NULL,
+                mutuelle INTEGER NOT NULL DEFAULT 0,
+                nb_enfants INTEGER NOT NULL DEFAULT 0,
+                transport REAL NOT NULL DEFAULT 0,
+                acompte REAL NOT NULL DEFAULT 0,
+                saisie_salaire REAL NOT NULL DEFAULT 0,
+                pret_avance REAL NOT NULL DEFAULT 0,
+                autres_regularisation REAL NOT NULL DEFAULT 0,
+                commentaire TEXT,
+                heures_reelles REAL,
+                heures_supps REAL,
+                saisi_par INTEGER,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id),
+                FOREIGN KEY (saisi_par) REFERENCES users(id),
+                UNIQUE(user_id, mois, annee)
+            )''',
+            ['id', 'user_id', 'mois', 'annee', 'mutuelle', 'nb_enfants',
+             'transport', 'acompte', 'saisie_salaire', 'pret_avance',
+             'autres_regularisation', 'commentaire', 'heures_reelles',
+             'heures_supps', 'saisi_par', 'created_at', 'updated_at'],
+            {
+                'mutuelle': 'CASE WHEN CAST(mutuelle AS INTEGER) <> 0 THEN 1 ELSE 0 END',
+                'nb_enfants': 'COALESCE(CAST(nb_enfants AS INTEGER), 0)',
+                'transport': 'COALESCE(CAST(transport AS REAL), 0)',
+                'acompte': 'COALESCE(CAST(acompte AS REAL), 0)',
+                'saisie_salaire': 'COALESCE(CAST(saisie_salaire AS REAL), 0)',
+                'pret_avance': 'COALESCE(CAST(pret_avance AS REAL), 0)',
+                'autres_regularisation': 'COALESCE(CAST(autres_regularisation AS REAL), 0)',
+            },
+        )
+
+    if _affinite_colonne(cursor, 'variables_paie_defauts', 'mutuelle') not in (None, 'INTEGER'):
+        _reconstruire(
+            'variables_paie_defauts',
+            '''CREATE TABLE variables_paie_defauts_corrige (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL UNIQUE,
+                mutuelle INTEGER NOT NULL DEFAULT 0,
+                nb_enfants INTEGER NOT NULL DEFAULT 0,
+                saisie_salaire REAL NOT NULL DEFAULT 0,
+                pret_avance REAL NOT NULL DEFAULT 0,
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            )''',
+            ['id', 'user_id', 'mutuelle', 'nb_enfants', 'saisie_salaire', 'pret_avance'],
+            {
+                'mutuelle': 'CASE WHEN CAST(mutuelle AS INTEGER) <> 0 THEN 1 ELSE 0 END',
+                'nb_enfants': 'COALESCE(CAST(nb_enfants AS INTEGER), 0)',
+                'saisie_salaire': 'COALESCE(CAST(saisie_salaire AS REAL), 0)',
+                'pret_avance': 'COALESCE(CAST(pret_avance AS REAL), 0)',
+            },
+        )
 
 
 def init_db():
@@ -440,14 +536,17 @@ def init_db():
     ''')
 
     # ===== Table variables paie defauts (migration 0004) =====
+    # Types numeriques obligatoires : une affinite TEXT stockerait 0/1 sous
+    # forme de chaine ('0'), valeur consideree comme vraie cote Python/Jinja
+    # (cases mutuelle toutes cochees a l'affichage).
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS variables_paie_defauts (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL UNIQUE,
-            mutuelle TEXT,
-            nb_enfants INTEGER DEFAULT 0,
-            saisie_salaire TEXT,
-            pret_avance TEXT,
+            mutuelle INTEGER NOT NULL DEFAULT 0,
+            nb_enfants INTEGER NOT NULL DEFAULT 0,
+            saisie_salaire REAL NOT NULL DEFAULT 0,
+            pret_avance REAL NOT NULL DEFAULT 0,
             FOREIGN KEY (user_id) REFERENCES users(id)
         )
     ''')
@@ -459,13 +558,13 @@ def init_db():
             user_id INTEGER NOT NULL,
             mois INTEGER NOT NULL,
             annee INTEGER NOT NULL,
-            mutuelle TEXT,
-            nb_enfants INTEGER DEFAULT 0,
-            transport TEXT,
-            acompte TEXT,
-            saisie_salaire TEXT,
-            pret_avance TEXT,
-            autres_regularisation TEXT,
+            mutuelle INTEGER NOT NULL DEFAULT 0,
+            nb_enfants INTEGER NOT NULL DEFAULT 0,
+            transport REAL NOT NULL DEFAULT 0,
+            acompte REAL NOT NULL DEFAULT 0,
+            saisie_salaire REAL NOT NULL DEFAULT 0,
+            pret_avance REAL NOT NULL DEFAULT 0,
+            autres_regularisation REAL NOT NULL DEFAULT 0,
             commentaire TEXT,
             heures_reelles REAL,
             heures_supps REAL,
@@ -1437,6 +1536,12 @@ def init_db():
             cursor.execute(f"SELECT {col} FROM presence_forfait_jour LIMIT 1")
         except sqlite3.OperationalError:
             cursor.execute(f"ALTER TABLE presence_forfait_jour ADD COLUMN {col} TEXT")
+
+    # Migration 0038 : corriger les colonnes numeriques creees en TEXT dans
+    # variables_paie / variables_paie_defauts (cases mutuelle toutes cochees).
+    # Fallback indispensable : les bases creees par d'anciennes versions
+    # d'init_db ont le schema TEXT alors que 0004 y est marquee appliquee.
+    _corriger_types_variables_paie(cursor)
 
     conn.commit()
     conn.close()

--- a/migrations/0038_correctif_types_variables_paie.py
+++ b/migrations/0038_correctif_types_variables_paie.py
@@ -1,0 +1,31 @@
+"""
+Migration 0038 : Correction des types numeriques des tables variables_paie
+et variables_paie_defauts.
+
+Sur les bases creees par init_db (database.py), les colonnes mutuelle,
+transport, acompte, saisie_salaire, pret_avance et autres_regularisation
+avaient une affinite TEXT : SQLite stockait 0/1 sous forme de texte ('0'),
+valeur consideree comme vraie cote Python/Jinja. Consequence visible :
+toutes les cases "Mutuelle" de la page Variables de paie apparaissaient
+cochees apres le premier enregistrement.
+
+Reconstruit les deux tables avec les types INTEGER/REAL (schema des
+migrations 0004 et 0010) et convertit les donnees existantes.
+"""
+
+NOM = "Correctif types variables paie"
+DESCRIPTION = (
+    "Reconstruit variables_paie et variables_paie_defauts avec des types "
+    "INTEGER/REAL (les colonnes TEXT faisaient apparaitre toutes les cases "
+    "mutuelle cochees) et convertit les donnees existantes."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    # Logique partagee avec le fallback execute par init_db() au demarrage
+    # (meme correctif, idempotent).
+    from database import _corriger_types_variables_paie
+
+    _corriger_types_variables_paie(conn.cursor())
+    conn.commit()

--- a/templates/variables_paie.html
+++ b/templates/variables_paie.html
@@ -25,11 +25,11 @@
         <input type="hidden" name="mois" value="{{ mois }}">
         <input type="hidden" name="annee" value="{{ annee }}">
 
-        <div style="overflow-x: auto;">
+        <div class="vp-table-scroll">
             <table class="data-table variables-paie-table">
                 <thead>
                     <tr>
-                        <th style="min-width: 160px; position: sticky; left: 0; background: var(--gray-100); z-index: 2;">Salarie</th>
+                        <th class="vp-sticky-col" style="min-width: 160px;">Salarie</th>
                         <th style="min-width: 100px;">Secteur</th>
                         <th style="min-width: 80px; background: #e8f5e9;">Mutuelle</th>
                         <th style="min-width: 80px; background: #e8f5e9;">Nb enfants</th>
@@ -46,9 +46,9 @@
                 </thead>
                 <tbody>
                     {% for row in grille %}
-                    <input type="hidden" name="user_ids" value="{{ row.user_id }}">
                     <tr>
-                        <td style="position: sticky; left: 0; background: var(--white, #fff); z-index: 1; white-space: nowrap;">
+                        <td class="vp-sticky-col">
+                            <input type="hidden" name="user_ids" value="{{ row.user_id }}">
                             <strong>{{ row.nom }}</strong> {{ row.prenom }}
                         </td>
                         <td style="font-size: 0.85rem;">{{ row.secteur }}</td>
@@ -168,6 +168,42 @@
 </div>
 
 <style>
+/* Conteneur de defilement limite a la hauteur de l'ecran : les barres de
+   defilement (notamment horizontale) restent accessibles sans descendre en
+   bas de la page, et les en-tetes / la colonne Salarie restent figes. */
+.vp-table-scroll {
+    overflow: auto;
+    max-height: max(420px, calc(100vh - 310px));
+    border: 1px solid var(--gray-200, #e0e0e0);
+    border-radius: var(--radius-md, 10px);
+}
+.variables-paie-table {
+    /* .data-table pose overflow:hidden, ce qui neutralise position:sticky ;
+       le rognage des coins est assure par .vp-table-scroll. */
+    overflow: visible;
+    border: none;
+    border-radius: 0;
+}
+.variables-paie-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: var(--gray-100, #f5f5f5);
+}
+.variables-paie-table th.vp-sticky-col {
+    left: 0;
+    z-index: 4; /* coin Salarie : au-dessus des autres en-tetes et de la colonne */
+}
+.variables-paie-table td.vp-sticky-col {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background: var(--white, #fff);
+    white-space: nowrap;
+}
+.variables-paie-table tbody tr:hover td.vp-sticky-col {
+    background: var(--gray-50, #fafafa);
+}
 .variables-paie-table input[type="number"],
 .variables-paie-table input[type="text"] {
     padding: 4px 6px;
@@ -197,12 +233,6 @@
 }
 [data-theme="dark"] .variables-paie-table td[style*="f1f8e9"] {
     background: #1b3a1b !important;
-}
-[data-theme="dark"] .variables-paie-table td[style*="sticky"] {
-    background: var(--gray-800, #1e1e1e) !important;
-}
-[data-theme="dark"] .variables-paie-table thead th[style*="sticky"] {
-    background: var(--gray-700, #333) !important;
 }
 [data-theme="dark"] span[style*="e8f5e9"] {
     background: #1b5e20 !important;

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -85,6 +85,11 @@ class TestInitDb:
         versions = {m['version'] for m in lister_fichiers_migrations()}
         assert '0034' in versions
 
+    def test_fichier_migration_0038_present(self):
+        """La migration 0038 doit exister sous forme de fichier."""
+        versions = {m['version'] for m in lister_fichiers_migrations()}
+        assert '0038' in versions
+
     def test_postes_depense_initialises(self, app, db):
         """Les postes de dépense par défaut doivent être créés."""
         with app.app_context():

--- a/tests/test_variables_paie.py
+++ b/tests/test_variables_paie.py
@@ -1,0 +1,222 @@
+"""
+Tests de la page Variables de paie :
+- Types numeriques corrects dans le schema initial (bug "cases mutuelle
+  toutes cochees apres enregistrement", colonnes creees en TEXT)
+- Correction des anciennes bases par _corriger_types_variables_paie
+  (fallback init_db + migration 0038)
+- Cycle enregistrer -> reafficher : les cases mutuelle restent fideles
+  a la saisie
+"""
+import os
+import re
+
+import database
+
+
+def _type_colonne(db, table, colonne):
+    """Retourne le type declare d'une colonne via PRAGMA table_info."""
+    for row in db.execute(f'PRAGMA table_info({table})'):
+        if row[1] == colonne:
+            return (row[2] or '').strip().upper()
+    return None
+
+
+def _case_mutuelle_cochee(html, user_id):
+    """Retourne True si la checkbox mutuelle du salarie est cochee dans le HTML."""
+    m = re.search(rf'<input[^>]*name="mutuelle_{user_id}"[^>]*>', html)
+    assert m, f"Checkbox mutuelle_{user_id} absente de la page"
+    return 'checked' in m.group(0)
+
+
+class TestSchemaVariablesPaie:
+    """Le schema initial doit utiliser des types numeriques (pas TEXT)."""
+
+    def test_types_variables_paie(self, app, db):
+        with app.app_context():
+            assert _type_colonne(db, 'variables_paie', 'mutuelle') == 'INTEGER'
+            assert _type_colonne(db, 'variables_paie', 'nb_enfants') == 'INTEGER'
+            for col in ('transport', 'acompte', 'saisie_salaire',
+                        'pret_avance', 'autres_regularisation'):
+                assert _type_colonne(db, 'variables_paie', col) == 'REAL', col
+
+    def test_types_variables_paie_defauts(self, app, db):
+        with app.app_context():
+            assert _type_colonne(db, 'variables_paie_defauts', 'mutuelle') == 'INTEGER'
+            assert _type_colonne(db, 'variables_paie_defauts', 'nb_enfants') == 'INTEGER'
+            for col in ('saisie_salaire', 'pret_avance'):
+                assert _type_colonne(db, 'variables_paie_defauts', col) == 'REAL', col
+
+
+class TestCorrectionAncienneBase:
+    """Reconstruction des tables creees en TEXT par d'anciennes versions."""
+
+    def _creer_ancien_schema(self, db):
+        """Recree les tables avec l'ancien schema bogue (colonnes TEXT)."""
+        db.execute('DROP TABLE variables_paie')
+        db.execute('DROP TABLE variables_paie_defauts')
+        db.execute('''
+            CREATE TABLE variables_paie_defauts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL UNIQUE,
+                mutuelle TEXT,
+                nb_enfants INTEGER DEFAULT 0,
+                saisie_salaire TEXT,
+                pret_avance TEXT,
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            )
+        ''')
+        db.execute('''
+            CREATE TABLE variables_paie (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                mois INTEGER NOT NULL,
+                annee INTEGER NOT NULL,
+                mutuelle TEXT,
+                nb_enfants INTEGER DEFAULT 0,
+                transport TEXT,
+                acompte TEXT,
+                saisie_salaire TEXT,
+                pret_avance TEXT,
+                autres_regularisation TEXT,
+                commentaire TEXT,
+                heures_reelles REAL,
+                heures_supps REAL,
+                saisi_par INTEGER,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id),
+                FOREIGN KEY (saisi_par) REFERENCES users(id),
+                UNIQUE(user_id, mois, annee)
+            )
+        ''')
+
+    def test_reconstruction_et_conversion(self, app, db, sample_users):
+        with app.app_context():
+            self._creer_ancien_schema(db)
+            uid = sample_users['salarie_id']
+            uid2 = sample_users['responsable_id']
+            db.execute(
+                'INSERT INTO variables_paie (user_id, mois, annee, mutuelle, nb_enfants, transport) '
+                'VALUES (?, 6, 2026, 0, 2, 12.5)', (uid,)
+            )
+            db.execute(
+                'INSERT INTO variables_paie (user_id, mois, annee, mutuelle) '
+                'VALUES (?, 6, 2026, 1)', (uid2,)
+            )
+            db.execute(
+                'INSERT INTO variables_paie_defauts (user_id, mutuelle, pret_avance) '
+                'VALUES (?, 0, 50)', (uid,)
+            )
+            db.commit()
+
+            # Le bug d'origine : la colonne TEXT stocke '0', chaine non vide
+            # donc consideree comme vraie cote Python (case affichee cochee).
+            brut = db.execute(
+                'SELECT mutuelle, typeof(mutuelle) AS t FROM variables_paie WHERE user_id = ?',
+                (uid,)
+            ).fetchone()
+            assert brut['t'] == 'text'
+            assert bool(brut['mutuelle'])
+
+            database._corriger_types_variables_paie(db.cursor())
+            db.commit()
+
+            assert _type_colonne(db, 'variables_paie', 'mutuelle') == 'INTEGER'
+            row = db.execute(
+                'SELECT *, typeof(mutuelle) AS t FROM variables_paie WHERE user_id = ?',
+                (uid,)
+            ).fetchone()
+            assert row['t'] == 'integer'
+            assert row['mutuelle'] == 0
+            assert not bool(row['mutuelle'])
+            assert row['nb_enfants'] == 2
+            assert row['transport'] == 12.5
+
+            row2 = db.execute(
+                'SELECT mutuelle FROM variables_paie WHERE user_id = ?', (uid2,)
+            ).fetchone()
+            assert row2['mutuelle'] == 1
+
+            defaut = db.execute(
+                'SELECT mutuelle, pret_avance, typeof(mutuelle) AS t '
+                'FROM variables_paie_defauts WHERE user_id = ?', (uid,)
+            ).fetchone()
+            assert defaut['t'] == 'integer'
+            assert defaut['mutuelle'] == 0
+            assert defaut['pret_avance'] == 50.0
+
+    def test_idempotent_sur_schema_correct(self, app, db):
+        with app.app_context():
+            database._corriger_types_variables_paie(db.cursor())
+            assert _type_colonne(db, 'variables_paie', 'mutuelle') == 'INTEGER'
+            assert _type_colonne(db, 'variables_paie_defauts', 'mutuelle') == 'INTEGER'
+
+    def test_migration_0038_applique_le_correctif(self, app, db, sample_users):
+        with app.app_context():
+            self._creer_ancien_schema(db)
+            db.execute(
+                'INSERT INTO variables_paie (user_id, mois, annee, mutuelle) '
+                'VALUES (?, 6, 2026, 0)', (sample_users['salarie_id'],)
+            )
+            db.commit()
+
+            from migration_manager import _load_migration_module, MIGRATIONS_DIR
+            module = _load_migration_module(
+                os.path.join(MIGRATIONS_DIR, '0038_correctif_types_variables_paie.py')
+            )
+            module.upgrade(db)
+
+            assert _type_colonne(db, 'variables_paie', 'mutuelle') == 'INTEGER'
+            row = db.execute(
+                'SELECT mutuelle FROM variables_paie WHERE user_id = ?',
+                (sample_users['salarie_id'],)
+            ).fetchone()
+            assert row['mutuelle'] == 0
+
+
+class TestPageVariablesPaie:
+    """Cycle HTTP complet : enregistrement puis reaffichage de la grille."""
+
+    def test_acces_refuse_salarie(self, auth_client):
+        resp = auth_client.get('/variables_paie', follow_redirects=False)
+        assert resp.status_code == 302
+
+    def test_cases_non_cochees_restent_decochees(self, comptable_client, sample_users):
+        """Bug d'origine : apres validation, toutes les cases se cochaient."""
+        ids = [sample_users['salarie_id'], sample_users['responsable_id'],
+               sample_users['directeur_id'], sample_users['comptable_id']]
+        resp = comptable_client.post('/variables_paie/enregistrer', data={
+            'mois': '6',
+            'annee': '2026',
+            'user_ids': [str(i) for i in ids],
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+        html = comptable_client.get('/variables_paie?mois=6&annee=2026').data.decode('utf-8')
+        for uid in ids:
+            assert _case_mutuelle_cochee(html, uid) is False, \
+                f"La case mutuelle du salarie {uid} ne doit pas se cocher toute seule"
+
+    def test_case_cochee_conservee(self, comptable_client, sample_users, app, db):
+        """Une case cochee doit le rester, les autres rester decochees."""
+        salarie_id = sample_users['salarie_id']
+        responsable_id = sample_users['responsable_id']
+        comptable_client.post('/variables_paie/enregistrer', data={
+            'mois': '6',
+            'annee': '2026',
+            'user_ids': [str(salarie_id), str(responsable_id)],
+            f'mutuelle_{salarie_id}': '1',
+        }, follow_redirects=True)
+
+        html = comptable_client.get('/variables_paie?mois=6&annee=2026').data.decode('utf-8')
+        assert _case_mutuelle_cochee(html, salarie_id) is True
+        assert _case_mutuelle_cochee(html, responsable_id) is False
+
+        # La valeur doit etre stockee en entier, pas en texte
+        with app.app_context():
+            row = db.execute(
+                'SELECT mutuelle, typeof(mutuelle) AS t FROM variables_paie WHERE user_id = ?',
+                (salarie_id,)
+            ).fetchone()
+            assert row['t'] == 'integer'
+            assert row['mutuelle'] == 1


### PR DESCRIPTION
## Problèmes traités

1. **Bug mutuelle** : après validation de la page, toutes les cases « Mutuelle » se cochaient automatiquement.
2. **Navigation** : impossible de défiler horizontalement sans descendre tout en bas de la page ; en-têtes et colonne Salarié non figés.

## Cause racine du bug mutuelle

Les tables `variables_paie` et `variables_paie_defauts` étaient créées par `init_db()` (database.py) avec des colonnes numériques en affinité **TEXT** (`mutuelle TEXT`, `transport TEXT`, …), alors que la migration 0004 les déclarait `INTEGER`/`REAL`. Comme `init_db()` marque toutes les migrations comme appliquées sur une base neuve, la migration 0004 ne s'exécutait jamais : toutes les installations ont le schéma TEXT.

Avec l'affinité TEXT, SQLite stocke `0`/`1` sous forme de chaîne `'0'`/`'1'`. Or `'0'` est une chaîne non vide, donc « vraie » côté Python/Jinja : `{% if row.data.mutuelle %}checked{% endif %}` cochait toutes les cases dès le premier enregistrement. Le même problème touchait l'affichage « Oui/Non » de la prépa paie.

## Correctifs

- **Schéma initial corrigé** (`database.py`) : types `INTEGER`/`REAL` pour les nouvelles bases, alignés sur les migrations 0004 + 0010.
- **Migration 0038** + **fallback dans `init_db()`** (exécuté à chaque démarrage) : reconstruction des deux tables avec conversion des données existantes (`'0'` → `0`, `'12.5'` → `12.5`). Idempotent : aucun effet si les types sont déjà corrects. Un simple redémarrage de l'application corrige la base.
- **Normalisation défensive** en entier dans `variables_paie.py` et `prepa_paie.py` pour les bases pas encore corrigées.

## Navigation

- Le tableau défile dans un conteneur limité à la hauteur de l'écran : la barre de défilement horizontale reste accessible sans descendre en bas de page.
- Ligne d'en-têtes figée en haut pendant le défilement vertical.
- Colonne « Salarié » figée à gauche pendant le défilement horizontal (le `overflow: hidden` de `.data-table` neutralisait le `position: sticky` déjà présent ; il est désormais surchargé).
- Thème sombre conservé (les variables CSS s'inversant en sombre, les anciens overrides spécifiques deviennent inutiles).

## Tests

- Nouveau `tests/test_variables_paie.py` : types du schéma, conversion d'une ancienne base TEXT (valeurs préservées), migration 0038, idempotence, et cycle HTTP enregistrer → réafficher (cases non cochées qui restent décochées — le scénario du bug — et case cochée conservée).
- Suite complète : **422 tests passants**.

https://claude.ai/code/session_01GwUdu3wZp7usVCJZZh4StD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwUdu3wZp7usVCJZZh4StD)_