### PR TITLE
Dashboard comptable : fiche d'heures compactée (mobile) + retrait des documents obligatoires

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1834,8 +1834,11 @@ a.btn-icon:-webkit-any-link {
         grid-template-columns: 1fr;
     }
     .direction-mini-stats {
-        flex-direction: column;
-        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
+    .direction-mini-value {
+        font-size: 1.5rem;
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}CS-PILOT{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=17">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=18">
     <script>
         (function(){var t=localStorage.getItem('theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark');})();
     </script>

--- a/templates/dashboard_comptable.html
+++ b/templates/dashboard_comptable.html
@@ -83,9 +83,9 @@
     </div>
 
     {# ════════════════════════════════════════════════════════════
-       SECTION 2 : MA FICHE D'HEURES + DOCUMENTS MANQUANTS
+       SECTION 2 : MA FICHE D'HEURES
        ════════════════════════════════════════════════════════════ #}
-    <div class="direction-row direction-row-equal">
+    <div>
         {# Ma fiche d'heures #}
         <div class="section">
             <h2>✏️ Ma fiche d'heures</h2>
@@ -126,43 +126,6 @@
             {% endif %}
             <div style="margin-top:0.75rem;text-align:right;">
                 <a href="{{ url_for('saisie_bp.saisie_heures') }}" class="btn btn-sm btn-primary">Saisir mes heures</a>
-            </div>
-        </div>
-
-        {# Documents obligatoires manquants #}
-        <div class="section">
-            <h2>📁 Documents obligatoires</h2>
-            <p style="font-size:0.85rem;color:var(--gray-500);margin-bottom:0.75rem;">
-                Verification : contrat (PDF), carte d'identite, carte vitale pour chaque salarie sous contrat actif.
-            </p>
-            {% if salaries_docs_manquants|length > 0 %}
-            <div class="table-responsive">
-            <table class="data-table data-table-cards">
-                <thead><tr><th>Salarie</th><th>Contrat</th><th>Manquant{{ 's' if salaries_docs_manquants|length > 1 }}</th></tr></thead>
-                <tbody>
-                    {% for s in salaries_docs_manquants %}
-                    <tr>
-                        <td data-label="Salarie">
-                            <a href="{{ url_for('infos_salaries_bp.infos_salaries', user_id=s.id) }}" style="font-weight:600;">
-                                {{ s.nom }} {{ s.prenom }}
-                            </a>
-                        </td>
-                        <td data-label="Contrat"><span class="badge {% if s.type_contrat == 'CDI' %}badge-success{% elif s.type_contrat == 'CDD' %}badge-info{% else %}badge-warning{% endif %}">{{ s.type_contrat }}</span></td>
-                        <td data-label="Manquants">
-                            {% for m in s.manquants %}
-                            <span class="badge badge-danger" style="font-size:0.75rem;">{{ m }}</span>
-                            {% endfor %}
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-            </div>
-            {% else %}
-            <div class="direction-empty direction-empty-ok"><p>✅ Tous les documents sont a jour</p></div>
-            {% endif %}
-            <div style="margin-top:0.75rem;text-align:right;">
-                <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}" class="btn btn-sm btn-secondary">Fiches salaries</a>
             </div>
         </div>
     </div>

--- a/tests/test_dashboard_comptable.py
+++ b/tests/test_dashboard_comptable.py
@@ -23,7 +23,8 @@ def test_dashboard_comptable_sections_specifiques(comptable_client):
     assert 'Cloture' in html
     assert 'Prepa paie' in html
     # Sections
-    assert 'Documents obligatoires' in html
+    # La section detaillee "Documents obligatoires" a ete retiree du dashboard.
+    assert 'Documents obligatoires' not in html
     assert 'Ecritures brouillon' in html
     assert 'Pretes a exporter' in html
     assert 'Factures en attente' in html


### PR DESCRIPTION
## Dashboard comptable : « Ma fiche d'heures » compactée + « Documents obligatoires » retirée

Suite des retours mobile sur le tableau de bord comptable.

### 1. « Ma fiche d'heures » optimisée sur mobile
- Les 3 mini‑stats (CP solde / CC solde / Solde récup) passaient en **colonne** sous 640px et occupaient tout l'écran. Elles repassent en **ligne compacte** (`flex-wrap`) avec une valeur réduite (1.5rem au lieu de 2rem).
- La section passe en **pleine largeur** (avant, elle occupait une demi‑colonne avec un vide à côté une fois la section voisine retirée).

### 2. Section « Documents obligatoires » retirée (à la demande)
- Suppression de la section détaillée `📁 Documents obligatoires` (et de son tableau) du dashboard comptable.
- La **carte KPI « Documents manquants »** (compteur en haut) est **conservée**.

### Détails
- `static/css/style.css` : règle mobile des `.direction-mini-stats` (ligne compacte au lieu de colonne) + bump cache `?v=17` → `?v=18`.
- `templates/dashboard_comptable.html` : section documents retirée, fiche d'heures en pleine largeur.
- `tests/test_dashboard_comptable.py` : assertion mise à jour (la section retirée ne doit plus apparaître).

### Vérifications
- ✅ `test_dashboard_comptable` (7), `test_dashboard_direction` (4), `test_mobile_responsive_pages` (4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_