### PR TITLE
Prépa paie : colonnes Traite et Nom Prenom figées à gauche

### DIFF
--- a/templates/prepa_paie.html
+++ b/templates/prepa_paie.html
@@ -30,8 +30,8 @@
             <table class="data-table prepa-paie-table">
                 <thead>
                     <tr>
-                        <th>Traite</th>
-                        <th>Nom Prenom</th>
+                        <th class="pp-col-traite">Traite</th>
+                        <th class="pp-col-nom">Nom Prenom</th>
                         <th>Secteur</th>
                         <th style="min-width: 280px;">Contrat</th>
                         <th>Forfait</th>
@@ -47,19 +47,18 @@
                         <th>Autres regul.</th>
                         <th style="min-width: 150px;">Commentaire</th>
                         <th style="min-width: 300px;">Absences du mois</th>
-                        <th style="white-space: nowrap;">Nom Prenom</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for row in grille %}
-                    <input type="hidden" name="user_ids" value="{{ row.user_id }}">
                     <tr class="{% if row.traite %}row-traite{% elif loop.index is odd %}row-odd{% else %}row-even{% endif %} row-separator">
-                        <td style="text-align: center;">
+                        <td class="pp-col-traite" style="text-align: center;">
+                            <input type="hidden" name="user_ids" value="{{ row.user_id }}">
                             <input type="checkbox" name="traite_{{ row.user_id }}" value="1"
                                    {% if row.traite %}checked{% endif %}
                                    style="width: 18px; height: 18px; cursor: pointer;">
                         </td>
-                        <td style="white-space: nowrap;">
+                        <td class="pp-col-nom">
                             <strong>{{ row.nom }}</strong> {{ row.prenom }}
                         </td>
                         <td style="font-size: 0.85rem;">{{ row.secteur }}</td>
@@ -117,9 +116,6 @@
                             <span style="color: var(--gray-400); font-size: 0.85rem;">Aucune</span>
                             {% endif %}
                         </td>
-                        <td style="white-space: nowrap;">
-                            <strong>{{ row.nom }}</strong> {{ row.prenom }}
-                        </td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -151,7 +147,11 @@
 
 /* ── Base ── */
 .prepa-paie-table {
-    border-collapse: collapse;
+    /* "separate" (et non "collapse") : avec collapse, les bordures
+       appartiennent au tableau et ne suivent pas les cellules figees
+       (position: sticky) au defilement. */
+    border-collapse: separate;
+    border-spacing: 0;
     /* Le cadre est porte par .prepa-paie-scroll ; "overflow: visible" est
        indispensable pour que l'en-tete sticky se cale sur le conteneur. */
     border: none;
@@ -181,6 +181,34 @@
     /* Trait sous l'en-tete via box-shadow pour rester colle a la cellule
        sticky (un border-bottom disparaitrait avec border-collapse au defilement). */
     box-shadow: inset 0 -2px 0 var(--gray-300, #bbb);
+}
+
+/* ── Colonnes figees a gauche (Traite + Nom Prenom) ── */
+.prepa-paie-table .pp-col-traite,
+.prepa-paie-table .pp-col-nom {
+    position: sticky;
+    z-index: 3; /* au-dessus des cellules qui defilent dessous */
+}
+.prepa-paie-table .pp-col-traite {
+    left: 0;
+    width: 60px;
+    min-width: 60px;
+}
+.prepa-paie-table .pp-col-nom {
+    left: 60px; /* = largeur de la colonne Traite */
+    white-space: nowrap;
+    /* Bord droit renforce pour marquer la limite de la zone figee */
+    border-right: none;
+    box-shadow: inset -2px 0 0 var(--gray-300, #bbb);
+}
+.prepa-paie-table thead th.pp-col-traite,
+.prepa-paie-table thead th.pp-col-nom {
+    z-index: 6; /* coins : au-dessus des autres en-tetes (z-index 5) */
+}
+.prepa-paie-table thead th.pp-col-nom {
+    /* Cumule le bord droit de la zone figee et le trait sous l'en-tete */
+    box-shadow: inset -2px 0 0 var(--gray-300, #bbb),
+                inset 0 -2px 0 var(--gray-300, #bbb);
 }
 
 /* ── Row alternation ── */
@@ -214,6 +242,13 @@
 }
 [data-theme="dark"] .prepa-paie-table thead th {
     box-shadow: inset 0 -2px 0 var(--gray-500, #555);
+}
+[data-theme="dark"] .prepa-paie-table .pp-col-nom {
+    box-shadow: inset -2px 0 0 var(--gray-500, #555);
+}
+[data-theme="dark"] .prepa-paie-table thead th.pp-col-nom {
+    box-shadow: inset -2px 0 0 var(--gray-500, #555),
+                inset 0 -2px 0 var(--gray-500, #555);
 }
 [data-theme="dark"] .prepa-paie-table tr.row-odd td {
     background: var(--white, #1a1a1a);

--- a/tests/test_prepa_paie.py
+++ b/tests/test_prepa_paie.py
@@ -1,0 +1,41 @@
+"""
+Tests de la page Preparation de paie :
+- controle d'acces
+- rendu de la grille : colonnes figees (Traite, Nom Prenom) presentes,
+  colonne "Nom Prenom" dupliquee en fin de tableau supprimee
+"""
+
+
+def _inserer_contrat(db, user_id):
+    """Cree un contrat actif pour que le salarie apparaisse dans la grille."""
+    db.execute(
+        "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+        "VALUES (?, 'CDI', '2026-01-01', NULL)", (user_id,)
+    )
+    db.commit()
+
+
+class TestPagePrepaPaie:
+
+    def test_acces_refuse_salarie(self, auth_client):
+        resp = auth_client.get('/prepa_paie', follow_redirects=False)
+        assert resp.status_code == 302
+
+    def test_grille_colonnes_figees_sans_doublon_nom(self, comptable_client, sample_users, app, db):
+        with app.app_context():
+            _inserer_contrat(db, sample_users['salarie_id'])
+
+        resp = comptable_client.get('/prepa_paie?mois=6&annee=2026')
+        assert resp.status_code == 200
+        html = resp.data.decode('utf-8')
+
+        # La grille est bien rendue avec le salarie sous contrat
+        assert f"traite_{sample_users['salarie_id']}" in html
+        # Colonnes figees a gauche
+        assert 'pp-col-traite' in html
+        assert 'pp-col-nom' in html
+        # L'en-tete "Nom Prenom" n'apparait qu'une fois : la colonne dupliquee
+        # en fin de tableau a ete supprimee
+        assert html.count('>Nom Prenom</th>') == 1
+        # Le nom du salarie n'apparait qu'une fois par ligne (plus de rappel a droite)
+        assert html.count('<strong>Martin</strong>') == 1


### PR DESCRIPTION
## Objet

Suite de la PR #143, même traitement pour la page **Préparation de paie** :

1. **Colonnes « Traite » et « Nom Prenom » figées à gauche** pendant le défilement horizontal, avec un bord droit renforcé qui marque la limite de la zone figée (thèmes clair et sombre). Les coins d'en-tête restent au-dessus des autres cellules pendant le défilement combiné (vertical + horizontal).
2. **Suppression de la colonne « Nom Prenom » dupliquée en fin de tableau** : elle servait à garder le nom sous les yeux en bout de ligne, ce que la colonne figée rend inutile.

## Détails techniques

- Passage de `border-collapse: collapse` à `separate` + `border-spacing: 0` : avec `collapse`, les bordures appartiennent au tableau et ne suivent pas les cellules `position: sticky` au défilement (la page utilisait déjà un `box-shadow` pour contourner ce problème sur l'en-tête). Rendu visuel inchangé au repos.
- La colonne « Traite » a une largeur fixe (60px) qui sert d'offset `left` à la colonne « Nom Prenom ».
- Champ caché `user_ids` déplacé à l'intérieur de la première cellule (il était enfant direct de `<tbody>`, HTML invalide).
- L'export Excel n'est pas concerné (il ne dupliquait pas le nom).

## Tests

- Nouveau `tests/test_prepa_paie.py` : contrôle d'accès, rendu de la grille avec colonnes figées, absence du doublon « Nom Prenom ».
- Tests ciblés verts ; suite complète lancée en parallèle (résultat confirmé dans la conversation).

https://claude.ai/code/session_01GwUdu3wZp7usVCJZZh4StD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwUdu3wZp7usVCJZZh4StD)_