### PR TITLE
Afficher les modales du simulateur PS au-dessus du menu latéral

### DIFF
--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -970,6 +970,14 @@ function savePsSimulator(){
     }).catch(function(){ if (msg) msg.textContent = ''; alert('Erreur réseau lors de l\'enregistrement'); });
 }
 
+// Déplace les modales au niveau du <body> : le conteneur .container crée un
+// contexte d'empilement (animation) qui les confinerait sinon sous la barre
+// latérale de gauche (menu). Rattachées au body, elles s'affichent par-dessus.
+['psSimulatorModal', 'psConfigModal'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el && el.parentNode !== document.body) document.body.appendChild(el);
+});
+
 loadPsComptes().then(chargerBudget);
 </script>
 {% endblock %}

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -292,6 +292,13 @@ def test_budget_previsionnel_config_ps_absente_responsable(resp_client):
     assert 'Comptes concernés par une Prestation de Service' not in html
 
 
+def test_budget_previsionnel_modales_rattachees_au_body(admin_client):
+    """Les modales sont déplacées au <body> pour s'afficher par-dessus le menu."""
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert "'psSimulatorModal', 'psConfigModal'" in html
+    assert 'document.body.appendChild(el)' in html
+
+
 def test_api_ps_comptes_crud_directeur(app, db, admin_client):
     """Le directeur peut rattacher un compte 70 à une PS, le lister puis le retirer."""
     resp = admin_client.post('/api/budget-previsionnel/ps-comptes', json={


### PR DESCRIPTION
## Contexte

Suite à la fusion de #163 (simulateur de PS CAF), un défaut d'affichage a été constaté : la fenêtre du simulateur ne s'affichait pas par-dessus le menu latéral de gauche, masquant une partie du contenu.

## Cause

Les modales (`#psSimulatorModal`, `#psConfigModal`) étaient rendues à l'intérieur de `.container`. Or `.container` porte une `animation` qui crée un **contexte d'empilement** : les overlays `position: fixed` y restent confinés et passent **sous** la barre latérale fixe, quelle que soit leur `z-index`. C'est précisément pour cette raison que les autres modales de l'application (message CSE, chatbot) sont placées comme **enfants directs du `<body>`**.

## Correctif

Au chargement de la page, les deux modales sont rattachées au `<body>` :

```js
['psSimulatorModal', 'psConfigModal'].forEach(function(id){
    var el = document.getElementById(id);
    if (el && el.parentNode !== document.body) document.body.appendChild(el);
});
```

Elles s'affichent désormais par-dessus le menu, sur toute la largeur de l'écran.

## Tests
- Test ajouté vérifiant le rattachement au `<body>`.
- Suite complète : **540 tests OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3)_