### PR TITLE
Simulateur PS EAJE : saisie prévisionnelle ou réelle par mois

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1224,22 +1224,36 @@ def _compute_ps_eaje(donnees):
     }
     places_list = []
     for m in mois_in:
+        # Par défaut « réel » : c'est le comportement historique (heures saisies,
+        # taux calculés) et le tableau actuel.
+        prev_reel = m.get('prev_reel') or 'reel'
         jours = _ps_num(m.get('jours_ouverture'))
-        h_fact = _ps_num(m.get('heures_facturees'))
-        h_real = _ps_num(m.get('heures_realisees'))
-        participation = _ps_num(m.get('participation'))
         places = _ps_num(m.get('places'))
         amplitude_h = _ps_num(m.get('amplitude_horaire'), PS_EAJE_DEFAULTS['amplitude_horaire'])
         heures_ouv = amplitude_h * jours
         amplitude_tot = heures_ouv * places
-        taux_occ = (h_fact / amplitude_tot) if amplitude_tot else 0.0
-        taux_horaire = (participation / h_fact) if h_fact else 0.0
+        if prev_reel == 'reel':
+            # Réel : heures facturées / réalisées / participation saisies,
+            #        taux d'occupation et taux horaire calculés.
+            h_fact = _ps_num(m.get('heures_facturees'))
+            h_real = _ps_num(m.get('heures_realisees'))
+            participation = _ps_num(m.get('participation'))
+            taux_occ = (h_fact / amplitude_tot) if amplitude_tot else 0.0
+            taux_horaire = (participation / h_fact) if h_fact else 0.0
+        else:
+            # Prévisionnel : taux d'occupation (%) et taux horaire saisis,
+            #                heures facturées / réalisées et participation calculées.
+            taux_occ = _ps_num(m.get('taux_occupation')) / 100.0
+            taux_horaire = _ps_num(m.get('taux_horaire'))
+            h_fact = taux_occ * amplitude_tot
+            h_real = h_fact
+            participation = taux_horaire * h_fact
         psu = h_fact * taux_ps * taux_regime
         psu_part = psu - participation
         mois_out.append({
-            'prev_reel': m.get('prev_reel') or 'prev',
-            'jours_ouverture': jours, 'heures_facturees': h_fact,
-            'heures_realisees': h_real, 'participation': participation,
+            'prev_reel': prev_reel,
+            'jours_ouverture': jours, 'heures_facturees': round(h_fact, 2),
+            'heures_realisees': round(h_real, 2), 'participation': round(participation, 2),
             'places': places, 'amplitude_horaire': amplitude_h,
             'heures_ouverture': round(heures_ouv, 2),
             'amplitude_totale': round(amplitude_tot, 2),

--- a/migrations/0043_ps_eaje_mode_reel_defaut.py
+++ b/migrations/0043_ps_eaje_mode_reel_defaut.py
@@ -1,0 +1,55 @@
+"""
+Migration 0043 : compatibilité prévisionnel/réel du simulateur PS EAJE.
+
+Le sélecteur « Prév/Réel » par mois devient fonctionnel :
+- en « réel » (comportement historique) les heures facturées / réalisées et la
+  participation sont saisies, le taux d'occupation et le taux horaire sont
+  calculés ;
+- en « prévisionnel » le taux d'occupation (%) et le taux horaire sont saisis,
+  les heures et la participation sont calculées.
+
+Les simulations déjà enregistrées contiennent des saisies « réel » (heures),
+mais leurs mois pouvaient porter l'ancienne valeur par défaut « prev » (qui
+n'avait alors aucun effet). On force donc ces mois à « reel » afin de préserver
+les totaux existants une fois le mode prévisionnel actif.
+"""
+import json
+
+NOM = "Compat simulateur PS EAJE prév/réel"
+DESCRIPTION = ("Force les mois des simulations EAJE existantes en mode 'reel' "
+               "pour préserver les totaux après activation du mode prévisionnel.")
+
+
+def upgrade(conn):
+    """Bascule chaque mois des simulations EAJE existantes en mode 'reel'."""
+    rows = conn.execute(
+        "SELECT id, donnees FROM budget_ps_simulations WHERE type_ps = 'eaje'"
+    ).fetchall()
+    for row in rows:
+        if not row['donnees']:
+            continue
+        try:
+            donnees = json.loads(row['donnees'])
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(donnees, dict):
+            continue
+        mois = donnees.get('mois')
+        if not isinstance(mois, list):
+            continue
+        changed = False
+        for m in mois:
+            if isinstance(m, dict) and m.get('prev_reel') != 'reel':
+                m['prev_reel'] = 'reel'
+                changed = True
+        if changed:
+            conn.execute(
+                "UPDATE budget_ps_simulations SET donnees = ? WHERE id = ?",
+                (json.dumps(donnees), row['id']),
+            )
+    conn.commit()
+
+
+def downgrade(conn):
+    """Pas de downgrade : le mode 'reel' reproduit le calcul historique."""
+    conn.commit()

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -704,7 +704,7 @@ function renderAlshSimulator(){
 function defaultEajeState(){
     var mois = [];
     for (var i = 0; i < 12; i++){
-        mois.push({prev_reel:'reel', jours_ouverture:'', heures_facturees:'', heures_realisees:'', participation:'', taux_occupation:'', taux_horaire:'', places:'', amplitude_horaire:10});
+        mois.push({prev_reel:'prev', jours_ouverture:'', heures_facturees:'', heures_realisees:'', participation:'', taux_occupation:'', taux_horaire:'', places:'', amplitude_horaire:10});
     }
     return {
         taux_ps:6.63, taux_regime:100, mois:mois,

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -704,7 +704,7 @@ function renderAlshSimulator(){
 function defaultEajeState(){
     var mois = [];
     for (var i = 0; i < 12; i++){
-        mois.push({prev_reel:'prev', jours_ouverture:'', heures_facturees:'', heures_realisees:'', participation:'', places:'', amplitude_horaire:10});
+        mois.push({prev_reel:'reel', jours_ouverture:'', heures_facturees:'', heures_realisees:'', participation:'', taux_occupation:'', taux_horaire:'', places:'', amplitude_horaire:10});
     }
     return {
         taux_ps:6.63, taux_regime:100, mois:mois,
@@ -740,19 +740,29 @@ function computePsEaje(d){
     var placesList = [];
     for (var i = 0; i < mois.length; i++){
         var m = mois[i] || {};
+        var prevReel = m.prev_reel || 'reel';
         var jours = psNum(m.jours_ouverture);
-        var hFact = psNum(m.heures_facturees);
-        var hReal = psNum(m.heures_realisees);
-        var part = psNum(m.participation);
         var places = psNum(m.places);
         var ampH = psNum(m.amplitude_horaire, 10);
         var hOuv = ampH * jours;
         var ampTot = hOuv * places;
-        var tauxOcc = ampTot ? hFact / ampTot : 0;
-        var tauxHor = hFact ? part / hFact : 0;
+        var hFact, hReal, part, tauxOcc, tauxHor;
+        if (prevReel === 'reel'){
+            hFact = psNum(m.heures_facturees);
+            hReal = psNum(m.heures_realisees);
+            part = psNum(m.participation);
+            tauxOcc = ampTot ? hFact / ampTot : 0;
+            tauxHor = hFact ? part / hFact : 0;
+        } else {
+            tauxOcc = psNum(m.taux_occupation) / 100;
+            tauxHor = psNum(m.taux_horaire);
+            hFact = tauxOcc * ampTot;
+            hReal = hFact;
+            part = tauxHor * hFact;
+        }
         var psu = hFact * tauxPs * tauxRegime;
         var psuPart = psu - part;
-        out.push({heures_ouverture:hOuv, amplitude_totale:ampTot, taux_occupation:tauxOcc, taux_horaire:tauxHor, psu:psu, psu_participation:psuPart});
+        out.push({heures_ouverture:hOuv, amplitude_totale:ampTot, heures_facturees:hFact, heures_realisees:hReal, participation:part, taux_occupation:tauxOcc, taux_horaire:tauxHor, psu:psu, psu_participation:psuPart});
         tot.jours_ouverture += jours; tot.heures_facturees += hFact; tot.heures_realisees += hReal;
         tot.participation += part; tot.amplitude_totale += ampTot; tot.psu += psu; tot.psu_participation += psuPart;
         if (places > 0) placesList.push(places);
@@ -789,6 +799,11 @@ function psCell(i, key, val, dis){
     return '<td><input class="ps-input" type="number" step="' + step + '" value="' + psAttr(val) +
         '" data-ps-m="' + i + '" data-ps-key="' + key + '"' + dis + '></td>';
 }
+function psCalcCell(spanId){ return '<td class="bp-ps-calc" id="' + spanId + '"></td>'; }
+function psToggleCell(i, key, val, isInput, spanId, dis){
+    // Selon le mode du mois : cellule éditable (saisie) ou calculée (surlignée).
+    return isInput ? psCell(i, key, val, dis) : psCalcCell(spanId);
+}
 function psBmRow(seuilKey, seuilVal, montantKey, montantVal, dis){
     return '<div class="ps-field"><label>Jusqu\'à un taux horaire de</label>' +
         '<input class="ps-input" type="number" step="0.01" value="' + psAttr(seuilVal) + '" data-ps-group="bonus_mixite" data-ps-key="' + seuilKey + '"' + dis + '>' +
@@ -806,32 +821,37 @@ function renderEajeSimulator(){
         '<div class="ps-field"><label>Taux de régime général (%)</label>' +
         '<input class="ps-input" type="number" step="0.01" value="' + psAttr(st.taux_regime) + '" data-ps-top="taux_regime"' + dis + '></div>' +
         '</div>';
-    html += '<div class="ps-legend">Les colonnes <span class="bp-ps-calc">surlignées</span> sont calculées automatiquement.</div>';
+    html += '<div class="ps-legend">Choisissez <strong>Prévisionnel</strong> ou <strong>Réel</strong> pour chaque mois. ' +
+        'Les cellules <span class="bp-ps-calc">surlignées</span> sont calculées automatiquement. ' +
+        'En <em>réel</em> : heures facturées / réalisées et participation se saisissent, le taux d\'occupation (%) et le taux horaire en découlent. ' +
+        'En <em>prévisionnel</em> : le taux d\'occupation (%) et le taux horaire se saisissent, les heures et la participation en découlent.</div>';
     html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
         '<th>Mois</th><th>Prév/Réel</th><th>Jours d\'ouv.</th><th>Heures facturées</th><th>Heures réalisées</th>' +
         '<th>Particip. usagers</th><th>Places</th><th>Amplitude horaire</th>' +
         '<th class="bp-ps-calc">Heures ouverture</th><th class="bp-ps-calc">Amplitude totale</th>' +
-        '<th class="bp-ps-calc">Taux occup.</th><th class="bp-ps-calc">Taux horaire</th>' +
+        '<th>Taux occup. (%)</th><th>Taux horaire</th>' +
         '<th class="bp-ps-calc">PSU</th><th class="bp-ps-calc">PSU − Particip.</th>' +
         '</tr></thead><tbody>';
     for (var i = 0; i < 12; i++){
         var m = st.mois[i];
+        var reel = (m.prev_reel !== 'prev');  // défaut « réel »
         html += '<tr>' +
             '<td class="ps-col-mois">' + NOMS_MOIS_PS[i] + '</td>' +
             '<td><select class="ps-input ps-input-sel" data-ps-m="' + i + '" data-ps-key="prev_reel"' + dis + '>' +
-                '<option value="prev"' + (m.prev_reel === 'reel' ? '' : ' selected') + '>Prévisionnel</option>' +
-                '<option value="reel"' + (m.prev_reel === 'reel' ? ' selected' : '') + '>Réel</option>' +
+                '<option value="prev"' + (reel ? '' : ' selected') + '>Prévisionnel</option>' +
+                '<option value="reel"' + (reel ? ' selected' : '') + '>Réel</option>' +
             '</select></td>' +
             psCell(i, 'jours_ouverture', m.jours_ouverture, dis) +
-            psCell(i, 'heures_facturees', m.heures_facturees, dis) +
-            psCell(i, 'heures_realisees', m.heures_realisees, dis) +
-            psCell(i, 'participation', m.participation, dis) +
+            // Réel : heures saisies / taux calculés — Prévisionnel : l'inverse
+            psToggleCell(i, 'heures_facturees', m.heures_facturees, reel, 'psc-' + i + '-hf', dis) +
+            psToggleCell(i, 'heures_realisees', m.heures_realisees, reel, 'psc-' + i + '-hr', dis) +
+            psToggleCell(i, 'participation', m.participation, reel, 'psc-' + i + '-pa', dis) +
             psCell(i, 'places', m.places, dis) +
             psCell(i, 'amplitude_horaire', m.amplitude_horaire, dis) +
             '<td class="bp-ps-calc" id="psc-' + i + '-ho"></td>' +
             '<td class="bp-ps-calc" id="psc-' + i + '-at"></td>' +
-            '<td class="bp-ps-calc" id="psc-' + i + '-to"></td>' +
-            '<td class="bp-ps-calc" id="psc-' + i + '-th"></td>' +
+            psToggleCell(i, 'taux_occupation', m.taux_occupation, !reel, 'psc-' + i + '-to', dis) +
+            psToggleCell(i, 'taux_horaire', m.taux_horaire, !reel, 'psc-' + i + '-th', dis) +
             '<td class="bp-ps-calc" id="psc-' + i + '-psu"></td>' +
             '<td class="bp-ps-calc" id="psc-' + i + '-psup"></td>' +
             '</tr>';
@@ -905,7 +925,12 @@ function bindEajeInputs(){
         el.addEventListener('input', h); el.addEventListener('change', h);
     });
     body.querySelectorAll('[data-ps-m]').forEach(function(el){
-        var h = function(){ psSim.state.mois[parseInt(this.dataset.psM, 10)][this.dataset.psKey] = this.value; psRecompute(); };
+        var h = function(){
+            psSim.state.mois[parseInt(this.dataset.psM, 10)][this.dataset.psKey] = this.value;
+            // Changer le mode du mois change les cellules saisissables : on redessine.
+            if (this.dataset.psKey === 'prev_reel'){ renderEajeSimulator(); }
+            psRecompute();
+        };
         el.addEventListener('input', h); el.addEventListener('change', h);
     });
 }
@@ -919,8 +944,13 @@ function psRecompute(){
         var mc = c.mois[i] || {};
         psSet('psc-' + i + '-ho', fmtR(mc.heures_ouverture, 2));
         psSet('psc-' + i + '-at', fmtR(mc.amplitude_totale, 2));
-        psSet('psc-' + i + '-to', fmtPct(mc.taux_occupation));
-        psSet('psc-' + i + '-th', fmtR(mc.taux_horaire, 2));
+        // Cellules calculées présentes uniquement dans le mode concerné
+        // (psSet est sans effet si l'élément n'existe pas) :
+        psSet('psc-' + i + '-hf', fmtR(mc.heures_facturees, 2));   // mode prévisionnel
+        psSet('psc-' + i + '-hr', fmtR(mc.heures_realisees, 2));   // mode prévisionnel
+        psSet('psc-' + i + '-pa', fmt(mc.participation));          // mode prévisionnel
+        psSet('psc-' + i + '-to', fmtPct(mc.taux_occupation));     // mode réel
+        psSet('psc-' + i + '-th', fmtR(mc.taux_horaire, 2));       // mode réel
         psSet('psc-' + i + '-psu', fmt(mc.psu));
         psSet('psc-' + i + '-psup', fmt(mc.psu_participation));
     }

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -724,7 +724,14 @@ function mergeEajeState(saved){
     if (saved.journees_peda) Object.assign(s.journees_peda, saved.journees_peda);
     if (Array.isArray(saved.mois)){
         for (var i = 0; i < 12 && i < saved.mois.length; i++){
-            if (saved.mois[i]) Object.assign(s.mois[i], saved.mois[i]);
+            var sm = saved.mois[i];
+            if (sm){
+                Object.assign(s.mois[i], sm);
+                // Rétro-compat : un mois enregistré sans mode était calculé en « réel »
+                // côté serveur (budget.py : m.get('prev_reel') or 'reel'). On aligne l'UI
+                // pour ne pas rouvrir ces simulations en prévisionnel et écraser les heures.
+                if (sm.prev_reel === undefined || sm.prev_reel === null) s.mois[i].prev_reel = 'reel';
+            }
         }
     }
     return s;

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -597,6 +597,9 @@ def test_budget_previsionnel_simulateur_mode_par_mois_present(admin_client):
     assert "prev_reel:'prev'" in html
     # …mais le repli quand le mode est absent reste « réel » (rétro-compat)
     assert "|| 'reel'" in html
+    # Un mois enregistré sans mode est réaligné sur « réel » au chargement,
+    # comme le serveur, pour ne pas rouvrir en prévisionnel et écraser les heures.
+    assert "s.mois[i].prev_reel = 'reel'" in html
 
 
 def _load_migration(version_prefix):

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -593,6 +593,10 @@ def test_budget_previsionnel_simulateur_mode_par_mois_present(admin_client):
     html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
     assert 'psToggleCell(' in html
     assert "prevReel === 'reel'" in html  # calcul inversé selon le mode
+    # Nouvelle simulation : mois en prévisionnel par défaut…
+    assert "prev_reel:'prev'" in html
+    # …mais le repli quand le mode est absent reste « réel » (rétro-compat)
+    assert "|| 'reel'" in html
 
 
 def _load_migration(version_prefix):

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,4 +1,9 @@
+import importlib.util
+import json
+import os
 from datetime import datetime
+
+from blueprints.budget import _compute_ps_eaje
 
 TEST_SECTOR_TYPE_HIGH_ORDER = 999
 
@@ -503,3 +508,120 @@ def test_api_ps_simulation_refuse_responsable(resp_client, sample_users):
         'type_ps': 'eaje', 'secteur_id': secteur_id, 'donnees': {}
     })
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Simulateur PS EAJE : modes prévisionnel / réel par mois
+# ---------------------------------------------------------------------------
+
+_PS_BASE = {
+    'taux_ps': 6.63, 'taux_regime': 100,
+    'nb_enfants_inscrits': 50, 'financement_par_enfant': 8,
+    'journees_peda': {'nb_journees': 3, 'nb_heures': 10},
+    'bonus_attractivite_taux': 970,
+}
+
+
+def test_compute_ps_eaje_mode_reel_calcule_les_taux():
+    """Réel : heures/participation saisies → taux d'occupation et horaire calculés."""
+    d = dict(_PS_BASE, mois=[{
+        'prev_reel': 'reel', 'jours_ouverture': 20, 'heures_facturees': 1000,
+        'heures_realisees': 1100, 'participation': 1500, 'places': 20, 'amplitude_horaire': 10,
+    }])
+    c = _compute_ps_eaje(d)
+    m = c['mois'][0]
+    assert m['taux_occupation'] == 0.25      # 1000 / (10*20*20)
+    assert m['taux_horaire'] == 1.5          # 1500 / 1000
+    assert m['heures_realisees'] == 1100     # saisie indépendante en réel
+
+
+def test_compute_ps_eaje_defaut_reel_retrocompat():
+    """Un mois sans prev_reel garde le comportement historique (réel)."""
+    d = dict(_PS_BASE, mois=[{
+        'jours_ouverture': 20, 'heures_facturees': 1000, 'heures_realisees': 1000,
+        'participation': 1500, 'places': 20, 'amplitude_horaire': 10,
+    }])
+    m = _compute_ps_eaje(d)['mois'][0]
+    assert m['taux_occupation'] == 0.25
+    assert m['taux_horaire'] == 1.5
+
+
+def test_compute_ps_eaje_mode_previsionnel_calcule_les_heures():
+    """Prévisionnel : taux occup (%) et taux horaire saisis → heures et participation calculées."""
+    d = dict(_PS_BASE, mois=[{
+        'prev_reel': 'prev', 'jours_ouverture': 20, 'places': 20, 'amplitude_horaire': 10,
+        'taux_occupation': 25, 'taux_horaire': 1.5,
+    }])
+    m = _compute_ps_eaje(d)['mois'][0]
+    assert m['heures_facturees'] == 1000.0   # 0.25 * (10*20*20)
+    assert m['heures_realisees'] == 1000.0   # copie des heures facturées
+    assert m['participation'] == 1500.0      # 1.5 * 1000
+
+
+def test_compute_ps_eaje_previsionnel_equivaut_au_reel():
+    """Un mois prévisionnel reproduit le total d'un mois réel équivalent."""
+    reel = dict(_PS_BASE, mois=[{
+        'prev_reel': 'reel', 'jours_ouverture': 20, 'heures_facturees': 1000,
+        'heures_realisees': 1000, 'participation': 1500, 'places': 20, 'amplitude_horaire': 10,
+    }])
+    prev = dict(_PS_BASE, mois=[{
+        'prev_reel': 'prev', 'jours_ouverture': 20, 'places': 20, 'amplitude_horaire': 10,
+        'taux_occupation': 25, 'taux_horaire': 1.5,
+    }])
+    assert abs(_compute_ps_eaje(reel)['total'] - _compute_ps_eaje(prev)['total']) < 0.01
+
+
+def test_api_ps_simulation_previsionnel_reporte_le_total(app, db, admin_client, sample_users):
+    """La saisie prévisionnelle calcule heures/participation côté serveur et reporte le total."""
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    donnees = dict(_PS_BASE, mois=[{
+        'prev_reel': 'prev', 'jours_ouverture': 20, 'places': 20, 'amplitude_horaire': 10,
+        'taux_occupation': 25, 'taux_horaire': 1.5,
+    }] + [{} for _ in range(11)])
+    resp = admin_client.post('/api/budget-previsionnel/ps-simulation', json={
+        'compte_num': '706000', 'annee': annee, 'type_budget': 'initial',
+        'type_ps': 'eaje', 'secteur_id': secteur_id, 'donnees': donnees,
+    })
+    assert resp.status_code == 200
+    # Même total que l'exemple réel équivalent (cf. test_api_ps_simulation_eaje_calcule_et_reporte)
+    assert abs(resp.get_json()['total'] - 34908.0) < 0.01
+
+
+def test_budget_previsionnel_simulateur_mode_par_mois_present(admin_client):
+    """Le simulateur expose le basculement saisie/calcul selon le mode du mois."""
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert 'psToggleCell(' in html
+    assert "prevReel === 'reel'" in html  # calcul inversé selon le mode
+
+
+def _load_migration(version_prefix):
+    fname = next(f for f in os.listdir(os.path.join(os.path.dirname(__file__), '..', 'migrations'))
+                 if f.startswith(version_prefix))
+    path = os.path.join(os.path.dirname(__file__), '..', 'migrations', fname)
+    spec = importlib.util.spec_from_file_location('mig_' + version_prefix, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_migration_0043_bascule_mois_eaje_en_reel(app, db, sample_users):
+    """Les simulations EAJE existantes (mois 'prev' = données réelles) passent en 'reel'."""
+    secteur_id = sample_users['secteur_id']
+    donnees = {'mois': [
+        {'prev_reel': 'prev', 'heures_facturees': 1000, 'participation': 1500},
+        {'prev_reel': 'prev', 'heures_facturees': 500, 'participation': 700},
+    ]}
+    with app.app_context():
+        db.execute(
+            "INSERT INTO budget_ps_simulations (compte_num, annee, secteur_id, type_budget, "
+            "type_ps, donnees, total) VALUES ('706000', 2025, ?, 'initial', 'eaje', ?, 0)",
+            (secteur_id, json.dumps(donnees)),
+        )
+        db.commit()
+        _load_migration('0043').upgrade(db)
+        row = db.execute(
+            "SELECT donnees FROM budget_ps_simulations WHERE compte_num='706000'"
+        ).fetchone()
+    mois = json.loads(row['donnees'])['mois']
+    assert all(m['prev_reel'] == 'reel' for m in mois)


### PR DESCRIPTION
## Demande

Sur le simulateur **PS EAJE** (crèche), pouvoir saisir les champs mensuels différemment selon une sélection **Prévisionnel / Réel** :
- **Réel** = tableau actuel.
- **Prévisionnel** : on saisit *Taux occup.* et *Taux horaire* ; *Heures facturées* en est déduit, *Heures réalisées* en est une copie, et *Participation usagers* est calculée à partir du taux horaire.

## Réponse : oui, et c'était à moitié préparé

Chaque ligne de mois portait déjà un sélecteur **« Prév/Réel »** (`prev_reel`), mais il était **inerte** : le calcul dérivait toujours les taux depuis les heures. Ce PR le rend fonctionnel. La relation est inversible :

| Mode | Saisi | Calculé |
|------|-------|---------|
| **Réel** (défaut) | heures facturées / réalisées, participation | `taux_occ = h_fact / amplitude_totale`, `taux_horaire = participation / h_fact` |
| **Prévisionnel** | taux occup. (%), taux horaire | `h_fact = taux_occ × amplitude_totale`, `h_réal = h_fact`, `participation = taux_horaire × h_fact` |

(`amplitude_totale = amplitude_horaire × jours × places` reste saisie dans les deux modes.)

## Modifications

- **Backend** `_compute_ps_eaje` (`budget.py`) : calcul branché par mois selon `prev_reel`, symétrique et inversible. Le total reporté sur le compte reste fiable dans les deux modes (recalcul serveur à l'enregistrement).
- **Frontend** `budget_previsionnel.html` : les cellules basculent saisie ↔ calcul selon le mode (`psToggleCell`), re-rendu de la ligne au changement de sélecteur, `computePsEaje` aligné sur le backend, en-tête + légende mis à jour.
- **Rétro-compatibilité** : le défaut passe à **« réel »** (= comportement historique). **Migration 0043** : force les mois des simulations EAJE déjà enregistrées en `reel` (leurs données sont des heures = réel), ce qui **préserve les totaux existants**.

## Tests

7 nouveaux tests (`test_budget.py`) : calcul réel, calcul prévisionnel, **équivalence des totaux prév↔réel**, rétro-compat du défaut, report via l'API en prévisionnel, présence du basculement dans la page, et la migration 0043. L'ancien test `test_api_ps_simulation_eaje_calcule_et_reporte` reste vert (back-compat).

✅ **Suite complète : 547 tests passés.**

> Note : la logique JS est le miroir exact du calcul Python vérifié ; je n'ai pas pu piloter la modale dans un navigateur ici. Je peux faire une vérification visuelle en lançant l'app si tu le souhaites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTXS8V7VFcoNQ2UUR4Z3xr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTXS8V7VFcoNQ2UUR4Z3xr)_