### PR TITLE
Saisie libre du temps hebdo des contrats (infos_salaries)

### DIFF
--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -115,7 +115,7 @@
                 </div>
                 <div class="form-group" style="margin-bottom: 0;">
                     <label for="temps_hebdo_contrat">Temps Hebdo (h)</label>
-                    <input type="number" name="temps_hebdo" id="temps_hebdo_contrat" step="0.5" min="0" placeholder="Ex: 35" style="width: 90px;">
+                    <input type="number" name="temps_hebdo" id="temps_hebdo_contrat" step="any" min="0" placeholder="Ex: 35" style="width: 90px;">
                 </div>
                 <div class="form-group cee-field" style="margin-bottom: 0; display: none;">
                     <label for="forfait_contrat">Forfait</label>
@@ -159,7 +159,7 @@
                     <td><span class="badge badge-info">{{ c.type_contrat }}</span></td>
                     <td>{{ c.date_debut }}</td>
                     <td>{{ c.date_fin or '-' }}</td>
-                    <td>{{ ("%.1f"|format(c.temps_hebdo) ~ 'h') if c.temps_hebdo else '-' }}</td>
+                    <td>{{ (("%.2f"|format(c.temps_hebdo)).rstrip('0').rstrip('.') ~ 'h') if c.temps_hebdo else '-' }}</td>
                     <td>{{ c.forfait or '-' }}</td>
                     <td>{{ c.nbr_jours if c.nbr_jours else '-' }}</td>
                     <td>

--- a/tests/test_nouvelles_fonctionnalites.py
+++ b/tests/test_nouvelles_fonctionnalites.py
@@ -151,8 +151,51 @@ class TestContratsTempsHebdo:
         assert row is not None
         assert row['temps_hebdo'] == 35.0
 
+    def test_champ_temps_hebdo_saisie_libre(self, client, users_with_contracts):
+        """Le champ temps_hebdo autorise une saisie libre (plus de pas de 0.5)."""
+        _login(client, 'dir_test', 'Dir1234')
+        resp = client.get(f'/infos_salaries?user_id={users_with_contracts["sal1_id"]}')
+        html = resp.get_data(as_text=True)
+        assert 'name="temps_hebdo" id="temps_hebdo_contrat" step="any"' in html
 
-# ── Tests budget_previsionnel boutons ─────────────────────────────────────────
+    def test_ajout_contrat_temps_hebdo_decimal_libre(self, client, db, users_with_contracts):
+        """Une valeur hors multiple de 0.5 (ex. 33.75) est acceptée et enregistrée."""
+        _login(client, 'dir_test', 'Dir1234')
+        user_id = users_with_contracts['sal1_id']
+        resp = client.post('/infos_salaries/contrat', data={
+            'user_id': user_id,
+            'type_contrat': 'CDI',
+            'date_debut': '2025-02-01',
+            'temps_hebdo': '33.75',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        with client.application.app_context():
+            import database
+            conn = database.get_db()
+            row = conn.execute(
+                'SELECT temps_hebdo FROM contrats WHERE user_id=? ORDER BY id DESC LIMIT 1',
+                (user_id,)
+            ).fetchone()
+            conn.close()
+        assert row is not None
+        assert row['temps_hebdo'] == 33.75
+
+    def test_affichage_temps_hebdo_decimal_non_arrondi(self, client, users_with_contracts):
+        """Le tableau affiche la valeur exacte (33.75h), sans arrondi à 0.1 (33.8h)."""
+        _login(client, 'dir_test', 'Dir1234')
+        user_id = users_with_contracts['sal1_id']
+        client.post('/infos_salaries/contrat', data={
+            'user_id': user_id,
+            'type_contrat': 'CDI',
+            'date_debut': '2025-03-01',
+            'temps_hebdo': '33.75',
+        }, follow_redirects=True)
+        resp = client.get(f'/infos_salaries?user_id={user_id}')
+        html = resp.get_data(as_text=True)
+        assert '33.75h' in html
+        assert '33.8h' not in html
+        # Un temps entier reste affiché sans décimale superflue
+        assert '35h' in html
 
 class TestBudgetPrevisionnelBoutons:
 


### PR DESCRIPTION
## Contexte

Sur la page **Infos salariés**, le champ « Temps Hebdo » du formulaire d'ajout de contrat n'acceptait que des entiers ou des multiples de 0,5. Une valeur comme **33.75** était bloquée par le navigateur.

## Cause

`templates/infos_salaries.html` : l'input portait `step="0.5"`, ce qui restreint la saisie aux multiples de 0,5 (le serveur, lui, parsait déjà la valeur en `float` sans restriction).

## Changement

- **Saisie libre** : `step="0.5"` → `step="any"` sur le champ `temps_hebdo` (on garde `min="0"`). Toute valeur décimale est désormais acceptée.
- **Affichage fidèle** : le tableau arrondissait à une décimale (`%.1f`) et aurait affiché `33.8h` pour `33.75`. Il préserve maintenant la valeur exacte saisie (`33.75h`) tout en masquant les décimales superflues des valeurs entières (`35h` au lieu de `35.0h`).

Périmètre volontairement limité à la page `infos_salaries`, comme demandé.

## Tests

3 nouveaux tests dans `tests/test_nouvelles_fonctionnalites.py` :
- le champ expose bien `step="any"` ;
- l'ajout d'un contrat à `33.75` est enregistré tel quel ;
- le tableau affiche `33.75h` (et pas `33.8h`), les entiers restant en `35h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MZDKiPDPC6k8hAFAWophs

---
_Generated by [Claude Code](https://claude.ai/code/session_011MZDKiPDPC6k8hAFAWophs)_