### PR TITLE
Afficher le temps de travail hebdomadaire des CDD sur la prépa paie

### DIFF
--- a/blueprints/prepa_paie.py
+++ b/blueprints/prepa_paie.py
@@ -90,7 +90,7 @@ def _get_donnees_prepa(conn, salaries, mois, annee, date_debut_mois, date_fin_mo
         # Contrats actifs sur le mois
         contrats = conn.execute('''
             SELECT id, type_contrat, date_debut, date_fin, forfait, nbr_jours,
-                   fichier_path, fichier_nom
+                   temps_hebdo, fichier_path, fichier_nom
             FROM contrats
             WHERE user_id = ?
             AND date_debut <= ?

--- a/templates/prepa_paie.html
+++ b/templates/prepa_paie.html
@@ -66,7 +66,7 @@
                             {% for c in row.contrats %}
                             <div style="margin-bottom: 4px; font-size: 0.85rem;{% if not loop.first %} border-top: 1px solid var(--gray-200); padding-top: 4px;{% endif %}">
                                 <span class="badge badge-info">{{ c.type_contrat }}</span>
-                                {{ c.date_debut }} &rarr; {{ c.date_fin or 'En cours' }}
+                                {{ c.date_debut }} &rarr; {{ c.date_fin or 'En cours' }}{% if c.type_contrat == 'CDD' and c.temps_hebdo %} ({{ "%.1f"|format(c.temps_hebdo) }}h){% endif %}
                                 {% if c.fichier_path %}
                                 <a href="{{ url_for('infos_salaries_bp.telecharger_contrat', contrat_id=c.id) }}" class="btn btn-sm" style="padding: 1px 6px; font-size: 0.75rem; margin-left: 4px;">PDF</a>
                                 {% endif %}

--- a/tests/test_prepa_paie.py
+++ b/tests/test_prepa_paie.py
@@ -15,6 +15,15 @@ def _inserer_contrat(db, user_id):
     db.commit()
 
 
+def _inserer_contrat_cdd(db, user_id, temps_hebdo=28.0):
+    """Cree un CDD actif avec un temps de travail hebdomadaire."""
+    db.execute(
+        "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin, temps_hebdo) "
+        "VALUES (?, 'CDD', '2026-01-01', '2026-12-31', ?)", (user_id, temps_hebdo)
+    )
+    db.commit()
+
+
 class TestPagePrepaPaie:
 
     def test_acces_refuse_salarie(self, auth_client):
@@ -39,3 +48,32 @@ class TestPagePrepaPaie:
         assert html.count('>Nom Prenom</th>') == 1
         # Le nom du salarie n'apparait qu'une fois par ligne (plus de rappel a droite)
         assert html.count('<strong>Martin</strong>') == 1
+
+    def test_cdd_affiche_temps_hebdo_entre_parentheses(self, comptable_client, sample_users, app, db):
+        """Pour un CDD, le temps de travail hebdomadaire suit les dates entre parentheses."""
+        with app.app_context():
+            _inserer_contrat_cdd(db, sample_users['salarie_id'], temps_hebdo=28.0)
+
+        resp = comptable_client.get('/prepa_paie?mois=6&annee=2026')
+        assert resp.status_code == 200
+        html = resp.data.decode('utf-8')
+
+        # Les dates du contrat sont suivies du temps hebdo entre parentheses
+        assert '(28.0h)' in html
+
+    def test_cdi_n_affiche_pas_temps_hebdo(self, comptable_client, sample_users, app, db):
+        """Le temps hebdo entre parentheses est reserve aux CDD (pas les CDI)."""
+        with app.app_context():
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin, temps_hebdo) "
+                "VALUES (?, 'CDI', '2026-01-01', NULL, 35.0)",
+                (sample_users['salarie_id'],)
+            )
+            db.commit()
+
+        resp = comptable_client.get('/prepa_paie?mois=6&annee=2026')
+        assert resp.status_code == 200
+        html = resp.data.decode('utf-8')
+
+        # Pas de temps hebdo entre parentheses pour un CDI
+        assert '(35.0h)' not in html


### PR DESCRIPTION
## Objectif

Sur la page **Préparation de paie** (`prepa_paie`), afficher le temps de travail hebdomadaire entre parenthèses après les dates du contrat, **uniquement pour les CDD**.

## Modifications

- **`blueprints/prepa_paie.py`** : ajout du champ `temps_hebdo` à la requête SQL qui récupère les contrats actifs du mois.
- **`templates/prepa_paie.html`** : dans la colonne « Contrat », le temps hebdo s'affiche entre parenthèses après les dates pour les contrats de type `CDD` (lorsque `temps_hebdo` est renseigné).

  Exemple de rendu : `CDD  01/01/2026 → 31/12/2026 (28.0h)`

- **`tests/test_prepa_paie.py`** : ajout de deux tests
  - le temps hebdo apparaît bien entre parenthèses pour un CDD ;
  - il n'apparaît pas pour un CDI (comportement réservé aux CDD).

## Notes

- Le format `%.1f` reprend celui de la fiche salarié (`infos_salaries.html`) pour préserver les demi-heures (ex. `17.5h`).
- Aucune modification de schéma : le champ `temps_hebdo` existe déjà sur la table `contrats`.

## Tests

```
tests/test_prepa_paie.py ....            [4 passed]
tests/test_database.py ........          [17 passed]
tests/test_nouvelles_fonctionnalites.py  [15 passed]
```

https://claude.ai/code/session_0143nq1SqxyjQeKKfXfSgGmL

---
_Generated by [Claude Code](https://claude.ai/code/session_0143nq1SqxyjQeKKfXfSgGmL)_