### PR TITLE
CSE : journaliser l'ajout / le retrait d'un membre

### DIFF
--- a/access_log.py
+++ b/access_log.py
@@ -49,6 +49,8 @@ ACTION_MODIF_USER = 'modification_user'
 ACTION_STATUT_USER = 'changement_statut_user'
 ACTION_VALIDATION_MOIS = 'validation_mois'
 ACTION_DEVERROUILLAGE_MOIS = 'deverrouillage_mois'
+ACTION_AJOUT_MEMBRE_CSE = 'ajout_membre_cse'
+ACTION_RETRAIT_MEMBRE_CSE = 'retrait_membre_cse'
 
 # Libelles lisibles des actions metier
 ACTIONS_LABELS = {
@@ -64,6 +66,8 @@ ACTIONS_LABELS = {
     ACTION_STATUT_USER: 'Activation / désactivation d\'un utilisateur',
     ACTION_VALIDATION_MOIS: 'Validation mensuelle d\'une fiche',
     ACTION_DEVERROUILLAGE_MOIS: 'Déverrouillage d\'une fiche validée',
+    ACTION_AJOUT_MEMBRE_CSE: 'Ajout d\'un membre du CSE',
+    ACTION_RETRAIT_MEMBRE_CSE: 'Retrait d\'un membre du CSE',
 }
 
 

--- a/blueprints/cse.py
+++ b/blueprints/cse.py
@@ -16,6 +16,11 @@ from flask import (
     Blueprint, flash, redirect, render_template, request, session, url_for
 )
 
+from access_log import (
+    ACTION_AJOUT_MEMBRE_CSE,
+    ACTION_RETRAIT_MEMBRE_CSE,
+    journaliser_action,
+)
 from database import get_db
 from utils import login_required
 
@@ -359,7 +364,7 @@ def ajouter_membre():
     conn = get_db()
     try:
         salarie = conn.execute(
-            "SELECT id, prenom, nom FROM users WHERE id = ? AND actif = 1 AND profil != 'prestataire'",
+            "SELECT id, prenom, nom, profil FROM users WHERE id = ? AND actif = 1 AND profil != 'prestataire'",
             (user_id,)
         ).fetchone()
         if not salarie:
@@ -376,6 +381,11 @@ def ajouter_membre():
         conn.execute(
             "INSERT INTO cse_membres (user_id, ajoute_par) VALUES (?, ?)",
             (user_id, session['user_id'])
+        )
+        journaliser_action(
+            conn, ACTION_AJOUT_MEMBRE_CSE,
+            cible_type='user', cible_id=user_id,
+            details=f"profil={salarie['profil']}",
         )
         conn.commit()
         flash(f"{salarie['prenom']} {salarie['nom']} a été ajouté(e) au CSE.", "success")
@@ -397,7 +407,7 @@ def supprimer_membre(membre_id):
     try:
         membre = conn.execute(
             '''
-            SELECT m.id, u.prenom, u.nom
+            SELECT m.id, m.user_id, u.prenom, u.nom, u.profil
             FROM cse_membres m JOIN users u ON u.id = m.user_id
             WHERE m.id = ?
             ''',
@@ -408,6 +418,11 @@ def supprimer_membre(membre_id):
             return redirect(url_for('cse_bp.cse_accueil'))
 
         conn.execute("DELETE FROM cse_membres WHERE id = ?", (membre_id,))
+        journaliser_action(
+            conn, ACTION_RETRAIT_MEMBRE_CSE,
+            cible_type='user', cible_id=membre['user_id'],
+            details=f"profil={membre['profil']}",
+        )
         conn.commit()
         flash(f"{membre['prenom']} {membre['nom']} a été retiré(e) du CSE.", "success")
     finally:

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -109,6 +109,54 @@ def test_salarie_ne_peut_ajouter_membre(auth_client, db, sample_users):
     assert row is None
 
 
+def test_ajout_membre_journalise(admin_client, db, sample_users):
+    admin_client.post(
+        '/cse/membres/ajouter',
+        data={'user_id': sample_users['salarie_id']},
+        follow_redirects=True,
+    )
+    row = db.execute(
+        "SELECT * FROM journal_actions WHERE action = 'ajout_membre_cse' ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row['user_id'] == sample_users['directeur_id']   # auteur = directeur connecté
+    assert row['cible_type'] == 'user'
+    assert row['cible_id'] == sample_users['salarie_id']     # cible = salarié ajouté
+
+
+def test_retrait_membre_journalise(admin_client, db, sample_users):
+    admin_client.post('/cse/membres/ajouter', data={'user_id': sample_users['salarie_id']})
+    membre = db.execute(
+        "SELECT id FROM cse_membres WHERE user_id = ?", (sample_users['salarie_id'],)
+    ).fetchone()
+    admin_client.post(f"/cse/membres/{membre['id']}/supprimer", follow_redirects=True)
+    row = db.execute(
+        "SELECT * FROM journal_actions WHERE action = 'retrait_membre_cse' ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row['cible_id'] == sample_users['salarie_id']
+
+
+def test_auto_designation_comptable_est_tracee(comptable_client, db, sample_users):
+    """Cas visé : un comptable qui se désigne lui-même laisse une trace (auteur == cible)."""
+    comptable_client.post(
+        '/cse/membres/ajouter',
+        data={'user_id': sample_users['comptable_id']},
+        follow_redirects=True,
+    )
+    row = db.execute(
+        "SELECT * FROM journal_actions WHERE action = 'ajout_membre_cse' ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row['user_id'] == sample_users['comptable_id']    # auteur
+    assert row['cible_id'] == sample_users['comptable_id']   # cible = lui-même
+
+    # L'action apparaît, avec son libellé, dans le journal de sécurité.
+    page = comptable_client.get('/securite/journal-actions')
+    assert page.status_code == 200
+    assert 'membre du CSE' in page.get_data(as_text=True)
+
+
 def test_supprimer_membre(admin_client, db, sample_users):
     admin_client.post('/cse/membres/ajouter', data={'user_id': sample_users['salarie_id']})
     membre = db.execute(


### PR DESCRIPTION
## Journalisation des membres du CSE

Fait suite au module CSE (#151). L'accès à l'espace CSE (messages + budget) étant **verrouillé aux membres désignés**, on trace désormais dans le **journal des actions** (*Administration → Sécurité → Journal des actions*) toute **désignation** ou **retrait** d'un membre.

Objectif : pouvoir repérer une **auto-désignation** — un comptable ou la direction qui se donne accès aux données du CSE — au-delà d'éventuels tests.

### Détails
- **`access_log.py`** : deux nouvelles actions auditées avec libellés (et donc filtrables) :
  - `ajout_membre_cse` → « Ajout d'un membre du CSE »
  - `retrait_membre_cse` → « Retrait d'un membre du CSE »
- **`blueprints/cse.py`** : appel à `journaliser_action(...)` dans la **même transaction** que l'opération (auteur = utilisateur connecté via la session, cible = salarié concerné `cible_type='user'`, détail = profil de la cible).
- Le journal résout déjà le nom de la cible : on lit donc directement *« Qui a ajouté/retiré Qui »*. Lorsqu'un comptable se désigne lui-même, **auteur = cible**.

### Tests
- ✅ Ajout et retrait correctement tracés (auteur, cible, type d'action)
- ✅ Cas ciblé : auto-désignation d'un comptable → trace avec `user_id == cible_id` + libellé visible dans le journal de sécurité
- ✅ `tests/test_cse.py` (32) + `tests/test_journal_actions.py` (9) + `tests/test_securite.py` (21) passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_