### PR TITLE
Mobile : modale du CSE décalée à droite (débordement horizontal de la page)

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -182,6 +182,12 @@ body {
     font-size: 15px;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Empeche tout debordement horizontal de la page (sinon les elements
+       position:fixed comme la modale du CSE apparaissent decales sur mobile).
+       overflow-x:clip ne cree pas de conteneur de defilement : position:sticky
+       (en-tetes de tableaux) reste fonctionnel. 'hidden' = repli navigateurs anciens. */
+    overflow-x: hidden;
+    overflow-x: clip;
 }
 
 /* === NAVIGATION SIDEBAR === */

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}CS-PILOT{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=16">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=17">
     <script>
         (function(){var t=localStorage.getItem('theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark');})();
     </script>


### PR DESCRIPTION
## Fenêtre du message du CSE décalée à droite sur mobile

Suite de #155 (la largeur est maintenant correcte). La fenêtre restait **décalée vers la droite**.

### Cause
Un **débordement horizontal de la page** (un élément qui dépasse à droite) rend le document plus large que l'écran. Les éléments `position: fixed` — comme l'overlay de la modale — sont alors positionnés par rapport à ce repère plus large et apparaissent **décentrés** sur mobile, même si leur centrage flex est correct.

### Correctif (`static/css/style.css`)
- `body { overflow-x: clip; }` (avec repli `overflow-x: hidden` pour les navigateurs anciens) : empêche la page de dépasser horizontalement, donc le repère des éléments fixes redevient l'écran visible et la modale se recentre.
- `overflow-x: clip` **ne crée pas de conteneur de défilement** : les `position: sticky` (en‑têtes/colonnes figées des tableaux paie, équipe, trésorerie…) restent fonctionnels (contrairement à `overflow: hidden`).
- Bump du cache CSS `?v=16` → `?v=17`.

### Vérifications
- ✅ `test_cse` (32) au vert
- ⚠️ À voir après fusion + déploiement + rechargement mobile.

Si le décalage persistait, il faudrait identifier l'élément précis qui déborde sur le tableau de bord concerné (capture / inspecteur), mais ce `overflow-x: clip` neutralise le symptôme de façon générale et sûre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_