### PR TITLE
Prepa paie : dévalider "traité" quand les variables de paie changent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 
 ### Preparation de la paie
 - Module de preparation de paie avec statut par salarie
+- Toute modification des variables de paie d'un mois retire automatiquement la validation "traite" du salarie concerne en preparation de paie : le prestataire revalide apres verification
 - Variables de paie configurables
 - Informations complementaires salaries
 - Generation de contrats de travail a partir de modeles DOCX

--- a/blueprints/variables_paie.py
+++ b/blueprints/variables_paie.py
@@ -25,6 +25,34 @@ def _peut_gerer_variables_paie():
     return session.get('profil') in ['comptable', 'directeur']
 
 
+def _variables_modifiees(ancien, nouveau):
+    """Indique si les variables de paie visibles en prepa paie ont change.
+
+    `ancien` : ligne variables_paie existante (sqlite Row / dict) ou None
+    lorsqu'aucune donnee n'a encore ete enregistree pour ce salarie ce mois-la.
+    `nouveau` : dict des valeurs issues du formulaire.
+
+    La comparaison porte sur les memes champs (et avec la meme tolerance
+    "valeur vide = 0") que ceux repris dans la grille de preparation de paie :
+    on ne retire la validation du prestataire que lorsqu'une donnee qu'il voit
+    change reellement. En l'absence de ligne existante, la reference est l'etat
+    "tout a zero" affiche en prepa paie tant que rien n'a ete saisi.
+    """
+    a = dict(ancien) if ancien else {}
+
+    if int(a.get('mutuelle') or 0) != int(nouveau['mutuelle'] or 0):
+        return True
+    if int(a.get('nb_enfants') or 0) != int(nouveau['nb_enfants'] or 0):
+        return True
+    for champ in ('heures_reelles', 'heures_supps', 'transport', 'acompte',
+                  'saisie_salaire', 'pret_avance', 'autres_regularisation'):
+        if float(a.get(champ) or 0) != float(nouveau[champ] or 0):
+            return True
+    if (a.get('commentaire') or '') != (nouveau['commentaire'] or ''):
+        return True
+    return False
+
+
 @variables_paie_bp.route('/variables_paie', methods=['GET'])
 @login_required
 def variables_paie():
@@ -155,6 +183,9 @@ def enregistrer_variables_paie():
 
     conn = get_db()
     nb_saved = 0
+    # Salaries dont une variable de paie change ce mois-ci : leur validation
+    # eventuelle en preparation de paie sera retiree (case a recocher).
+    uids_modifies = []
 
     try:
         for uid in user_ids:
@@ -171,12 +202,29 @@ def enregistrer_variables_paie():
             autres_reg = request.form.get(f'autres_regularisation_{uid}', 0, type=float)
             commentaire = request.form.get(f'commentaire_{uid}', '').strip() or None
 
-            # Upsert donnees mensuelles
+            # Donnees existantes (sert a la fois a detecter un changement et a
+            # l'upsert ci-dessous).
             existing = conn.execute(
-                'SELECT id FROM variables_paie WHERE user_id = ? AND mois = ? AND annee = ?',
+                'SELECT * FROM variables_paie WHERE user_id = ? AND mois = ? AND annee = ?',
                 (uid, mois, annee)
             ).fetchone()
 
+            nouveau = {
+                'mutuelle': mutuelle,
+                'nb_enfants': nb_enfants,
+                'heures_reelles': heures_reelles,
+                'heures_supps': heures_supps,
+                'transport': transport,
+                'acompte': acompte,
+                'saisie_salaire': saisie_salaire,
+                'pret_avance': pret_avance,
+                'autres_regularisation': autres_reg,
+                'commentaire': commentaire,
+            }
+            if _variables_modifiees(existing, nouveau):
+                uids_modifies.append(uid)
+
+            # Upsert donnees mensuelles
             if existing:
                 conn.execute('''
                     UPDATE variables_paie
@@ -220,14 +268,35 @@ def enregistrer_variables_paie():
 
             nb_saved += 1
 
+        # Toute modification d'une variable retire la validation "traite" de la
+        # preparation de paie pour ce salarie/mois : le prestataire doit ainsi
+        # revoir et revalider les bulletins concernes. On ne touche que les
+        # lignes encore cochees (traite = 1) afin de compter les seules
+        # devalidations reelles.
+        nb_devalidees = 0
+        if uids_modifies:
+            placeholders = ','.join('?' for _ in uids_modifies)
+            cur = conn.execute(f'''
+                UPDATE prepa_paie_statut
+                SET traite = 0, updated_at = CURRENT_TIMESTAMP
+                WHERE mois = ? AND annee = ? AND traite = 1
+                  AND user_id IN ({placeholders})
+            ''', (mois, annee, *uids_modifies))
+            nb_devalidees = cur.rowcount
+
         # Trace d'audit dans la meme transaction que l'enregistrement
         journaliser_action(
             conn, ACTION_ENREG_VARIABLES_PAIE,
             cible_type='mois_paie',
-            details=f"{nb_saved} salarie(s), mois={mois}/{annee}",
+            details=f"{nb_saved} salarie(s), mois={mois}/{annee}, "
+                    f"{nb_devalidees} prepa paie devalidee(s)",
         )
         conn.commit()
-        flash(f"Variables de paie enregistrees pour {nb_saved} salarie(s) - {NOMS_MOIS[mois]} {annee}.", 'success')
+        msg = f"Variables de paie enregistrees pour {nb_saved} salarie(s) - {NOMS_MOIS[mois]} {annee}."
+        if nb_devalidees:
+            msg += (f" {nb_devalidees} validation(s) de preparation de paie retiree(s) "
+                    "suite a modification (a revalider par le prestataire).")
+        flash(msg, 'success')
     except Exception:
         conn.rollback()
         logger.exception(

--- a/tests/test_variables_paie.py
+++ b/tests/test_variables_paie.py
@@ -220,3 +220,101 @@ class TestPageVariablesPaie:
             ).fetchone()
             assert row['t'] == 'integer'
             assert row['mutuelle'] == 1
+
+
+class TestDevalidationPrepaPaie:
+    """Toute modification d'une variable de paie retire la validation 'traite'
+    de la preparation de paie pour le(s) salarie(s) reellement modifie(s)."""
+
+    def _valider_prepa(self, db, user_id, mois=6, annee=2026):
+        """Marque un salarie comme 'traite' en preparation de paie."""
+        db.execute(
+            'INSERT INTO prepa_paie_statut (user_id, mois, annee, traite) '
+            'VALUES (?, ?, ?, 1)', (user_id, mois, annee)
+        )
+        db.commit()
+
+    def _traite(self, db, user_id, mois=6, annee=2026):
+        """Retourne la valeur 'traite' (ou None si aucune ligne)."""
+        row = db.execute(
+            'SELECT traite FROM prepa_paie_statut '
+            'WHERE user_id = ? AND mois = ? AND annee = ?',
+            (user_id, mois, annee)
+        ).fetchone()
+        return row['traite'] if row else None
+
+    def test_modification_retire_la_validation(self, comptable_client, sample_users, app, db):
+        """Modifier une variable d'un salarie deja valide retire sa case."""
+        salarie_id = sample_users['salarie_id']
+        with app.app_context():
+            self._valider_prepa(db, salarie_id)
+
+        comptable_client.post('/variables_paie/enregistrer', data={
+            'mois': '6', 'annee': '2026',
+            'user_ids': [str(salarie_id)],
+            f'transport_{salarie_id}': '50',
+        }, follow_redirects=True)
+
+        with app.app_context():
+            assert self._traite(db, salarie_id) == 0
+
+    def test_sans_modification_conserve_la_validation(self, comptable_client, sample_users, app, db):
+        """Re-enregistrer a l'identique ne doit PAS retirer la validation.
+
+        Le formulaire resoumet toutes les lignes : sans detection de
+        changement, la validation du prestataire serait effacee a chaque clic.
+        """
+        salarie_id = sample_users['salarie_id']
+        # Etat de reference enregistre
+        comptable_client.post('/variables_paie/enregistrer', data={
+            'mois': '6', 'annee': '2026',
+            'user_ids': [str(salarie_id)],
+            f'transport_{salarie_id}': '50',
+        }, follow_redirects=True)
+        with app.app_context():
+            self._valider_prepa(db, salarie_id)
+
+        # Nouvel enregistrement avec exactement les memes valeurs
+        comptable_client.post('/variables_paie/enregistrer', data={
+            'mois': '6', 'annee': '2026',
+            'user_ids': [str(salarie_id)],
+            f'transport_{salarie_id}': '50',
+        }, follow_redirects=True)
+
+        with app.app_context():
+            assert self._traite(db, salarie_id) == 1
+
+    def test_seul_salarie_modifie_est_devalide(self, comptable_client, sample_users, app, db):
+        """Seule la validation du salarie modifie est retiree (pas les autres)."""
+        salarie_id = sample_users['salarie_id']
+        responsable_id = sample_users['responsable_id']
+        with app.app_context():
+            self._valider_prepa(db, salarie_id)
+            self._valider_prepa(db, responsable_id)
+
+        # Le formulaire envoie les deux lignes, mais seul le salarie change
+        comptable_client.post('/variables_paie/enregistrer', data={
+            'mois': '6', 'annee': '2026',
+            'user_ids': [str(salarie_id), str(responsable_id)],
+            f'transport_{salarie_id}': '50',
+        }, follow_redirects=True)
+
+        with app.app_context():
+            assert self._traite(db, salarie_id) == 0
+            assert self._traite(db, responsable_id) == 1
+
+    def test_modification_autre_mois_sans_effet(self, comptable_client, sample_users, app, db):
+        """Une modification sur un mois ne touche pas la validation d'un autre mois."""
+        salarie_id = sample_users['salarie_id']
+        with app.app_context():
+            self._valider_prepa(db, salarie_id, mois=5, annee=2026)
+
+        # Modification sur juin : la validation de mai doit rester intacte
+        comptable_client.post('/variables_paie/enregistrer', data={
+            'mois': '6', 'annee': '2026',
+            'user_ids': [str(salarie_id)],
+            f'transport_{salarie_id}': '50',
+        }, follow_redirects=True)
+
+        with app.app_context():
+            assert self._traite(db, salarie_id, mois=5, annee=2026) == 1


### PR DESCRIPTION
## Objectif

Sur la page **Préparation de paie**, le prestataire coche les salariés traités. Cette PR fait en sorte que **toute modification des variables d'un salarié pour un mois** (page **Variables de paie**) **retire automatiquement sa case « traité »** pour ce mois.

Ainsi, au moment d'éditer les bulletins, le prestataire repère immédiatement les lignes modifiées après sa validation et peut vérifier que tout est réellement validé.

## Comportement

- L'enregistrement des variables de paie compare, pour chaque salarié, les **nouvelles valeurs** aux **valeurs existantes** (mêmes champs que ceux affichés en prépa paie : mutuelle, enfants, heures, transport, acompte, saisie/salaire, prêt/avance, autres régul., commentaire).
- Seuls les salariés **réellement modifiés** voient leur validation retirée — important car le formulaire resoumet **toutes** les lignes à chaque clic (sinon on effacerait toutes les validations à chaque enregistrement).
- La dévalidation est **ciblée** : uniquement le(s) salarié(s) concerné(s) et uniquement le **mois** enregistré.
- Le comptable est informé du nombre de validations retirées (message flash + trace dans le journal d'audit `enregistrement_variables_paie`).

## Implémentation

- `blueprints/variables_paie.py`
  - Nouvelle fonction `_variables_modifiees(ancien, nouveau)` (détection de changement, tolérance « vide = 0 » alignée sur l'affichage prépa paie).
  - `enregistrer_variables_paie` : collecte des `user_id` modifiés puis `UPDATE prepa_paie_statut SET traite = 0 ... WHERE traite = 1` pour le mois, dans la même transaction.

## Tests

4 nouveaux tests (`tests/test_variables_paie.py` → `TestDevalidationPrepaPaie`) :
- modification ⇒ validation retirée ;
- ré-enregistrement à l'identique ⇒ validation **conservée** ;
- seul le salarié modifié est dévalidé ;
- un autre mois n'est pas impacté.

✅ Suite complète : **442 passed**.

https://claude.ai/code/session_01USMhP6BKrJvF52A932ev6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01USMhP6BKrJvF52A932ev6b)_