### PR TITLE
Simulateur de PS CAF dans le budget prévisionnel

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1408,9 +1408,10 @@ def api_ps_simulation_get():
         return jsonify({'error': 'Accès non autorisé'}), 403
     compte_num = (request.args.get('compte_num') or '').strip()
     annee = request.args.get('annee', type=int)
+    secteur_id = request.args.get('secteur_id', type=int)
     type_budget = request.args.get('type_budget', 'initial')
-    if not compte_num or not annee:
-        return jsonify({'error': 'Compte et année requis'}), 400
+    if not compte_num or not annee or not secteur_id:
+        return jsonify({'error': 'Compte, secteur et année requis'}), 400
     if type_budget not in ('initial', 'actualise'):
         return jsonify({'error': 'Type de budget invalide'}), 400
     conn = get_db()
@@ -1421,8 +1422,8 @@ def api_ps_simulation_get():
         type_ps = type_row['type_ps'] if type_row else 'eaje'
         row = conn.execute('''
             SELECT donnees, total, type_ps, updated_at FROM budget_ps_simulations
-            WHERE compte_num = ? AND annee = ? AND type_budget = ?
-        ''', (compte_num, annee, type_budget)).fetchone()
+            WHERE compte_num = ? AND annee = ? AND secteur_id = ? AND type_budget = ?
+        ''', (compte_num, annee, secteur_id, type_budget)).fetchone()
         if not row:
             return jsonify({'found': False, 'type_ps': type_ps, 'donnees': None})
         try:
@@ -1459,8 +1460,8 @@ def api_ps_simulation_save():
     if not isinstance(donnees, dict):
         donnees = {}
 
-    if not compte_num or not annee:
-        return jsonify({'error': 'Compte et année requis'}), 400
+    if not compte_num or not annee or not secteur_id:
+        return jsonify({'error': 'Compte, secteur et année requis'}), 400
     if type_budget not in ('initial', 'actualise'):
         return jsonify({'error': 'Type de budget invalide'}), 400
     if type_ps not in PS_TYPES:
@@ -1478,35 +1479,30 @@ def api_ps_simulation_save():
     try:
         conn.execute('''
             INSERT INTO budget_ps_simulations
-            (compte_num, annee, type_budget, type_ps, secteur_id, donnees, total, updated_by, updated_at)
+            (compte_num, annee, secteur_id, type_budget, type_ps, donnees, total, updated_by, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-            ON CONFLICT(compte_num, annee, type_budget) DO UPDATE SET
+            ON CONFLICT(compte_num, annee, secteur_id, type_budget) DO UPDATE SET
                 type_ps = excluded.type_ps,
-                secteur_id = excluded.secteur_id,
                 donnees = excluded.donnees,
                 total = excluded.total,
                 updated_by = excluded.updated_by,
                 updated_at = CURRENT_TIMESTAMP
-        ''', (compte_num, int(annee), type_budget, type_ps,
-              int(secteur_id) if secteur_id else None,
+        ''', (compte_num, int(annee), int(secteur_id), type_budget, type_ps,
               json.dumps(donnees), total, user_id))
 
-        # Report du total sur la valeur définitive du compte dans le budget,
-        # en préservant la valeur temporaire et le commentaire éventuels.
-        reported = False
-        if secteur_id:
-            conn.execute('''
-                INSERT INTO budget_prev_saisies
-                (type_budget, annee, secteur_id, compte_num, valeur_def, updated_by, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-                ON CONFLICT(type_budget, annee, secteur_id, compte_num) DO UPDATE SET
-                    valeur_def = excluded.valeur_def,
-                    updated_by = excluded.updated_by,
-                    updated_at = CURRENT_TIMESTAMP
-            ''', (type_budget, int(annee), int(secteur_id), compte_num, total, user_id))
-            reported = True
+        # Report du total sur la valeur définitive du compte dans le budget du
+        # secteur, en préservant la valeur temporaire et le commentaire éventuels.
+        conn.execute('''
+            INSERT INTO budget_prev_saisies
+            (type_budget, annee, secteur_id, compte_num, valeur_def, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(type_budget, annee, secteur_id, compte_num) DO UPDATE SET
+                valeur_def = excluded.valeur_def,
+                updated_by = excluded.updated_by,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (type_budget, int(annee), int(secteur_id), compte_num, total, user_id))
 
         conn.commit()
-        return jsonify({'success': True, 'total': total, 'reported': reported, 'computed': computed})
+        return jsonify({'success': True, 'total': total, 'reported': True, 'computed': computed})
     finally:
         conn.close()

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -11,6 +11,7 @@ Fonctionnalites :
   responsables ajustent la repartition sans depasser le global
 """
 import io
+import json
 import sqlite3
 from datetime import datetime, date, timedelta
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash, jsonify, current_app
@@ -1164,5 +1165,348 @@ def api_budget_previsionnel_export_pdf():
         resp = current_app.response_class(pdf, mimetype='application/pdf')
         resp.headers['Content-Disposition'] = f'attachment; filename=budget_previsionnel_{annee}.pdf'
         return resp
+    finally:
+        conn.close()
+
+
+# ============================================================
+# SIMULATEUR PRESTATION DE SERVICE (PS) CAF
+# ============================================================
+
+PS_TYPES = ('eaje', 'alsh')
+
+# Valeurs par défaut du simulateur PS EAJE (modifiables dans l'interface).
+PS_EAJE_DEFAULTS = {
+    'taux_ps': 6.63,
+    'taux_regime': 100,
+    'amplitude_horaire': 10,
+    'financement_par_enfant': 8,
+    'bonus_mixite': {
+        'seuil1': 0.91, 'montant1': 2100,
+        'seuil2': 1.20, 'montant2': 800,
+        'seuil3': 1.52, 'montant3': 300,
+    },
+    'journees_peda': {'nb_journees': 3, 'nb_heures': 10},
+    'bonus_attractivite_taux': 970,
+}
+
+
+def _ps_num(value, default=0.0):
+    """Convertit une valeur saisie (str/None) en float, avec valeur par défaut."""
+    try:
+        if value is None or value == '':
+            return float(default)
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _compute_ps_eaje(donnees):
+    """Calcule le détail du simulateur PS EAJE (crèche) à partir des saisies.
+
+    Les colonnes calculées (heures d'ouverture, amplitude totale, taux
+    d'occupation, taux horaire, PSU, PSU - participation), les totaux/moyennes
+    et les bonus sont dérivés ici afin que le montant stocké et reporté sur le
+    compte soit toujours fiable (recalcul côté serveur).
+    """
+    d = donnees or {}
+    taux_ps = _ps_num(d.get('taux_ps'), PS_EAJE_DEFAULTS['taux_ps'])
+    taux_regime_pct = _ps_num(d.get('taux_regime'), PS_EAJE_DEFAULTS['taux_regime'])
+    taux_regime = taux_regime_pct / 100.0
+
+    mois_in = d.get('mois') or []
+    if not isinstance(mois_in, list):
+        mois_in = []
+    mois_out = []
+    tot = {
+        'jours_ouverture': 0.0, 'heures_facturees': 0.0, 'heures_realisees': 0.0,
+        'participation': 0.0, 'amplitude_totale': 0.0, 'psu': 0.0, 'psu_participation': 0.0,
+    }
+    places_list = []
+    for m in mois_in:
+        jours = _ps_num(m.get('jours_ouverture'))
+        h_fact = _ps_num(m.get('heures_facturees'))
+        h_real = _ps_num(m.get('heures_realisees'))
+        participation = _ps_num(m.get('participation'))
+        places = _ps_num(m.get('places'))
+        amplitude_h = _ps_num(m.get('amplitude_horaire'), PS_EAJE_DEFAULTS['amplitude_horaire'])
+        heures_ouv = amplitude_h * jours
+        amplitude_tot = heures_ouv * places
+        taux_occ = (h_fact / amplitude_tot) if amplitude_tot else 0.0
+        taux_horaire = (participation / h_fact) if h_fact else 0.0
+        psu = h_fact * taux_ps * taux_regime
+        psu_part = psu - participation
+        mois_out.append({
+            'prev_reel': m.get('prev_reel') or 'prev',
+            'jours_ouverture': jours, 'heures_facturees': h_fact,
+            'heures_realisees': h_real, 'participation': participation,
+            'places': places, 'amplitude_horaire': amplitude_h,
+            'heures_ouverture': round(heures_ouv, 2),
+            'amplitude_totale': round(amplitude_tot, 2),
+            'taux_occupation': round(taux_occ, 4),
+            'taux_horaire': round(taux_horaire, 4),
+            'psu': round(psu, 2),
+            'psu_participation': round(psu_part, 2),
+        })
+        tot['jours_ouverture'] += jours
+        tot['heures_facturees'] += h_fact
+        tot['heures_realisees'] += h_real
+        tot['participation'] += participation
+        tot['amplitude_totale'] += amplitude_tot
+        tot['psu'] += psu
+        tot['psu_participation'] += psu_part
+        if places > 0:
+            places_list.append(places)
+
+    # Le nombre de places est généralement constant : sinon on prend la moyenne
+    # des mois renseignés (places > 0).
+    places_moyen = (sum(places_list) / len(places_list)) if places_list else 0.0
+    # Moyennes pondérées (cohérentes avec le calcul CAF du taux de participation).
+    taux_occ_moyen = (tot['heures_facturees'] / tot['amplitude_totale']) if tot['amplitude_totale'] else 0.0
+    taux_horaire_moyen = (tot['participation'] / tot['heures_facturees']) if tot['heures_facturees'] else 0.0
+
+    nb_enfants = _ps_num(d.get('nb_enfants_inscrits'))
+    financement_enfant = _ps_num(d.get('financement_par_enfant'), PS_EAJE_DEFAULTS['financement_par_enfant'])
+    ps_prepa = nb_enfants * financement_enfant * taux_regime
+
+    bm = d.get('bonus_mixite') or {}
+    bm_def = PS_EAJE_DEFAULTS['bonus_mixite']
+    seuil1 = _ps_num(bm.get('seuil1'), bm_def['seuil1'])
+    montant1 = _ps_num(bm.get('montant1'), bm_def['montant1'])
+    seuil2 = _ps_num(bm.get('seuil2'), bm_def['seuil2'])
+    montant2 = _ps_num(bm.get('montant2'), bm_def['montant2'])
+    seuil3 = _ps_num(bm.get('seuil3'), bm_def['seuil3'])
+    montant3 = _ps_num(bm.get('montant3'), bm_def['montant3'])
+    if taux_horaire_moyen <= seuil1:
+        bonus_mixite_place = montant1
+    elif taux_horaire_moyen <= seuil2:
+        bonus_mixite_place = montant2
+    elif taux_horaire_moyen <= seuil3:
+        bonus_mixite_place = montant3
+    else:
+        bonus_mixite_place = 0.0
+    bonus_mixite = bonus_mixite_place * places_moyen
+
+    jp = d.get('journees_peda') or {}
+    jp_def = PS_EAJE_DEFAULTS['journees_peda']
+    jp_nb = _ps_num(jp.get('nb_journees'), jp_def['nb_journees'])
+    jp_h = _ps_num(jp.get('nb_heures'), jp_def['nb_heures'])
+    journees_peda = jp_nb * jp_h * taux_ps * taux_regime * places_moyen
+
+    bonus_attr_taux = _ps_num(d.get('bonus_attractivite_taux'), PS_EAJE_DEFAULTS['bonus_attractivite_taux'])
+    bonus_attractivite = bonus_attr_taux * places_moyen
+
+    total = tot['psu_participation'] + ps_prepa + bonus_mixite + journees_peda + bonus_attractivite
+
+    return {
+        'mois': mois_out,
+        'totaux': {k: round(v, 2) for k, v in tot.items()},
+        'taux_occupation_moyen': round(taux_occ_moyen, 4),
+        'taux_horaire_moyen': round(taux_horaire_moyen, 4),
+        'places_moyen': round(places_moyen, 2),
+        'ps_prepa': round(ps_prepa, 2),
+        'bonus_mixite': round(bonus_mixite, 2),
+        'bonus_mixite_place': round(bonus_mixite_place, 2),
+        'journees_peda': round(journees_peda, 2),
+        'bonus_attractivite': round(bonus_attractivite, 2),
+        'total': round(total, 2),
+    }
+
+
+@budget_bp.route('/api/budget-previsionnel/ps-comptes')
+@login_required
+def api_ps_comptes_liste():
+    """Liste des comptes paramétrés comme PS (compte_num -> type_ps)."""
+    profil = session.get('profil')
+    if not _can_access_budget_previsionnel(profil):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            'SELECT compte_num, type_ps FROM budget_ps_comptes ORDER BY compte_num'
+        ).fetchall()
+        return jsonify({'comptes': {r['compte_num']: r['type_ps'] for r in rows}})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/ps-comptes-disponibles')
+@login_required
+def api_ps_comptes_disponibles():
+    """Liste des comptes de produits 70x disponibles pour le paramétrage PS."""
+    profil = session.get('profil')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    conn = get_db()
+    try:
+        comptes = {}
+        for r in conn.execute(
+            "SELECT compte_num, libelle FROM plan_comptable_general WHERE compte_num LIKE '70%'"
+        ).fetchall():
+            comptes[r['compte_num']] = r['libelle'] or r['compte_num']
+        for r in conn.execute(
+            "SELECT DISTINCT compte_num, libelle FROM bilan_fec_donnees WHERE compte_num LIKE '70%'"
+        ).fetchall():
+            comptes.setdefault(r['compte_num'], r['libelle'] or r['compte_num'])
+        liste = [{'compte_num': k, 'libelle': v} for k, v in sorted(comptes.items())]
+        return jsonify({'comptes': liste})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/ps-comptes', methods=['POST'])
+@login_required
+def api_ps_comptes_save():
+    """Rattache un compte 70x à un type de PS (EAJE/ALSH)."""
+    profil = session.get('profil')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    data = request.get_json() or {}
+    compte_num = (data.get('compte_num') or '').strip()
+    type_ps = (data.get('type_ps') or '').strip()
+    if not compte_num:
+        return jsonify({'error': 'Compte requis'}), 400
+    if type_ps not in PS_TYPES:
+        return jsonify({'error': 'Type de PS invalide'}), 400
+    conn = get_db()
+    try:
+        conn.execute('''
+            INSERT INTO budget_ps_comptes (compte_num, type_ps, updated_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(compte_num) DO UPDATE SET
+                type_ps = excluded.type_ps,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (compte_num, type_ps))
+        conn.commit()
+        return jsonify({'success': True})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/ps-comptes/<compte_num>', methods=['DELETE'])
+@login_required
+def api_ps_comptes_delete(compte_num):
+    """Retire un compte du paramétrage PS."""
+    profil = session.get('profil')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    conn = get_db()
+    try:
+        conn.execute('DELETE FROM budget_ps_comptes WHERE compte_num = ?', (compte_num,))
+        conn.commit()
+        return jsonify({'success': True})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/ps-simulation')
+@login_required
+def api_ps_simulation_get():
+    """Récupère une simulation PS enregistrée pour (compte, année, type budget)."""
+    profil = session.get('profil')
+    if not _can_access_budget_previsionnel(profil):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    compte_num = (request.args.get('compte_num') or '').strip()
+    annee = request.args.get('annee', type=int)
+    type_budget = request.args.get('type_budget', 'initial')
+    if not compte_num or not annee:
+        return jsonify({'error': 'Compte et année requis'}), 400
+    if type_budget not in ('initial', 'actualise'):
+        return jsonify({'error': 'Type de budget invalide'}), 400
+    conn = get_db()
+    try:
+        type_row = conn.execute(
+            'SELECT type_ps FROM budget_ps_comptes WHERE compte_num = ?', (compte_num,)
+        ).fetchone()
+        type_ps = type_row['type_ps'] if type_row else 'eaje'
+        row = conn.execute('''
+            SELECT donnees, total, type_ps, updated_at FROM budget_ps_simulations
+            WHERE compte_num = ? AND annee = ? AND type_budget = ?
+        ''', (compte_num, annee, type_budget)).fetchone()
+        if not row:
+            return jsonify({'found': False, 'type_ps': type_ps, 'donnees': None})
+        try:
+            donnees = json.loads(row['donnees']) if row['donnees'] else None
+        except (ValueError, TypeError):
+            donnees = None
+        return jsonify({
+            'found': True,
+            'type_ps': row['type_ps'] or type_ps,
+            'donnees': donnees,
+            'total': row['total'],
+            'updated_at': row['updated_at'],
+        })
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/ps-simulation', methods=['POST'])
+@login_required
+def api_ps_simulation_save():
+    """Enregistre une simulation PS et reporte le total sur le compte produit."""
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+
+    data = request.get_json() or {}
+    compte_num = (data.get('compte_num') or '').strip()
+    annee = data.get('annee')
+    type_budget = data.get('type_budget')
+    type_ps = (data.get('type_ps') or 'eaje').strip()
+    secteur_id = data.get('secteur_id')
+    donnees = data.get('donnees') or {}
+    if not isinstance(donnees, dict):
+        donnees = {}
+
+    if not compte_num or not annee:
+        return jsonify({'error': 'Compte et année requis'}), 400
+    if type_budget not in ('initial', 'actualise'):
+        return jsonify({'error': 'Type de budget invalide'}), 400
+    if type_ps not in PS_TYPES:
+        return jsonify({'error': 'Type de PS invalide'}), 400
+
+    # Le total reporté est recalculé côté serveur pour le simulateur EAJE.
+    if type_ps == 'eaje':
+        computed = _compute_ps_eaje(donnees)
+        total = computed['total']
+    else:
+        computed = None
+        total = 0.0
+
+    conn = get_db()
+    try:
+        conn.execute('''
+            INSERT INTO budget_ps_simulations
+            (compte_num, annee, type_budget, type_ps, secteur_id, donnees, total, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(compte_num, annee, type_budget) DO UPDATE SET
+                type_ps = excluded.type_ps,
+                secteur_id = excluded.secteur_id,
+                donnees = excluded.donnees,
+                total = excluded.total,
+                updated_by = excluded.updated_by,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (compte_num, int(annee), type_budget, type_ps,
+              int(secteur_id) if secteur_id else None,
+              json.dumps(donnees), total, user_id))
+
+        # Report du total sur la valeur définitive du compte dans le budget,
+        # en préservant la valeur temporaire et le commentaire éventuels.
+        reported = False
+        if secteur_id:
+            conn.execute('''
+                INSERT INTO budget_prev_saisies
+                (type_budget, annee, secteur_id, compte_num, valeur_def, updated_by, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ON CONFLICT(type_budget, annee, secteur_id, compte_num) DO UPDATE SET
+                    valeur_def = excluded.valeur_def,
+                    updated_by = excluded.updated_by,
+                    updated_at = CURRENT_TIMESTAMP
+            ''', (type_budget, int(annee), int(secteur_id), compte_num, total, user_id))
+            reported = True
+
+        conn.commit()
+        return jsonify({'success': True, 'total': total, 'reported': reported, 'computed': computed})
     finally:
         conn.close()

--- a/database.py
+++ b/database.py
@@ -1441,6 +1441,39 @@ def init_db():
         )
     ''')
 
+    # ===== Tables simulateur Prestation de Service CAF (migration 0042) =====
+    # Comptes de produits (70x) marqués comme relevant d'une PS CAF, avec le
+    # type de simulateur associé (EAJE = crèche, ALSH = accueil de loisirs).
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_ps_comptes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL UNIQUE,
+            type_ps TEXT NOT NULL CHECK(type_ps IN ('eaje', 'alsh')),
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    # Saisies du simulateur de PS, attachées au compte, à l'année et au type
+    # de budget. Les données détaillées (paramètres + saisie mensuelle) sont
+    # stockées en JSON ; total = montant à reporter sur le compte produit.
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_ps_simulations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL,
+            annee INTEGER NOT NULL,
+            type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
+            type_ps TEXT NOT NULL,
+            secteur_id INTEGER,
+            donnees TEXT,
+            total REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE SET NULL,
+            FOREIGN KEY (updated_by) REFERENCES users(id),
+            UNIQUE(compte_num, annee, type_budget)
+        )
+    ''')
+
     # ===== Table de suivi des migrations de schema =====
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/database.py
+++ b/database.py
@@ -1453,24 +1453,26 @@ def init_db():
         )
     ''')
 
-    # Saisies du simulateur de PS, attachées au compte, à l'année et au type
-    # de budget. Les données détaillées (paramètres + saisie mensuelle) sont
-    # stockées en JSON ; total = montant à reporter sur le compte produit.
+    # Saisies du simulateur de PS, attachées au compte, à l'année, au secteur
+    # et au type de budget. Le secteur fait partie de la clé : un même compte
+    # produit peut être utilisé par deux secteurs (ex. deux crèches). Les
+    # données détaillées (paramètres + saisie mensuelle) sont stockées en
+    # JSON ; total = montant à reporter sur le compte produit.
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS budget_ps_simulations (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             compte_num TEXT NOT NULL,
             annee INTEGER NOT NULL,
+            secteur_id INTEGER NOT NULL,
             type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
             type_ps TEXT NOT NULL,
-            secteur_id INTEGER,
             donnees TEXT,
             total REAL DEFAULT 0,
             updated_by INTEGER,
             updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE SET NULL,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE CASCADE,
             FOREIGN KEY (updated_by) REFERENCES users(id),
-            UNIQUE(compte_num, annee, type_budget)
+            UNIQUE(compte_num, annee, secteur_id, type_budget)
         )
     ''')
 

--- a/migrations/0042_simulateur_ps_caf.py
+++ b/migrations/0042_simulateur_ps_caf.py
@@ -4,7 +4,8 @@ Migration 0042 : Ajout du simulateur de Prestation de Service (PS) CAF.
 - budget_ps_comptes     : comptes de produits (70x) rattachés à une PS CAF
                           (type EAJE = crèche, ALSH = accueil de loisirs)
 - budget_ps_simulations : saisies du simulateur, attachées au compte, à
-                          l'année et au type de budget (initial/actualisé)
+                          l'année, au secteur et au type de budget
+                          (initial/actualisé)
 """
 
 NOM = "Ajout simulateur PS CAF"
@@ -32,16 +33,16 @@ def upgrade(conn):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             compte_num TEXT NOT NULL,
             annee INTEGER NOT NULL,
+            secteur_id INTEGER NOT NULL,
             type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
             type_ps TEXT NOT NULL,
-            secteur_id INTEGER,
             donnees TEXT,
             total REAL DEFAULT 0,
             updated_by INTEGER,
             updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
-            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE SET NULL,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE CASCADE,
             FOREIGN KEY (updated_by) REFERENCES users(id),
-            UNIQUE(compte_num, annee, type_budget)
+            UNIQUE(compte_num, annee, secteur_id, type_budget)
         )
     ''')
 

--- a/migrations/0042_simulateur_ps_caf.py
+++ b/migrations/0042_simulateur_ps_caf.py
@@ -1,0 +1,53 @@
+"""
+Migration 0042 : Ajout du simulateur de Prestation de Service (PS) CAF.
+
+- budget_ps_comptes     : comptes de produits (70x) rattachés à une PS CAF
+                          (type EAJE = crèche, ALSH = accueil de loisirs)
+- budget_ps_simulations : saisies du simulateur, attachées au compte, à
+                          l'année et au type de budget (initial/actualisé)
+"""
+
+NOM = "Ajout simulateur PS CAF"
+DESCRIPTION = (
+    "Ajoute les tables du simulateur de Prestation de Service CAF "
+    "(comptes paramétrés et saisies des simulateurs EAJE/ALSH)."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_ps_comptes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL UNIQUE,
+            type_ps TEXT NOT NULL CHECK(type_ps IN ('eaje', 'alsh')),
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_ps_simulations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL,
+            annee INTEGER NOT NULL,
+            type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
+            type_ps TEXT NOT NULL,
+            secteur_id INTEGER,
+            donnees TEXT,
+            total REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE SET NULL,
+            FOREIGN KEY (updated_by) REFERENCES users(id),
+            UNIQUE(compte_num, annee, type_budget)
+        )
+    ''')
+
+
+def downgrade(conn):
+    """Supprime les tables du simulateur de PS."""
+    cursor = conn.cursor()
+    cursor.execute('DROP TABLE IF EXISTS budget_ps_simulations')
+    cursor.execute('DROP TABLE IF EXISTS budget_ps_comptes')

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -19,12 +19,6 @@
     border-top: 2px solid #c4ced9;
     border-bottom: 2px solid #c4ced9;
 }
-.budget-prev-table .bp-cat-header td {
-    font-size: 0.78rem;
-    color: #556677;
-    background: #f2f6fb !important;
-    border-top: 1px solid #d9e2ec;
-}
 .bp-input-def {
     width: 100%;
     max-width: 135px;
@@ -37,10 +31,200 @@
     min-width: 0;
     box-sizing: border-box;
 }
+/* Étape 1 : en-têtes figés via conteneur défilant + thead sticky */
+.bp-table-scroll {
+    max-height: 70vh;
+    overflow: auto;
+    border: 1px solid var(--gray-200, #e7ddd1);
+    border-radius: 8px;
+}
+.bp-table-scroll .budget-prev-table {
+    border: none;
+    border-radius: 0;
+    overflow: visible;
+    animation: none;
+}
+.budget-prev-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: var(--gray-100, #f3eee7);
+    box-shadow: inset 0 -2px 0 var(--gray-300, #d3c2b1);
+}
+.bp-ps-btn {
+    margin-left: 8px;
+    padding: 2px 8px;
+    font-size: 0.72rem;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+/* Simulateur PS : modale large */
+.ps-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    z-index: 10000;
+    display: none;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 24px;
+    overflow-y: auto;
+}
+.ps-modal-overlay.open { display: flex; }
+.ps-modal {
+    background: var(--white);
+    border-radius: 12px;
+    width: 100%;
+    max-width: 1500px;
+    margin: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+.ps-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--gray-200);
+    position: sticky;
+    top: 0;
+    background: var(--white);
+    z-index: 5;
+    border-radius: 12px 12px 0 0;
+}
+.ps-modal-header h3 { margin: 0; font-size: 1.1rem; }
+.ps-modal-body { padding: 16px 20px; }
+.ps-modal-footer {
+    padding: 14px 20px;
+    border-top: 1px solid var(--gray-200);
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 10px;
+    position: sticky;
+    bottom: 0;
+    background: var(--white);
+    border-radius: 0 0 12px 12px;
+}
+.ps-table-scroll { overflow-x: auto; }
+.ps-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+.ps-table th, .ps-table td {
+    border: 1px solid var(--gray-200);
+    padding: 4px 6px;
+    text-align: right;
+    white-space: nowrap;
+}
+.ps-table thead th {
+    background: var(--gray-100);
+    text-align: center;
+    font-size: 0.72rem;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+.ps-table td.ps-col-mois { text-align: left; font-weight: 600; white-space: nowrap; }
+.ps-table tfoot td { font-weight: 700; background: var(--gray-50); }
+.ps-input {
+    width: 100%;
+    min-width: 64px;
+    padding: 3px 5px;
+    text-align: right;
+    border: 1px solid var(--gray-300);
+    border-radius: 4px;
+    box-sizing: border-box;
+    background: var(--white);
+    color: var(--gray-900);
+    font-size: 0.82rem;
+}
+.ps-input-sel { min-width: 96px; text-align: left; }
+/* Colonnes calculées : couleur spéciale */
+.bp-ps-calc { background: #e8f1fb; }
+.ps-table tfoot td.bp-ps-calc { background: #dce9f7; }
+[data-theme="dark"] .bp-ps-calc { background: #1d2c3f; }
+[data-theme="dark"] .ps-table tfoot td.bp-ps-calc { background: #233349; }
+.ps-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 14px;
+    margin-top: 18px;
+}
+.ps-card {
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    padding: 12px 14px;
+    background: var(--gray-50);
+}
+.ps-card h4 { margin: 0 0 10px; font-size: 0.9rem; color: var(--primary); }
+.ps-field { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; }
+.ps-field label { font-size: 0.82rem; color: var(--gray-700); flex: 1 1 auto; min-width: 0; }
+.ps-field .ps-input { flex: 0 0 110px; min-width: 90px; }
+.ps-result {
+    font-weight: 700;
+    color: var(--gray-900);
+    margin-top: 6px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--gray-300);
+}
+.ps-total-box {
+    margin-top: 16px;
+    padding: 14px 18px;
+    border: 2px solid var(--primary);
+    border-radius: 10px;
+    background: var(--primary);
+    color: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    font-size: 1.05rem;
+}
+.ps-total-box strong { font-size: 1.35rem; }
+.ps-params {
+    display: flex;
+    gap: 18px;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    margin-bottom: 14px;
+    padding: 12px 14px;
+    background: var(--gray-50);
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+}
+.ps-params .ps-field { margin-bottom: 0; }
+.ps-legend { font-size: 0.78rem; color: var(--gray-500); margin: 10px 0; }
+.ps-legend .bp-ps-calc { padding: 1px 8px; border-radius: 3px; }
+/* Modale de paramétrage des comptes PS */
+.ps-config-list { list-style: none; padding: 0; margin: 0 0 16px; }
+.ps-config-list li {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border: 1px solid var(--gray-200);
+    border-radius: 6px;
+    margin-bottom: 6px;
+}
+.ps-config-list .ps-config-lib { flex: 1 1 auto; min-width: 0; }
+.ps-badge {
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--primary-light);
+    color: #fff;
+    white-space: nowrap;
+}
+[data-theme="dark"] .ps-modal, [data-theme="dark"] .ps-modal-header,
+[data-theme="dark"] .ps-modal-footer { background: var(--white); }
+[data-theme="dark"] .ps-input { background: var(--gray-50); border-color: var(--gray-300); }
 </style>
 <div class="page-header" style="display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;">
     <h2>💶 Budget prévisionnel</h2>
     <div style="display:flex;gap:8px;flex-wrap:wrap;">
+        {% if profil in ['directeur', 'comptable'] %}
+        <button class="btn btn-secondary" onclick="openPsConfig()">⚙️ Paramétrer les comptes PS</button>
+        {% endif %}
         <button class="btn btn-secondary" onclick="exporterPdf(false)">📄 Export PDF secteur</button>
         {% if profil in ['directeur', 'comptable'] %}
         <button class="btn btn-secondary" onclick="exporterPdf(true)">📄 Export PDF budget global</button>
@@ -98,10 +282,57 @@
 </div>
 {% endif %}
 
+{% if profil in ['directeur', 'comptable'] %}
+<!-- Étape 2 : modale de paramétrage des comptes PS -->
+<div id="psConfigModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closePsConfig()">
+    <div class="modal-content" style="max-width:640px;">
+        <div class="modal-header">
+            <h3>⚙️ Comptes concernés par une Prestation de Service</h3>
+            <button class="modal-close" type="button" onclick="closePsConfig()" aria-label="Fermer">&times;</button>
+        </div>
+        <div style="padding:0 1.5rem 1.5rem;">
+            <p class="help-text" style="margin-top:0;">
+                Sélectionnez un compte de produits 70 et le type de PS associé. Un bouton de
+                simulateur apparaîtra à côté du compte dans le budget. Les comptes restent en mémoire.
+            </p>
+            <ul id="psConfigList" class="ps-config-list"></ul>
+            <div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;">
+                <div class="form-group" style="margin:0;flex:1 1 220px;">
+                    <label>Compte 70</label>
+                    <select id="psConfigCompte" class="form-select" style="width:100%;"></select>
+                </div>
+                <div class="form-group" style="margin:0;flex:0 0 200px;">
+                    <label>Type de PS</label>
+                    <select id="psConfigType" class="form-select" style="width:100%;">
+                        <option value="eaje">PS EAJE (crèche)</option>
+                        <option value="alsh">PS ALSH (Accueil de loisirs)</option>
+                    </select>
+                </div>
+                <button class="btn btn-primary" type="button" onclick="addPsCompte()">➕ Ajouter</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Étape 3 : modale du simulateur de PS (contenu généré dynamiquement) -->
+<div id="psSimulatorModal" class="ps-modal-overlay" onclick="if(event.target===this)closePsSimulator()">
+    <div class="ps-modal" role="dialog" aria-modal="true">
+        <div class="ps-modal-header">
+            <h3 id="psSimTitle">Simulateur PS</h3>
+            <button class="modal-close" type="button" onclick="closePsSimulator()" aria-label="Fermer">&times;</button>
+        </div>
+        <div class="ps-modal-body" id="psSimBody"></div>
+        <div class="ps-modal-footer" id="psSimFooter"></div>
+    </div>
+</div>
+
 <script>
 var isReadOnly = {{ 'true' if profil == 'responsable' else 'false' }};
+var canEditPs = {{ 'true' if profil in ['directeur', 'comptable'] else 'false' }};
 var salaryMeta = null;
 var currentRows = [];
+var psComptes = {};   // { compte_num: 'eaje' | 'alsh' }
 
 function fmt(n){ return (Number(n || 0)).toLocaleString('fr-FR', {minimumFractionDigits:2, maximumFractionDigits:2}); }
 function escapeHtml(value){
@@ -162,6 +393,7 @@ function renderBudgetTable(targetId, rows, meta, globalMode){
                  '<h3 style="margin-top:18px;">Produits</h3>' + buildTable(produits, nTemp, nDef, globalMode);
     document.getElementById(targetId).innerHTML = html;
     bindBudgetInputHandlers(targetId);
+    bindPsButtons(targetId);
 }
 
 function bindBudgetInputHandlers(targetId){
@@ -188,7 +420,7 @@ function bindBudgetInputHandlers(targetId){
 
 function buildTable(rows, labelTemp, labelDef, globalMode){
     if (!rows.length) return '<p style="color:var(--text-muted);">Aucune donnée disponible.</p>';
-    let html = '<table class="data-table budget-prev-table"><colgroup>' +
+    let html = '<div class="bp-table-scroll"><table class="data-table budget-prev-table"><colgroup>' +
       '<col class="bp-col-compte"><col class="bp-col-libelle"><col class="bp-col-value"><col class="bp-col-value"><col class="bp-col-value"><col class="bp-col-input"><col class="bp-col-input"><col class="bp-col-comment">' +
       '</colgroup><thead><tr>' +
       '<th>Compte</th><th>Libellé</th><th class="bp-col-num">N-2</th><th class="bp-col-num">N-1</th><th class="bp-col-num">N</th><th class="bp-col-num">' + labelTemp + '</th><th class="bp-col-num">' + labelDef + '</th><th>Commentaire</th>' +
@@ -206,9 +438,6 @@ function buildTable(rows, labelTemp, labelDef, globalMode){
             pushCatTotal();
             currentCat = r.categorie;
             catTotals = {n2:0,n1:0,n:0,temp:0,def:0};
-            html += '<tr class="bp-cat-header"><td><small>Compte</small></td><td><small>Libellé</small></td>' +
-              '<td class="bp-col-num"><small>N-2</small></td><td class="bp-col-num"><small>N-1</small></td><td class="bp-col-num"><small>N</small></td>' +
-              '<td class="bp-col-num"><small>' + labelTemp + '</small></td><td class="bp-col-num"><small>' + labelDef + '</small></td><td><small>Commentaire</small></td></tr>';
         }
         catTotals.n2 += r['N-2']; catTotals.n1 += r['N-1']; catTotals.n += r['N']; catTotals.temp += r.temp; catTotals.def += r.def;
         const isBrut = (salaryMeta && salaryMeta.salary_brut_account === r.compte_num);
@@ -222,13 +451,16 @@ function buildTable(rows, labelTemp, labelDef, globalMode){
         const commentInput = (!globalMode && !isReadOnly)
             ? '<input class="form-control bp-input-comment" value="' + escapeHtml(r.commentaire || '') + '" data-bp-comment-compte="' + escapeHtml(r.compte_num) + '">'
             : escapeHtml(r.commentaire || '');
+        const psBtn = (!globalMode && psComptes[r.compte_num])
+            ? '<button type="button" class="btn btn-sm btn-secondary bp-ps-btn" data-ps-compte="' + escapeHtml(r.compte_num) + '" title="Ouvrir le simulateur de PS">🧮 PS</button>'
+            : '';
         html += '<tr' + rowStyle + '>' +
-          '<td>' + escapeHtml(r.compte_num) + '</td><td>' + escapeHtml(r.libelle) + '</td>' +
+          '<td>' + escapeHtml(r.compte_num) + '</td><td>' + escapeHtml(r.libelle) + psBtn + '</td>' +
           '<td class="bp-col-num">' + fmt(r['N-2']) + '</td><td class="bp-col-num">' + fmt(r['N-1']) + '</td><td class="bp-col-num">' + fmt(r['N']) + '</td>' +
           '<td class="bp-col-num">' + tempInput + '</td><td class="bp-col-num">' + defInput + '</td><td>' + commentInput + '</td></tr>';
     }
     pushCatTotal();
-    html += '</tbody></table>';
+    html += '</tbody></table></div>';
     return html;
 }
 
@@ -313,6 +545,424 @@ function exporterPdf(globalMode){
     window.open(url, '_blank');
 }
 
-chargerBudget();
+// ============================================================
+// Simulateur de Prestation de Service (PS) CAF
+// ============================================================
+var NOMS_MOIS_PS = ['Janvier','Février','Mars','Avril','Mai','Juin','Juillet','Août','Septembre','Octobre','Novembre','Décembre'];
+
+function fmtR(n, dec){ return (Number(n || 0)).toLocaleString('fr-FR', {minimumFractionDigits:dec, maximumFractionDigits:dec}); }
+function fmtPct(r){ return fmtR((Number(r || 0)) * 100, 1) + ' %'; }
+function psNum(v, def){ var n = parseFloat(v); if (isNaN(n)) return (def === undefined ? 0 : def); return n; }
+
+function loadPsComptes(){
+    return fetch('/api/budget-previsionnel/ps-comptes')
+        .then(r => r.json())
+        .then(data => { psComptes = (data && data.comptes) ? data.comptes : {}; })
+        .catch(() => { psComptes = {}; });
+}
+
+function bindPsButtons(targetId){
+    var root = document.getElementById(targetId);
+    if (!root) return;
+    root.querySelectorAll('button[data-ps-compte]').forEach(function(btn){
+        btn.addEventListener('click', function(){ openPsSimulator(this.dataset.psCompte || ''); });
+    });
+}
+
+function refreshBudgetButtons(){
+    if (currentRows && currentRows.length){
+        renderBudgetTable('budgetTables', currentRows, salaryMeta, false);
+    }
+}
+
+function renderResultFromRows(){
+    if (!salaryMeta) return;
+    var ch = currentRows.filter(function(r){ return r.nature === 'charges'; });
+    var pr = currentRows.filter(function(r){ return r.nature === 'produits'; });
+    var sum = function(arr, key){ return arr.reduce(function(s, r){ return s + Number(r[key] || 0); }, 0); };
+    var tot = {
+        charges_temp: sum(ch, 'temp'), produits_temp: sum(pr, 'temp'),
+        charges_def: sum(ch, 'def'), produits_def: sum(pr, 'def')
+    };
+    tot.resultat_temp = tot.produits_temp - tot.charges_temp;
+    tot.resultat_def = tot.produits_def - tot.charges_def;
+    renderResult('budgetResultat', tot);
+}
+
+// ---- Étape 2 : paramétrage des comptes PS ----
+function openPsConfig(){
+    var modal = document.getElementById('psConfigModal');
+    if (!modal) return;
+    modal.style.display = 'flex';
+    loadPsCompteOptions();
+    renderPsConfigList();
+}
+function closePsConfig(){
+    var modal = document.getElementById('psConfigModal');
+    if (modal) modal.style.display = 'none';
+}
+function loadPsCompteOptions(){
+    fetch('/api/budget-previsionnel/ps-comptes-disponibles')
+        .then(r => r.json())
+        .then(data => {
+            var sel = document.getElementById('psConfigCompte');
+            if (!sel) return;
+            var list = (data && data.comptes) ? data.comptes : [];
+            if (!list.length){ sel.innerHTML = '<option value="">Aucun compte 70 disponible</option>'; return; }
+            sel.innerHTML = list.map(function(c){
+                return '<option value="' + escapeHtml(c.compte_num) + '">' +
+                    escapeHtml(c.compte_num + ' — ' + (c.libelle || '')) + '</option>';
+            }).join('');
+        });
+}
+function renderPsConfigList(){
+    var ul = document.getElementById('psConfigList');
+    if (!ul) return;
+    var keys = Object.keys(psComptes).sort();
+    if (!keys.length){
+        ul.innerHTML = '<li style="border:none;color:var(--text-muted);">Aucun compte paramétré pour le moment.</li>';
+        return;
+    }
+    ul.innerHTML = keys.map(function(compte){
+        var type = psComptes[compte];
+        var label = type === 'alsh' ? 'PS ALSH' : 'PS EAJE';
+        return '<li><span class="ps-config-lib">' + escapeHtml(compte) + '</span>' +
+            '<span class="ps-badge">' + label + '</span>' +
+            '<button type="button" class="btn btn-sm btn-danger" data-ps-remove="' + escapeHtml(compte) + '">Retirer</button></li>';
+    }).join('');
+    ul.querySelectorAll('button[data-ps-remove]').forEach(function(btn){
+        btn.addEventListener('click', function(){ removePsCompte(this.dataset.psRemove); });
+    });
+}
+function addPsCompte(){
+    var compte = (document.getElementById('psConfigCompte') || {}).value || '';
+    var type = (document.getElementById('psConfigType') || {}).value || 'eaje';
+    if (!compte){ alert('Sélectionnez un compte 70.'); return; }
+    fetch('/api/budget-previsionnel/ps-comptes', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({compte_num: compte, type_ps: type})
+    }).then(r => r.json()).then(data => {
+        if (!data.success){ alert(data.error || 'Erreur'); return; }
+        loadPsComptes().then(function(){ renderPsConfigList(); refreshBudgetButtons(); });
+    });
+}
+function removePsCompte(compte){
+    fetch('/api/budget-previsionnel/ps-comptes/' + encodeURIComponent(compte), {method:'DELETE'})
+        .then(r => r.json()).then(data => {
+            if (!data.success){ alert(data.error || 'Erreur'); return; }
+            loadPsComptes().then(function(){ renderPsConfigList(); refreshBudgetButtons(); });
+        });
+}
+
+// ---- Étape 3 : simulateurs ----
+var psSim = null;  // { compte, type_ps, libelle, ctx, state }
+
+function openPsSimulator(compteNum){
+    var type = psComptes[compteNum] || 'eaje';
+    var rowMeta = currentRows.find(function(r){ return r.compte_num === compteNum; });
+    var libelle = rowMeta ? rowMeta.libelle : '';
+    var ctx = getCurrentBudgetContext();
+    psSim = {compte: compteNum, type_ps: type, libelle: libelle, ctx: ctx, state: null};
+    document.getElementById('psSimTitle').textContent =
+        (type === 'alsh' ? 'Simulateur PS ALSH' : 'Simulateur PS EAJE') +
+        ' — ' + compteNum + (libelle ? ' (' + libelle + ')' : '');
+    if (type === 'alsh'){ renderAlshSimulator(); showPsModal(); return; }
+    var url = '/api/budget-previsionnel/ps-simulation?compte_num=' + encodeURIComponent(compteNum) +
+        '&annee=' + ctx.annee + '&type_budget=' + encodeURIComponent(ctx.type_budget);
+    fetch(url).then(r => r.json()).then(data => {
+        psSim.state = mergeEajeState((data && data.found) ? data.donnees : null);
+        renderEajeSimulator(); showPsModal(); psRecompute();
+    }).catch(function(){
+        psSim.state = mergeEajeState(null);
+        renderEajeSimulator(); showPsModal(); psRecompute();
+    });
+}
+function showPsModal(){ document.getElementById('psSimulatorModal').classList.add('open'); }
+function closePsSimulator(){ document.getElementById('psSimulatorModal').classList.remove('open'); psSim = null; }
+document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && document.getElementById('psSimulatorModal').classList.contains('open')) closePsSimulator();
+});
+
+function renderAlshSimulator(){
+    document.getElementById('psSimBody').innerHTML =
+        '<div style="padding:48px 20px;text-align:center;color:var(--text-muted,#777);">' +
+        '<div style="font-size:2.6rem;margin-bottom:12px;">🚧</div>' +
+        '<p style="font-size:1.08rem;">Le simulateur de <strong>PS ALSH</strong> (Accueil de loisirs) est en cours de réalisation.</p>' +
+        '<p>Il sera disponible prochainement.</p></div>';
+    document.getElementById('psSimFooter').innerHTML =
+        '<button class="btn btn-secondary" type="button" onclick="closePsSimulator()">Fermer</button>';
+}
+
+function defaultEajeState(){
+    var mois = [];
+    for (var i = 0; i < 12; i++){
+        mois.push({prev_reel:'prev', jours_ouverture:'', heures_facturees:'', heures_realisees:'', participation:'', places:'', amplitude_horaire:10});
+    }
+    return {
+        taux_ps:6.63, taux_regime:100, mois:mois,
+        nb_enfants_inscrits:'', financement_par_enfant:8,
+        bonus_mixite:{seuil1:0.91, montant1:2100, seuil2:1.20, montant2:800, seuil3:1.52, montant3:300},
+        journees_peda:{nb_journees:3, nb_heures:10},
+        bonus_attractivite_taux:970
+    };
+}
+function mergeEajeState(saved){
+    var s = defaultEajeState();
+    if (!saved) return s;
+    ['taux_ps','taux_regime','nb_enfants_inscrits','financement_par_enfant','bonus_attractivite_taux'].forEach(function(k){
+        if (saved[k] !== undefined && saved[k] !== null) s[k] = saved[k];
+    });
+    if (saved.bonus_mixite) Object.assign(s.bonus_mixite, saved.bonus_mixite);
+    if (saved.journees_peda) Object.assign(s.journees_peda, saved.journees_peda);
+    if (Array.isArray(saved.mois)){
+        for (var i = 0; i < 12 && i < saved.mois.length; i++){
+            if (saved.mois[i]) Object.assign(s.mois[i], saved.mois[i]);
+        }
+    }
+    return s;
+}
+
+function computePsEaje(d){
+    d = d || {};
+    var tauxPs = psNum(d.taux_ps, 6.63);
+    var tauxRegime = psNum(d.taux_regime, 100) / 100;
+    var mois = d.mois || [];
+    var out = [];
+    var tot = {jours_ouverture:0, heures_facturees:0, heures_realisees:0, participation:0, amplitude_totale:0, psu:0, psu_participation:0};
+    var placesList = [];
+    for (var i = 0; i < mois.length; i++){
+        var m = mois[i] || {};
+        var jours = psNum(m.jours_ouverture);
+        var hFact = psNum(m.heures_facturees);
+        var hReal = psNum(m.heures_realisees);
+        var part = psNum(m.participation);
+        var places = psNum(m.places);
+        var ampH = psNum(m.amplitude_horaire, 10);
+        var hOuv = ampH * jours;
+        var ampTot = hOuv * places;
+        var tauxOcc = ampTot ? hFact / ampTot : 0;
+        var tauxHor = hFact ? part / hFact : 0;
+        var psu = hFact * tauxPs * tauxRegime;
+        var psuPart = psu - part;
+        out.push({heures_ouverture:hOuv, amplitude_totale:ampTot, taux_occupation:tauxOcc, taux_horaire:tauxHor, psu:psu, psu_participation:psuPart});
+        tot.jours_ouverture += jours; tot.heures_facturees += hFact; tot.heures_realisees += hReal;
+        tot.participation += part; tot.amplitude_totale += ampTot; tot.psu += psu; tot.psu_participation += psuPart;
+        if (places > 0) placesList.push(places);
+    }
+    var placesMoyen = placesList.length ? placesList.reduce(function(a,b){ return a + b; }, 0) / placesList.length : 0;
+    var tauxOccMoyen = tot.amplitude_totale ? tot.heures_facturees / tot.amplitude_totale : 0;
+    var tauxHorMoyen = tot.heures_facturees ? tot.participation / tot.heures_facturees : 0;
+    var nbEnfants = psNum(d.nb_enfants_inscrits);
+    var finEnfant = psNum(d.financement_par_enfant, 8);
+    var psPrepa = nbEnfants * finEnfant * tauxRegime;
+    var bm = d.bonus_mixite || {};
+    var s1 = psNum(bm.seuil1, 0.91), m1 = psNum(bm.montant1, 2100);
+    var s2 = psNum(bm.seuil2, 1.20), m2 = psNum(bm.montant2, 800);
+    var s3 = psNum(bm.seuil3, 1.52), m3 = psNum(bm.montant3, 300);
+    var bmPlace;
+    if (tauxHorMoyen <= s1) bmPlace = m1;
+    else if (tauxHorMoyen <= s2) bmPlace = m2;
+    else if (tauxHorMoyen <= s3) bmPlace = m3;
+    else bmPlace = 0;
+    var bonusMixite = bmPlace * placesMoyen;
+    var jp = d.journees_peda || {};
+    var jpNb = psNum(jp.nb_journees, 3), jpH = psNum(jp.nb_heures, 10);
+    var journeesPeda = jpNb * jpH * tauxPs * tauxRegime * placesMoyen;
+    var bonusAttrTaux = psNum(d.bonus_attractivite_taux, 970);
+    var bonusAttr = bonusAttrTaux * placesMoyen;
+    var total = tot.psu_participation + psPrepa + bonusMixite + journeesPeda + bonusAttr;
+    return {mois:out, totaux:tot, taux_occupation_moyen:tauxOccMoyen, taux_horaire_moyen:tauxHorMoyen,
+        places_moyen:placesMoyen, ps_prepa:psPrepa, bonus_mixite:bonusMixite, bonus_mixite_place:bmPlace,
+        journees_peda:journeesPeda, bonus_attractivite:bonusAttr, total:total};
+}
+
+function psCell(i, key, val, dis){
+    var step = (key === 'jours_ouverture') ? '1' : '0.01';
+    var v = (val === null || val === undefined) ? '' : val;
+    return '<td><input class="ps-input" type="number" step="' + step + '" value="' + v +
+        '" data-ps-m="' + i + '" data-ps-key="' + key + '"' + dis + '></td>';
+}
+function psBmRow(seuilKey, seuilVal, montantKey, montantVal, dis){
+    return '<div class="ps-field"><label>Jusqu\'à un taux horaire de</label>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + seuilVal + '" data-ps-group="bonus_mixite" data-ps-key="' + seuilKey + '"' + dis + '>' +
+        '<label style="flex:0 0 auto;">→ par place (€)</label>' +
+        '<input class="ps-input" type="number" step="1" value="' + montantVal + '" data-ps-group="bonus_mixite" data-ps-key="' + montantKey + '"' + dis + '></div>';
+}
+
+function renderEajeSimulator(){
+    var st = psSim.state;
+    var dis = canEditPs ? '' : ' disabled';
+    var html = '';
+    html += '<div class="ps-params">' +
+        '<div class="ps-field"><label>Taux de PS</label>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + st.taux_ps + '" data-ps-top="taux_ps"' + dis + '></div>' +
+        '<div class="ps-field"><label>Taux de régime général (%)</label>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + st.taux_regime + '" data-ps-top="taux_regime"' + dis + '></div>' +
+        '</div>';
+    html += '<div class="ps-legend">Les colonnes <span class="bp-ps-calc">surlignées</span> sont calculées automatiquement.</div>';
+    html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
+        '<th>Mois</th><th>Prév/Réel</th><th>Jours d\'ouv.</th><th>Heures facturées</th><th>Heures réalisées</th>' +
+        '<th>Particip. usagers</th><th>Places</th><th>Amplitude horaire</th>' +
+        '<th class="bp-ps-calc">Heures ouverture</th><th class="bp-ps-calc">Amplitude totale</th>' +
+        '<th class="bp-ps-calc">Taux occup.</th><th class="bp-ps-calc">Taux horaire</th>' +
+        '<th class="bp-ps-calc">PSU</th><th class="bp-ps-calc">PSU − Particip.</th>' +
+        '</tr></thead><tbody>';
+    for (var i = 0; i < 12; i++){
+        var m = st.mois[i];
+        html += '<tr>' +
+            '<td class="ps-col-mois">' + NOMS_MOIS_PS[i] + '</td>' +
+            '<td><select class="ps-input ps-input-sel" data-ps-m="' + i + '" data-ps-key="prev_reel"' + dis + '>' +
+                '<option value="prev"' + (m.prev_reel === 'reel' ? '' : ' selected') + '>Prévisionnel</option>' +
+                '<option value="reel"' + (m.prev_reel === 'reel' ? ' selected' : '') + '>Réel</option>' +
+            '</select></td>' +
+            psCell(i, 'jours_ouverture', m.jours_ouverture, dis) +
+            psCell(i, 'heures_facturees', m.heures_facturees, dis) +
+            psCell(i, 'heures_realisees', m.heures_realisees, dis) +
+            psCell(i, 'participation', m.participation, dis) +
+            psCell(i, 'places', m.places, dis) +
+            psCell(i, 'amplitude_horaire', m.amplitude_horaire, dis) +
+            '<td class="bp-ps-calc" id="psc-' + i + '-ho"></td>' +
+            '<td class="bp-ps-calc" id="psc-' + i + '-at"></td>' +
+            '<td class="bp-ps-calc" id="psc-' + i + '-to"></td>' +
+            '<td class="bp-ps-calc" id="psc-' + i + '-th"></td>' +
+            '<td class="bp-ps-calc" id="psc-' + i + '-psu"></td>' +
+            '<td class="bp-ps-calc" id="psc-' + i + '-psup"></td>' +
+            '</tr>';
+    }
+    html += '</tbody><tfoot>' +
+        '<tr><td colspan="2">Total</td>' +
+        '<td id="pst-jo"></td><td id="pst-hf"></td><td id="pst-hr"></td><td id="pst-pa"></td>' +
+        '<td>—</td><td>—</td>' +
+        '<td class="bp-ps-calc">—</td><td class="bp-ps-calc">—</td><td class="bp-ps-calc">—</td><td class="bp-ps-calc">—</td>' +
+        '<td class="bp-ps-calc" id="pst-psu"></td><td class="bp-ps-calc" id="pst-psup"></td></tr>' +
+        '<tr><td colspan="10">Moyenne (pondérée)</td>' +
+        '<td class="bp-ps-calc" id="psm-to"></td><td class="bp-ps-calc" id="psm-th"></td>' +
+        '<td class="bp-ps-calc" colspan="2">—</td></tr>' +
+        '</tfoot></table></div>';
+
+    html += '<div class="ps-summary">';
+    html += '<div class="ps-card"><h4>PS de préparation à l\'accueil de l\'enfant</h4>' +
+        '<div class="ps-field"><label>Nombre d\'enfants inscrits au cours de l\'année</label>' +
+        '<input class="ps-input" type="number" step="1" value="' + st.nb_enfants_inscrits + '" data-ps-top="nb_enfants_inscrits"' + dis + '></div>' +
+        '<div class="ps-field"><label>Financement par enfant (€)</label>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + st.financement_par_enfant + '" data-ps-top="financement_par_enfant"' + dis + '></div>' +
+        '<div class="ps-result">PS prépa accueil : <span id="ps-ps_prepa">0,00</span> €</div></div>';
+    html += '<div class="ps-card"><h4>Bonus mixité</h4>' +
+        '<p class="help-text" style="margin-top:0;">Dépend du taux horaire moyen : <strong id="ps-th-mixite">0,00</strong> €/h.</p>' +
+        psBmRow('seuil1', st.bonus_mixite.seuil1, 'montant1', st.bonus_mixite.montant1, dis) +
+        psBmRow('seuil2', st.bonus_mixite.seuil2, 'montant2', st.bonus_mixite.montant2, dis) +
+        psBmRow('seuil3', st.bonus_mixite.seuil3, 'montant3', st.bonus_mixite.montant3, dis) +
+        '<p class="help-text">Au-delà du dernier seuil : 0 € / place.</p>' +
+        '<div class="ps-result">Montant retenu : <span id="ps-bonus_mixite_place">0,00</span> € / place · Bonus mixité : <span id="ps-bonus_mixite">0,00</span> €</div></div>';
+    html += '<div class="ps-card"><h4>Journées pédagogiques</h4>' +
+        '<div class="ps-field"><label>Nombre de journées</label>' +
+        '<input class="ps-input" type="number" step="1" value="' + st.journees_peda.nb_journees + '" data-ps-group="journees_peda" data-ps-key="nb_journees"' + dis + '></div>' +
+        '<div class="ps-field"><label>Nombre d\'heures par journée</label>' +
+        '<input class="ps-input" type="number" step="0.5" value="' + st.journees_peda.nb_heures + '" data-ps-group="journees_peda" data-ps-key="nb_heures"' + dis + '></div>' +
+        '<div class="ps-result">Journées pédagogiques : <span id="ps-journees_peda">0,00</span> €</div></div>';
+    html += '<div class="ps-card"><h4>Bonus d\'attractivité</h4>' +
+        '<div class="ps-field"><label>Montant par place (€)</label>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + st.bonus_attractivite_taux + '" data-ps-top="bonus_attractivite_taux"' + dis + '></div>' +
+        '<div class="ps-field"><label>Nombre de places retenu (moyenne)</label>&nbsp;<span id="ps-places_moyen" style="font-weight:700;">0,00</span></div>' +
+        '<div class="ps-result">Bonus attractivité : <span id="ps-bonus_attractivite">0,00</span> €</div></div>';
+    html += '</div>';
+
+    html += '<div class="ps-total-box"><span>Total à renseigner sur le compte ' + escapeHtml(psSim.compte) + '</span>' +
+        '<strong><span id="ps-total">0,00</span> €</strong></div>';
+
+    document.getElementById('psSimBody').innerHTML = html;
+
+    var footer = '';
+    if (canEditPs){
+        footer += '<span id="psSaveMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>';
+        footer += '<button class="btn btn-secondary" type="button" onclick="closePsSimulator()">Annuler</button>';
+        footer += '<button class="btn btn-primary" type="button" onclick="savePsSimulator()">💾 Enregistrer et reporter sur le compte</button>';
+    } else {
+        footer += '<span style="margin-right:auto;color:var(--text-muted);">Lecture seule</span>';
+        footer += '<button class="btn btn-secondary" type="button" onclick="closePsSimulator()">Fermer</button>';
+    }
+    document.getElementById('psSimFooter').innerHTML = footer;
+
+    bindEajeInputs();
+}
+
+function bindEajeInputs(){
+    var body = document.getElementById('psSimBody');
+    if (!body) return;
+    body.querySelectorAll('[data-ps-top]').forEach(function(el){
+        var h = function(){ psSim.state[this.dataset.psTop] = this.value; psRecompute(); };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+    body.querySelectorAll('[data-ps-group]').forEach(function(el){
+        var h = function(){ psSim.state[this.dataset.psGroup][this.dataset.psKey] = this.value; psRecompute(); };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+    body.querySelectorAll('[data-ps-m]').forEach(function(el){
+        var h = function(){ psSim.state.mois[parseInt(this.dataset.psM, 10)][this.dataset.psKey] = this.value; psRecompute(); };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+}
+
+function psSet(id, text){ var el = document.getElementById(id); if (el) el.textContent = text; }
+
+function psRecompute(){
+    if (!psSim || !psSim.state) return;
+    var c = computePsEaje(psSim.state);
+    for (var i = 0; i < 12; i++){
+        var mc = c.mois[i] || {};
+        psSet('psc-' + i + '-ho', fmtR(mc.heures_ouverture, 2));
+        psSet('psc-' + i + '-at', fmtR(mc.amplitude_totale, 2));
+        psSet('psc-' + i + '-to', fmtPct(mc.taux_occupation));
+        psSet('psc-' + i + '-th', fmtR(mc.taux_horaire, 2));
+        psSet('psc-' + i + '-psu', fmt(mc.psu));
+        psSet('psc-' + i + '-psup', fmt(mc.psu_participation));
+    }
+    psSet('pst-jo', fmtR(c.totaux.jours_ouverture, 0));
+    psSet('pst-hf', fmtR(c.totaux.heures_facturees, 2));
+    psSet('pst-hr', fmtR(c.totaux.heures_realisees, 2));
+    psSet('pst-pa', fmt(c.totaux.participation));
+    psSet('pst-psu', fmt(c.totaux.psu));
+    psSet('pst-psup', fmt(c.totaux.psu_participation));
+    psSet('psm-to', fmtPct(c.taux_occupation_moyen));
+    psSet('psm-th', fmtR(c.taux_horaire_moyen, 2));
+    psSet('ps-th-mixite', fmtR(c.taux_horaire_moyen, 2));
+    psSet('ps-places_moyen', fmtR(c.places_moyen, 2));
+    psSet('ps-ps_prepa', fmt(c.ps_prepa));
+    psSet('ps-bonus_mixite_place', fmt(c.bonus_mixite_place));
+    psSet('ps-bonus_mixite', fmt(c.bonus_mixite));
+    psSet('ps-journees_peda', fmt(c.journees_peda));
+    psSet('ps-bonus_attractivite', fmt(c.bonus_attractivite));
+    psSet('ps-total', fmt(c.total));
+}
+
+function savePsSimulator(){
+    if (!psSim || !canEditPs) return;
+    var ctx = psSim.ctx || getCurrentBudgetContext();
+    var payload = {
+        compte_num: psSim.compte,
+        annee: ctx.annee,
+        type_budget: ctx.type_budget,
+        secteur_id: ctx.secteur_id,
+        type_ps: 'eaje',
+        donnees: psSim.state
+    };
+    var msg = document.getElementById('psSaveMsg');
+    if (msg) msg.textContent = 'Enregistrement…';
+    fetch('/api/budget-previsionnel/ps-simulation', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body:JSON.stringify(payload)
+    }).then(r => r.json()).then(data => {
+        if (!data.success){ if (msg) msg.textContent = ''; alert(data.error || 'Erreur lors de l\'enregistrement'); return; }
+        var row = currentRows.find(function(r){ return r.compte_num === psSim.compte; });
+        if (row){
+            row.def = Number(data.total || 0);
+            renderBudgetTable('budgetTables', currentRows, salaryMeta, false);
+            renderResultFromRows();
+        }
+        if (msg) msg.textContent = '✓ Enregistré · total reporté : ' + fmt(data.total) + ' €';
+    }).catch(function(){ if (msg) msg.textContent = ''; alert('Erreur réseau lors de l\'enregistrement'); });
+}
+
+loadPsComptes().then(chargerBudget);
 </script>
 {% endblock %}

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -553,6 +553,14 @@ var NOMS_MOIS_PS = ['Janvier','Février','Mars','Avril','Mai','Juin','Juillet','
 function fmtR(n, dec){ return (Number(n || 0)).toLocaleString('fr-FR', {minimumFractionDigits:dec, maximumFractionDigits:dec}); }
 function fmtPct(r){ return fmtR((Number(r || 0)) * 100, 1) + ' %'; }
 function psNum(v, def){ var n = parseFloat(v); if (isNaN(n)) return (def === undefined ? 0 : def); return n; }
+// Échappe une valeur persistée (potentiellement arbitraire) avant injection
+// dans un attribut HTML. Contrairement à escapeHtml, conserve le « 0 ».
+function psAttr(value){
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
 
 function loadPsComptes(){
     return fetch('/api/budget-previsionnel/ps-comptes')
@@ -668,7 +676,7 @@ function openPsSimulator(compteNum){
         ' — ' + compteNum + (libelle ? ' (' + libelle + ')' : '');
     if (type === 'alsh'){ renderAlshSimulator(); showPsModal(); return; }
     var url = '/api/budget-previsionnel/ps-simulation?compte_num=' + encodeURIComponent(compteNum) +
-        '&annee=' + ctx.annee + '&type_budget=' + encodeURIComponent(ctx.type_budget);
+        '&annee=' + ctx.annee + '&secteur_id=' + ctx.secteur_id + '&type_budget=' + encodeURIComponent(ctx.type_budget);
     fetch(url).then(r => r.json()).then(data => {
         psSim.state = mergeEajeState((data && data.found) ? data.donnees : null);
         renderEajeSimulator(); showPsModal(); psRecompute();
@@ -778,15 +786,14 @@ function computePsEaje(d){
 
 function psCell(i, key, val, dis){
     var step = (key === 'jours_ouverture') ? '1' : '0.01';
-    var v = (val === null || val === undefined) ? '' : val;
-    return '<td><input class="ps-input" type="number" step="' + step + '" value="' + v +
+    return '<td><input class="ps-input" type="number" step="' + step + '" value="' + psAttr(val) +
         '" data-ps-m="' + i + '" data-ps-key="' + key + '"' + dis + '></td>';
 }
 function psBmRow(seuilKey, seuilVal, montantKey, montantVal, dis){
     return '<div class="ps-field"><label>Jusqu\'à un taux horaire de</label>' +
-        '<input class="ps-input" type="number" step="0.01" value="' + seuilVal + '" data-ps-group="bonus_mixite" data-ps-key="' + seuilKey + '"' + dis + '>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + psAttr(seuilVal) + '" data-ps-group="bonus_mixite" data-ps-key="' + seuilKey + '"' + dis + '>' +
         '<label style="flex:0 0 auto;">→ par place (€)</label>' +
-        '<input class="ps-input" type="number" step="1" value="' + montantVal + '" data-ps-group="bonus_mixite" data-ps-key="' + montantKey + '"' + dis + '></div>';
+        '<input class="ps-input" type="number" step="1" value="' + psAttr(montantVal) + '" data-ps-group="bonus_mixite" data-ps-key="' + montantKey + '"' + dis + '></div>';
 }
 
 function renderEajeSimulator(){
@@ -795,9 +802,9 @@ function renderEajeSimulator(){
     var html = '';
     html += '<div class="ps-params">' +
         '<div class="ps-field"><label>Taux de PS</label>' +
-        '<input class="ps-input" type="number" step="0.01" value="' + st.taux_ps + '" data-ps-top="taux_ps"' + dis + '></div>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + psAttr(st.taux_ps) + '" data-ps-top="taux_ps"' + dis + '></div>' +
         '<div class="ps-field"><label>Taux de régime général (%)</label>' +
-        '<input class="ps-input" type="number" step="0.01" value="' + st.taux_regime + '" data-ps-top="taux_regime"' + dis + '></div>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + psAttr(st.taux_regime) + '" data-ps-top="taux_regime"' + dis + '></div>' +
         '</div>';
     html += '<div class="ps-legend">Les colonnes <span class="bp-ps-calc">surlignées</span> sont calculées automatiquement.</div>';
     html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
@@ -843,9 +850,9 @@ function renderEajeSimulator(){
     html += '<div class="ps-summary">';
     html += '<div class="ps-card"><h4>PS de préparation à l\'accueil de l\'enfant</h4>' +
         '<div class="ps-field"><label>Nombre d\'enfants inscrits au cours de l\'année</label>' +
-        '<input class="ps-input" type="number" step="1" value="' + st.nb_enfants_inscrits + '" data-ps-top="nb_enfants_inscrits"' + dis + '></div>' +
+        '<input class="ps-input" type="number" step="1" value="' + psAttr(st.nb_enfants_inscrits) + '" data-ps-top="nb_enfants_inscrits"' + dis + '></div>' +
         '<div class="ps-field"><label>Financement par enfant (€)</label>' +
-        '<input class="ps-input" type="number" step="0.01" value="' + st.financement_par_enfant + '" data-ps-top="financement_par_enfant"' + dis + '></div>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + psAttr(st.financement_par_enfant) + '" data-ps-top="financement_par_enfant"' + dis + '></div>' +
         '<div class="ps-result">PS prépa accueil : <span id="ps-ps_prepa">0,00</span> €</div></div>';
     html += '<div class="ps-card"><h4>Bonus mixité</h4>' +
         '<p class="help-text" style="margin-top:0;">Dépend du taux horaire moyen : <strong id="ps-th-mixite">0,00</strong> €/h.</p>' +
@@ -856,13 +863,13 @@ function renderEajeSimulator(){
         '<div class="ps-result">Montant retenu : <span id="ps-bonus_mixite_place">0,00</span> € / place · Bonus mixité : <span id="ps-bonus_mixite">0,00</span> €</div></div>';
     html += '<div class="ps-card"><h4>Journées pédagogiques</h4>' +
         '<div class="ps-field"><label>Nombre de journées</label>' +
-        '<input class="ps-input" type="number" step="1" value="' + st.journees_peda.nb_journees + '" data-ps-group="journees_peda" data-ps-key="nb_journees"' + dis + '></div>' +
+        '<input class="ps-input" type="number" step="1" value="' + psAttr(st.journees_peda.nb_journees) + '" data-ps-group="journees_peda" data-ps-key="nb_journees"' + dis + '></div>' +
         '<div class="ps-field"><label>Nombre d\'heures par journée</label>' +
-        '<input class="ps-input" type="number" step="0.5" value="' + st.journees_peda.nb_heures + '" data-ps-group="journees_peda" data-ps-key="nb_heures"' + dis + '></div>' +
+        '<input class="ps-input" type="number" step="0.5" value="' + psAttr(st.journees_peda.nb_heures) + '" data-ps-group="journees_peda" data-ps-key="nb_heures"' + dis + '></div>' +
         '<div class="ps-result">Journées pédagogiques : <span id="ps-journees_peda">0,00</span> €</div></div>';
     html += '<div class="ps-card"><h4>Bonus d\'attractivité</h4>' +
         '<div class="ps-field"><label>Montant par place (€)</label>' +
-        '<input class="ps-input" type="number" step="0.01" value="' + st.bonus_attractivite_taux + '" data-ps-top="bonus_attractivite_taux"' + dis + '></div>' +
+        '<input class="ps-input" type="number" step="0.01" value="' + psAttr(st.bonus_attractivite_taux) + '" data-ps-top="bonus_attractivite_taux"' + dis + '></div>' +
         '<div class="ps-field"><label>Nombre de places retenu (moyenne)</label>&nbsp;<span id="ps-places_moyen" style="font-weight:700;">0,00</span></div>' +
         '<div class="ps-result">Bonus attractivité : <span id="ps-bonus_attractivite">0,00</span> €</div></div>';
     html += '</div>';

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -61,11 +61,20 @@ def test_budget_previsionnel_rendu_contient_classes_mise_en_page_table(admin_cli
     assert response.status_code == 200
     assert 'bp-col-input' in html
     assert 'bp-cat-total' in html
-    assert 'bp-cat-header' in html
     assert 'data-bp-def-compte=' in html
     assert 'data-bp-comment-compte=' in html
     assert 'oninput="queueSave(' not in html
     assert 'onchange="updateBrutTemp(' not in html
+
+
+def test_budget_previsionnel_entete_fige_sans_repetition(admin_client):
+    """Étape 1 : en-têtes figés (thead sticky dans un conteneur défilant) et
+    suppression de la répétition de l'en-tête par catégorie."""
+    response = admin_client.get('/budget-previsionnel')
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'bp-table-scroll' in html
+    assert 'bp-cat-header' not in html
 
 
 def test_budget_previsionnel_sauvegarde_liee_au_contexte_edite(admin_client):
@@ -257,3 +266,166 @@ def test_api_budget_previsionnel_sauvegarde_separee_par_type_et_annee(app, db, a
         ('actualise', annee, 200, 220),
         ('initial', annee + 1, 300, 320),
     }
+
+
+# ============================================================
+# Simulateur Prestation de Service (PS) CAF
+# ============================================================
+
+def test_budget_previsionnel_bouton_config_ps_directeur(admin_client):
+    """Le directeur dispose du bouton de paramétrage et de la modale simulateur."""
+    response = admin_client.get('/budget-previsionnel')
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'Paramétrer les comptes PS' in html
+    assert 'Comptes concernés par une Prestation de Service' in html
+    # La modale du simulateur est disponible pour tous ceux qui voient la page
+    assert 'id="psSimulatorModal"' in html
+
+
+def test_budget_previsionnel_config_ps_absente_responsable(resp_client):
+    """Le responsable n'a pas accès au paramétrage des comptes PS (bouton + modale)."""
+    response = resp_client.get('/budget-previsionnel')
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'Paramétrer les comptes PS' not in html
+    assert 'Comptes concernés par une Prestation de Service' not in html
+
+
+def test_api_ps_comptes_crud_directeur(app, db, admin_client):
+    """Le directeur peut rattacher un compte 70 à une PS, le lister puis le retirer."""
+    resp = admin_client.post('/api/budget-previsionnel/ps-comptes', json={
+        'compte_num': '706000', 'type_ps': 'eaje'
+    })
+    assert resp.status_code == 200 and resp.get_json().get('success') is True
+
+    resp = admin_client.get('/api/budget-previsionnel/ps-comptes')
+    assert resp.get_json()['comptes'] == {'706000': 'eaje'}
+
+    # Mise à jour du type
+    admin_client.post('/api/budget-previsionnel/ps-comptes', json={
+        'compte_num': '706000', 'type_ps': 'alsh'
+    })
+    assert admin_client.get('/api/budget-previsionnel/ps-comptes').get_json()['comptes'] == {'706000': 'alsh'}
+
+    resp = admin_client.delete('/api/budget-previsionnel/ps-comptes/706000')
+    assert resp.status_code == 200
+    assert admin_client.get('/api/budget-previsionnel/ps-comptes').get_json()['comptes'] == {}
+
+
+def test_api_ps_comptes_refuse_responsable(resp_client):
+    """Le responsable ne peut pas paramétrer les comptes PS."""
+    resp = resp_client.post('/api/budget-previsionnel/ps-comptes', json={
+        'compte_num': '706000', 'type_ps': 'eaje'
+    })
+    assert resp.status_code == 403
+
+
+def test_api_ps_comptes_type_invalide(admin_client):
+    resp = admin_client.post('/api/budget-previsionnel/ps-comptes', json={
+        'compte_num': '706000', 'type_ps': 'autre'
+    })
+    assert resp.status_code == 400
+
+
+def test_api_ps_comptes_disponibles_liste_comptes_70(app, db, admin_client):
+    """Les comptes 70 du plan comptable et du FEC sont proposés au paramétrage."""
+    with app.app_context():
+        db.execute(
+            "INSERT INTO plan_comptable_general (compte_num, libelle) VALUES ('706100', 'PS EAJE')"
+        )
+        db.execute(
+            "INSERT INTO plan_comptable_general (compte_num, libelle) VALUES ('601000', 'Achats')"
+        )
+        db.commit()
+    resp = admin_client.get('/api/budget-previsionnel/ps-comptes-disponibles')
+    comptes = {c['compte_num'] for c in resp.get_json()['comptes']}
+    assert '706100' in comptes
+    assert '601000' not in comptes
+
+
+def test_api_ps_simulation_eaje_calcule_et_reporte(app, db, admin_client, sample_users):
+    """La simulation EAJE calcule le total côté serveur et le reporte sur le
+    compte (valeur définitive du budget prévisionnel)."""
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    donnees = {
+        'taux_ps': 6.63,
+        'taux_regime': 100,
+        'mois': [
+            {'jours_ouverture': 20, 'heures_facturees': 1000, 'heures_realisees': 1100,
+             'participation': 1500, 'places': 20, 'amplitude_horaire': 10}
+        ] + [{} for _ in range(11)],
+        'nb_enfants_inscrits': 50,
+        'financement_par_enfant': 8,
+        'journees_peda': {'nb_journees': 3, 'nb_heures': 10},
+        'bonus_attractivite_taux': 970,
+    }
+    resp = admin_client.post('/api/budget-previsionnel/ps-simulation', json={
+        'compte_num': '706000', 'annee': annee, 'type_budget': 'initial',
+        'type_ps': 'eaje', 'secteur_id': secteur_id, 'donnees': donnees
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success'] is True
+
+    # Détail attendu :
+    # PSU = 1000 * 6.63 * 1.0 = 6630 ; PSU - participation = 6630 - 1500 = 5130
+    # taux horaire moyen = 1500 / 1000 = 1.5 -> bonus mixité bracket <=1.52 : 300/place
+    # places moyen = 20 ; bonus mixité = 300 * 20 = 6000
+    # PS prépa = 50 * 8 * 1.0 = 400
+    # journées péda = 3 * 10 * 6.63 * 1.0 * 20 = 3978
+    # bonus attractivité = 970 * 20 = 19400
+    # total = 5130 + 400 + 6000 + 3978 + 19400 = 34908
+    assert abs(data['total'] - 34908.0) < 0.01
+    assert data['reported'] is True
+
+    # Report sur la valeur définitive du compte
+    row = db.execute('''
+        SELECT valeur_def FROM budget_prev_saisies
+        WHERE type_budget = 'initial' AND annee = ? AND secteur_id = ? AND compte_num = '706000'
+    ''', (annee, secteur_id)).fetchone()
+    assert row is not None and abs(row['valeur_def'] - 34908.0) < 0.01
+
+    # La simulation est relue avec les mêmes données
+    resp_get = admin_client.get(
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&type_budget=initial'
+    )
+    got = resp_get.get_json()
+    assert got['found'] is True
+    assert abs(got['total'] - 34908.0) < 0.01
+    assert got['donnees']['nb_enfants_inscrits'] == 50
+
+
+def test_api_ps_simulation_attachee_au_type_et_annee(admin_client, sample_users):
+    """Une simulation est attachée au couple (compte, année, type de budget)."""
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    base = {'compte_num': '706000', 'type_ps': 'eaje', 'secteur_id': secteur_id,
+            'donnees': {'mois': [{'heures_facturees': 100, 'participation': 50, 'places': 10}]}}
+    admin_client.post('/api/budget-previsionnel/ps-simulation',
+                      json={**base, 'annee': annee, 'type_budget': 'initial'})
+    admin_client.post('/api/budget-previsionnel/ps-simulation',
+                      json={**base, 'annee': annee, 'type_budget': 'actualise'})
+
+    r_init = admin_client.get(
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&type_budget=initial'
+    ).get_json()
+    r_actu = admin_client.get(
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&type_budget=actualise'
+    ).get_json()
+    assert r_init['found'] is True and r_actu['found'] is True
+    # Une année/type non saisi reste vide
+    r_vide = admin_client.get(
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee + 1}&type_budget=initial'
+    ).get_json()
+    assert r_vide['found'] is False
+
+
+def test_api_ps_simulation_refuse_responsable(resp_client, sample_users):
+    secteur_id = sample_users['secteur_id']
+    resp = resp_client.post('/api/budget-previsionnel/ps-simulation', json={
+        'compte_num': '706000', 'annee': datetime.now().year, 'type_budget': 'initial',
+        'type_ps': 'eaje', 'secteur_id': secteur_id, 'donnees': {}
+    })
+    assert resp.status_code == 403

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -389,7 +389,7 @@ def test_api_ps_simulation_eaje_calcule_et_reporte(app, db, admin_client, sample
 
     # La simulation est relue avec les mêmes données
     resp_get = admin_client.get(
-        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&type_budget=initial'
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&secteur_id={secteur_id}&type_budget=initial'
     )
     got = resp_get.get_json()
     assert got['found'] is True
@@ -409,17 +409,84 @@ def test_api_ps_simulation_attachee_au_type_et_annee(admin_client, sample_users)
                       json={**base, 'annee': annee, 'type_budget': 'actualise'})
 
     r_init = admin_client.get(
-        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&type_budget=initial'
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&secteur_id={secteur_id}&type_budget=initial'
     ).get_json()
     r_actu = admin_client.get(
-        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&type_budget=actualise'
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&secteur_id={secteur_id}&type_budget=actualise'
     ).get_json()
     assert r_init['found'] is True and r_actu['found'] is True
     # Une année/type non saisi reste vide
     r_vide = admin_client.get(
-        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee + 1}&type_budget=initial'
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee + 1}&secteur_id={secteur_id}&type_budget=initial'
     ).get_json()
     assert r_vide['found'] is False
+
+
+def test_api_ps_simulation_attachee_au_secteur(app, db, admin_client, sample_users):
+    """Deux secteurs (ex. deux crèches) partageant le même compte produit ont
+    des simulations distinctes pour la même année et le même type de budget."""
+    secteur1 = sample_users['secteur_id']
+    with app.app_context():
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Crèche B', 'creche')")
+        secteur2 = db.execute("SELECT id FROM secteurs WHERE nom='Crèche B'").fetchone()['id']
+        db.commit()
+    annee = datetime.now().year
+
+    def payload(secteur_id, hfact, part):
+        return {
+            'compte_num': '706000', 'annee': annee, 'type_budget': 'initial',
+            'type_ps': 'eaje', 'secteur_id': secteur_id,
+            'donnees': {'mois': [{'heures_facturees': hfact, 'participation': part, 'places': 10,
+                                  'jours_ouverture': 20, 'amplitude_horaire': 10}]}
+        }
+    admin_client.post('/api/budget-previsionnel/ps-simulation', json=payload(secteur1, 1000, 1500))
+    admin_client.post('/api/budget-previsionnel/ps-simulation', json=payload(secteur2, 2000, 1000))
+
+    # Deux lignes distinctes en base (pas d'écrasement)
+    with app.app_context():
+        rows = db.execute('''
+            SELECT secteur_id FROM budget_ps_simulations
+            WHERE compte_num='706000' AND annee=? AND type_budget='initial'
+            ORDER BY secteur_id
+        ''', (annee,)).fetchall()
+    assert {r['secteur_id'] for r in rows} == {secteur1, secteur2}
+
+    # La relecture par secteur renvoie les données propres à chaque secteur
+    r1 = admin_client.get(
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&secteur_id={secteur1}&type_budget=initial'
+    ).get_json()
+    r2 = admin_client.get(
+        f'/api/budget-previsionnel/ps-simulation?compte_num=706000&annee={annee}&secteur_id={secteur2}&type_budget=initial'
+    ).get_json()
+    assert r1['donnees']['mois'][0]['heures_facturees'] == 1000
+    assert r2['donnees']['mois'][0]['heures_facturees'] == 2000
+
+    # Report sur le budget de chaque secteur séparément
+    with app.app_context():
+        defs = db.execute('''
+            SELECT secteur_id FROM budget_prev_saisies
+            WHERE compte_num='706000' AND annee=? AND type_budget='initial'
+        ''', (annee,)).fetchall()
+    assert {r['secteur_id'] for r in defs} == {secteur1, secteur2}
+
+
+def test_api_ps_simulation_secteur_requis(admin_client):
+    """Le secteur est obligatoire à l'enregistrement d'une simulation."""
+    resp = admin_client.post('/api/budget-previsionnel/ps-simulation', json={
+        'compte_num': '706000', 'annee': datetime.now().year, 'type_budget': 'initial',
+        'type_ps': 'eaje', 'donnees': {}
+    })
+    assert resp.status_code == 400
+
+
+def test_budget_previsionnel_simulateur_echappe_valeurs(admin_client):
+    """Les valeurs persistées sont échappées avant injection HTML (P2 / anti-XSS)."""
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert 'function psAttr(' in html
+    # Plus d'injection brute des valeurs persistées dans les attributs value
+    assert "value=\"' + st.taux_ps + '\"" not in html
+    assert 'psAttr(st.taux_ps)' in html
+    assert 'psAttr(val)' in html
 
 
 def test_api_ps_simulation_refuse_responsable(resp_client, sample_users):


### PR DESCRIPTION
## Résumé

Amélioration de la page **Budget prévisionnel** en trois étapes.

### Étape 1 — En-têtes figés
- Les tableaux Charges/Produits sont placés dans un conteneur défilant (`.bp-table-scroll`) avec un `thead` figé (`position: sticky`).
- Suppression de la répétition de l'en-tête par catégorie (le palliatif mis en place précédemment).

### Étape 2 — Paramétrage des comptes PS
- Bouton **« ⚙️ Paramétrer les comptes PS »** (direction/comptable) ouvrant une modale.
- Liste déroulante des comptes de produits **70**, avec choix **PS EAJE (crèche)** ou **PS ALSH (accueil de loisirs)**.
- Plusieurs comptes paramétrables, conservés en mémoire (table `budget_ps_comptes`).
- Un bouton **« 🧮 PS »** apparaît à côté des comptes concernés dans le budget.

### Étape 3 — Simulateurs
- **PS ALSH** : fenêtre « en cours de réalisation » (à faire ultérieurement).
- **PS EAJE** : simulateur complet.
  - Paramètres : taux de PS (défaut 6,63) et taux de régime général (défaut 100 %).
  - Saisie mensuelle (Prév/Réel, jours d'ouverture, heures facturées/réalisées, participation usagers, places, amplitude horaire).
  - **Colonnes calculées surlignées** : heures d'ouverture, amplitude totale, taux d'occupation, taux horaire, PSU, PSU − participation.
  - Lignes **Total** (jours, heures facturées/réalisées, participation, PSU, PSU − participation) et **Moyenne** pondérée (taux d'occupation et taux horaire).
  - PS de préparation à l'accueil de l'enfant, **bonus mixité paramétrable** (sommes et plafonds), journées pédagogiques, bonus d'attractivité.
  - **Total à renseigner sur le compte** affiché et reporté sur la valeur définitive.
  - Le nombre de places retenu est la moyenne des mois renseignés (utile si variable).

### Notes techniques
- Saisies attachées au **compte + année + type de budget** (table `budget_ps_simulations`), enregistrées **uniquement au clic** sur le bouton de validation — aucun verrouillage de la base pendant le travail.
- Le total est **recalculé côté serveur** à l'enregistrement (cohérence garantie entre l'affichage JS et le montant stocké/reporté).
- Tables créées via la **migration 0042** et dans `init_db()`.

### Tests
- Mise à jour du test de mise en page (en-têtes figés) et ajout de tests pour le CRUD des comptes PS, le calcul EAJE (report + rattachement année/type), et les contrôles d'accès.
- Suite complète : **536 tests OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3)_