### PR TITLE
Budget secteur : corriger l'échec d'enregistrement pour un responsable (jeton CSRF expiré)

### DIFF
--- a/app.py
+++ b/app.py
@@ -191,6 +191,13 @@ else:
     app.config['SESSION_COOKIE_SECURE'] = False
 
 # ==================== Initialisation des extensions ====================
+# Le jeton CSRF reste valide tant que la session l'est (pas d'expiration au
+# bout d'1h). Evite l'echec des enregistrements AJAX quand une page reste
+# ouverte longtemps (ex: saisie d'un budget secteur avec de nombreuses
+# colonnes), qui se manifestait par une redirection vers /login interpretee
+# a tort comme une "Erreur reseau" cote navigateur. La protection CSRF reste
+# entiere (jeton toujours requis et lie a la session).
+app.config['WTF_CSRF_TIME_LIMIT'] = None
 csrf.init_app(app)
 limiter.init_app(app)
 

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import os
 import sys
 import secrets
 from dotenv import load_dotenv
-from flask import Flask, session, render_template, flash, redirect, url_for
+from flask import Flask, session, render_template, flash, redirect, url_for, request
 from flask_wtf.csrf import CSRFError
 from werkzeug.middleware.proxy_fix import ProxyFix
 import logging
@@ -58,6 +58,7 @@ def configure_logging():
 
 
 configure_logging()
+logger = logging.getLogger(__name__)
 
 
 def generate_env_file(env_path):
@@ -459,6 +460,15 @@ def ratelimit_handler(e):
 @app.errorhandler(CSRFError)
 def handle_csrf_error(e):
     """Gestion des erreurs CSRF : redirige vers login avec message explicite."""
+    # Trace l'echec CSRF (sinon invisible) : un POST AJAX rejete est redirige
+    # vers /login (HTML), ce que le navigateur affiche a tort comme une
+    # "Erreur reseau". La raison (jeton expire / absent / non concordant) aide
+    # a diagnostiquer ces echecs d'enregistrement.
+    logger.warning(
+        "Echec CSRF: %s | endpoint=%s method=%s path=%s user_id=%s",
+        getattr(e, 'description', 'inconnu'),
+        request.endpoint, request.method, request.path, session.get('user_id'),
+    )
     session.clear()
     flash('Votre session a expiré ou est invalide. Veuillez vous reconnecter.', 'error')
     return redirect(url_for('auth.login'))

--- a/templates/budget_secteur.html
+++ b/templates/budget_secteur.html
@@ -657,6 +657,23 @@
         recalculate();
     }
 
+    // Lecture robuste de la reponse : une reponse non-JSON traduit une
+    // redirection (session / jeton CSRF expire) et non une panne reseau.
+    function readSaveResponse(resp) {
+        var ct = resp.headers.get('Content-Type') || '';
+        if (ct.indexOf('application/json') === -1) {
+            var e = new Error('session'); e.sessionError = true; throw e;
+        }
+        return resp.json().then(function(data) { return {ok: resp.ok, data: data}; });
+    }
+
+    function showSaveError(statusEl, err) {
+        statusEl.textContent = (err && err.sessionError)
+            ? '✗ Session expirée ou invalide. Rechargez la page (F5) puis réessayez.'
+            : '✗ Erreur réseau. Vérifiez votre connexion puis réessayez.';
+        statusEl.className = 'budget-save-status budget-save-error';
+    }
+
     // ============================================================
     // SAUVEGARDE PARAMETRAGE
     // ============================================================
@@ -691,7 +708,7 @@
                 lignes: lignes
             })
         })
-        .then(function(resp) { return resp.json().then(function(data) { return {ok: resp.ok, data: data}; }); })
+        .then(readSaveResponse)
         .then(function(result) {
             btnEl.disabled = false;
             if (result.ok && result.data.success) {
@@ -707,8 +724,7 @@
         })
         .catch(function(err) {
             btnEl.disabled = false;
-            statusEl.textContent = '✗ Erreur réseau';
-            statusEl.className = 'budget-save-status budget-save-error';
+            showSaveError(statusEl, err);
         });
     };
 
@@ -742,7 +758,7 @@
                 lignes: lignes
             })
         })
-        .then(function(resp) { return resp.json().then(function(data) { return {ok: resp.ok, data: data}; }); })
+        .then(readSaveResponse)
         .then(function(result) {
             btnEl.disabled = false;
             if (result.ok && result.data.success) {
@@ -756,8 +772,7 @@
         })
         .catch(function(err) {
             btnEl.disabled = false;
-            statusEl.textContent = '✗ Erreur réseau';
-            statusEl.className = 'budget-save-status budget-save-error';
+            showSaveError(statusEl, err);
         });
     };
 })();

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -88,6 +88,56 @@ def test_budget_previsionnel_responsable_sans_onglet_global(resp_client):
     assert 'Budget général' not in html
 
 
+def test_jeton_csrf_sans_expiration(app):
+    """Le jeton CSRF ne doit pas expirer (sinon enregistrements AJAX rejetés)."""
+    assert app.config.get('WTF_CSRF_TIME_LIMIT') is None
+
+
+def test_responsable_enregistre_budget_de_son_secteur(resp_client, db, sample_users):
+    """Un responsable peut enregistrer les montants du budget de SON secteur."""
+    sid = sample_users['secteur_id']
+    db.execute("INSERT INTO budgets (secteur_id, annee, montant_global) VALUES (?, 2026, 5000)", (sid,))
+    poste_id = db.execute("SELECT id FROM postes_depense ORDER BY id LIMIT 1").fetchone()['id']
+    db.commit()
+
+    resp = resp_client.post('/api/budget/save', json={
+        'secteur_id': sid, 'annee': 2026, 'montant_global': None,
+        'lignes': [{'poste_depense_id': poste_id, 'periode': 'annuel', 'montant': 1000}],
+    })
+    assert resp.status_code == 200
+    assert resp.is_json
+    assert resp.get_json().get('success') is True
+    row = db.execute(
+        "SELECT montant FROM budget_lignes WHERE poste_depense_id = ? AND periode = 'annuel'",
+        (poste_id,)
+    ).fetchone()
+    assert row is not None and abs(row['montant'] - 1000) < 0.001
+
+
+def test_responsable_ne_peut_pas_enregistrer_autre_secteur(resp_client, db):
+    """Un responsable ne peut pas enregistrer le budget d'un autre secteur."""
+    db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Autre secteur','administratif')")
+    autre = db.execute("SELECT id FROM secteurs WHERE nom='Autre secteur'").fetchone()['id']
+    db.execute("INSERT INTO budgets (secteur_id, annee, montant_global) VALUES (?, 2026, 5000)", (autre,))
+    db.commit()
+
+    resp = resp_client.post('/api/budget/save', json={
+        'secteur_id': autre, 'annee': 2026, 'montant_global': None, 'lignes': [],
+    })
+    assert resp.status_code == 403
+
+
+def test_budget_secteur_distingue_session_expiree_de_panne_reseau(resp_client, sample_users):
+    """Le template doit afficher un message clair en cas de réponse non-JSON
+    (session / jeton CSRF expiré) plutôt qu'une simple « Erreur réseau »."""
+    sid = sample_users['secteur_id']
+    resp = resp_client.get(f'/budget_secteur/{sid}?annee=2026')
+    html = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'readSaveResponse' in html
+    assert 'Session expirée ou invalide' in html
+
+
 def test_api_budget_previsionnel_initial_calcule_temp(app, db, admin_client, sample_users):
     n = datetime.now().year
     secteur_id = sample_users['secteur_id']


### PR DESCRIPTION
## Échec d'enregistrement du budget secteur pour un responsable

### Symptôme
Sur la page budget d'un secteur, un **responsable** (testé sur un secteur enfance/ALP avec de **nombreuses colonnes** de périodes) ne parvenait pas à enregistrer les montants : message **« Erreur réseau »**, alors que la connexion fonctionnait. Un **comptable** n'avait pas le problème.

### Cause
Le **jeton CSRF expirait au bout d'1 h** (valeur par défaut de Flask‑WTF). Sur une page restée ouverte longtemps — précisément le cas d'une grille budgétaire ALP à nombreuses colonnes que l'on remplit posément — le POST AJAX d'enregistrement était **rejeté puis redirigé vers `/login`** (réponse HTML). Le frontend faisait `response.json()` sur cette page HTML → échec → affichage générique **« Erreur réseau »**, trompeur puisque la session était toujours active.

Le comptable, testant rapidement, ne laissait pas le jeton expirer → pas de symptôme. La différence n'était donc pas liée au profil mais au **temps passé sur la page**.

### Correctifs
- **`app.py`** : `WTF_CSRF_TIME_LIMIT = None` → le jeton CSRF reste valide tant que la session l'est. La protection CSRF reste entière (jeton toujours requis, lié à la session). Corrige la cause **pour toutes les pages AJAX**, pas seulement le budget.
- **`templates/budget_secteur.html`** : l'enregistrement distingue désormais une **réponse non‑JSON** (session/jeton expiré → « Session expirée ou invalide. Rechargez la page (F5) ») d'une **vraie panne réseau** — fini le « Erreur réseau » trompeur.

### Tests
- ✅ Un responsable peut enregistrer le budget de **son** secteur ; refus (403) sur un **autre** secteur
- ✅ `WTF_CSRF_TIME_LIMIT is None`
- ✅ Le template expose le nouveau traitement (`readSaveResponse`, message « Session expirée »)
- ✅ Suites ciblées vertes : `test_budget` (15), `test_security` (24), `test_auth` (27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_