### PR TITLE
Tableau de bord responsable : tableaux responsives sur mobile

### DIFF
--- a/templates/dashboard_responsable.html
+++ b/templates/dashboard_responsable.html
@@ -99,28 +99,30 @@
         <div class="section">
             <h2>👥 Mon equipe</h2>
             {% if equipe|length > 0 %}
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead>
                     <tr><th>Salarie</th><th>Contrat</th><th>Temps hebdo</th></tr>
                 </thead>
                 <tbody>
                     {% for m in equipe %}
                     <tr>
-                        <td><strong>{{ m.nom }} {{ m.prenom }}</strong></td>
-                        <td>
+                        <td data-label="Salarie"><strong>{{ m.nom }} {{ m.prenom }}</strong></td>
+                        <td data-label="Contrat">
                             {% if m.type_contrat %}
                             <span class="badge {% if m.type_contrat == 'CDI' %}badge-success{% elif m.type_contrat == 'CDD' %}badge-info{% elif m.type_contrat == 'CEE' %}badge-warning{% else %}badge-info{% endif %}">{{ m.type_contrat }}</span>
                             {% else %}
                             <span class="badge badge-inactive">—</span>
                             {% endif %}
                         </td>
-                        <td>
+                        <td data-label="Temps hebdo">
                             {% if m.temps_hebdo %}{{ "%.0f"|format(m.temps_hebdo) }}h{% elif m.type_contrat == 'CEE' %}Forfait{% else %}—{% endif %}
                         </td>
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
             <div style="text-align:right;margin-top:0.75rem;font-size:0.85rem;color:var(--gray-500);">
                 Total : <strong style="color:var(--primary-dark);">{{ nb_salaries }}</strong> salarie{{ 's' if nb_salaries > 1 }} · <strong style="color:var(--primary-dark);">{{ "%.1f"|format(total_etp) }}</strong> ETP
             </div>
@@ -164,26 +166,28 @@
                         {% endfor %}
                     </div>
                 {% endif %}
-                <table class="data-table" style="margin-top:1rem;">
+                <div class="table-responsive">
+                <table class="data-table data-table-cards" style="margin-top:1rem;">
                     <thead>
                         <tr><th>Salarie</th><th>Motif</th><th>Du</th><th>Au</th><th>Jours</th></tr>
                     </thead>
                     <tbody>
                         {% for ab in absences_en_cours %}
                         <tr>
-                            <td><strong>{{ ab.salarie_nom }} {{ ab.salarie_prenom }}</strong></td>
-                            <td>
+                            <td data-label="Salarie"><strong>{{ ab.salarie_nom }} {{ ab.salarie_prenom }}</strong></td>
+                            <td data-label="Motif">
                                 <span class="badge {% if ab.motif == 'Arret maladie' or ab.motif == 'Arrêt maladie' %}badge-danger{% elif 'Conge' in ab.motif or 'Congé' in ab.motif %}badge-info{% else %}badge-warning{% endif %}">
                                     {{ ab.motif }}
                                 </span>
                             </td>
-                            <td>{{ ab.date_debut }}</td>
-                            <td>{{ ab.date_fin }}</td>
-                            <td><strong>{{ ab.jours_ouvres }}</strong></td>
+                            <td data-label="Du">{{ ab.date_debut }}</td>
+                            <td data-label="Au">{{ ab.date_fin }}</td>
+                            <td data-label="Jours"><strong>{{ ab.jours_ouvres }}</strong></td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
+                </div>
             {% else %}
                 <div class="direction-empty direction-empty-ok">
                     <p>✅ Aucune absence en cours aujourd'hui</p>
@@ -339,26 +343,28 @@
         {% if fiches_en_attente|length > 0 %}
         <details class="direction-details">
             <summary>Voir les {{ fiches_en_attente|length }} fiche{{ 's' if fiches_en_attente|length > 1 }} non completee{{ 's' if fiches_en_attente|length > 1 }}</summary>
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead>
                     <tr><th>Salarie</th><th>Etapes manquantes</th><th>Actions</th></tr>
                 </thead>
                 <tbody>
                     {% for f in fiches_en_attente %}
                     <tr>
-                        <td><strong>{{ f.nom }} {{ f.prenom }}</strong></td>
-                        <td>
+                        <td data-label="Salarie"><strong>{{ f.nom }} {{ f.prenom }}</strong></td>
+                        <td data-label="Etapes manquantes">
                             {% for e in f.etapes_manquantes %}
                             <span class="badge badge-warning">{{ e }}</span>
                             {% endfor %}
                         </td>
-                        <td>
+                        <td data-label="Actions">
                             <a href="{{ url_for('validation_bp.vue_mensuelle', user_id=f.user_id, mois=mois_validation, annee=annee_validation) }}" class="btn btn-sm btn-primary">Voir</a>
                         </td>
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
         </details>
         {% endif %}
     </div>
@@ -371,19 +377,20 @@
         <div class="section">
             <h2>🧾 Factures a approuver</h2>
             {% if factures_en_attente|length > 0 %}
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead>
                     <tr><th>Fournisseur</th><th>Montant</th><th>Echeance</th></tr>
                 </thead>
                 <tbody>
                     {% for f in factures_en_attente %}
                     <tr>
-                        <td>
+                        <td data-label="Fournisseur">
                             <strong>{{ f.fournisseur_nom or 'N/A' }}</strong>
                             {% if f.numero_facture %}<br><small style="color:var(--gray-500);">{{ f.numero_facture }}</small>{% endif %}
                         </td>
-                        <td style="font-weight:600;">{{ "{:,.2f}".format(f.montant_ttc).replace(",", " ") }} €</td>
-                        <td>
+                        <td data-label="Montant" style="font-weight:600;">{{ "{:,.2f}".format(f.montant_ttc).replace(",", " ") }} €</td>
+                        <td data-label="Echeance">
                             {% if f.date_echeance %}
                             <span class="badge {% if f.date_echeance < today.strftime('%Y-%m-%d') %}badge-danger{% else %}badge-info{% endif %}">{{ f.date_echeance }}</span>
                             {% else %}—{% endif %}
@@ -392,6 +399,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
             {% if nb_factures_attente > factures_en_attente|length %}
             <div style="text-align:center;font-size:0.85rem;color:var(--gray-500);margin-top:0.5rem;">
                 + {{ nb_factures_attente - factures_en_attente|length }} autre{{ 's' if nb_factures_attente - factures_en_attente|length > 1 }}
@@ -409,23 +417,24 @@
         <div class="section">
             <h2>🏖️ Demandes récup & congés</h2>
             {% if demandes_recup|length > 0 or demandes_conges|default([])|length > 0 %}
-            <table class="data-table">
+            <div class="table-responsive">
+            <table class="data-table data-table-cards">
                 <thead>
                     <tr><th>Type</th><th>Demandeur</th><th>Jours</th><th>Statut</th></tr>
                 </thead>
                 <tbody>
                     {% for d in demandes_conges|default([]) %}
                     <tr>
-                        <td>
+                        <td data-label="Type">
                             {% if d.type_conge == 'Congé payé' %}
                             <span class="badge" style="background: #dbeafe; color: #1e40af;">CP</span>
                             {% else %}
                             <span class="badge" style="background: #fae8ff; color: #86198f;">CC</span>
                             {% endif %}
                         </td>
-                        <td><strong>{{ d.demandeur_nom }} {{ d.demandeur_prenom }}</strong></td>
-                        <td><strong>{{ d.nb_jours }}</strong> j</td>
-                        <td>
+                        <td data-label="Demandeur"><strong>{{ d.demandeur_nom }} {{ d.demandeur_prenom }}</strong></td>
+                        <td data-label="Jours"><strong>{{ d.nb_jours }}</strong> j</td>
+                        <td data-label="Statut">
                             {% if d.statut == 'en_attente_responsable' %}
                             <span class="badge badge-warning">Resp.</span>
                             {% elif d.statut == 'en_attente_direction' %}
@@ -436,10 +445,10 @@
                     {% endfor %}
                     {% for d in demandes_recup %}
                     <tr>
-                        <td><span class="badge" style="background: #dcfce7; color: #166534;">Récup</span></td>
-                        <td><strong>{{ d.demandeur_nom }} {{ d.demandeur_prenom }}</strong></td>
-                        <td><strong>{{ d.nb_jours }}</strong> j</td>
-                        <td>
+                        <td data-label="Type"><span class="badge" style="background: #dcfce7; color: #166534;">Récup</span></td>
+                        <td data-label="Demandeur"><strong>{{ d.demandeur_nom }} {{ d.demandeur_prenom }}</strong></td>
+                        <td data-label="Jours"><strong>{{ d.nb_jours }}</strong> j</td>
+                        <td data-label="Statut">
                             {% if d.statut == 'en_attente_responsable' %}
                             <span class="badge badge-warning">Resp.</span>
                             {% elif d.statut == 'en_attente_direction' %}
@@ -450,6 +459,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            </div>
             {% else %}
             <div class="direction-empty direction-empty-ok"><p>✅ Aucune demande en attente</p></div>
             {% endif %}
@@ -465,25 +475,26 @@
     <div class="section">
         <h2>🏖️ Conges de l'equipe</h2>
         {% if conges_equipe|length > 0 %}
-        <table class="data-table">
+        <div class="table-responsive">
+        <table class="data-table data-table-cards">
             <thead>
                 <tr><th>Salarie</th><th>CP solde</th><th>CC solde</th><th>Total</th></tr>
             </thead>
             <tbody>
                 {% for tc in conges_equipe %}
                 <tr>
-                    <td><strong>{{ tc.nom }} {{ tc.prenom }}</strong></td>
-                    <td>
+                    <td data-label="Salarie"><strong>{{ tc.nom }} {{ tc.prenom }}</strong></td>
+                    <td data-label="CP solde">
                         <span style="color:{% if (tc.cp_a_prendre - tc.cp_pris) > 10 %}var(--warning){% elif (tc.cp_a_prendre - tc.cp_pris) > 0 %}var(--success){% else %}var(--gray-500){% endif %};">
                             {{ "%.1f"|format(tc.cp_a_prendre - tc.cp_pris) }} j
                         </span>
                     </td>
-                    <td>
+                    <td data-label="CC solde">
                         <span style="color:{% if tc.cc_solde > 4 %}var(--warning){% elif tc.cc_solde > 0 %}var(--success){% else %}var(--gray-500){% endif %};">
                             {{ "%.1f"|format(tc.cc_solde) }} j
                         </span>
                     </td>
-                    <td>
+                    <td data-label="Total">
                         <strong style="color:{% if tc.total_conges > 15 %}var(--danger){% elif tc.total_conges > 10 %}var(--warning){% else %}var(--success){% endif %};">
                             {{ "%.1f"|format(tc.total_conges) }} j
                         </strong>
@@ -492,6 +503,7 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
         {% else %}
         <div class="direction-empty"><p>Aucun solde de conges</p></div>
         {% endif %}


### PR DESCRIPTION
## Tableau de bord responsable : tableaux responsives sur mobile

Le tableau de bord **responsable** avait été oublié et présentait le même problème que direction/comptable : des `<table class="data-table">` non wrappées qui débordaient horizontalement sur smartphone.

### Correctif (`templates/dashboard_responsable.html`)
Les **6 tableaux** passent au motif mobile déjà appliqué ailleurs (`data-table data-table-cards` + `data-label` sur chaque cellule + wrapper `.table-responsive`) :
1. Mon équipe (salarié / contrat / temps hebdo)
2. Absences en cours (salarié / motif / du / au / jours)
3. Fiches non complétées (validations)
4. Factures à approuver
5. Demandes récup & congés
6. Congés de l'équipe

→ affichage en **cartes empilées sous 768px**, plus de débordement horizontal, et fenêtre du CSE recentrée pour ce profil. Les grilles et mini‑stats étaient déjà responsives (CSS commun).

Aucun changement CSS → pas de souci de cache (le HTML se recharge tout seul).

### Vérifications
- ✅ `test_dashboard_responsable` (10), `test_mobile_responsive_pages` (4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4

---
_Generated by [Claude Code](https://claude.ai/code/session_019oFhG9MQKfBHJyjrqCe2f4)_