### PR TITLE
Ajout du module CSE (RH &amp; Paie)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Gestion des dossiers de subventions en kanban (Nouveau → Envoye → Accepte / Refuse)
 - Gestion des benevoles avec suivi des heures assignees
 
+### CSE (Comite Social et Economique)
+- Accessible depuis le menu **RH & Paie**
+- Designation des membres du CSE par la direction et la comptabilite (liste deroulante des salaries, ajout / suppression)
+- Espace reserve aux membres du CSE :
+  - Message a l'attention des salaries avec date de validite (un seul message affiche a la fois ; archivage automatique a l'expiration)
+  - Budget simplifie : soldes de depart banque / caisse (avec date), entrees et sorties (date, montant, commentaire)
+  - Bilan annuel imprimable reprenant l'ensemble des mouvements de l'annee selectionnee
+- Bandeau "Message du CSE a lire" en haut du tableau de bord (ouverture dans une fenetre, compatible mobile)
+
 ### Tableau de bord direction
 - Vue d'ensemble effectifs, absences, validations et anomalies
 - Demandes de recuperation en attente et top conges cumules
@@ -210,6 +219,7 @@ CS-PILOT/
 │   ├── subventions.py         # Gestion des subventions (kanban)
 │   ├── benevoles.py           # Gestion des benevoles
 │   ├── salles.py              # Reservations de salles
+│   ├── cse.py                 # CSE (membres, messages, budget, bilan)
 │   ├── parametres.py          # Parametres personnels
 │   ├── api_keys.py            # Gestion des cles API
 │   └── notifications.py       # Notifications email

--- a/app.py
+++ b/app.py
@@ -244,6 +244,7 @@ from blueprints.compte_resultat import compte_resultat_bp
 from blueprints.indicateurs_financiers import indicateurs_financiers_bp
 from blueprints.import_bi import import_bi_bp
 from blueprints.commandes_salaries import commandes_salaries_bp
+from blueprints.cse import cse_bp
 
 app.register_blueprint(auth)
 app.register_blueprint(dashboard_bp)
@@ -294,6 +295,7 @@ app.register_blueprint(compte_resultat_bp)
 app.register_blueprint(indicateurs_financiers_bp)
 app.register_blueprint(import_bi_bp)
 app.register_blueprint(commandes_salaries_bp)
+app.register_blueprint(cse_bp)
 
 
 # ==================== Context Processors ====================
@@ -408,6 +410,36 @@ def inject_app_options():
             'generation_contrats_responsable_autorise': True,
             'budget_previsionnel_responsable_autorise': True,
         }
+
+
+@app.context_processor
+def inject_cse_context():
+    """Injecte le contexte CSE (rôle et message actif) dans tous les templates."""
+    defaults = {
+        'is_cse_membre': False,
+        'is_cse_gestionnaire': False,
+        'cse_message_actif': None,
+    }
+    if 'user_id' not in session:
+        return defaults
+
+    profil = session.get('profil', '')
+    conn = None
+    try:
+        from blueprints.cse import est_membre_cse, get_message_actif, PROFILS_GESTION
+        conn = get_db()
+        is_membre = est_membre_cse(conn, session.get('user_id'))
+        message_actif = get_message_actif(conn) if profil != 'prestataire' else None
+        return {
+            'is_cse_membre': is_membre,
+            'is_cse_gestionnaire': profil in PROFILS_GESTION,
+            'cse_message_actif': message_actif,
+        }
+    except Exception:
+        return defaults
+    finally:
+        if conn:
+            conn.close()
 
 
 @app.errorhandler(429)

--- a/blueprints/cse.py
+++ b/blueprints/cse.py
@@ -251,7 +251,10 @@ def _calculer_bilan_annuel(conn, annee):
         sorties = sum(m['montant'] for m in mouvements
                       if m['compte'] == compte and m['type'] == 'sortie')
 
-        base = soldes_init[compte]['montant'] if soldes_init[compte] else 0.0
+        # Le solde de départ ne compte que si sa date de référence est atteinte
+        # à la fin de l'année du bilan (sinon il gonflerait les années antérieures).
+        solde_row = soldes_init[compte]
+        base = solde_row['montant'] if (solde_row and solde_row['date_solde'] <= fin_annee) else 0.0
         agg = conn.execute(
             '''
             SELECT

--- a/blueprints/cse.py
+++ b/blueprints/cse.py
@@ -1,0 +1,739 @@
+"""
+Module CSE (Comité Social et Économique).
+
+Accessible depuis le menu RH & Paie :
+- La direction et le comptable désignent les membres du CSE (ajout / suppression).
+- Les membres du CSE disposent d'un espace dédié :
+    * un message à l'attention des salariés (avec date de validité, un seul actif
+      à la fois, archivage automatique des messages expirés) ;
+    * un budget simplifié (soldes de départ banque / caisse, entrées / sorties) ;
+    * un bilan annuel imprimable reprenant l'ensemble des mouvements de l'année.
+"""
+import re
+from datetime import date, datetime
+
+from flask import (
+    Blueprint, flash, redirect, render_template, request, session, url_for
+)
+
+from database import get_db
+from utils import login_required
+
+cse_bp = Blueprint('cse_bp', __name__)
+
+# Profils habilités à gérer la composition du CSE (désignation des membres).
+PROFILS_GESTION = ('directeur', 'comptable')
+
+# Comptes du budget du CSE.
+COMPTES = {'banque': 'Banque', 'caisse': 'Caisse'}
+# Types de mouvement.
+TYPES_MOUVEMENT = {'entree': 'Entrée', 'sortie': 'Sortie'}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Helpers d'accès
+# ──────────────────────────────────────────────────────────────────────────
+
+def _is_gestionnaire():
+    """La direction et le comptable gèrent la composition du CSE."""
+    return session.get('profil') in PROFILS_GESTION
+
+
+def est_membre_cse(conn, user_id):
+    """Indique si l'utilisateur est désigné comme membre du CSE."""
+    if not user_id:
+        return False
+    row = conn.execute(
+        "SELECT 1 FROM cse_membres WHERE user_id = ?", (user_id,)
+    ).fetchone()
+    return row is not None
+
+
+def _peut_acceder(conn):
+    """Accès au module : gestionnaire (direction/comptable) ou membre du CSE."""
+    return _is_gestionnaire() or est_membre_cse(conn, session.get('user_id'))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Helpers de formatage / validation
+# ──────────────────────────────────────────────────────────────────────────
+
+def _today():
+    return date.today().isoformat()
+
+
+def _format_euro(value):
+    """Formate un montant en euros à la française : 1 234,56 €."""
+    if value is None:
+        value = 0
+    formatted = f"{value:,.2f}".replace(',', ' ').replace('.', ',')
+    return f"{formatted} €"
+
+
+def _parse_montant(raw_value, *, signe_autorise=False, zero_autorise=False):
+    """Convertit une saisie monétaire en float.
+
+    Accepte la virgule ou le point décimal, max 2 décimales. Lève ValueError
+    si la saisie est vide ou invalide. Par défaut, refuse les montants négatifs
+    et nuls (mouvements). Les soldes de départ autorisent négatif et zéro.
+    """
+    value = (raw_value or '').strip()
+    for sep in (' ', ' ', ' ', '€'):
+        value = value.replace(sep, '')
+    if not value:
+        raise ValueError
+
+    negatif = False
+    if value.startswith('-'):
+        if not signe_autorise:
+            raise ValueError
+        negatif = True
+        value = value[1:]
+
+    if value.count(',') > 1 or value.count('.') > 1 or (',' in value and '.' in value):
+        raise ValueError
+
+    normalized = value.replace(',', '.')
+    if not re.fullmatch(r'\d+(?:\.\d{1,2})?', normalized):
+        raise ValueError
+
+    montant = float(normalized)
+    if montant == 0 and not zero_autorise:
+        raise ValueError
+    return -montant if negatif else montant
+
+
+def _parse_date(raw_value):
+    """Valide une date 'YYYY-MM-DD' et la retourne normalisée."""
+    value = (raw_value or '').strip()
+    try:
+        return datetime.strptime(value, '%Y-%m-%d').strftime('%Y-%m-%d')
+    except ValueError:
+        raise ValueError
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Helpers métier : membres
+# ──────────────────────────────────────────────────────────────────────────
+
+def _get_membres(conn):
+    """Liste des membres du CSE avec les informations du salarié."""
+    return conn.execute(
+        '''
+        SELECT m.id, m.user_id, m.created_at,
+               u.prenom, u.nom, u.profil
+        FROM cse_membres m
+        JOIN users u ON u.id = m.user_id
+        ORDER BY u.nom COLLATE NOCASE, u.prenom COLLATE NOCASE
+        '''
+    ).fetchall()
+
+
+def _get_salaries_disponibles(conn):
+    """Salariés actifs pouvant être désignés membres (hors prestataires et
+    membres déjà désignés)."""
+    return conn.execute(
+        '''
+        SELECT id, prenom, nom, profil
+        FROM users
+        WHERE actif = 1
+          AND profil != 'prestataire'
+          AND id NOT IN (SELECT user_id FROM cse_membres)
+        ORDER BY nom COLLATE NOCASE, prenom COLLATE NOCASE
+        '''
+    ).fetchall()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Helpers métier : messages
+# ──────────────────────────────────────────────────────────────────────────
+
+def _archiver_messages_expires(conn):
+    """Archive les messages dont la date de validité est dépassée."""
+    conn.execute(
+        '''
+        UPDATE cse_messages
+        SET statut = 'archive',
+            archive_le = COALESCE(archive_le, ?)
+        WHERE statut = 'actif' AND date_validite < ?
+        ''',
+        (datetime.now().strftime('%Y-%m-%d %H:%M:%S'), _today())
+    )
+    conn.commit()
+
+
+def get_message_actif(conn):
+    """Retourne le message du CSE actuellement affichable, ou None.
+
+    Un seul message peut être actif : statut 'actif' et date de validité non
+    dépassée. Les messages expirés sont filtrés par la date.
+    """
+    return conn.execute(
+        '''
+        SELECT m.*, u.prenom AS auteur_prenom, u.nom AS auteur_nom
+        FROM cse_messages m
+        LEFT JOIN users u ON u.id = m.cree_par
+        WHERE m.statut = 'actif' AND m.date_validite >= ?
+        ORDER BY m.created_at DESC, m.id DESC
+        LIMIT 1
+        ''',
+        (_today(),)
+    ).fetchone()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Helpers métier : budget
+# ──────────────────────────────────────────────────────────────────────────
+
+def _get_soldes_initiaux(conn):
+    """Retourne les soldes de départ par compte : {compte: row|None}."""
+    rows = conn.execute("SELECT * FROM cse_soldes_initiaux").fetchall()
+    par_compte = {r['compte']: r for r in rows}
+    return {compte: par_compte.get(compte) for compte in COMPTES}
+
+
+def _calculer_soldes_courants(conn):
+    """Solde courant par compte = solde de départ + entrées - sorties."""
+    soldes_init = _get_soldes_initiaux(conn)
+    soldes = {}
+    for compte in COMPTES:
+        base = soldes_init[compte]['montant'] if soldes_init[compte] else 0.0
+        agg = conn.execute(
+            '''
+            SELECT
+                COALESCE(SUM(CASE WHEN type = 'entree' THEN montant ELSE 0 END), 0) AS entrees,
+                COALESCE(SUM(CASE WHEN type = 'sortie' THEN montant ELSE 0 END), 0) AS sorties
+            FROM cse_mouvements WHERE compte = ?
+            ''',
+            (compte,)
+        ).fetchone()
+        soldes[compte] = base + agg['entrees'] - agg['sorties']
+    soldes['total'] = soldes['banque'] + soldes['caisse']
+    return soldes
+
+
+def _annees_disponibles(conn):
+    """Années pour lesquelles un bilan est pertinent (dates des opérations)."""
+    annees = set()
+    for r in conn.execute(
+        "SELECT DISTINCT substr(date_mouvement, 1, 4) AS a FROM cse_mouvements"
+    ).fetchall():
+        if r['a']:
+            annees.add(r['a'])
+    for r in conn.execute(
+        "SELECT DISTINCT substr(date_solde, 1, 4) AS a FROM cse_soldes_initiaux"
+    ).fetchall():
+        if r['a']:
+            annees.add(r['a'])
+    annees.add(str(date.today().year))
+    return sorted(annees, reverse=True)
+
+
+def _calculer_bilan_annuel(conn, annee):
+    """Construit le bilan d'une année : mouvements, totaux et soldes."""
+    annee = str(annee)
+    mouvements = conn.execute(
+        '''
+        SELECT * FROM cse_mouvements
+        WHERE substr(date_mouvement, 1, 4) = ?
+        ORDER BY date_mouvement ASC, id ASC
+        ''',
+        (annee,)
+    ).fetchall()
+
+    fin_annee = f"{annee}-12-31"
+    soldes_init = _get_soldes_initiaux(conn)
+
+    comptes = {}
+    for compte in COMPTES:
+        entrees = sum(m['montant'] for m in mouvements
+                      if m['compte'] == compte and m['type'] == 'entree')
+        sorties = sum(m['montant'] for m in mouvements
+                      if m['compte'] == compte and m['type'] == 'sortie')
+
+        base = soldes_init[compte]['montant'] if soldes_init[compte] else 0.0
+        agg = conn.execute(
+            '''
+            SELECT
+                COALESCE(SUM(CASE WHEN type = 'entree' THEN montant ELSE 0 END), 0) AS e,
+                COALESCE(SUM(CASE WHEN type = 'sortie' THEN montant ELSE 0 END), 0) AS s
+            FROM cse_mouvements
+            WHERE compte = ? AND date_mouvement <= ?
+            ''',
+            (compte, fin_annee)
+        ).fetchone()
+        solde_fin = base + agg['e'] - agg['s']
+        solde_debut = solde_fin - (entrees - sorties)
+
+        comptes[compte] = {
+            'entrees': entrees,
+            'sorties': sorties,
+            'variation': entrees - sorties,
+            'solde_debut': solde_debut,
+            'solde_fin': solde_fin,
+            'entrees_fmt': _format_euro(entrees),
+            'sorties_fmt': _format_euro(sorties),
+            'variation_fmt': _format_euro(entrees - sorties),
+            'solde_debut_fmt': _format_euro(solde_debut),
+            'solde_fin_fmt': _format_euro(solde_fin),
+        }
+
+    total = {}
+    for key in ('entrees', 'sorties', 'variation', 'solde_debut', 'solde_fin'):
+        total[key] = sum(c[key] for c in comptes.values())
+        total[key + '_fmt'] = _format_euro(total[key])
+
+    lignes = []
+    for m in mouvements:
+        lignes.append({
+            'id': m['id'],
+            'date': m['date_mouvement'],
+            'compte': m['compte'],
+            'compte_label': COMPTES.get(m['compte'], m['compte']),
+            'type': m['type'],
+            'type_label': TYPES_MOUVEMENT.get(m['type'], m['type']),
+            'montant': m['montant'],
+            'montant_fmt': _format_euro(m['montant']),
+            'commentaire': m['commentaire'] or '',
+        })
+
+    return {'annee': annee, 'lignes': lignes, 'comptes': comptes, 'total': total}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Routes : accueil + gestion des membres
+# ──────────────────────────────────────────────────────────────────────────
+
+@cse_bp.route('/cse')
+@login_required
+def cse_accueil():
+    """Page d'accueil du module CSE."""
+    conn = get_db()
+    try:
+        if not _peut_acceder(conn):
+            flash("Accès réservé au CSE.", "error")
+            return redirect(url_for('dashboard_bp.dashboard'))
+
+        is_gestionnaire = _is_gestionnaire()
+        is_membre = est_membre_cse(conn, session.get('user_id'))
+
+        membres = _get_membres(conn) if is_gestionnaire else []
+        salaries = _get_salaries_disponibles(conn) if is_gestionnaire else []
+
+        message_actif = None
+        if is_membre:
+            _archiver_messages_expires(conn)
+            message_actif = get_message_actif(conn)
+    finally:
+        conn.close()
+
+    return render_template(
+        'cse.html',
+        is_gestionnaire=is_gestionnaire,
+        is_membre=is_membre,
+        membres=membres,
+        salaries=salaries,
+        message_actif=message_actif,
+        profils_labels={'directeur': 'Direction', 'comptable': 'Comptable',
+                        'responsable': 'Responsable', 'salarie': 'Salarié'},
+    )
+
+
+@cse_bp.route('/cse/membres/ajouter', methods=['POST'])
+@login_required
+def ajouter_membre():
+    """Désigne un salarié comme membre du CSE (direction / comptable)."""
+    if not _is_gestionnaire():
+        flash("Seules la direction et la comptabilité peuvent désigner les membres du CSE.", "error")
+        return redirect(url_for('cse_bp.cse_accueil'))
+
+    try:
+        user_id = int(request.form.get('user_id', ''))
+    except (TypeError, ValueError):
+        flash("Veuillez sélectionner un salarié.", "error")
+        return redirect(url_for('cse_bp.cse_accueil'))
+
+    conn = get_db()
+    try:
+        salarie = conn.execute(
+            "SELECT id, prenom, nom FROM users WHERE id = ? AND actif = 1 AND profil != 'prestataire'",
+            (user_id,)
+        ).fetchone()
+        if not salarie:
+            flash("Salarié introuvable.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        deja = conn.execute(
+            "SELECT 1 FROM cse_membres WHERE user_id = ?", (user_id,)
+        ).fetchone()
+        if deja:
+            flash(f"{salarie['prenom']} {salarie['nom']} fait déjà partie du CSE.", "warning")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        conn.execute(
+            "INSERT INTO cse_membres (user_id, ajoute_par) VALUES (?, ?)",
+            (user_id, session['user_id'])
+        )
+        conn.commit()
+        flash(f"{salarie['prenom']} {salarie['nom']} a été ajouté(e) au CSE.", "success")
+    finally:
+        conn.close()
+
+    return redirect(url_for('cse_bp.cse_accueil'))
+
+
+@cse_bp.route('/cse/membres/<int:membre_id>/supprimer', methods=['POST'])
+@login_required
+def supprimer_membre(membre_id):
+    """Retire un membre du CSE (direction / comptable)."""
+    if not _is_gestionnaire():
+        flash("Seules la direction et la comptabilité peuvent modifier les membres du CSE.", "error")
+        return redirect(url_for('cse_bp.cse_accueil'))
+
+    conn = get_db()
+    try:
+        membre = conn.execute(
+            '''
+            SELECT m.id, u.prenom, u.nom
+            FROM cse_membres m JOIN users u ON u.id = m.user_id
+            WHERE m.id = ?
+            ''',
+            (membre_id,)
+        ).fetchone()
+        if not membre:
+            flash("Membre introuvable.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        conn.execute("DELETE FROM cse_membres WHERE id = ?", (membre_id,))
+        conn.commit()
+        flash(f"{membre['prenom']} {membre['nom']} a été retiré(e) du CSE.", "success")
+    finally:
+        conn.close()
+
+    return redirect(url_for('cse_bp.cse_accueil'))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Routes : messages aux salariés (membres du CSE)
+# ──────────────────────────────────────────────────────────────────────────
+
+@cse_bp.route('/cse/messages')
+@login_required
+def cse_messages():
+    """Gestion des messages à l'attention des salariés."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        _archiver_messages_expires(conn)
+        message_actif = get_message_actif(conn)
+
+        archives = conn.execute(
+            '''
+            SELECT m.*, u.prenom AS auteur_prenom, u.nom AS auteur_nom
+            FROM cse_messages m
+            LEFT JOIN users u ON u.id = m.cree_par
+            WHERE NOT (m.statut = 'actif' AND m.date_validite >= ?)
+            ORDER BY m.created_at DESC, m.id DESC
+            ''',
+            (_today(),)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    return render_template(
+        'cse_messages.html',
+        message_actif=message_actif,
+        archives=archives,
+        aujourd_hui=_today(),
+    )
+
+
+@cse_bp.route('/cse/messages/creer', methods=['POST'])
+@login_required
+def creer_message():
+    """Publie un nouveau message (archive automatiquement le précédent)."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        titre = (request.form.get('titre') or '').strip()
+        contenu = (request.form.get('contenu') or '').strip()
+        try:
+            date_validite = _parse_date(request.form.get('date_validite'))
+        except ValueError:
+            flash("La date de validité est invalide.", "error")
+            return redirect(url_for('cse_bp.cse_messages'))
+
+        if not contenu:
+            flash("Le contenu du message est obligatoire.", "error")
+            return redirect(url_for('cse_bp.cse_messages'))
+        if date_validite < _today():
+            flash("La date de validité doit être aujourd'hui ou dans le futur.", "error")
+            return redirect(url_for('cse_bp.cse_messages'))
+
+        # Un seul message actif à la fois : on archive l'éventuel précédent.
+        conn.execute(
+            '''
+            UPDATE cse_messages
+            SET statut = 'archive', archive_le = COALESCE(archive_le, ?)
+            WHERE statut = 'actif'
+            ''',
+            (datetime.now().strftime('%Y-%m-%d %H:%M:%S'),)
+        )
+        conn.execute(
+            '''
+            INSERT INTO cse_messages (titre, contenu, date_validite, statut, cree_par)
+            VALUES (?, ?, ?, 'actif', ?)
+            ''',
+            (titre or None, contenu, date_validite, session['user_id'])
+        )
+        conn.commit()
+        flash("Le message a été publié.", "success")
+    finally:
+        conn.close()
+
+    return redirect(url_for('cse_bp.cse_messages'))
+
+
+@cse_bp.route('/cse/messages/<int:message_id>/archiver', methods=['POST'])
+@login_required
+def archiver_message(message_id):
+    """Retire (archive) manuellement le message actif."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        message = conn.execute(
+            "SELECT id FROM cse_messages WHERE id = ?", (message_id,)
+        ).fetchone()
+        if not message:
+            flash("Message introuvable.", "error")
+            return redirect(url_for('cse_bp.cse_messages'))
+
+        conn.execute(
+            '''
+            UPDATE cse_messages
+            SET statut = 'archive', archive_le = COALESCE(archive_le, ?)
+            WHERE id = ?
+            ''',
+            (datetime.now().strftime('%Y-%m-%d %H:%M:%S'), message_id)
+        )
+        conn.commit()
+        flash("Le message a été retiré et archivé.", "success")
+    finally:
+        conn.close()
+
+    return redirect(url_for('cse_bp.cse_messages'))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Routes : budget (membres du CSE)
+# ──────────────────────────────────────────────────────────────────────────
+
+@cse_bp.route('/cse/budget')
+@login_required
+def cse_budget():
+    """Gestion simplifiée du budget du CSE."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        soldes_init = _get_soldes_initiaux(conn)
+        soldes_courants = _calculer_soldes_courants(conn)
+
+        rows = conn.execute(
+            '''
+            SELECT mv.*, u.prenom, u.nom
+            FROM cse_mouvements mv
+            LEFT JOIN users u ON u.id = mv.cree_par
+            ORDER BY mv.date_mouvement DESC, mv.id DESC
+            '''
+        ).fetchall()
+        annees = _annees_disponibles(conn)
+    finally:
+        conn.close()
+
+    mouvements = []
+    for m in rows:
+        mouvements.append({
+            'id': m['id'],
+            'date': m['date_mouvement'],
+            'compte': m['compte'],
+            'compte_label': COMPTES.get(m['compte'], m['compte']),
+            'type': m['type'],
+            'type_label': TYPES_MOUVEMENT.get(m['type'], m['type']),
+            'montant': m['montant'],
+            'montant_fmt': _format_euro(m['montant']),
+            'commentaire': m['commentaire'] or '',
+        })
+
+    soldes_init_fmt = {}
+    for compte, row in soldes_init.items():
+        soldes_init_fmt[compte] = {
+            'defini': row is not None,
+            'date': row['date_solde'] if row else None,
+            'montant': row['montant'] if row else 0.0,
+            'montant_fmt': _format_euro(row['montant'] if row else 0.0),
+        }
+
+    return render_template(
+        'cse_budget.html',
+        comptes=COMPTES,
+        types_mouvement=TYPES_MOUVEMENT,
+        soldes_init=soldes_init_fmt,
+        soldes_courants={k: _format_euro(v) for k, v in soldes_courants.items()},
+        soldes_courants_val=soldes_courants,
+        mouvements=mouvements,
+        annees=annees,
+        aujourd_hui=_today(),
+    )
+
+
+@cse_bp.route('/cse/budget/solde', methods=['POST'])
+@login_required
+def definir_solde():
+    """Définit (ou met à jour) un solde de départ banque / caisse."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        compte = request.form.get('compte')
+        if compte not in COMPTES:
+            flash("Compte invalide.", "error")
+            return redirect(url_for('cse_bp.cse_budget'))
+        try:
+            date_solde = _parse_date(request.form.get('date_solde'))
+            montant = _parse_montant(
+                request.form.get('montant'), signe_autorise=True, zero_autorise=True
+            )
+        except ValueError:
+            flash("La date ou le montant du solde de départ est invalide.", "error")
+            return redirect(url_for('cse_bp.cse_budget'))
+
+        conn.execute(
+            '''
+            INSERT INTO cse_soldes_initiaux (compte, date_solde, montant, updated_par, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(compte) DO UPDATE SET
+                date_solde = excluded.date_solde,
+                montant = excluded.montant,
+                updated_par = excluded.updated_par,
+                updated_at = excluded.updated_at
+            ''',
+            (compte, date_solde, montant, session['user_id'],
+             datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+        )
+        conn.commit()
+        flash(f"Solde de départ « {COMPTES[compte]} » enregistré.", "success")
+    finally:
+        conn.close()
+
+    return redirect(url_for('cse_bp.cse_budget'))
+
+
+@cse_bp.route('/cse/budget/mouvement', methods=['POST'])
+@login_required
+def ajouter_mouvement():
+    """Ajoute une entrée ou une sortie au budget du CSE."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        compte = request.form.get('compte')
+        type_mvt = request.form.get('type')
+        commentaire = (request.form.get('commentaire') or '').strip()
+
+        if compte not in COMPTES:
+            flash("Compte invalide.", "error")
+            return redirect(url_for('cse_bp.cse_budget'))
+        if type_mvt not in TYPES_MOUVEMENT:
+            flash("Type de mouvement invalide.", "error")
+            return redirect(url_for('cse_bp.cse_budget'))
+        try:
+            date_mvt = _parse_date(request.form.get('date_mouvement'))
+            montant = _parse_montant(request.form.get('montant'))
+        except ValueError:
+            flash("La date ou le montant du mouvement est invalide.", "error")
+            return redirect(url_for('cse_bp.cse_budget'))
+
+        conn.execute(
+            '''
+            INSERT INTO cse_mouvements (compte, type, date_mouvement, montant, commentaire, cree_par)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ''',
+            (compte, type_mvt, date_mvt, montant, commentaire or None, session['user_id'])
+        )
+        conn.commit()
+        flash("Le mouvement a été enregistré.", "success")
+    finally:
+        conn.close()
+
+    return redirect(url_for('cse_bp.cse_budget'))
+
+
+@cse_bp.route('/cse/budget/mouvement/<int:mouvement_id>/supprimer', methods=['POST'])
+@login_required
+def supprimer_mouvement(mouvement_id):
+    """Supprime un mouvement du budget du CSE."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        mvt = conn.execute(
+            "SELECT id FROM cse_mouvements WHERE id = ?", (mouvement_id,)
+        ).fetchone()
+        if not mvt:
+            flash("Mouvement introuvable.", "error")
+            return redirect(url_for('cse_bp.cse_budget'))
+
+        conn.execute("DELETE FROM cse_mouvements WHERE id = ?", (mouvement_id,))
+        conn.commit()
+        flash("Le mouvement a été supprimé.", "success")
+    finally:
+        conn.close()
+
+    return redirect(url_for('cse_bp.cse_budget'))
+
+
+@cse_bp.route('/cse/bilan')
+@login_required
+def cse_bilan():
+    """Bilan annuel imprimable du budget du CSE."""
+    conn = get_db()
+    try:
+        if not est_membre_cse(conn, session.get('user_id')):
+            flash("Accès réservé aux membres du CSE.", "error")
+            return redirect(url_for('cse_bp.cse_accueil'))
+
+        annees = _annees_disponibles(conn)
+        annee = request.args.get('annee', '').strip()
+        if annee not in annees:
+            annee = annees[0] if annees else str(date.today().year)
+
+        bilan = _calculer_bilan_annuel(conn, annee)
+    finally:
+        conn.close()
+
+    return render_template(
+        'cse_bilan.html',
+        comptes=COMPTES,
+        annees=annees,
+        annee=annee,
+        bilan=bilan,
+        genere_le=datetime.now().strftime('%d/%m/%Y à %H:%M'),
+    )

--- a/database.py
+++ b/database.py
@@ -77,6 +77,7 @@ ALL_MIGRATION_VERSIONS = [
     ('0037', 'Journal des acces'),
     ('0038', 'Correctif types variables paie'),
     ('0039', 'Journal des actions metier'),
+    ('0040', 'Module CSE'),
 ]
 
 # Postes de depense par defaut (migration 0012)
@@ -885,6 +886,58 @@ def init_db():
             FOREIGN KEY (delegated_by_user_id) REFERENCES users(id)
         )
     ''')
+
+    # ===== Module CSE (migration 0040) =====
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS cse_membres (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL UNIQUE,
+            ajoute_par INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            FOREIGN KEY (ajoute_par) REFERENCES users(id)
+        )
+    ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS cse_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            titre TEXT,
+            contenu TEXT NOT NULL,
+            date_validite TEXT NOT NULL,
+            statut TEXT NOT NULL DEFAULT 'actif',
+            cree_par INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            archive_le TEXT,
+            FOREIGN KEY (cree_par) REFERENCES users(id)
+        )
+    ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS cse_soldes_initiaux (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte TEXT NOT NULL UNIQUE,
+            date_solde TEXT NOT NULL,
+            montant REAL NOT NULL DEFAULT 0,
+            updated_par INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (updated_par) REFERENCES users(id)
+        )
+    ''')
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS cse_mouvements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte TEXT NOT NULL DEFAULT 'banque',
+            type TEXT NOT NULL,
+            date_mouvement TEXT NOT NULL,
+            montant REAL NOT NULL,
+            commentaire TEXT,
+            cree_par INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (cree_par) REFERENCES users(id)
+        )
+    ''')
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_cse_mouvements_date ON cse_mouvements(date_mouvement)"
+    )
 
     # ===== Tables salles (migration 0018) =====
     cursor.execute('''

--- a/migrations/0040_module_cse.py
+++ b/migrations/0040_module_cse.py
@@ -1,0 +1,95 @@
+"""
+Migration 0040 : Module CSE (Comité Social et Économique).
+
+Ajoute les tables nécessaires au module CSE accessible depuis RH & Paie :
+- cse_membres          : désignation des salariés membres du CSE
+- cse_messages         : messages à l'attention des salariés (avec date de validité)
+- cse_soldes_initiaux  : soldes de départ banque / caisse (avec date)
+- cse_mouvements       : entrées / sorties du budget du CSE
+"""
+
+NOM = "Module CSE"
+DESCRIPTION = (
+    "Ajoute les tables cse_membres, cse_messages, cse_soldes_initiaux et "
+    "cse_mouvements pour la gestion du CSE (membres, messages aux salariés, "
+    "budget simplifié et bilan annuel)."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+
+    cursor.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS cse_membres (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL UNIQUE,
+            ajoute_par INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            FOREIGN KEY (ajoute_par) REFERENCES users(id)
+        )
+        '''
+    )
+
+    cursor.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS cse_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            titre TEXT,
+            contenu TEXT NOT NULL,
+            date_validite TEXT NOT NULL,
+            statut TEXT NOT NULL DEFAULT 'actif',
+            cree_par INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            archive_le TEXT,
+            FOREIGN KEY (cree_par) REFERENCES users(id)
+        )
+        '''
+    )
+
+    cursor.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS cse_soldes_initiaux (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte TEXT NOT NULL UNIQUE,
+            date_solde TEXT NOT NULL,
+            montant REAL NOT NULL DEFAULT 0,
+            updated_par INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (updated_par) REFERENCES users(id)
+        )
+        '''
+    )
+
+    cursor.execute(
+        '''
+        CREATE TABLE IF NOT EXISTS cse_mouvements (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte TEXT NOT NULL DEFAULT 'banque',
+            type TEXT NOT NULL,
+            date_mouvement TEXT NOT NULL,
+            montant REAL NOT NULL,
+            commentaire TEXT,
+            cree_par INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (cree_par) REFERENCES users(id)
+        )
+        '''
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_cse_mouvements_date ON cse_mouvements(date_mouvement)"
+    )
+
+    conn.commit()
+
+
+def downgrade(conn):
+    """Annule la migration."""
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cse_mouvements")
+    cursor.execute("DROP TABLE IF EXISTS cse_soldes_initiaux")
+    cursor.execute("DROP TABLE IF EXISTS cse_messages")
+    cursor.execute("DROP TABLE IF EXISTS cse_membres")
+    conn.commit()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3643,3 +3643,154 @@ a.btn-icon:-webkit-any-link {
         justify-content: center;
     }
 }
+
+/* === Bannière "Message du CSE à lire" (tableau de bord) === */
+.cse-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    margin-bottom: 1.25rem;
+    padding: 0.85rem 1.1rem;
+    border: 1px solid var(--primary-light);
+    border-left: 4px solid var(--primary);
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, rgba(47, 93, 80, 0.10), rgba(47, 93, 80, 0.04));
+    color: var(--gray-900);
+    font-family: inherit;
+    font-size: 0.95rem;
+    text-align: left;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.cse-banner:hover {
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.cse-banner-icon {
+    font-size: 1.35rem;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.cse-banner-text {
+    flex: 1;
+    font-weight: 600;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.cse-banner-cta {
+    flex-shrink: 0;
+    font-weight: 700;
+    color: var(--primary);
+    white-space: nowrap;
+}
+
+[data-theme="dark"] .cse-banner {
+    background: linear-gradient(135deg, rgba(63, 118, 102, 0.22), rgba(63, 118, 102, 0.08));
+    color: var(--gray-900);
+}
+
+@media (max-width: 600px) {
+    .cse-banner {
+        font-size: 0.9rem;
+        padding: 0.75rem 0.9rem;
+        gap: 0.5rem;
+    }
+    .cse-banner-text {
+        white-space: normal;
+    }
+}
+
+/* === Module CSE === */
+.cse-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.cse-nav-card {
+    display: block;
+    padding: 1.25rem;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    background: var(--white);
+    box-shadow: var(--shadow-sm);
+    text-decoration: none;
+    color: var(--gray-900);
+    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.cse-nav-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--primary-light);
+}
+
+.cse-nav-card .cse-nav-icon {
+    font-size: 1.8rem;
+}
+
+.cse-nav-card h3 {
+    margin: 0.5rem 0 0.35rem;
+    font-size: 1.05rem;
+}
+
+.cse-nav-card p {
+    margin: 0;
+    color: var(--gray-500);
+    font-size: 0.85rem;
+    line-height: 1.45;
+}
+
+.cse-solde-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.cse-solde-card {
+    padding: 1.1rem 1.25rem;
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-lg);
+    background: var(--white);
+    box-shadow: var(--shadow-sm);
+}
+
+.cse-solde-card .cse-solde-label {
+    font-size: 0.82rem;
+    color: var(--gray-500);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.cse-solde-card .cse-solde-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 0.25rem;
+}
+
+.cse-solde-card.cse-solde-total {
+    border-color: var(--primary-light);
+    background: linear-gradient(135deg, rgba(47, 93, 80, 0.08), rgba(47, 93, 80, 0.02));
+}
+
+.cse-amount-in { color: var(--success); font-weight: 600; }
+.cse-amount-out { color: var(--danger); font-weight: 600; }
+
+@media print {
+    .sidebar, .sidebar-toggle, .sidebar-overlay, footer,
+    #cspChatBtn, #cspChatWindow, .no-print, .cse-banner {
+        display: none !important;
+    }
+    .main-content.has-sidebar { margin-left: 0 !important; }
+    .cse-print-only { display: block !important; }
+    .data-table { font-size: 0.85em; }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -74,6 +74,7 @@
                     <a href="{{ url_for('variables_paie_bp.variables_paie') }}">💰 Variables Paie</a>
                     <a href="{{ url_for('prepa_paie_bp.prepa_paie') }}">📋 Prépa Paie</a>
                     <a href="{{ url_for('planning_enfance_bp.planning_enfance') }}">🕐 Temps annualisé</a>
+                    <a href="{{ url_for('cse_bp.cse_accueil') }}">🧑‍⚖️ CSE</a>
                 </div>
             </div>
             <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
@@ -190,6 +191,7 @@
                     <a href="{{ url_for('variables_paie_bp.variables_paie') }}">💰 Variables Paie</a>
                     <a href="{{ url_for('prepa_paie_bp.prepa_paie') }}">📋 Prépa Paie</a>
                     <a href="{{ url_for('planning_enfance_bp.planning_enfance') }}">🕐 Temps annualisé</a>
+                    <a href="{{ url_for('cse_bp.cse_accueil') }}">🧑‍⚖️ CSE</a>
                 </div>
             </div>
             <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
@@ -309,6 +311,9 @@
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
                     {% endif %}
                     <a href="{{ url_for('planning_enfance_bp.planning_enfance') }}">🕐 Temps annualisé</a>
+                    {% if is_cse_membre %}
+                    <a href="{{ url_for('cse_bp.cse_accueil') }}">🧑‍⚖️ CSE</a>
+                    {% endif %}
                 </div>
             </div>
             <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
@@ -346,6 +351,9 @@
                 </div>
 	            </div>
                 <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
+                {% if is_cse_membre %}
+                <a href="{{ url_for('cse_bp.cse_accueil') }}" class="sidebar-link">🧑‍⚖️ CSE</a>
+                {% endif %}
                 <a href="{{ url_for('salles_bp.salles') }}" class="sidebar-link">🏠 Salles</a>
                 {% if can_access_vue_ensemble_validation %}
                 <a href="{{ url_for('validation_bp.vue_ensemble_validation') }}" class="sidebar-link">📋 Vue ensemble</a>
@@ -371,6 +379,14 @@
 
     <div class="main-content{% if session.user_id %} has-sidebar{% endif %}">
         <div class="container">
+            {% set cse_dashboard_endpoints = ['dashboard_bp.dashboard', 'dashboard_direction_bp.dashboard_direction', 'dashboard_comptable_bp.dashboard_comptable', 'dashboard_responsable_bp.dashboard_responsable'] %}
+            {% if cse_message_actif and request.endpoint in cse_dashboard_endpoints %}
+            <button type="button" class="cse-banner" onclick="cseOpenMessage()">
+                <span class="cse-banner-icon">📢</span>
+                <span class="cse-banner-text">Message du CSE à lire{% if cse_message_actif.titre %} — {{ cse_message_actif.titre }}{% endif %}</span>
+                <span class="cse-banner-cta">Lire&nbsp;›</span>
+            </button>
+            {% endif %}
             {% with messages = get_flashed_messages(with_categories=true) %}
                 {% if messages %}
                     {% for category, message in messages %}
@@ -388,6 +404,36 @@
             <p>CS-PILOT - Version {{ app_version }}</p>
         </footer>
     </div>
+
+    {% if cse_message_actif and request.endpoint in cse_dashboard_endpoints %}
+    {# ── Modale message du CSE ── #}
+    <div id="cseMessageModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)cseCloseMessage()">
+        <div class="modal-content" style="max-width:560px;">
+            <div class="modal-header">
+                <h3>📢 Message du CSE</h3>
+                <button class="modal-close" type="button" onclick="cseCloseMessage()" aria-label="Fermer">&times;</button>
+            </div>
+            <div style="padding:0 1.5rem 1.5rem;">
+                {% if cse_message_actif.titre %}
+                <h4 style="margin:0 0 .75rem;color:var(--gray-900);font-size:1.05rem;">{{ cse_message_actif.titre }}</h4>
+                {% endif %}
+                <p style="white-space:pre-wrap;word-break:break-word;line-height:1.6;color:var(--gray-700);margin:0 0 1rem;">{{ cse_message_actif.contenu }}</p>
+                <p style="font-size:.8rem;color:var(--gray-500);margin:0;">
+                    {% if cse_message_actif.auteur_prenom %}Publié par {{ cse_message_actif.auteur_prenom }} {{ cse_message_actif.auteur_nom }} · {% endif %}
+                    Valable jusqu'au {{ cse_message_actif.date_validite[8:10] }}/{{ cse_message_actif.date_validite[5:7] }}/{{ cse_message_actif.date_validite[0:4] }}
+                </p>
+                <div class="actions" style="margin-top:1.25rem;">
+                    <button type="button" class="btn btn-primary" onclick="cseCloseMessage()">J'ai lu</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        function cseOpenMessage(){var m=document.getElementById('cseMessageModal');if(m)m.style.display='flex';}
+        function cseCloseMessage(){var m=document.getElementById('cseMessageModal');if(m)m.style.display='none';}
+        document.addEventListener('keydown',function(e){if(e.key==='Escape')cseCloseMessage();});
+    </script>
+    {% endif %}
 
     {% if session.user_id and chatbot_enabled %}
     {# ── Chatbot contextuel flottant ── #}

--- a/templates/cse.html
+++ b/templates/cse.html
@@ -1,0 +1,115 @@
+{% extends "base.html" %}
+
+{% block title %}CSE - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="cse-page">
+    <h1>🧑‍⚖️ CSE</h1>
+    <p class="subtitle">Comité Social et Économique</p>
+
+    {% if is_gestionnaire %}
+    {# ── Gestion des membres (direction / comptable) ── #}
+    <div class="section">
+        <h2>👥 Membres du CSE</h2>
+        <p style="color:var(--gray-500);margin-top:-0.25rem;">
+            Désignez les salariés membres du CSE. Ils accèderont alors à leur espace
+            (messages aux salariés et budget) depuis ce menu.
+        </p>
+
+        <form method="POST" action="{{ url_for('cse_bp.ajouter_membre') }}" class="cse-add-form"
+              style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:flex-end;margin:1rem 0 1.5rem;">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="form-group" style="flex:1;min-width:240px;margin-bottom:0;">
+                <label for="user_id">Ajouter un salarié</label>
+                <select id="user_id" name="user_id" required {% if not salaries %}disabled{% endif %}>
+                    {% if salaries %}
+                    <option value="">— Sélectionner un salarié —</option>
+                    {% for s in salaries %}
+                    <option value="{{ s.id }}">{{ s.prenom }} {{ s.nom }}{% if s.profil %} ({{ profils_labels.get(s.profil, s.profil) }}){% endif %}</option>
+                    {% endfor %}
+                    {% else %}
+                    <option value="">Aucun salarié disponible</option>
+                    {% endif %}
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary" {% if not salaries %}disabled{% endif %}>➕ Ajouter</button>
+        </form>
+
+        {% if membres %}
+        <div class="table-responsive">
+            <table class="data-table data-table-cards">
+                <thead>
+                    <tr>
+                        <th>Nom</th>
+                        <th>Profil</th>
+                        <th>Désigné le</th>
+                        <th style="text-align:right;">Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for m in membres %}
+                    <tr>
+                        <td data-label="Nom"><strong>{{ m.prenom }} {{ m.nom }}</strong></td>
+                        <td data-label="Profil">{{ profils_labels.get(m.profil, m.profil) }}</td>
+                        <td data-label="Désigné le">{{ m.created_at[8:10] }}/{{ m.created_at[5:7] }}/{{ m.created_at[0:4] }}</td>
+                        <td data-label="Action" style="text-align:right;">
+                            <form method="POST" action="{{ url_for('cse_bp.supprimer_membre', membre_id=m.id) }}"
+                                  style="display:inline;" onsubmit="return confirm('Retirer {{ m.prenom }} {{ m.nom }} du CSE ?');">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn btn-secondary" style="padding:6px 12px;">🗑️ Retirer</button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="no-data">Aucun membre du CSE pour le moment.</p>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    {% if is_membre %}
+    {# ── Espace membre du CSE ── #}
+    <div class="section">
+        <h2>📂 Mon espace CSE</h2>
+        {% if message_actif %}
+        <p style="color:var(--gray-500);margin-top:-0.25rem;">
+            ✅ Un message est actuellement affiché aux salariés
+            (valable jusqu'au {{ message_actif.date_validite[8:10] }}/{{ message_actif.date_validite[5:7] }}/{{ message_actif.date_validite[0:4] }}).
+        </p>
+        {% else %}
+        <p style="color:var(--gray-500);margin-top:-0.25rem;">
+            Aucun message n'est actuellement affiché aux salariés.
+        </p>
+        {% endif %}
+
+        <div class="cse-cards">
+            <a class="cse-nav-card" href="{{ url_for('cse_bp.cse_messages') }}">
+                <div class="cse-nav-icon">📢</div>
+                <h3>Message aux salariés</h3>
+                <p>Publier un message avec une date de validité. Un seul message affiché à la fois.</p>
+            </a>
+            <a class="cse-nav-card" href="{{ url_for('cse_bp.cse_budget') }}">
+                <div class="cse-nav-icon">💶</div>
+                <h3>Budget du CSE</h3>
+                <p>Soldes de départ (banque / caisse), entrées et sorties.</p>
+            </a>
+            <a class="cse-nav-card" href="{{ url_for('cse_bp.cse_bilan') }}">
+                <div class="cse-nav-icon">🖨️</div>
+                <h3>Bilan annuel</h3>
+                <p>Récapitulatif des mouvements d'une année, imprimable.</p>
+            </a>
+        </div>
+    </div>
+    {% elif is_gestionnaire %}
+    <div class="section">
+        <p class="no-data" style="margin:0;">
+            L'espace CSE (messages et budget) est réservé aux membres du CSE.
+            Désignez-vous comme membre ci-dessus pour y accéder.
+        </p>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/cse.html
+++ b/templates/cse.html
@@ -54,7 +54,7 @@
                         <td data-label="Désigné le">{{ m.created_at[8:10] }}/{{ m.created_at[5:7] }}/{{ m.created_at[0:4] }}</td>
                         <td data-label="Action" style="text-align:right;">
                             <form method="POST" action="{{ url_for('cse_bp.supprimer_membre', membre_id=m.id) }}"
-                                  style="display:inline;" onsubmit="return confirm('Retirer {{ m.prenom }} {{ m.nom }} du CSE ?');">
+                                  class="cse-remove-form" data-membre="{{ m.prenom }} {{ m.nom }}" style="display:inline;">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="btn btn-secondary" style="padding:6px 12px;">🗑️ Retirer</button>
                             </form>
@@ -112,4 +112,18 @@
     </div>
     {% endif %}
 </div>
+
+<script>
+    // Confirmation de retrait : le nom est lu depuis un attribut data- (donnée,
+    // jamais interprétée comme du code), ce qui évite toute injection ou rupture
+    // de la chaîne JS lorsqu'un nom contient une apostrophe.
+    document.querySelectorAll('.cse-remove-form').forEach(function (form) {
+        form.addEventListener('submit', function (e) {
+            var nom = form.dataset.membre || 'ce membre';
+            if (!confirm('Retirer ' + nom + ' du CSE ?')) {
+                e.preventDefault();
+            }
+        });
+    });
+</script>
 {% endblock %}

--- a/templates/cse_bilan.html
+++ b/templates/cse_bilan.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+
+{% block title %}CSE · Bilan annuel - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="cse-page">
+    <div class="no-print" style="display:flex;justify-content:space-between;align-items:flex-end;gap:1rem;flex-wrap:wrap;">
+        <div>
+            <h1>🖨️ Bilan annuel du CSE</h1>
+            <p class="subtitle" style="margin:0;">
+                <a href="{{ url_for('cse_bp.cse_budget') }}">← Budget</a>
+            </p>
+        </div>
+        <div style="display:flex;gap:0.5rem;align-items:flex-end;flex-wrap:wrap;">
+            <form method="GET" action="{{ url_for('cse_bp.cse_bilan') }}" style="margin:0;">
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="annee">Année</label>
+                    <select id="annee" name="annee" onchange="this.form.submit()">
+                        {% for a in annees %}
+                        <option value="{{ a }}" {% if a == annee %}selected{% endif %}>{{ a }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <noscript><button type="submit" class="btn btn-secondary">Afficher</button></noscript>
+            </form>
+            <button type="button" class="btn btn-primary" onclick="window.print()">🖨️ Imprimer</button>
+        </div>
+    </div>
+
+    {# ── En-tête (visible à l'impression) ── #}
+    <div class="cse-print-header" style="margin:1.5rem 0;">
+        <h2 style="margin:0;">Bilan annuel du CSE — Année {{ annee }}</h2>
+        <p style="margin:0.25rem 0 0;color:var(--gray-500);font-size:0.85rem;">Édité le {{ genere_le }}</p>
+    </div>
+
+    {# ── Synthèse par compte ── #}
+    <div class="section">
+        <h2>Synthèse</h2>
+        <div class="table-responsive">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Compte</th>
+                        <th style="text-align:right;">Solde au 01/01</th>
+                        <th style="text-align:right;">Entrées</th>
+                        <th style="text-align:right;">Sorties</th>
+                        <th style="text-align:right;">Variation</th>
+                        <th style="text-align:right;">Solde au 31/12</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for ck, cl in comptes.items() %}
+                    <tr>
+                        <td>{{ cl }}</td>
+                        <td style="text-align:right;">{{ bilan.comptes[ck].solde_debut_fmt }}</td>
+                        <td style="text-align:right;" class="cse-amount-in">{{ bilan.comptes[ck].entrees_fmt }}</td>
+                        <td style="text-align:right;" class="cse-amount-out">{{ bilan.comptes[ck].sorties_fmt }}</td>
+                        <td style="text-align:right;">{{ bilan.comptes[ck].variation_fmt }}</td>
+                        <td style="text-align:right;"><strong>{{ bilan.comptes[ck].solde_fin_fmt }}</strong></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td><strong>Total</strong></td>
+                        <td style="text-align:right;"><strong>{{ bilan.total.solde_debut_fmt }}</strong></td>
+                        <td style="text-align:right;"><strong>{{ bilan.total.entrees_fmt }}</strong></td>
+                        <td style="text-align:right;"><strong>{{ bilan.total.sorties_fmt }}</strong></td>
+                        <td style="text-align:right;"><strong>{{ bilan.total.variation_fmt }}</strong></td>
+                        <td style="text-align:right;"><strong>{{ bilan.total.solde_fin_fmt }}</strong></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+
+    {# ── Détail des mouvements ── #}
+    <div class="section">
+        <h2>Détail des mouvements {{ annee }}</h2>
+        {% if bilan.lignes %}
+        <div class="table-responsive">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Compte</th>
+                        <th>Type</th>
+                        <th style="text-align:right;">Montant</th>
+                        <th>Commentaire</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for l in bilan.lignes %}
+                    <tr>
+                        <td>{{ l.date[8:10] }}/{{ l.date[5:7] }}/{{ l.date[0:4] }}</td>
+                        <td>{{ l.compte_label }}</td>
+                        <td>{{ l.type_label }}</td>
+                        <td style="text-align:right;" class="{% if l.type == 'entree' %}cse-amount-in{% else %}cse-amount-out{% endif %}">
+                            {% if l.type == 'entree' %}+{% else %}−{% endif %}{{ l.montant_fmt }}
+                        </td>
+                        <td>{{ l.commentaire or '—' }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="no-data">Aucun mouvement pour l'année {{ annee }}.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/cse_budget.html
+++ b/templates/cse_budget.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+
+{% block title %}CSE · Budget - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="cse-page">
+    <div style="display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;">
+        <div>
+            <h1>💶 Budget du CSE</h1>
+            <p class="subtitle" style="margin:0;">
+                <a href="{{ url_for('cse_bp.cse_accueil') }}">← Espace CSE</a>
+            </p>
+        </div>
+        <a href="{{ url_for('cse_bp.cse_bilan') }}" class="btn btn-secondary">🖨️ Bilan annuel</a>
+    </div>
+
+    {# ── Soldes courants ── #}
+    <div class="cse-solde-grid" style="margin-top:1.5rem;">
+        <div class="cse-solde-card">
+            <div class="cse-solde-label">🏦 Banque</div>
+            <div class="cse-solde-value">{{ soldes_courants.banque }}</div>
+        </div>
+        <div class="cse-solde-card">
+            <div class="cse-solde-label">💵 Caisse</div>
+            <div class="cse-solde-value">{{ soldes_courants.caisse }}</div>
+        </div>
+        <div class="cse-solde-card cse-solde-total">
+            <div class="cse-solde-label">Σ Total</div>
+            <div class="cse-solde-value">{{ soldes_courants.total }}</div>
+        </div>
+    </div>
+
+    {# ── Soldes de départ ── #}
+    <div class="section">
+        <h2>Soldes de départ</h2>
+        <p style="color:var(--gray-500);margin-top:-0.25rem;">
+            Définissez le solde initial de chaque compte avec sa date de référence.
+        </p>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;">
+            {% for compte_key, compte_label in comptes.items() %}
+            <form method="POST" action="{{ url_for('cse_bp.definir_solde') }}"
+                  style="border:1px solid var(--gray-200);border-radius:var(--radius-md);padding:1rem 1.25rem;background:var(--white);">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="compte" value="{{ compte_key }}">
+                <h3 style="margin:0 0 0.75rem;font-size:1rem;">
+                    {% if compte_key == 'banque' %}🏦{% else %}💵{% endif %} {{ compte_label }}
+                    {% if soldes_init[compte_key].defini %}
+                    <span style="font-weight:400;color:var(--gray-500);font-size:0.85rem;">
+                        — actuel : {{ soldes_init[compte_key].montant_fmt }}
+                    </span>
+                    {% endif %}
+                </h3>
+                <div class="form-group">
+                    <label for="date_solde_{{ compte_key }}">Date du solde</label>
+                    <input type="date" id="date_solde_{{ compte_key }}" name="date_solde" required
+                           value="{{ soldes_init[compte_key].date or aujourd_hui }}">
+                </div>
+                <div class="form-group">
+                    <label for="montant_{{ compte_key }}">Montant (€)</label>
+                    <input type="text" inputmode="decimal" id="montant_{{ compte_key }}" name="montant" required
+                           placeholder="0,00"
+                           value="{% if soldes_init[compte_key].defini %}{{ '%.2f'|format(soldes_init[compte_key].montant)|replace('.', ',') }}{% endif %}">
+                </div>
+                <button type="submit" class="btn btn-primary" style="width:100%;">💾 Enregistrer</button>
+            </form>
+            {% endfor %}
+        </div>
+    </div>
+
+    {# ── Nouveau mouvement ── #}
+    <div class="section">
+        <h2>Ajouter un mouvement</h2>
+        <form method="POST" action="{{ url_for('cse_bp.ajouter_mouvement') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:1rem;">
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="type">Type</label>
+                    <select id="type" name="type" required>
+                        {% for type_key, type_label in types_mouvement.items() %}
+                        <option value="{{ type_key }}">{{ type_label }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="compte">Compte</label>
+                    <select id="compte" name="compte" required>
+                        {% for compte_key, compte_label in comptes.items() %}
+                        <option value="{{ compte_key }}">{{ compte_label }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="date_mouvement">Date</label>
+                    <input type="date" id="date_mouvement" name="date_mouvement" required value="{{ aujourd_hui }}">
+                </div>
+                <div class="form-group" style="margin-bottom:0;">
+                    <label for="montant_mvt">Montant (€)</label>
+                    <input type="text" inputmode="decimal" id="montant_mvt" name="montant" required placeholder="0,00">
+                </div>
+            </div>
+            <div class="form-group" style="margin-top:1rem;">
+                <label for="commentaire">Commentaire <span style="color:var(--gray-500);font-weight:400;">(facultatif)</span></label>
+                <input type="text" id="commentaire" name="commentaire" maxlength="255" placeholder="Ex : Cotisation, achat cadeaux…">
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="btn btn-primary">➕ Enregistrer le mouvement</button>
+            </div>
+        </form>
+    </div>
+
+    {# ── Liste des mouvements ── #}
+    <div class="section">
+        <h2>Mouvements</h2>
+        {% if mouvements %}
+        <div class="table-responsive">
+            <table class="data-table data-table-cards">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Compte</th>
+                        <th>Type</th>
+                        <th style="text-align:right;">Montant</th>
+                        <th>Commentaire</th>
+                        <th style="text-align:right;">Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for m in mouvements %}
+                    <tr>
+                        <td data-label="Date">{{ m.date[8:10] }}/{{ m.date[5:7] }}/{{ m.date[0:4] }}</td>
+                        <td data-label="Compte">{{ m.compte_label }}</td>
+                        <td data-label="Type">{{ m.type_label }}</td>
+                        <td data-label="Montant" style="text-align:right;">
+                            <span class="{% if m.type == 'entree' %}cse-amount-in{% else %}cse-amount-out{% endif %}">
+                                {% if m.type == 'entree' %}+{% else %}−{% endif %}{{ m.montant_fmt }}
+                            </span>
+                        </td>
+                        <td data-label="Commentaire">{{ m.commentaire or '—' }}</td>
+                        <td data-label="Action" style="text-align:right;">
+                            <form method="POST" action="{{ url_for('cse_bp.supprimer_mouvement', mouvement_id=m.id) }}"
+                                  style="display:inline;" onsubmit="return confirm('Supprimer ce mouvement ?');">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="btn-icon" title="Supprimer">🗑️</button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="no-data">Aucun mouvement enregistré.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/cse_messages.html
+++ b/templates/cse_messages.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+
+{% block title %}CSE · Messages - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="cse-page">
+    <h1>📢 Message aux salariés</h1>
+    <p class="subtitle">
+        <a href="{{ url_for('cse_bp.cse_accueil') }}">← Espace CSE</a>
+    </p>
+
+    <div class="alert alert-info" style="display:block;">
+        ℹ️ <strong>Un seul message peut être affiché à la fois.</strong>
+        Publier un nouveau message archivera automatiquement le précédent.
+        Lorsque la date de validité est dépassée, le message est retiré de l'affichage
+        et conservé dans les archives ci-dessous.
+    </div>
+
+    {# ── Message actuellement affiché ── #}
+    <div class="section">
+        <h2>Message actuellement affiché</h2>
+        {% if message_actif %}
+        <div style="border:1px solid var(--gray-200);border-left:4px solid var(--primary);border-radius:var(--radius-md);padding:1rem 1.25rem;background:var(--white);">
+            {% if message_actif.titre %}
+            <h3 style="margin:0 0 0.5rem;">{{ message_actif.titre }}</h3>
+            {% endif %}
+            <p style="white-space:pre-wrap;word-break:break-word;line-height:1.6;margin:0 0 0.75rem;color:var(--gray-700);">{{ message_actif.contenu }}</p>
+            <p style="font-size:0.8rem;color:var(--gray-500);margin:0 0 0.75rem;">
+                Valable jusqu'au {{ message_actif.date_validite[8:10] }}/{{ message_actif.date_validite[5:7] }}/{{ message_actif.date_validite[0:4] }}
+                {% if message_actif.auteur_prenom %} · publié par {{ message_actif.auteur_prenom }} {{ message_actif.auteur_nom }}{% endif %}
+            </p>
+            <form method="POST" action="{{ url_for('cse_bp.archiver_message', message_id=message_actif.id) }}"
+                  onsubmit="return confirm('Retirer ce message de l\'affichage ?');">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-secondary" style="padding:6px 12px;">🗑️ Retirer ce message</button>
+            </form>
+        </div>
+        {% else %}
+        <p class="no-data">Aucun message n'est actuellement affiché aux salariés.</p>
+        {% endif %}
+    </div>
+
+    {# ── Nouveau message ── #}
+    <div class="section">
+        <h2>{% if message_actif %}Remplacer le message{% else %}Publier un message{% endif %}</h2>
+        <form method="POST" action="{{ url_for('cse_bp.creer_message') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="form-group">
+                <label for="titre">Titre <span style="color:var(--gray-500);font-weight:400;">(facultatif)</span></label>
+                <input type="text" id="titre" name="titre" maxlength="150" placeholder="Ex : Réunion CSE du mois">
+            </div>
+            <div class="form-group">
+                <label for="contenu">Message <span style="color:var(--danger);">*</span></label>
+                <textarea id="contenu" name="contenu" rows="5" required
+                          placeholder="Votre message à l'attention des salariés…"></textarea>
+            </div>
+            <div class="form-group">
+                <label for="date_validite">Date de validité <span style="color:var(--danger);">*</span></label>
+                <input type="date" id="date_validite" name="date_validite" required min="{{ aujourd_hui }}">
+                <small style="color:var(--gray-500);">Le message sera affiché jusqu'à cette date incluse.</small>
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="btn btn-primary">📤 Publier le message</button>
+            </div>
+        </form>
+    </div>
+
+    {# ── Archives ── #}
+    <div class="section">
+        <h2>🗄️ Messages archivés</h2>
+        {% if archives %}
+        <div class="table-responsive">
+            <table class="data-table data-table-cards">
+                <thead>
+                    <tr>
+                        <th>Titre / message</th>
+                        <th>Validité</th>
+                        <th>Publié le</th>
+                        <th>Statut</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for a in archives %}
+                    <tr>
+                        <td data-label="Titre / message">
+                            {% if a.titre %}<strong>{{ a.titre }}</strong><br>{% endif %}
+                            <span style="color:var(--gray-500);">{{ a.contenu|truncate(120) }}</span>
+                        </td>
+                        <td data-label="Validité">jusqu'au {{ a.date_validite[8:10] }}/{{ a.date_validite[5:7] }}/{{ a.date_validite[0:4] }}</td>
+                        <td data-label="Publié le">{{ a.created_at[8:10] }}/{{ a.created_at[5:7] }}/{{ a.created_at[0:4] }}</td>
+                        <td data-label="Statut"><span class="badge badge-inactive">Supprimé (archivé)</span></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="no-data">Aucun message archivé.</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -332,3 +332,51 @@ def test_calcul_bilan_soldes(auth_client, db, sample_users):
     assert abs(banque['entrees'] - 300.0) < 0.001
     assert abs(banque['sorties'] - 100.0) < 0.001
     assert abs(banque['solde_fin'] - 700.0) < 0.001     # 500 + 300 - 100
+
+
+def test_bilan_ignore_solde_initial_date_apres_annee(auth_client, db, sample_users):
+    """Un solde de départ daté après l'année du bilan ne doit pas la gonfler."""
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    db.execute("INSERT INTO cse_soldes_initiaux (compte, date_solde, montant) VALUES ('banque','2026-01-01',1000)")
+    db.execute("INSERT INTO cse_mouvements (compte, type, date_mouvement, montant) VALUES ('banque','entree','2025-06-10',300)")
+    db.commit()
+
+    from blueprints.cse import _calculer_bilan_annuel
+    import database
+    conn = database.get_db()
+    try:
+        bilan_2025 = _calculer_bilan_annuel(conn, '2025')
+        bilan_2026 = _calculer_bilan_annuel(conn, '2026')
+    finally:
+        conn.close()
+
+    # 2025 : le solde de départ daté 2026 ne compte pas (300 de mouvement seul).
+    assert abs(bilan_2025['comptes']['banque']['solde_fin'] - 300.0) < 0.001
+    assert abs(bilan_2025['comptes']['banque']['solde_debut'] - 0.0) < 0.001
+    # 2026 : le solde de départ est désormais pris en compte (1000 + 300).
+    assert abs(bilan_2026['comptes']['banque']['solde_fin'] - 1300.0) < 0.001
+
+
+def test_suppression_membre_nom_avec_apostrophe(admin_client, db):
+    """Un nom avec apostrophe ne doit pas casser le JS ni permettre d'injection."""
+    from werkzeug.security import generate_password_hash
+    db.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?,?,?,?,?)",
+        ("D'Arc", "O'Neil", 'oneil', generate_password_hash('Oneil1234'), 'salarie')
+    )
+    db.commit()
+    uid = db.execute("SELECT id FROM users WHERE login = 'oneil'").fetchone()['id']
+    db.execute("INSERT INTO cse_membres (user_id, ajoute_par) VALUES (?, ?)", (uid, uid))
+    db.commit()
+
+    resp = admin_client.get('/cse')
+    html = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    # Le nom passe par un attribut data- (échappé) et plus par un confirm() inline.
+    assert 'cse-remove-form' in html
+    assert 'data-membre=' in html
+    assert 'onsubmit="return confirm' not in html
+    # Le nom n'apparaît jamais brut (non échappé) dans la page.
+    assert "O'Neil D'Arc" not in html
+    # L'apostrophe est échappée en entité HTML.
+    assert 'D&#39;Arc' in html or 'D&#x27;Arc' in html

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -1,0 +1,334 @@
+"""
+Tests du module CSE (Comité Social et Économique).
+
+Couvre :
+- la désignation des membres (direction / comptable) ;
+- l'espace réservé aux membres ;
+- les messages aux salariés (un seul actif, archivage, bannière dashboard) ;
+- le budget simplifié (soldes de départ, mouvements) ;
+- le bilan annuel.
+"""
+
+
+def _faire_membre(db, user_id, par_id):
+    """Insère directement un membre du CSE (raccourci de mise en place)."""
+    db.execute(
+        "INSERT INTO cse_membres (user_id, ajoute_par) VALUES (?, ?)",
+        (user_id, par_id)
+    )
+    db.commit()
+
+
+def _inserer_message(db, contenu, date_validite, statut='actif', cree_par=None):
+    db.execute(
+        "INSERT INTO cse_messages (contenu, date_validite, statut, cree_par) VALUES (?, ?, ?, ?)",
+        (contenu, date_validite, statut, cree_par)
+    )
+    db.commit()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Accès
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_salarie_non_membre_redirige(auth_client):
+    resp = auth_client.get('/cse', follow_redirects=True)
+    assert resp.status_code == 200
+    assert 'Accès réservé au CSE' in resp.get_data(as_text=True)
+
+
+def test_directeur_voit_gestion_membres(admin_client):
+    resp = admin_client.get('/cse')
+    assert resp.status_code == 200
+    assert 'Membres du CSE' in resp.get_data(as_text=True)
+
+
+def test_comptable_voit_gestion_membres(comptable_client):
+    resp = comptable_client.get('/cse')
+    assert resp.status_code == 200
+    assert 'Membres du CSE' in resp.get_data(as_text=True)
+
+
+def test_non_membre_bloque_sur_sous_pages(auth_client):
+    for url in ('/cse/messages', '/cse/budget', '/cse/bilan'):
+        resp = auth_client.get(url, follow_redirects=True)
+        assert resp.status_code == 200
+        assert 'réservé aux membres du CSE' in resp.get_data(as_text=True)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Gestion des membres
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_directeur_ajoute_membre(admin_client, db, sample_users):
+    resp = admin_client.post(
+        '/cse/membres/ajouter',
+        data={'user_id': sample_users['salarie_id']},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    row = db.execute(
+        "SELECT * FROM cse_membres WHERE user_id = ?", (sample_users['salarie_id'],)
+    ).fetchone()
+    assert row is not None
+
+
+def test_ajout_membre_duplique_refuse(admin_client, db, sample_users):
+    admin_client.post('/cse/membres/ajouter', data={'user_id': sample_users['salarie_id']})
+    admin_client.post('/cse/membres/ajouter', data={'user_id': sample_users['salarie_id']})
+    rows = db.execute(
+        "SELECT COUNT(*) AS nb FROM cse_membres WHERE user_id = ?",
+        (sample_users['salarie_id'],)
+    ).fetchone()
+    assert rows['nb'] == 1
+
+
+def test_ajout_prestataire_refuse(admin_client, db):
+    from werkzeug.security import generate_password_hash
+    db.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?,?,?,?,?)",
+        ('Presta', 'Paul', 'presta_test', generate_password_hash('Presta1234'), 'prestataire')
+    )
+    db.commit()
+    presta_id = db.execute("SELECT id FROM users WHERE login = 'presta_test'").fetchone()['id']
+
+    admin_client.post('/cse/membres/ajouter', data={'user_id': presta_id}, follow_redirects=True)
+    row = db.execute("SELECT * FROM cse_membres WHERE user_id = ?", (presta_id,)).fetchone()
+    assert row is None
+
+
+def test_salarie_ne_peut_ajouter_membre(auth_client, db, sample_users):
+    auth_client.post(
+        '/cse/membres/ajouter',
+        data={'user_id': sample_users['salarie_id']},
+        follow_redirects=True,
+    )
+    row = db.execute(
+        "SELECT * FROM cse_membres WHERE user_id = ?", (sample_users['salarie_id'],)
+    ).fetchone()
+    assert row is None
+
+
+def test_supprimer_membre(admin_client, db, sample_users):
+    admin_client.post('/cse/membres/ajouter', data={'user_id': sample_users['salarie_id']})
+    membre = db.execute(
+        "SELECT id FROM cse_membres WHERE user_id = ?", (sample_users['salarie_id'],)
+    ).fetchone()
+    admin_client.post(f"/cse/membres/{membre['id']}/supprimer", follow_redirects=True)
+    row = db.execute("SELECT * FROM cse_membres WHERE id = ?", (membre['id'],)).fetchone()
+    assert row is None
+
+
+def test_membre_accede_a_son_espace(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    resp = auth_client.get('/cse')
+    assert resp.status_code == 200
+    assert 'Mon espace CSE' in resp.get_data(as_text=True)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Messages
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_membre_publie_message(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    resp = auth_client.post(
+        '/cse/messages/creer',
+        data={'titre': 'Réunion', 'contenu': 'Bonjour à tous', 'date_validite': '2999-12-31'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    actif = db.execute("SELECT * FROM cse_messages WHERE statut = 'actif'").fetchall()
+    assert len(actif) == 1
+    assert actif[0]['contenu'] == 'Bonjour à tous'
+
+
+def test_nouveau_message_archive_le_precedent(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    auth_client.post('/cse/messages/creer',
+                     data={'contenu': 'Premier', 'date_validite': '2999-12-31'})
+    auth_client.post('/cse/messages/creer',
+                     data={'contenu': 'Second', 'date_validite': '2999-12-31'})
+    actifs = db.execute("SELECT * FROM cse_messages WHERE statut = 'actif'").fetchall()
+    assert len(actifs) == 1
+    assert actifs[0]['contenu'] == 'Second'
+    archives = db.execute("SELECT * FROM cse_messages WHERE statut = 'archive'").fetchall()
+    assert len(archives) == 1
+    assert archives[0]['contenu'] == 'Premier'
+
+
+def test_message_avec_date_passee_refuse(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    auth_client.post('/cse/messages/creer',
+                     data={'contenu': 'Trop tard', 'date_validite': '2000-01-01'},
+                     follow_redirects=True)
+    rows = db.execute("SELECT COUNT(*) AS nb FROM cse_messages").fetchone()
+    assert rows['nb'] == 0
+
+
+def test_message_expire_est_archive(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    _inserer_message(db, 'Périmé', '2000-01-01', statut='actif',
+                     cree_par=sample_users['salarie_id'])
+    # La consultation déclenche l'archivage des messages expirés.
+    auth_client.get('/cse/messages')
+    row = db.execute("SELECT statut FROM cse_messages WHERE contenu = 'Périmé'").fetchone()
+    assert row['statut'] == 'archive'
+
+
+def test_archiver_message_manuellement(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    _inserer_message(db, 'A retirer', '2999-12-31', statut='actif',
+                     cree_par=sample_users['salarie_id'])
+    msg = db.execute("SELECT id FROM cse_messages WHERE contenu = 'A retirer'").fetchone()
+    auth_client.post(f"/cse/messages/{msg['id']}/archiver", follow_redirects=True)
+    row = db.execute("SELECT statut FROM cse_messages WHERE id = ?", (msg['id'],)).fetchone()
+    assert row['statut'] == 'archive'
+
+
+def test_banniere_sur_dashboard(auth_client, db, sample_users):
+    _inserer_message(db, 'Info importante', '2999-12-31', statut='actif',
+                     cree_par=sample_users['directeur_id'])
+    resp = auth_client.get('/dashboard')
+    assert resp.status_code == 200
+    assert 'Message du CSE à lire' in resp.get_data(as_text=True)
+
+
+def test_pas_de_banniere_sans_message(auth_client):
+    resp = auth_client.get('/dashboard')
+    assert resp.status_code == 200
+    assert 'Message du CSE à lire' not in resp.get_data(as_text=True)
+
+
+def test_banniere_absente_si_message_expire(auth_client, db, sample_users):
+    _inserer_message(db, 'Vieux', '2000-01-01', statut='actif',
+                     cree_par=sample_users['directeur_id'])
+    resp = auth_client.get('/dashboard')
+    assert 'Message du CSE à lire' not in resp.get_data(as_text=True)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Budget
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_definir_solde_initial(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    auth_client.post('/cse/budget/solde',
+                     data={'compte': 'banque', 'date_solde': '2026-01-01', 'montant': '1000,50'},
+                     follow_redirects=True)
+    row = db.execute("SELECT * FROM cse_soldes_initiaux WHERE compte = 'banque'").fetchone()
+    assert row is not None
+    assert abs(row['montant'] - 1000.50) < 0.001
+
+
+def test_solde_initial_mis_a_jour(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    auth_client.post('/cse/budget/solde',
+                     data={'compte': 'caisse', 'date_solde': '2026-01-01', 'montant': '100'})
+    auth_client.post('/cse/budget/solde',
+                     data={'compte': 'caisse', 'date_solde': '2026-02-01', 'montant': '250'})
+    rows = db.execute("SELECT * FROM cse_soldes_initiaux WHERE compte = 'caisse'").fetchall()
+    assert len(rows) == 1
+    assert abs(rows[0]['montant'] - 250.0) < 0.001
+
+
+def test_ajouter_mouvement_et_solde_courant(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    auth_client.post('/cse/budget/solde',
+                     data={'compte': 'banque', 'date_solde': '2026-01-01', 'montant': '1000'})
+    auth_client.post('/cse/budget/mouvement',
+                     data={'compte': 'banque', 'type': 'entree',
+                           'date_mouvement': '2026-03-01', 'montant': '200', 'commentaire': 'Cotisation'})
+    auth_client.post('/cse/budget/mouvement',
+                     data={'compte': 'banque', 'type': 'sortie',
+                           'date_mouvement': '2026-03-05', 'montant': '50', 'commentaire': 'Achat'})
+
+    from blueprints.cse import _calculer_soldes_courants
+    import database
+    conn = database.get_db()
+    try:
+        soldes = _calculer_soldes_courants(conn)
+    finally:
+        conn.close()
+    assert abs(soldes['banque'] - 1150.0) < 0.001  # 1000 + 200 - 50
+
+
+def test_mouvement_montant_invalide_refuse(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    auth_client.post('/cse/budget/mouvement',
+                     data={'compte': 'banque', 'type': 'entree',
+                           'date_mouvement': '2026-03-01', 'montant': 'abc'},
+                     follow_redirects=True)
+    rows = db.execute("SELECT COUNT(*) AS nb FROM cse_mouvements").fetchone()
+    assert rows['nb'] == 0
+
+
+def test_supprimer_mouvement(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    auth_client.post('/cse/budget/mouvement',
+                     data={'compte': 'caisse', 'type': 'entree',
+                           'date_mouvement': '2026-03-01', 'montant': '30'})
+    mvt = db.execute("SELECT id FROM cse_mouvements").fetchone()
+    auth_client.post(f"/cse/budget/mouvement/{mvt['id']}/supprimer", follow_redirects=True)
+    rows = db.execute("SELECT COUNT(*) AS nb FROM cse_mouvements").fetchone()
+    assert rows['nb'] == 0
+
+
+def test_non_membre_ne_peut_ajouter_mouvement(auth_client, db, sample_users):
+    auth_client.post('/cse/budget/mouvement',
+                     data={'compte': 'banque', 'type': 'entree',
+                           'date_mouvement': '2026-03-01', 'montant': '100'},
+                     follow_redirects=True)
+    rows = db.execute("SELECT COUNT(*) AS nb FROM cse_mouvements").fetchone()
+    assert rows['nb'] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Bilan annuel
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_bilan_annuel_affiche_mouvements(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    db.execute("INSERT INTO cse_soldes_initiaux (compte, date_solde, montant) VALUES ('banque','2025-01-01',500)")
+    db.execute("INSERT INTO cse_mouvements (compte, type, date_mouvement, montant, commentaire) "
+               "VALUES ('banque','entree','2025-06-10',300,'Don')")
+    db.execute("INSERT INTO cse_mouvements (compte, type, date_mouvement, montant, commentaire) "
+               "VALUES ('banque','sortie','2026-02-02',100,'Cadeau')")
+    db.commit()
+
+    resp = auth_client.get('/cse/bilan?annee=2025')
+    html = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'Bilan annuel du CSE' in html
+    assert 'Année 2025' in html
+    assert 'Don' in html
+    # Le mouvement 2026 ne doit pas apparaître dans le bilan 2025.
+    assert 'Cadeau' not in html
+
+
+def test_bilan_annee_invalide_retombe_sur_defaut(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    resp = auth_client.get('/cse/bilan?annee=abcd')
+    assert resp.status_code == 200
+    assert 'Bilan annuel du CSE' in resp.get_data(as_text=True)
+
+
+def test_calcul_bilan_soldes(auth_client, db, sample_users):
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    db.execute("INSERT INTO cse_soldes_initiaux (compte, date_solde, montant) VALUES ('banque','2025-01-01',500)")
+    db.execute("INSERT INTO cse_mouvements (compte, type, date_mouvement, montant) VALUES ('banque','entree','2025-06-10',300)")
+    db.execute("INSERT INTO cse_mouvements (compte, type, date_mouvement, montant) VALUES ('banque','sortie','2025-07-10',100)")
+    db.commit()
+
+    from blueprints.cse import _calculer_bilan_annuel
+    import database
+    conn = database.get_db()
+    try:
+        bilan = _calculer_bilan_annuel(conn, '2025')
+    finally:
+        conn.close()
+    banque = bilan['comptes']['banque']
+    assert abs(banque['solde_debut'] - 500.0) < 0.001   # solde de départ avant mouvements
+    assert abs(banque['entrees'] - 300.0) < 0.001
+    assert abs(banque['sorties'] - 100.0) < 0.001
+    assert abs(banque['solde_fin'] - 700.0) < 0.001     # 500 + 300 - 100


### PR DESCRIPTION
## Module CSE (Comité Social et Économique)

Nouveau menu **CSE** accessible depuis **RH & Paie**.

### 👥 Désignation des membres (direction & comptable)
- Liste déroulante des salariés actifs (hors prestataires et membres déjà désignés)
- Ajout / suppression d'un membre
- Bloc visible uniquement pour les profils `directeur` et `comptable`

### 📂 Espace réservé aux membres du CSE
- **Message aux salariés** : titre (facultatif), contenu, **date de validité**.
  - Un seul message affiché à la fois (rappelé sur la page) ; publier un nouveau message **archive automatiquement** le précédent.
  - Une fois la date dépassée, le message passe en statut **« Supprimé (archivé) »** mais reste consultable dans les archives.
- **Budget simplifié** : soldes de départ **banque** / **caisse** (avec date), puis **entrées / sorties** (date, montant, commentaire). Soldes courants calculés par compte + total.
- **Bilan annuel imprimable** : sélection de l'année parmi celles disponibles (déduites des dates des opérations), synthèse par compte (solde 01/01, entrées, sorties, variation, solde 31/12) et détail des mouvements. Bouton d'impression + `@media print`.

### 📢 Tableau de bord
- Bandeau **« Message du CSE à lire »** en haut du tableau de bord (tous profils internes) lorsqu'un message est actif.
- Clic → **fenêtre modale** responsive (compatible smartphone) avec le message.

## Détails techniques
- **Migration `0040_module_cse.py`** + création des tables dans `init_db()` : `cse_membres`, `cse_messages`, `cse_soldes_initiaux`, `cse_mouvements` (idempotent, base neuve et existante).
- **Blueprint `blueprints/cse.py`** (accès `@login_required` + contrôle de profil/appartenance), templates dédiés, styles dans `style.css` (thème clair/sombre + responsive).
- **Context processor** injectant `is_cse_membre`, `is_cse_gestionnaire` et `cse_message_actif`.
- Jetons CSRF explicites dans tous les formulaires POST.

## Tests
- ✅ **27 nouveaux tests** (`tests/test_cse.py`) : accès, membres, messages (un seul actif, archivage, expiration, bannière), budget (soldes, mouvements, validation), bilan annuel.
- ✅ Suite complète : **469 tests passent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_