### PR TITLE
CSE : corriger le débordement de la fenêtre message sur mobile

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3249,19 +3249,20 @@ a.btn-icon:-webkit-any-link {
 }
 
 /* Robustesse mobile : empeche le debordement horizontal des modales.
-   min-width:0 autorise l'element flex a se reduire sous la largeur de son
-   contenu (sinon un texte long fait deborder la fenetre hors de l'ecran). */
+   - min-width:0 : autorise l'element flex a respecter sa largeur (sinon un
+     contenu long le pousse au-dela de l'ecran) ;
+   - max-width plafonne a la largeur de l'ecran (vw) quel que soit le contexte ;
+   - overflow-x:hidden : filet de securite contre tout debordement residuel.
+   box-sizing est deja global (border-box). */
 .modal-content {
-    box-sizing: border-box;
     min-width: 0;
+    max-width: min(600px, calc(100vw - 24px));
+    overflow-x: hidden;
 }
 
 @media (max-width: 600px) {
-    .modal-overlay {
-        padding: 12px;
-    }
     .modal-content {
-        width: 100%;
+        width: calc(100vw - 24px);
         max-height: 88vh;
     }
     .modal-header {

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}CS-PILOT{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=15">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=16">
     <script>
         (function(){var t=localStorage.getItem('theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark');})();
     </script>
@@ -408,7 +408,7 @@
     {% if cse_message_actif and request.endpoint in cse_dashboard_endpoints %}
     {# ── Modale message du CSE ── #}
     <div id="cseMessageModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)cseCloseMessage()">
-        <div class="modal-content" style="max-width:560px;">
+        <div class="modal-content">
             <div class="modal-header">
                 <h3>📢 Message du CSE</h3>
                 <button class="modal-close" type="button" onclick="cseCloseMessage()" aria-label="Fermer">&times;</button>


### PR DESCRIPTION
## Fenêtre du message du CSE qui déborde sur mobile

### Symptôme
Sur smartphone, la fenêtre (modale) du message du CSE dépassait horizontalement de l'écran : le texte était coupé sur la droite.

### Cause
`.modal-content` est un élément flex. Par défaut, un élément flex a `min-width: auto`, ce qui l'empêche de se réduire sous la largeur intrinsèque de son contenu. Combiné au texte du message en `white-space: pre-wrap`, la fenêtre était poussée au‑delà de la largeur de l'écran.

### Correctifs (`static/css/style.css`, `templates/base.html`)
- `.modal-content` : `min-width: 0` (respecte sa largeur), `max-width: min(600px, calc(100vw - 24px))` (jamais plus large que l'écran) et `overflow-x: hidden` (filet de sécurité). **Bénéficie à toutes les modales** de l'application.
- En dessous de 600px : largeur `calc(100vw - 24px)`, en‑tête resserré.
- Texte du message en `overflow-wrap: anywhere` pour garantir le retour à la ligne.
- Retrait du `max-width` inline (560px) au profit de la règle CSS uniforme.
- **Bump du cache CSS `?v=15` → `?v=16`** : l'ancien style restait servi depuis le cache du navigateur, d'où l'absence d'effet visible des essais précédents.

### Vérifications
- ✅ `test_cse` (32) et `test_mobile_responsive_pages` (4) au vert
- ⚠️ Pour voir l'effet : fusionner + déployer, puis recharger sur mobile (le bump `?v=16` force le rechargement du CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_