### PR TITLE
Tableaux de bord direction &amp; comptable : tableaux responsives sur mobile

### DIFF
--- a/templates/dashboard_comptable.html
+++ b/templates/dashboard_comptable.html
@@ -104,21 +104,23 @@
                 </div>
             </div>
             {% if heures|length > 0 %}
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead><tr><th>Date</th><th>Reel</th><th>Theorique</th><th>Ecart</th></tr></thead>
                 <tbody>
                     {% for h in heures %}
                     <tr>
-                        <td>{{ h.date[8:10] }}/{{ h.date[5:7] }}/{{ h.date[0:4] }}</td>
-                        <td>{{ "%.1f"|format(h.total_reel) }}h</td>
-                        <td>{{ "%.1f"|format(h.total_theorique) }}h</td>
-                        <td style="color:{% if h.ecart > 0 %}var(--success){% elif h.ecart < 0 %}var(--danger){% else %}var(--gray-500){% endif %};">
+                        <td data-label="Date">{{ h.date[8:10] }}/{{ h.date[5:7] }}/{{ h.date[0:4] }}</td>
+                        <td data-label="Reel">{{ "%.1f"|format(h.total_reel) }}h</td>
+                        <td data-label="Theorique">{{ "%.1f"|format(h.total_theorique) }}h</td>
+                        <td data-label="Ecart" style="color:{% if h.ecart > 0 %}var(--success){% elif h.ecart < 0 %}var(--danger){% else %}var(--gray-500){% endif %};">
                             {{ "%+.1f"|format(h.ecart) }}h
                         </td>
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
             {% else %}
             <div class="direction-empty"><p>Aucune saisie recente</p></div>
             {% endif %}
@@ -134,18 +136,19 @@
                 Verification : contrat (PDF), carte d'identite, carte vitale pour chaque salarie sous contrat actif.
             </p>
             {% if salaries_docs_manquants|length > 0 %}
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead><tr><th>Salarie</th><th>Contrat</th><th>Manquant{{ 's' if salaries_docs_manquants|length > 1 }}</th></tr></thead>
                 <tbody>
                     {% for s in salaries_docs_manquants %}
                     <tr>
-                        <td>
+                        <td data-label="Salarie">
                             <a href="{{ url_for('infos_salaries_bp.infos_salaries', user_id=s.id) }}" style="font-weight:600;">
                                 {{ s.nom }} {{ s.prenom }}
                             </a>
                         </td>
-                        <td><span class="badge {% if s.type_contrat == 'CDI' %}badge-success{% elif s.type_contrat == 'CDD' %}badge-info{% else %}badge-warning{% endif %}">{{ s.type_contrat }}</span></td>
-                        <td>
+                        <td data-label="Contrat"><span class="badge {% if s.type_contrat == 'CDI' %}badge-success{% elif s.type_contrat == 'CDD' %}badge-info{% else %}badge-warning{% endif %}">{{ s.type_contrat }}</span></td>
+                        <td data-label="Manquants">
                             {% for m in s.manquants %}
                             <span class="badge badge-danger" style="font-size:0.75rem;">{{ m }}</span>
                             {% endfor %}
@@ -154,6 +157,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
             {% else %}
             <div class="direction-empty direction-empty-ok"><p>✅ Tous les documents sont a jour</p></div>
             {% endif %}
@@ -249,14 +253,15 @@
             {% else %}
             <details class="direction-details" style="margin-top:0.75rem;">
                 <summary>{{ fiches_non_validees|length }} fiche{{ 's' if fiches_non_validees|length > 1 }} non completee{{ 's' if fiches_non_validees|length > 1 }}</summary>
-                <table class="data-table">
+                <div class="table-responsive">
+                <table class="data-table data-table-cards">
                     <thead><tr><th>Salarie</th><th>Secteur</th><th>Etapes manquantes</th></tr></thead>
                     <tbody>
                         {% for f in fiches_non_validees[:15] %}
                         <tr>
-                            <td><strong>{{ f.nom }} {{ f.prenom }}</strong></td>
-                            <td style="font-size:0.85rem;">{{ f.secteur }}</td>
-                            <td>
+                            <td data-label="Salarie"><strong>{{ f.nom }} {{ f.prenom }}</strong></td>
+                            <td data-label="Secteur" style="font-size:0.85rem;">{{ f.secteur }}</td>
+                            <td data-label="Etapes manquantes">
                                 {% for e in f.etapes_manquantes %}
                                 <span class="badge badge-warning">{{ e }}</span>
                                 {% endfor %}
@@ -264,10 +269,11 @@
                         </tr>
                         {% endfor %}
                         {% if fiches_non_validees|length > 15 %}
-                        <tr><td colspan="3" style="text-align:center;color:var(--gray-500);">+ {{ fiches_non_validees|length - 15 }} autres</td></tr>
+                        <tr><td colspan="3" data-label="" style="text-align:center;color:var(--gray-500);">+ {{ fiches_non_validees|length - 15 }} autres</td></tr>
                         {% endif %}
                     </tbody>
                 </table>
+                </div>
             </details>
             {% endif %}
             {% else %}
@@ -317,13 +323,14 @@
             <div>
                 <h3 style="font-size:1rem;margin-bottom:0.5rem;">📊 Bilan secteurs / actions</h3>
                 {% if bilan_imports|length > 0 %}
-                <table class="data-table">
+                <div class="table-responsive">
+                <table class="data-table data-table-cards">
                     <thead><tr><th>Annee</th><th>Mois disponibles</th><th>Ecritures</th></tr></thead>
                     <tbody>
                         {% for bi in bilan_imports %}
                         <tr>
-                            <td><strong>{{ bi.annee }}</strong></td>
-                            <td>
+                            <td data-label="Annee"><strong>{{ bi.annee }}</strong></td>
+                            <td data-label="Mois disponibles">
                                 {% if bi.mois_min and bi.mois_max %}
                                     {% if bi.mois_min == bi.mois_max %}
                                     {{ bi.mois_min }}
@@ -334,11 +341,12 @@
                                 —
                                 {% endif %}
                             </td>
-                            <td>{{ bi.nb_ecritures }}</td>
+                            <td data-label="Ecritures">{{ bi.nb_ecritures }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
+                </div>
                 {% else %}
                 <div class="direction-empty"><p>Aucun import Bilan</p></div>
                 {% endif %}
@@ -351,24 +359,26 @@
             <div>
                 <h3 style="font-size:1rem;margin-bottom:0.5rem;">📈 Tresorerie / Budget previsionnel</h3>
                 {% if treso_imports|length > 0 %}
-                <table class="data-table">
+                <div class="table-responsive">
+                <table class="data-table data-table-cards">
                     <thead><tr><th>Annee</th><th>Mois disponibles</th><th>Lignes</th></tr></thead>
                     <tbody>
                         {% for ti in treso_imports %}
                         <tr>
-                            <td><strong>{{ ti.annee }}</strong></td>
-                            <td>
+                            <td data-label="Annee"><strong>{{ ti.annee }}</strong></td>
+                            <td data-label="Mois disponibles">
                                 {% if ti.mois_min == ti.mois_max %}
                                 {{ ti.mois_min }}
                                 {% else %}
                                 {{ ti.mois_min }} a {{ ti.mois_max }}
                                 {% endif %}
                             </td>
-                            <td>{{ ti.nb_lignes }}</td>
+                            <td data-label="Lignes">{{ ti.nb_lignes }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
+                </div>
                 {% else %}
                 <div class="direction-empty"><p>Aucun import Tresorerie</p></div>
                 {% endif %}

--- a/templates/dashboard_direction.html
+++ b/templates/dashboard_direction.html
@@ -145,26 +145,28 @@
                                 {{ secteur }}
                                 <span class="badge badge-warning">{{ liste|length }}</span>
                             </h4>
-                            <table class="data-table">
+                            <div class="table-responsive">
+                            <table class="data-table data-table-cards">
                                 <thead>
                                     <tr><th>Salarie</th><th>Motif</th><th>Du</th><th>Au</th><th>Jours</th></tr>
                                 </thead>
                                 <tbody>
                                     {% for ab in liste %}
                                     <tr>
-                                        <td><strong>{{ ab.salarie_nom }} {{ ab.salarie_prenom }}</strong></td>
-                                        <td>
+                                        <td data-label="Salarie"><strong>{{ ab.salarie_nom }} {{ ab.salarie_prenom }}</strong></td>
+                                        <td data-label="Motif">
                                             <span class="badge {% if ab.motif == 'Arret maladie' or ab.motif == 'Arrêt maladie' %}badge-danger{% elif 'Conge' in ab.motif or 'Congé' in ab.motif %}badge-info{% else %}badge-warning{% endif %}">
                                                 {{ ab.motif }}
                                             </span>
                                         </td>
-                                        <td>{{ ab.date_debut }}</td>
-                                        <td>{{ ab.date_fin }}</td>
-                                        <td><strong>{{ ab.jours_ouvres }}</strong></td>
+                                        <td data-label="Du">{{ ab.date_debut }}</td>
+                                        <td data-label="Au">{{ ab.date_fin }}</td>
+                                        <td data-label="Jours"><strong>{{ ab.jours_ouvres }}</strong></td>
                                     </tr>
                                     {% endfor %}
                                 </tbody>
                             </table>
+                            </div>
                         </div>
                         {% endfor %}
                     </div>
@@ -274,7 +276,7 @@
                     {% endfor %}
                 </div>
                 {% if total_subv_accorde > 0 or total_subv_demande > 0 %}
-                <div style="display:flex;gap:1.5rem;justify-content:center;margin-bottom:1rem;">
+                <div style="display:flex;flex-wrap:wrap;gap:1.5rem;justify-content:center;margin-bottom:1rem;">
                     <div class="direction-mini-stat">
                         <span class="direction-mini-value" style="font-size:1.3rem;">{{ "{:,.0f}".format(total_subv_demande).replace(",", " ") }} €</span>
                         <span class="direction-mini-label">demande</span>
@@ -376,27 +378,29 @@
         {% if fiches_en_attente|length > 0 %}
         <details class="direction-details">
             <summary>Voir les {{ fiches_en_attente|length }} fiche{{ 's' if fiches_en_attente|length > 1 }} non completee{{ 's' if fiches_en_attente|length > 1 }}</summary>
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead>
                     <tr><th>Salarie</th><th>Secteur</th><th>Etapes manquantes</th><th>Actions</th></tr>
                 </thead>
                 <tbody>
                     {% for f in fiches_en_attente %}
                     <tr>
-                        <td><strong>{{ f.nom }} {{ f.prenom }}</strong></td>
-                        <td>{{ f.secteur }}</td>
-                        <td>
+                        <td data-label="Salarie"><strong>{{ f.nom }} {{ f.prenom }}</strong></td>
+                        <td data-label="Secteur">{{ f.secteur }}</td>
+                        <td data-label="Etapes manquantes">
                             {% for e in f.etapes_manquantes %}
                             <span class="badge badge-warning">{{ e }}</span>
                             {% endfor %}
                         </td>
-                        <td>
+                        <td data-label="Actions">
                             <a href="{{ url_for('validation_bp.vue_mensuelle', user_id=f.user_id, mois=mois_validation, annee=annee_validation) }}" class="btn btn-sm btn-primary">Voir</a>
                         </td>
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
         </details>
         {% endif %}
     </div>
@@ -409,19 +413,20 @@
         <div class="section">
             <h2>🧾 Factures a approuver</h2>
             {% if factures_en_attente|length > 0 %}
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead>
                     <tr><th>Fournisseur</th><th>Montant</th><th>Echeance</th></tr>
                 </thead>
                 <tbody>
                     {% for f in factures_en_attente %}
                     <tr>
-                        <td>
+                        <td data-label="Fournisseur">
                             <strong>{{ f.fournisseur_nom or 'N/A' }}</strong>
                             {% if f.numero_facture %}<br><small style="color:var(--gray-500);">{{ f.numero_facture }}</small>{% endif %}
                         </td>
-                        <td style="font-weight:600;">{{ "{:,.2f}".format(f.montant_ttc).replace(",", " ") }} €</td>
-                        <td>
+                        <td data-label="Montant" style="font-weight:600;">{{ "{:,.2f}".format(f.montant_ttc).replace(",", " ") }} €</td>
+                        <td data-label="Echeance">
                             {% if f.date_echeance %}
                             <span class="badge {% if f.date_echeance < today.strftime('%Y-%m-%d') %}badge-danger{% else %}badge-info{% endif %}">{{ f.date_echeance }}</span>
                             {% else %}—{% endif %}
@@ -430,6 +435,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
             {% if nb_factures_attente > factures_en_attente|length %}
             <div style="text-align:center;font-size:0.85rem;color:var(--gray-500);margin-top:0.5rem;">
                 + {{ nb_factures_attente - factures_en_attente|length }} autre{{ 's' if nb_factures_attente - factures_en_attente|length > 1 }}
@@ -447,26 +453,27 @@
         <div class="section">
             <h2>🏖️ Demandes récup & congés</h2>
             {% if demandes_recup|length > 0 or demandes_conges|default([])|length > 0 %}
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead>
                     <tr><th>Type</th><th>Demandeur</th><th>Jours</th><th>Statut</th></tr>
                 </thead>
                 <tbody>
                     {% for d in demandes_conges|default([]) %}
                     <tr>
-                        <td>
+                        <td data-label="Type">
                             {% if d.type_conge == 'Congé payé' %}
                             <span class="badge" style="background: #dbeafe; color: #1e40af;">CP</span>
                             {% else %}
                             <span class="badge" style="background: #fae8ff; color: #86198f;">CC</span>
                             {% endif %}
                         </td>
-                        <td>
+                        <td data-label="Demandeur">
                             <strong>{{ d.demandeur_nom }} {{ d.demandeur_prenom }}</strong>
                             <br><small style="color:var(--gray-500);">{{ d.secteur_nom or '' }}</small>
                         </td>
-                        <td><strong>{{ d.nb_jours }}</strong> j</td>
-                        <td>
+                        <td data-label="Jours"><strong>{{ d.nb_jours }}</strong> j</td>
+                        <td data-label="Statut">
                             {% if d.statut == 'en_attente_responsable' %}
                             <span class="badge badge-warning">Resp.</span>
                             {% elif d.statut == 'en_attente_direction' %}
@@ -477,13 +484,13 @@
                     {% endfor %}
                     {% for d in demandes_recup %}
                     <tr>
-                        <td><span class="badge" style="background: #dcfce7; color: #166534;">Récup</span></td>
-                        <td>
+                        <td data-label="Type"><span class="badge" style="background: #dcfce7; color: #166534;">Récup</span></td>
+                        <td data-label="Demandeur">
                             <strong>{{ d.demandeur_nom }} {{ d.demandeur_prenom }}</strong>
                             <br><small style="color:var(--gray-500);">{{ d.secteur_nom or '' }}</small>
                         </td>
-                        <td><strong>{{ d.nb_jours }}</strong> j</td>
-                        <td>
+                        <td data-label="Jours"><strong>{{ d.nb_jours }}</strong> j</td>
+                        <td data-label="Statut">
                             {% if d.statut == 'en_attente_responsable' %}
                             <span class="badge badge-warning">Resp.</span>
                             {% elif d.statut == 'en_attente_direction' %}
@@ -494,6 +501,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
             {% else %}
             <div class="direction-empty direction-empty-ok"><p>✅ Aucune demande en attente</p></div>
             {% endif %}
@@ -537,26 +545,27 @@
     <div class="section">
         <h2>🏖️ Top conges cumules</h2>
         {% if top_conges|length > 0 %}
-        <table class="data-table">
+        <div class="table-responsive">
+        <table class="data-table data-table-cards">
             <thead>
                 <tr><th>Salarie</th><th>Secteur</th><th>CP solde</th><th>CC solde</th><th>Total</th></tr>
             </thead>
             <tbody>
                 {% for tc in top_conges %}
                 <tr>
-                    <td><strong>{{ tc.nom }} {{ tc.prenom }}</strong></td>
-                    <td style="font-size:0.85rem;">{{ tc.secteur_nom }}</td>
-                    <td>
+                    <td data-label="Salarie"><strong>{{ tc.nom }} {{ tc.prenom }}</strong></td>
+                    <td data-label="Secteur" style="font-size:0.85rem;">{{ tc.secteur_nom }}</td>
+                    <td data-label="CP solde">
                         <span style="color:{% if (tc.cp_a_prendre - tc.cp_pris) > 10 %}var(--warning){% elif (tc.cp_a_prendre - tc.cp_pris) > 0 %}var(--success){% else %}var(--gray-500){% endif %};">
                             {{ "%.1f"|format(tc.cp_a_prendre - tc.cp_pris) }} j
                         </span>
                     </td>
-                    <td>
+                    <td data-label="CC solde">
                         <span style="color:{% if tc.cc_solde > 4 %}var(--warning){% elif tc.cc_solde > 0 %}var(--success){% else %}var(--gray-500){% endif %};">
                             {{ "%.1f"|format(tc.cc_solde) }} j
                         </span>
                     </td>
-                    <td>
+                    <td data-label="Total">
                         <strong style="color:{% if tc.total_conges > 15 %}var(--danger){% elif tc.total_conges > 10 %}var(--warning){% else %}var(--success){% endif %};">
                             {{ "%.1f"|format(tc.total_conges) }} j
                         </strong>
@@ -565,6 +574,7 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
         {% else %}
         <div class="direction-empty"><p>Aucun solde de conges</p></div>
         {% endif %}


### PR DESCRIPTION
## Optimisation mobile des tableaux de bord direction & comptable

Suite logique du décalage de la fenêtre du CSE : la cause profonde était que ces tableaux de bord **ne sont pas optimisés pour smartphone**. Leurs tableaux (`data-table` simples, non wrappés) **débordaient horizontalement**, ce qui élargissait la page et décalait les éléments `position: fixed` (la modale du CSE), tout en rognant le contenu.

### Diagnostic
- Le tableau de bord **salarié** ne débordait pas → ses tableaux utilisent déjà le motif `data-table-cards` (affichage en cartes sur mobile).
- Les grilles (`stats-grid`, `dd-kpi-grid`, `direction-row`, `direction-validation-grid`, `direction-quick-links`) et les « graphiques » CSS étaient déjà responsives (media queries / `auto-fill` / largeurs en %).
- **Seuls les tableaux** restaient en `data-table` simple → source du débordement.

### Correctif (`templates/dashboard_direction.html`, `templates/dashboard_comptable.html`)
- **10 tableaux** (5 direction + 5 comptable) passés au motif mobile déjà utilisé ailleurs :
  - classe `data-table data-table-cards` + attribut `data-label` sur chaque cellule → **affichage en cartes empilées sous 768px** (plus de scroll horizontal, plus de débordement) ;
  - wrapper `.table-responsive` (filet de sécurité, scroll interne sur desktop si besoin).
- Ajout d'un `flex-wrap` sur une ligne de statistiques subventions.

### Effet
- Plus de débordement horizontal sur ces pages → la **fenêtre du CSE est centrée** pour direction/comptable, et les **tableaux deviennent lisibles** (cartes) sur smartphone.
- Aucun changement CSS (les règles `data-table-cards` existent déjà) → pas de souci de cache.

### Vérifications
- ✅ `test_dashboard_direction` (4), `test_dashboard_comptable` (7), `test_mobile_responsive_pages` (4)
- ✅ Rendu des deux pages confirmé (cartes + `data-label`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_