### PR TITLE
CSE : corriger le débordement de la modale message sur mobile

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3248,6 +3248,27 @@ a.btn-icon:-webkit-any-link {
     color: var(--gray-900);
 }
 
+/* Robustesse mobile : empeche le debordement horizontal des modales.
+   min-width:0 autorise l'element flex a se reduire sous la largeur de son
+   contenu (sinon un texte long fait deborder la fenetre hors de l'ecran). */
+.modal-content {
+    box-sizing: border-box;
+    min-width: 0;
+}
+
+@media (max-width: 600px) {
+    .modal-overlay {
+        padding: 12px;
+    }
+    .modal-content {
+        width: 100%;
+        max-height: 88vh;
+    }
+    .modal-header {
+        padding: 1rem 1.1rem;
+    }
+}
+
 /* ============================================================
    RESPONSIVE MOBILE – Pages salariés
    (dashboard, demande_recup, demande_conge,

--- a/templates/base.html
+++ b/templates/base.html
@@ -415,9 +415,9 @@
             </div>
             <div style="padding:0 1.5rem 1.5rem;">
                 {% if cse_message_actif.titre %}
-                <h4 style="margin:0 0 .75rem;color:var(--gray-900);font-size:1.05rem;">{{ cse_message_actif.titre }}</h4>
+                <h4 style="margin:0 0 .75rem;color:var(--gray-900);font-size:1.05rem;overflow-wrap:anywhere;">{{ cse_message_actif.titre }}</h4>
                 {% endif %}
-                <p style="white-space:pre-wrap;word-break:break-word;line-height:1.6;color:var(--gray-700);margin:0 0 1rem;">{{ cse_message_actif.contenu }}</p>
+                <p style="white-space:pre-wrap;overflow-wrap:anywhere;line-height:1.6;color:var(--gray-700);margin:0 0 1rem;">{{ cse_message_actif.contenu }}</p>
                 <p style="font-size:.8rem;color:var(--gray-500);margin:0;">
                     {% if cse_message_actif.auteur_prenom %}Publié par {{ cse_message_actif.auteur_prenom }} {{ cse_message_actif.auteur_nom }} · {% endif %}
                     Valable jusqu'au {{ cse_message_actif.date_validite[8:10] }}/{{ cse_message_actif.date_validite[5:7] }}/{{ cse_message_actif.date_validite[0:4] }}


### PR DESCRIPTION
La fenêtre du message du CSE débordait horizontalement sur petit écran : un élément flex (.modal-content) ne se réduit pas sous la largeur de son contenu (min-width:auto), et le texte en pre-wrap forçait la fenêtre hors de l'écran.

- style.css : .modal-content en min-width:0 + box-sizing border-box ; media query mobile (<600px) : marge de l'overlay, largeur 100%, header resserré. Bénéficie à toutes les modales.
- base.html : texte du message en overflow-wrap:anywhere pour garantir le retour à la ligne dans la largeur disponible.


Claude-Session: https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4