### PR TITLE
Simulateurs PS ALSH (périscolaire et extrascolaire)

### DIFF
--- a/blueprints/alsh.py
+++ b/blueprints/alsh.py
@@ -16,6 +16,7 @@ Fonctionnalites :
 - Accessible aux profils directeur et comptable
 """
 import json
+import sqlite3
 from datetime import datetime, date as _date
 from flask import (Blueprint, render_template, request, session,
                    flash, redirect, url_for, jsonify)
@@ -71,6 +72,32 @@ def _get_taux_logistique_global(conn, annee):
 def _normaliser(s):
     """Normalise une chaîne (minuscules, sans accents) pour la comparaison."""
     return unicodedata.normalize('NFD', s).encode('ascii', 'ignore').decode().lower()
+
+
+def _tranche_utilisee_dans_simulations_ps(conn, tranche_id):
+    """Compte les simulations PS ALSH dont une cellule référence cette tranche d'âge.
+
+    Les tranches d'âge sont partagées entre Analyse ALSH et les simulateurs PS :
+    une suppression doit être bloquée si une simulation enregistrée s'en sert,
+    sinon ses saisies seraient orphelinées et le total reporté faussé.
+    """
+    try:
+        rows = conn.execute(
+            'SELECT donnees FROM budget_ps_simulations WHERE donnees IS NOT NULL'
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return 0
+    count = 0
+    for row in rows:
+        try:
+            data = json.loads(row['donnees'])
+        except (ValueError, TypeError):
+            continue
+        for cell in (data.get('cellules') or []):
+            if isinstance(cell, dict) and str(cell.get('tranche_id')) == str(tranche_id):
+                count += 1
+                break
+    return count
 
 
 def _get_tarif_repartition_quotients():
@@ -351,9 +378,14 @@ def api_alsh_supprimer_tranche(tranche_id):
         nb_noe = conn.execute(
             'SELECT COUNT(*) FROM alsh_saisie_noe WHERE tranche_age_id = ?', (tranche_id,)
         ).fetchone()[0]
-        if nb_codes + nb_noe > 0:
+        # Les tranches sont partagees avec les simulateurs PS ALSH : verifier
+        # qu'aucune simulation enregistree ne reference cette tranche (sinon la
+        # suppression orphelinerait des saisies et fausserait le total reporte).
+        nb_ps = _tranche_utilisee_dans_simulations_ps(conn, tranche_id)
+        if nb_codes + nb_noe + nb_ps > 0:
             return jsonify({
-                'error': 'Cette tranche d\'âge est utilisée dans des données existantes.'
+                'error': 'Cette tranche d\'âge est utilisée dans des données existantes '
+                         '(Analyse ALSH ou simulateur PS).'
             }), 400
 
         conn.execute('DELETE FROM alsh_tranches_age WHERE id = ?', (tranche_id,))

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1514,13 +1514,21 @@ def _compute_ps_alsh_perisco(donnees, jours_initial, jours_restant, type_budget)
     }
 
 
+def _perisco_deduction_restant(annee, date_arrete):
+    """Jours à déduire du reste de l'année selon la date d'arrêté du réel :
+    5 jours si l'arrêté est avant fin août, 1 jour s'il est fin août ou après."""
+    return 1 if date_arrete >= f'{annee}-08-31' else 5
+
+
 def _ps_alsh_perisco_jours(conn, annee, donnees):
     """Retourne (jours_initial, jours_restant) pour la PS PERISCO."""
     mercredis = _alsh_mercredis_scolaires(conn, annee)
-    deduction = PS_ALSH_PERISCO_DEFAULTS['mercredis_deduction']
-    jours_initial = max(len(mercredis) - deduction, 0)
+    jours_initial = max(len(mercredis) - PS_ALSH_PERISCO_DEFAULTS['mercredis_deduction'], 0)
     date_arrete = ((donnees or {}).get('date_arrete') or '').strip()
-    jours_restant = sum(1 for dt in mercredis if date_arrete and dt > date_arrete)
+    if not date_arrete:
+        return jours_initial, 0
+    restants = sum(1 for dt in mercredis if dt > date_arrete)
+    jours_restant = max(restants - _perisco_deduction_restant(annee, date_arrete), 0)
     return jours_initial, jours_restant
 
 

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1173,7 +1173,7 @@ def api_budget_previsionnel_export_pdf():
 # SIMULATEUR PRESTATION DE SERVICE (PS) CAF
 # ============================================================
 
-PS_TYPES = ('eaje', 'alsh')
+PS_TYPES = ('eaje', 'alsh_perisco', 'alsh_extrasco')
 
 # Valeurs par défaut du simulateur PS EAJE (modifiables dans l'interface).
 PS_EAJE_DEFAULTS = {
@@ -1189,6 +1189,10 @@ PS_EAJE_DEFAULTS = {
     'journees_peda': {'nb_journees': 3, 'nb_heures': 10},
     'bonus_attractivite_taux': 970,
 }
+
+# Valeurs par défaut des simulateurs PS ALSH.
+PS_ALSH_EXTRASCO_DEFAULTS = {'taux_ps': 0.624, 'taux_compl_inclusif': 3.90, 'taux_regime': 100}
+PS_ALSH_PERISCO_DEFAULTS = {'taux_ps': 0.59, 'taux_compl_inclusif': 3.90, 'mercredis_deduction': 7}
 
 
 def _ps_num(value, default=0.0):
@@ -1327,6 +1331,199 @@ def _compute_ps_eaje(donnees):
     }
 
 
+# ---- PS ALSH : jours ouvrés / mercredis (dérivés du calendrier en base) ----
+
+def _alsh_jours_ouvres_periodes_reelles(conn, annee):
+    """Jours ouvrés (lun-ven hors fériés) par période de vacances de l'année.
+
+    Les périodes proviennent de la page Gestion des vacances (periodes_vacances),
+    bornées à l'année civile du budget.
+    """
+    feries = {r['date'] for r in conn.execute(
+        'SELECT date FROM jours_feries WHERE annee = ?', (annee,)
+    ).fetchall()}
+    rows = conn.execute('''
+        SELECT id, nom, date_debut, date_fin FROM periodes_vacances
+        WHERE date_debut <= ? AND date_fin >= ?
+        ORDER BY date_debut
+    ''', (f'{annee}-12-31', f'{annee}-01-01')).fetchall()
+    result = []
+    for r in rows:
+        try:
+            d0 = max(date.fromisoformat(r['date_debut']), date(annee, 1, 1))
+            d1 = min(date.fromisoformat(r['date_fin']), date(annee, 12, 31))
+        except (ValueError, TypeError):
+            continue
+        nb = 0
+        d = d0
+        while d <= d1:
+            if d.weekday() < 5 and d.isoformat() not in feries:
+                nb += 1
+            d += timedelta(days=1)
+        result.append({
+            'id': r['id'], 'nom': r['nom'],
+            'date_debut': r['date_debut'], 'date_fin': r['date_fin'],
+            'jours_ouvres': nb,
+        })
+    return result
+
+
+def _alsh_mercredis_scolaires(conn, annee):
+    """Liste ISO des mercredis de l'année en période scolaire (hors vacances/fériés)."""
+    feries = {r['date'] for r in conn.execute(
+        'SELECT date FROM jours_feries WHERE annee = ?', (annee,)
+    ).fetchall()}
+    periodes_vac = conn.execute('''
+        SELECT date_debut, date_fin FROM periodes_vacances
+        WHERE date_debut <= ? AND date_fin >= ?
+    ''', (f'{annee}-12-31', f'{annee}-01-01')).fetchall()
+    jours_vac = set()
+    for pv in periodes_vac:
+        try:
+            d0 = max(date.fromisoformat(pv['date_debut']), date(annee, 1, 1))
+            d1 = min(date.fromisoformat(pv['date_fin']), date(annee, 12, 31))
+        except (ValueError, TypeError):
+            continue
+        d = d0
+        while d <= d1:
+            jours_vac.add(d)
+            d += timedelta(days=1)
+    dates = []
+    d = date(annee, 1, 1)
+    while d.weekday() != 2:  # avancer au premier mercredi
+        d += timedelta(days=1)
+    while d.year == annee:
+        if d not in jours_vac and d.isoformat() not in feries:
+            dates.append(d.isoformat())
+        d += timedelta(days=7)
+    return dates
+
+
+def _compute_ps_alsh_extrasco(donnees, jours_by_periode):
+    """Calcule la PS ALSH EXTRASCO (par période de vacances × tranche d'âge).
+
+    Heures (prévisionnel) = enfants/jour × jours ouvrés × heures/jour ; en mode
+    réel, on saisit directement le nombre d'heures. PS = heures × taux PS × taux
+    régime. Le complément inclusif (bonus handicap) porte sur un total d'heures
+    d'enfants en situation de handicap saisi à part.
+    """
+    d = donnees or {}
+    taux_ps = _ps_num(d.get('taux_ps'), PS_ALSH_EXTRASCO_DEFAULTS['taux_ps'])
+    taux_compl = _ps_num(d.get('taux_compl_inclusif'), PS_ALSH_EXTRASCO_DEFAULTS['taux_compl_inclusif'])
+    taux_regime = _ps_num(d.get('taux_regime'), PS_ALSH_EXTRASCO_DEFAULTS['taux_regime']) / 100.0
+    cells_in = d.get('cellules') or []
+    if not isinstance(cells_in, list):
+        cells_in = []
+    cells_out = []
+    total_heures = 0.0
+    total_ps = 0.0
+    for c in cells_in:
+        if not isinstance(c, dict):
+            continue
+        try:
+            pid = int(c.get('periode_id'))
+        except (TypeError, ValueError):
+            continue
+        jours = float(jours_by_periode.get(pid, 0) or 0)
+        prev_reel = c.get('prev_reel') or 'prev'
+        enfants = _ps_num(c.get('enfants'))
+        heures_jour = _ps_num(c.get('heures_jour'))
+        if prev_reel == 'reel':
+            heures = _ps_num(c.get('heures_reel'))
+        else:
+            heures = enfants * jours * heures_jour
+        ps = heures * taux_ps * taux_regime
+        cells_out.append({
+            'periode_id': pid, 'tranche_id': c.get('tranche_id'),
+            'jours': jours, 'heures': round(heures, 2), 'ps': round(ps, 2),
+        })
+        total_heures += heures
+        total_ps += ps
+    heures_handicap = _ps_num(d.get('heures_handicap'))
+    compl_inclusif = heures_handicap * taux_compl * taux_regime
+    total = total_ps + compl_inclusif
+    return {
+        'cellules': cells_out,
+        'total_heures': round(total_heures, 2),
+        'total_ps': round(total_ps, 2),
+        'heures_handicap': round(heures_handicap, 2),
+        'compl_inclusif': round(compl_inclusif, 2),
+        'total': round(total, 2),
+    }
+
+
+def _compute_ps_alsh_perisco(donnees, jours_initial, jours_restant, type_budget):
+    """Calcule la PS ALSH PERISCO (mercredis périscolaires, par tranche d'âge).
+
+    Budget initial : heures = enfants × jours × heures/jour sur l'ensemble de
+    l'année (jours = mercredis scolaires − déduction). Budget actualisé : on
+    saisit le réel (heures) et on ajoute un prévisionnel sur le reste de l'année
+    (jours restants après la date d'arrêté). PS = heures × taux PS ; complément
+    inclusif = heures d'enfants en situation de handicap × taux complément.
+    """
+    d = donnees or {}
+    taux_ps = _ps_num(d.get('taux_ps'), PS_ALSH_PERISCO_DEFAULTS['taux_ps'])
+    taux_compl = _ps_num(d.get('taux_compl_inclusif'), PS_ALSH_PERISCO_DEFAULTS['taux_compl_inclusif'])
+    actualise = (type_budget == 'actualise')
+    cells_in = d.get('cellules') or []
+    if not isinstance(cells_in, list):
+        cells_in = []
+    cells_out = []
+    total_ps = 0.0
+    total_compl = 0.0
+    total_heures = 0.0
+    for c in cells_in:
+        if not isinstance(c, dict):
+            continue
+        enfants = _ps_num(c.get('enfants'))
+        heures_jour = _ps_num(c.get('heures_jour'))
+        enfants_handicap = _ps_num(c.get('enfants_handicap'))
+        if actualise:
+            heures_reel = _ps_num(c.get('heures_reel'))
+            heures_reste = enfants * jours_restant * heures_jour
+            heures = heures_reel + heures_reste
+            heures_h_reel = _ps_num(c.get('heures_handicap_reel'))
+            heures_h_reste = enfants_handicap * jours_restant * heures_jour
+            heures_h = heures_h_reel + heures_h_reste
+            cell = {'heures_reel': round(heures_reel, 2), 'heures_reste': round(heures_reste, 2),
+                    'heures_handicap_reste': round(heures_h_reste, 2)}
+        else:
+            heures = enfants * jours_initial * heures_jour
+            heures_h = enfants_handicap * jours_initial * heures_jour
+            cell = {}
+        ps = heures * taux_ps
+        compl = heures_h * taux_compl
+        cell.update({
+            'tranche_id': c.get('tranche_id'),
+            'heures': round(heures, 2), 'heures_handicap': round(heures_h, 2),
+            'ps': round(ps, 2), 'compl': round(compl, 2),
+        })
+        cells_out.append(cell)
+        total_ps += ps
+        total_compl += compl
+        total_heures += heures
+    total = total_ps + total_compl
+    return {
+        'cellules': cells_out,
+        'total_ps': round(total_ps, 2),
+        'compl_inclusif': round(total_compl, 2),
+        'total_heures': round(total_heures, 2),
+        'jours_initial': jours_initial,
+        'jours_restant': jours_restant,
+        'total': round(total, 2),
+    }
+
+
+def _ps_alsh_perisco_jours(conn, annee, donnees):
+    """Retourne (jours_initial, jours_restant) pour la PS PERISCO."""
+    mercredis = _alsh_mercredis_scolaires(conn, annee)
+    deduction = PS_ALSH_PERISCO_DEFAULTS['mercredis_deduction']
+    jours_initial = max(len(mercredis) - deduction, 0)
+    date_arrete = ((donnees or {}).get('date_arrete') or '').strip()
+    jours_restant = sum(1 for dt in mercredis if date_arrete and dt > date_arrete)
+    return jours_initial, jours_restant
+
+
 @budget_bp.route('/api/budget-previsionnel/ps-comptes')
 @login_required
 def api_ps_comptes_liste():
@@ -1413,6 +1610,41 @@ def api_ps_comptes_delete(compte_num):
         conn.close()
 
 
+@budget_bp.route('/api/budget-previsionnel/ps-alsh-context')
+@login_required
+def api_ps_alsh_context():
+    """Contexte des simulateurs ALSH : tranches d'âge, périodes de vacances avec
+    jours ouvrés et mercredis scolaires (déduits du calendrier en base)."""
+    profil = session.get('profil')
+    if not _can_access_budget_previsionnel(profil):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    annee = request.args.get('annee', type=int)
+    if not annee:
+        return jsonify({'error': 'Année requise'}), 400
+    conn = get_db()
+    try:
+        tranches = conn.execute(
+            'SELECT id, libelle FROM alsh_tranches_age WHERE active = 1 ORDER BY ordre, id'
+        ).fetchall()
+        periodes = _alsh_jours_ouvres_periodes_reelles(conn, annee)
+        mercredis = _alsh_mercredis_scolaires(conn, annee)
+        deduction = PS_ALSH_PERISCO_DEFAULTS['mercredis_deduction']
+        return jsonify({
+            'tranches': [dict(t) for t in tranches],
+            'periodes': periodes,
+            'mercredis_dates': mercredis,
+            'mercredis_count': len(mercredis),
+            'mercredis_deduction': deduction,
+            'jours_initial': max(len(mercredis) - deduction, 0),
+            'defaults': {
+                'extrasco': PS_ALSH_EXTRASCO_DEFAULTS,
+                'perisco': PS_ALSH_PERISCO_DEFAULTS,
+            },
+        })
+    finally:
+        conn.close()
+
+
 @budget_bp.route('/api/budget-previsionnel/ps-simulation')
 @login_required
 def api_ps_simulation_get():
@@ -1481,16 +1713,22 @@ def api_ps_simulation_save():
     if type_ps not in PS_TYPES:
         return jsonify({'error': 'Type de PS invalide'}), 400
 
-    # Le total reporté est recalculé côté serveur pour le simulateur EAJE.
-    if type_ps == 'eaje':
-        computed = _compute_ps_eaje(donnees)
-        total = computed['total']
-    else:
-        computed = None
-        total = 0.0
-
     conn = get_db()
     try:
+        # Le total reporté est recalculé côté serveur (source de vérité).
+        if type_ps == 'eaje':
+            computed = _compute_ps_eaje(donnees)
+        elif type_ps == 'alsh_extrasco':
+            periodes = _alsh_jours_ouvres_periodes_reelles(conn, int(annee))
+            jours_by = {p['id']: p['jours_ouvres'] for p in periodes}
+            computed = _compute_ps_alsh_extrasco(donnees, jours_by)
+        elif type_ps == 'alsh_perisco':
+            jours_initial, jours_restant = _ps_alsh_perisco_jours(conn, int(annee), donnees)
+            computed = _compute_ps_alsh_perisco(donnees, jours_initial, jours_restant, type_budget)
+        else:
+            computed = {'total': 0.0}
+        total = computed.get('total', 0.0)
+
         conn.execute('''
             INSERT INTO budget_ps_simulations
             (compte_num, annee, secteur_id, type_budget, type_ps, donnees, total, updated_by, updated_at)

--- a/database.py
+++ b/database.py
@@ -1448,7 +1448,7 @@ def init_db():
         CREATE TABLE IF NOT EXISTS budget_ps_comptes (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             compte_num TEXT NOT NULL UNIQUE,
-            type_ps TEXT NOT NULL CHECK(type_ps IN ('eaje', 'alsh')),
+            type_ps TEXT NOT NULL CHECK(type_ps IN ('eaje', 'alsh_perisco', 'alsh_extrasco')),
             updated_at TEXT DEFAULT CURRENT_TIMESTAMP
         )
     ''')

--- a/migrations/0044_ps_alsh_types.py
+++ b/migrations/0044_ps_alsh_types.py
@@ -1,0 +1,60 @@
+"""
+Migration 0044 : distinguer deux types de PS ALSH (PERISCO / EXTRASCO).
+
+Le simulateur PS gère désormais trois types : EAJE, ALSH PERISCO (périscolaire)
+et ALSH EXTRASCO (extrascolaire / vacances). La contrainte CHECK de
+budget_ps_comptes est reconstruite (SQLite ne permet pas de la modifier en
+place) et les éventuels comptes déjà rattachés au type générique 'alsh' sont
+basculés vers 'alsh_extrasco'.
+"""
+
+NOM = "Types PS ALSH (perisco / extrasco)"
+DESCRIPTION = (
+    "Reconstruit budget_ps_comptes pour autoriser les types alsh_perisco et "
+    "alsh_extrasco et migre les comptes 'alsh' existants vers alsh_extrasco."
+)
+
+
+def upgrade(conn):
+    """Reconstruit la table avec la nouvelle contrainte CHECK."""
+    cursor = conn.cursor()
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_ps_comptes_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL UNIQUE,
+            type_ps TEXT NOT NULL CHECK(type_ps IN ('eaje', 'alsh_perisco', 'alsh_extrasco')),
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+    # Copier en remappant l'ancien type générique 'alsh' -> 'alsh_extrasco'
+    cursor.execute('''
+        INSERT OR IGNORE INTO budget_ps_comptes_new (id, compte_num, type_ps, updated_at)
+        SELECT id, compte_num,
+               CASE WHEN type_ps = 'alsh' THEN 'alsh_extrasco' ELSE type_ps END,
+               updated_at
+        FROM budget_ps_comptes
+    ''')
+    cursor.execute('DROP TABLE budget_ps_comptes')
+    cursor.execute('ALTER TABLE budget_ps_comptes_new RENAME TO budget_ps_comptes')
+
+
+def downgrade(conn):
+    """Rebascule vers la contrainte d'origine ('eaje', 'alsh')."""
+    cursor = conn.cursor()
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_ps_comptes_old (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL UNIQUE,
+            type_ps TEXT NOT NULL CHECK(type_ps IN ('eaje', 'alsh')),
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+    cursor.execute('''
+        INSERT OR IGNORE INTO budget_ps_comptes_old (id, compte_num, type_ps, updated_at)
+        SELECT id, compte_num,
+               CASE WHEN type_ps IN ('alsh_perisco', 'alsh_extrasco') THEN 'alsh' ELSE type_ps END,
+               updated_at
+        FROM budget_ps_comptes
+    ''')
+    cursor.execute('DROP TABLE budget_ps_comptes')
+    cursor.execute('ALTER TABLE budget_ps_comptes_old RENAME TO budget_ps_comptes')

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -305,7 +305,8 @@
                     <label>Type de PS</label>
                     <select id="psConfigType" class="form-select" style="width:100%;">
                         <option value="eaje">PS EAJE (crèche)</option>
-                        <option value="alsh">PS ALSH (Accueil de loisirs)</option>
+                        <option value="alsh_perisco">PS ALSH Périscolaire</option>
+                        <option value="alsh_extrasco">PS ALSH Extrascolaire</option>
                     </select>
                 </div>
                 <button class="btn btn-primary" type="button" onclick="addPsCompte()">➕ Ajouter</button>
@@ -332,7 +333,7 @@ var isReadOnly = {{ 'true' if profil == 'responsable' else 'false' }};
 var canEditPs = {{ 'true' if profil in ['directeur', 'comptable'] else 'false' }};
 var salaryMeta = null;
 var currentRows = [];
-var psComptes = {};   // { compte_num: 'eaje' | 'alsh' }
+var psComptes = {};   // { compte_num: 'eaje' | 'alsh_perisco' | 'alsh_extrasco' }
 
 function fmt(n){ return (Number(n || 0)).toLocaleString('fr-FR', {minimumFractionDigits:2, maximumFractionDigits:2}); }
 function escapeHtml(value){
@@ -632,8 +633,7 @@ function renderPsConfigList(){
         return;
     }
     ul.innerHTML = keys.map(function(compte){
-        var type = psComptes[compte];
-        var label = type === 'alsh' ? 'PS ALSH' : 'PS EAJE';
+        var label = psTypeLabel(psComptes[compte]);
         return '<li><span class="ps-config-lib">' + escapeHtml(compte) + '</span>' +
             '<span class="ps-badge">' + label + '</span>' +
             '<button type="button" class="btn btn-sm btn-danger" data-ps-remove="' + escapeHtml(compte) + '">Retirer</button></li>';
@@ -665,25 +665,52 @@ function removePsCompte(compte){
 // ---- Étape 3 : simulateurs ----
 var psSim = null;  // { compte, type_ps, libelle, ctx, state }
 
+function psTypeLabel(type){
+    if (type === 'alsh_extrasco') return 'PS ALSH Extrasco';
+    if (type === 'alsh_perisco') return 'PS ALSH Périsco';
+    return 'PS EAJE';
+}
+function psSimTitle(type){
+    if (type === 'alsh_extrasco') return 'Simulateur PS ALSH Extrascolaire';
+    if (type === 'alsh_perisco') return 'Simulateur PS ALSH Périscolaire';
+    return 'Simulateur PS EAJE';
+}
+
 function openPsSimulator(compteNum){
     var type = psComptes[compteNum] || 'eaje';
     var rowMeta = currentRows.find(function(r){ return r.compte_num === compteNum; });
     var libelle = rowMeta ? rowMeta.libelle : '';
     var ctx = getCurrentBudgetContext();
-    psSim = {compte: compteNum, type_ps: type, libelle: libelle, ctx: ctx, state: null};
+    psSim = {compte: compteNum, type_ps: type, libelle: libelle, ctx: ctx, state: null, alshCtx: null};
     document.getElementById('psSimTitle').textContent =
-        (type === 'alsh' ? 'Simulateur PS ALSH' : 'Simulateur PS EAJE') +
-        ' — ' + compteNum + (libelle ? ' (' + libelle + ')' : '');
-    if (type === 'alsh'){ renderAlshSimulator(); showPsModal(); return; }
-    var url = '/api/budget-previsionnel/ps-simulation?compte_num=' + encodeURIComponent(compteNum) +
-        '&annee=' + ctx.annee + '&secteur_id=' + ctx.secteur_id + '&type_budget=' + encodeURIComponent(ctx.type_budget);
-    fetch(url).then(r => r.json()).then(data => {
-        psSim.state = mergeEajeState((data && data.found) ? data.donnees : null);
-        renderEajeSimulator(); showPsModal(); psRecompute();
-    }).catch(function(){
-        psSim.state = mergeEajeState(null);
-        renderEajeSimulator(); showPsModal(); psRecompute();
+        psSimTitle(type) + ' — ' + compteNum + (libelle ? ' (' + libelle + ')' : '');
+    if (type === 'eaje'){
+        fetchPsSimulation().then(function(saved){
+            psSim.state = mergeEajeState(saved);
+            renderEajeSimulator(); showPsModal(); psRecompute();
+        });
+        return;
+    }
+    Promise.all([fetchAlshContext(ctx.annee), fetchPsSimulation()]).then(function(res){
+        psSim.alshCtx = res[0] || {tranches:[], periodes:[], mercredis_dates:[]};
+        var saved = res[1];
+        if (type === 'alsh_extrasco') psSim.state = mergeExtrascoState(saved, psSim.alshCtx);
+        else psSim.state = mergePeriscoState(saved, psSim.alshCtx);
+        renderAlshActive(); showPsModal();
     });
+}
+function fetchPsSimulation(){
+    var ctx = psSim.ctx;
+    var url = '/api/budget-previsionnel/ps-simulation?compte_num=' + encodeURIComponent(psSim.compte) +
+        '&annee=' + ctx.annee + '&secteur_id=' + ctx.secteur_id + '&type_budget=' + encodeURIComponent(ctx.type_budget);
+    return fetch(url).then(r => r.json())
+        .then(function(d){ return (d && d.found) ? d.donnees : null; })
+        .catch(function(){ return null; });
+}
+function fetchAlshContext(annee){
+    return fetch('/api/budget-previsionnel/ps-alsh-context?annee=' + annee)
+        .then(r => r.json())
+        .catch(function(){ return {tranches:[], periodes:[], mercredis_dates:[]}; });
 }
 function showPsModal(){ document.getElementById('psSimulatorModal').classList.add('open'); }
 function closePsSimulator(){ document.getElementById('psSimulatorModal').classList.remove('open'); psSim = null; }
@@ -691,14 +718,334 @@ document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && document.getElementById('psSimulatorModal').classList.contains('open')) closePsSimulator();
 });
 
-function renderAlshSimulator(){
-    document.getElementById('psSimBody').innerHTML =
-        '<div style="padding:48px 20px;text-align:center;color:var(--text-muted,#777);">' +
-        '<div style="font-size:2.6rem;margin-bottom:12px;">🚧</div>' +
-        '<p style="font-size:1.08rem;">Le simulateur de <strong>PS ALSH</strong> (Accueil de loisirs) est en cours de réalisation.</p>' +
-        '<p>Il sera disponible prochainement.</p></div>';
-    document.getElementById('psSimFooter').innerHTML =
+// ===================== Simulateurs PS ALSH (EXTRASCO / PERISCO) =====================
+function renderAlshActive(){
+    if (psSim.type_ps === 'alsh_extrasco') renderExtrascoSimulator();
+    else renderPeriscoSimulator();
+    psRecomputeAlsh();
+}
+function psRecomputeAlsh(){
+    if (!psSim) return;
+    if (psSim.type_ps === 'alsh_extrasco') recomputeExtrasco();
+    else recomputePerisco();
+}
+function psTopField(label, key, val, step, dis){
+    return '<div class="ps-field"><label>' + label + '</label>' +
+        '<input class="ps-input" type="number" step="' + step + '" value="' + psAttr(val) +
+        '" data-alsh-top="' + key + '"' + dis + '></div>';
+}
+function alshCellInput(idx, key, val, dis){
+    return '<input class="ps-input" type="number" step="0.01" value="' + psAttr(val) +
+        '" data-alsh-ci="' + idx + '" data-alsh-key="' + key + '"' + (dis || '') + '>';
+}
+function alshFooter(){
+    if (canEditPs){
+        return '<span id="psSaveMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>' +
+            '<button class="btn btn-secondary" type="button" onclick="closePsSimulator()">Annuler</button>' +
+            '<button class="btn btn-primary" type="button" onclick="savePsSimulator()">💾 Enregistrer et reporter sur le compte</button>';
+    }
+    return '<span style="margin-right:auto;color:var(--text-muted);">Lecture seule</span>' +
         '<button class="btn btn-secondary" type="button" onclick="closePsSimulator()">Fermer</button>';
+}
+function alshTranchesBar(ctx){
+    if (!canEditPs) return '';
+    var chips = (ctx.tranches || []).map(function(t){
+        return '<span class="ps-badge" style="background:var(--gray-300);color:var(--gray-900);">' +
+            escapeHtml(t.libelle) + ' <a href="#" data-alsh-del-tranche="' + t.id +
+            '" title="Retirer" style="color:#b00;text-decoration:none;font-weight:700;">×</a></span>';
+    }).join(' ');
+    return '<div class="ps-params" style="gap:10px;align-items:center;">' +
+        '<div style="flex:1 1 auto;min-width:0;"><strong style="font-size:.8rem;">Tranches d\'âge (partagées avec Analyse ALSH) :</strong> ' +
+        (chips || '<em style="color:var(--gray-500);">aucune</em>') + '</div>' +
+        '<div class="ps-field" style="margin:0;"><input class="ps-input" id="alshNewTranche" placeholder="Ex. 6-8 ans" style="flex:0 0 140px;text-align:left;">' +
+        '<button class="btn btn-sm btn-secondary" type="button" onclick="alshAddTranche()">+ Ajouter</button></div></div>';
+}
+function bindAlshInputs(){
+    var body = document.getElementById('psSimBody');
+    if (!body) return;
+    body.querySelectorAll('[data-alsh-top]').forEach(function(el){
+        var h = function(){
+            psSim.state[this.dataset.alshTop] = this.value;
+            if (this.dataset.alshRerender === '1') renderAlshActive(); else psRecomputeAlsh();
+        };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+    body.querySelectorAll('[data-alsh-ci]').forEach(function(el){
+        var h = function(){
+            var idx = parseInt(this.dataset.alshCi, 10);
+            if (!psSim.state.cellules[idx]) return;
+            psSim.state.cellules[idx][this.dataset.alshKey] = this.value;
+            if (this.dataset.alshRerender === '1') renderAlshActive(); else psRecomputeAlsh();
+        };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+    body.querySelectorAll('[data-alsh-del-tranche]').forEach(function(a){
+        a.addEventListener('click', function(e){ e.preventDefault(); alshRemoveTranche(this.dataset.alshDelTranche); });
+    });
+}
+function alshAddTranche(){
+    var inp = document.getElementById('alshNewTranche');
+    var lib = inp ? inp.value.trim() : '';
+    if (!lib){ alert('Saisissez un libellé de tranche d\'âge.'); return; }
+    fetch('/api/alsh/tranches-age', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({libelle: lib})})
+        .then(r => r.json()).then(function(d){ if (d.error){ alert(d.error); return; } reloadAlshContext(); });
+}
+function alshRemoveTranche(id){
+    fetch('/api/alsh/tranches-age/' + encodeURIComponent(id), {method:'DELETE'})
+        .then(r => r.json()).then(function(d){ if (d.error){ alert(d.error); return; } reloadAlshContext(); });
+}
+function reloadAlshContext(){
+    fetchAlshContext(psSim.ctx.annee).then(function(ctx){
+        psSim.alshCtx = ctx || {tranches:[], periodes:[], mercredis_dates:[]};
+        if (psSim.type_ps === 'alsh_extrasco') psSim.state = mergeExtrascoState(psSim.state, psSim.alshCtx);
+        else psSim.state = mergePeriscoState(psSim.state, psSim.alshCtx);
+        renderAlshActive();
+    });
+}
+
+// ---- EXTRASCO ----
+function buildExtrascoCells(st, ctx, prev){
+    var byKey = {};
+    (prev || []).forEach(function(c){ byKey[c.periode_id + '_' + c.tranche_id] = c; });
+    var cells = [];
+    (ctx.periodes || []).forEach(function(p){
+        (ctx.tranches || []).forEach(function(t){
+            var ex = byKey[p.id + '_' + t.id] || {};
+            cells.push({periode_id: p.id, tranche_id: t.id,
+                prev_reel: ex.prev_reel || 'prev',
+                enfants: ex.enfants !== undefined ? ex.enfants : '',
+                heures_jour: ex.heures_jour !== undefined ? ex.heures_jour : '',
+                heures_reel: ex.heures_reel !== undefined ? ex.heures_reel : ''});
+        });
+    });
+    st.cellules = cells;
+}
+function defaultExtrascoState(ctx){
+    var st = {taux_ps:0.624, taux_compl_inclusif:3.90, taux_regime:100, heures_handicap:'', cellules:[]};
+    buildExtrascoCells(st, ctx, null);
+    return st;
+}
+function mergeExtrascoState(saved, ctx){
+    var st = defaultExtrascoState(ctx);
+    if (saved){
+        ['taux_ps','taux_compl_inclusif','taux_regime','heures_handicap'].forEach(function(k){
+            if (saved[k] !== undefined && saved[k] !== null) st[k] = saved[k];
+        });
+        buildExtrascoCells(st, ctx, saved.cellules || []);
+    }
+    return st;
+}
+function computeExtrascoJS(st, ctx){
+    var tauxPs = psNum(st.taux_ps, 0.624);
+    var tauxCompl = psNum(st.taux_compl_inclusif, 3.90);
+    var tauxRegime = psNum(st.taux_regime, 100) / 100;
+    var joursBy = {};
+    (ctx.periodes || []).forEach(function(p){ joursBy[p.id] = p.jours_ouvres; });
+    var cells = {}, totalHeures = 0, totalPs = 0;
+    (st.cellules || []).forEach(function(c){
+        var jours = Number(joursBy[c.periode_id] || 0);
+        var enfants = psNum(c.enfants), hj = psNum(c.heures_jour);
+        var heures = (c.prev_reel === 'reel') ? psNum(c.heures_reel) : enfants * jours * hj;
+        var ps = heures * tauxPs * tauxRegime;
+        cells[c.periode_id + '_' + c.tranche_id] = {jours: jours, heures: heures, ps: ps};
+        totalHeures += heures; totalPs += ps;
+    });
+    var compl = psNum(st.heures_handicap) * tauxCompl * tauxRegime;
+    return {cells: cells, totalHeures: totalHeures, totalPs: totalPs, compl: compl, total: totalPs + compl};
+}
+function renderExtrascoSimulator(){
+    var st = psSim.state, ctx = psSim.alshCtx || {};
+    var dis = canEditPs ? '' : ' disabled';
+    var html = '<div class="ps-params">' +
+        psTopField('Taux de PS', 'taux_ps', st.taux_ps, '0.001', dis) +
+        psTopField('Taux complément inclusif (handicap)', 'taux_compl_inclusif', st.taux_compl_inclusif, '0.01', dis) +
+        psTopField('Taux de régime général (%)', 'taux_regime', st.taux_regime, '0.01', dis) +
+        '</div>';
+    html += alshTranchesBar(ctx);
+    if (!(ctx.tranches || []).length){
+        html += '<p class="ps-legend">Ajoutez au moins une tranche d\'âge pour saisir la simulation.</p>';
+    } else if (!(ctx.periodes || []).length){
+        html += '<p class="ps-legend">Aucune période de vacances configurée pour ' + escapeHtml(String(psSim.ctx.annee)) +
+            '. Renseignez-les dans « Gestion des vacances » (Administration).</p>';
+    } else {
+        html += '<div class="ps-legend">Colonnes <span class="bp-ps-calc">surlignées</span> = calculées. « Réel » permet de saisir directement les heures réalisées.</div>';
+        html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
+            '<th>Période de vacances</th><th>Tranche d\'âge</th><th>Prév/Réel</th><th>Enfants / jour</th><th>Heures / jour</th>' +
+            '<th class="bp-ps-calc">Jours ouvrés</th><th class="bp-ps-calc">Heures total</th><th class="bp-ps-calc">PS période</th>' +
+            '</tr></thead><tbody>';
+        st.cellules.forEach(function(c, idx){
+            var per = (ctx.periodes || []).find(function(p){ return p.id === c.periode_id; }) || {};
+            var tr = (ctx.tranches || []).find(function(t){ return t.id === c.tranche_id; }) || {};
+            var reel = (c.prev_reel === 'reel');
+            html += '<tr><td class="ps-col-mois">' + escapeHtml(per.nom || '') +
+                '<br><small style="color:var(--gray-500);">' + escapeHtml((per.date_debut || '') + ' → ' + (per.date_fin || '')) + '</small></td>' +
+                '<td class="ps-col-mois">' + escapeHtml(tr.libelle || '') + '</td>' +
+                '<td><select class="ps-input ps-input-sel" data-alsh-ci="' + idx + '" data-alsh-key="prev_reel" data-alsh-rerender="1"' + dis + '>' +
+                    '<option value="prev"' + (reel ? '' : ' selected') + '>Prévisionnel</option>' +
+                    '<option value="reel"' + (reel ? ' selected' : '') + '>Réel</option></select></td>' +
+                '<td>' + alshCellInput(idx, 'enfants', c.enfants, reel ? ' disabled' : dis) + '</td>' +
+                '<td>' + alshCellInput(idx, 'heures_jour', c.heures_jour, reel ? ' disabled' : dis) + '</td>' +
+                '<td class="bp-ps-calc" id="exc-' + idx + '-jours"></td>' +
+                (reel ? '<td class="bp-ps-calc">' + alshCellInput(idx, 'heures_reel', c.heures_reel, dis) + '</td>'
+                      : '<td class="bp-ps-calc" id="exc-' + idx + '-heures"></td>') +
+                '<td class="bp-ps-calc" id="exc-' + idx + '-ps"></td></tr>';
+        });
+        html += '</tbody><tfoot><tr><td colspan="5">Total</td><td class="bp-ps-calc">—</td>' +
+            '<td class="bp-ps-calc" id="ex-total-heures"></td><td class="bp-ps-calc" id="ex-total-ps"></td></tr></tfoot></table></div>';
+        html += '<div class="ps-summary"><div class="ps-card"><h4>Complément inclusif (bonus handicap)</h4>' +
+            '<div class="ps-field"><label>Heures d\'enfants en situation de handicap (année)</label>' +
+            '<input class="ps-input" type="number" step="0.01" value="' + psAttr(st.heures_handicap) + '" data-alsh-top="heures_handicap"' + dis + '></div>' +
+            '<div class="ps-result">PS complément inclusif : <span id="ex-compl">0,00</span> €</div></div></div>';
+    }
+    html += '<div class="ps-total-box"><span>Total à reporter sur le compte ' + escapeHtml(psSim.compte) +
+        ' (PS + complément inclusif)</span><strong><span id="ex-total">0,00</span> €</strong></div>';
+    document.getElementById('psSimBody').innerHTML = html;
+    document.getElementById('psSimFooter').innerHTML = alshFooter();
+    bindAlshInputs();
+}
+function recomputeExtrasco(){
+    var c = computeExtrascoJS(psSim.state, psSim.alshCtx || {});
+    psSim.state.cellules.forEach(function(cell, idx){
+        var r = c.cells[cell.periode_id + '_' + cell.tranche_id] || {jours:0, heures:0, ps:0};
+        psSet('exc-' + idx + '-jours', fmtR(r.jours, 0));
+        psSet('exc-' + idx + '-heures', fmtR(r.heures, 2));
+        psSet('exc-' + idx + '-ps', fmt(r.ps));
+    });
+    psSet('ex-total-heures', fmtR(c.totalHeures, 2));
+    psSet('ex-total-ps', fmt(c.totalPs));
+    psSet('ex-compl', fmt(c.compl));
+    psSet('ex-total', fmt(c.total));
+}
+
+// ---- PERISCO ----
+function buildPeriscoCells(st, ctx, prev){
+    var byKey = {};
+    (prev || []).forEach(function(c){ byKey[c.tranche_id] = c; });
+    var cells = [];
+    (ctx.tranches || []).forEach(function(t){
+        var ex = byKey[t.id] || {};
+        cells.push({tranche_id: t.id,
+            enfants: ex.enfants !== undefined ? ex.enfants : '',
+            heures_jour: ex.heures_jour !== undefined ? ex.heures_jour : '',
+            enfants_handicap: ex.enfants_handicap !== undefined ? ex.enfants_handicap : '',
+            heures_reel: ex.heures_reel !== undefined ? ex.heures_reel : '',
+            heures_handicap_reel: ex.heures_handicap_reel !== undefined ? ex.heures_handicap_reel : ''});
+    });
+    st.cellules = cells;
+}
+function defaultPeriscoState(ctx){
+    var st = {taux_ps:0.59, taux_compl_inclusif:3.90, date_arrete:'', cellules:[]};
+    buildPeriscoCells(st, ctx, null);
+    return st;
+}
+function mergePeriscoState(saved, ctx){
+    var st = defaultPeriscoState(ctx);
+    if (saved){
+        ['taux_ps','taux_compl_inclusif','date_arrete'].forEach(function(k){
+            if (saved[k] !== undefined && saved[k] !== null) st[k] = saved[k];
+        });
+        buildPeriscoCells(st, ctx, saved.cellules || []);
+    }
+    return st;
+}
+function periscoJours(st, ctx){
+    var joursInitial = Math.max((ctx.mercredis_count || 0) - (ctx.mercredis_deduction || 7), 0);
+    var dateArrete = (st.date_arrete || '').trim();
+    var joursRestant = 0;
+    (ctx.mercredis_dates || []).forEach(function(d){ if (dateArrete && d > dateArrete) joursRestant++; });
+    return {joursInitial: joursInitial, joursRestant: joursRestant};
+}
+function computePeriscoJS(st, ctx, typeBudget){
+    var tauxPs = psNum(st.taux_ps, 0.59);
+    var tauxCompl = psNum(st.taux_compl_inclusif, 3.90);
+    var j = periscoJours(st, ctx);
+    var actualise = (typeBudget === 'actualise');
+    var cells = {}, totalPs = 0, totalCompl = 0, totalHeures = 0;
+    (st.cellules || []).forEach(function(c){
+        var enfants = psNum(c.enfants), hj = psNum(c.heures_jour), eh = psNum(c.enfants_handicap);
+        var heures, heuresH, reste = 0;
+        if (actualise){
+            reste = enfants * j.joursRestant * hj;
+            heures = psNum(c.heures_reel) + reste;
+            heuresH = psNum(c.heures_handicap_reel) + eh * j.joursRestant * hj;
+        } else {
+            heures = enfants * j.joursInitial * hj;
+            heuresH = eh * j.joursInitial * hj;
+        }
+        var ps = heures * tauxPs, compl = heuresH * tauxCompl;
+        cells[c.tranche_id] = {heures: heures, heuresH: heuresH, ps: ps, compl: compl, reste: reste};
+        totalPs += ps; totalCompl += compl; totalHeures += heures;
+    });
+    return {cells: cells, jours: j, totalPs: totalPs, totalCompl: totalCompl, totalHeures: totalHeures, total: totalPs + totalCompl};
+}
+function renderPeriscoSimulator(){
+    var st = psSim.state, ctx = psSim.alshCtx || {};
+    var dis = canEditPs ? '' : ' disabled';
+    var actualise = (psSim.ctx.type_budget === 'actualise');
+    var j = periscoJours(st, ctx);
+    var html = '<div class="ps-params">' +
+        psTopField('Taux de PS', 'taux_ps', st.taux_ps, '0.001', dis) +
+        psTopField('Taux complément inclusif (handicap)', 'taux_compl_inclusif', st.taux_compl_inclusif, '0.01', dis) +
+        '</div>';
+    html += '<div class="ps-legend">Mercredis scolaires ' + escapeHtml(String(psSim.ctx.annee)) + ' : <strong>' +
+        (ctx.mercredis_count || 0) + '</strong> − ' + (ctx.mercredis_deduction || 7) +
+        ' (fermetures + reprise) = <strong>' + j.joursInitial + ' jours</strong> sur l\'année.</div>';
+    if (actualise){
+        html += '<div class="ps-params"><div class="ps-field"><label>Date d\'arrêté du réel</label>' +
+            '<input class="ps-input" type="date" value="' + psAttr(st.date_arrete) + '" data-alsh-top="date_arrete" style="flex:0 0 160px;text-align:left;"' + dis + '></div>' +
+            '<div class="ps-field"><label>Mercredis restants après l\'arrêté</label>&nbsp;<strong id="pe-jours-restant">' + j.joursRestant + '</strong></div></div>';
+    }
+    html += alshTranchesBar(ctx);
+    if (!(ctx.tranches || []).length){
+        html += '<p class="ps-legend">Ajoutez au moins une tranche d\'âge pour saisir la simulation.</p>';
+    } else {
+        html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
+            '<th>Tranche d\'âge</th><th>Enfants moyen / jour</th><th>Heures / jour</th><th>Enfants handicap / jour</th>' +
+            (actualise ? '<th>Heures réelles à ce jour</th><th>Heures handicap réelles</th><th class="bp-ps-calc">Heures reste prév.</th>' : '') +
+            '<th class="bp-ps-calc">Heures total</th><th class="bp-ps-calc">PS</th><th class="bp-ps-calc">Compl. inclusif</th>' +
+            '</tr></thead><tbody>';
+        st.cellules.forEach(function(c, idx){
+            var tr = (ctx.tranches || []).find(function(t){ return t.id === c.tranche_id; }) || {};
+            html += '<tr><td class="ps-col-mois">' + escapeHtml(tr.libelle || '') + '</td>' +
+                '<td>' + alshCellInput(idx, 'enfants', c.enfants, dis) + '</td>' +
+                '<td>' + alshCellInput(idx, 'heures_jour', c.heures_jour, dis) + '</td>' +
+                '<td>' + alshCellInput(idx, 'enfants_handicap', c.enfants_handicap, dis) + '</td>' +
+                (actualise ? '<td>' + alshCellInput(idx, 'heures_reel', c.heures_reel, dis) + '</td>' +
+                    '<td>' + alshCellInput(idx, 'heures_handicap_reel', c.heures_handicap_reel, dis) + '</td>' +
+                    '<td class="bp-ps-calc" id="pec-' + idx + '-reste"></td>' : '') +
+                '<td class="bp-ps-calc" id="pec-' + idx + '-heures"></td>' +
+                '<td class="bp-ps-calc" id="pec-' + idx + '-ps"></td>' +
+                '<td class="bp-ps-calc" id="pec-' + idx + '-compl"></td></tr>';
+        });
+        var labelSpan = actualise ? 7 : 4;
+        html += '</tbody><tfoot><tr><td colspan="' + labelSpan + '">Total</td>' +
+            '<td class="bp-ps-calc" id="pe-total-heures"></td><td class="bp-ps-calc" id="pe-total-ps"></td>' +
+            '<td class="bp-ps-calc" id="pe-total-compl"></td></tr></tfoot></table></div>';
+    }
+    html += '<div class="ps-summary"><div class="ps-card"><h4>Récapitulatif</h4>' +
+        '<div class="ps-result">Total PS : <span id="pe-ps">0,00</span> € · Complément inclusif : <span id="pe-compl">0,00</span> €</div></div></div>';
+    html += '<div class="ps-total-box"><span>Total à reporter sur le compte ' + escapeHtml(psSim.compte) +
+        ' (PS + complément inclusif)</span><strong><span id="pe-total">0,00</span> €</strong></div>';
+    document.getElementById('psSimBody').innerHTML = html;
+    document.getElementById('psSimFooter').innerHTML = alshFooter();
+    bindAlshInputs();
+}
+function recomputePerisco(){
+    var c = computePeriscoJS(psSim.state, psSim.alshCtx || {}, psSim.ctx.type_budget);
+    psSim.state.cellules.forEach(function(cell, idx){
+        var r = c.cells[cell.tranche_id] || {heures:0, heuresH:0, ps:0, compl:0, reste:0};
+        psSet('pec-' + idx + '-reste', fmtR(r.reste, 2));
+        psSet('pec-' + idx + '-heures', fmtR(r.heures, 2));
+        psSet('pec-' + idx + '-ps', fmt(r.ps));
+        psSet('pec-' + idx + '-compl', fmt(r.compl));
+    });
+    psSet('pe-total-heures', fmtR(c.totalHeures, 2));
+    psSet('pe-total-ps', fmt(c.totalPs));
+    psSet('pe-total-compl', fmt(c.totalCompl));
+    psSet('pe-ps', fmt(c.totalPs));
+    psSet('pe-compl', fmt(c.totalCompl));
+    psSet('pe-total', fmt(c.total));
+    psSet('pe-jours-restant', String(c.jours.joursRestant));
 }
 
 function defaultEajeState(){
@@ -987,7 +1334,7 @@ function savePsSimulator(){
         annee: ctx.annee,
         type_budget: ctx.type_budget,
         secteur_id: ctx.secteur_id,
-        type_ps: 'eaje',
+        type_ps: psSim.type_ps,
         donnees: psSim.state
     };
     var msg = document.getElementById('psSaveMsg');

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -949,10 +949,16 @@ function mergePeriscoState(saved, ctx){
     return st;
 }
 function periscoJours(st, ctx){
+    var annee = psSim.ctx.annee;
     var joursInitial = Math.max((ctx.mercredis_count || 0) - (ctx.mercredis_deduction || 7), 0);
     var dateArrete = (st.date_arrete || '').trim();
     var joursRestant = 0;
-    (ctx.mercredis_dates || []).forEach(function(d){ if (dateArrete && d > dateArrete) joursRestant++; });
+    if (dateArrete){
+        var restants = 0;
+        (ctx.mercredis_dates || []).forEach(function(d){ if (d > dateArrete) restants++; });
+        var ded = (dateArrete >= (annee + '-08-31')) ? 1 : 5;
+        joursRestant = Math.max(restants - ded, 0);
+    }
     return {joursInitial: joursInitial, joursRestant: joursRestant};
 }
 function computePeriscoJS(st, ctx, typeBudget){
@@ -993,7 +999,8 @@ function renderPeriscoSimulator(){
     if (actualise){
         html += '<div class="ps-params"><div class="ps-field"><label>Date d\'arrêté du réel</label>' +
             '<input class="ps-input" type="date" value="' + psAttr(st.date_arrete) + '" data-alsh-top="date_arrete" style="flex:0 0 160px;text-align:left;"' + dis + '></div>' +
-            '<div class="ps-field"><label>Mercredis restants après l\'arrêté</label>&nbsp;<strong id="pe-jours-restant">' + j.joursRestant + '</strong></div></div>';
+            '<div class="ps-field"><label>Mercredis restants (après déduction)</label>&nbsp;<strong id="pe-jours-restant">' + j.joursRestant + '</strong></div></div>';
+        html += '<div class="ps-legend">Reste de l\'année = mercredis scolaires après la date d\'arrêté, moins 5 jours si l\'arrêté est avant fin août (1 jour si fin août ou après).</div>';
     }
     html += alshTranchesBar(ctx);
     if (!(ctx.tranches || []).length){

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -756,3 +756,32 @@ def test_api_ps_simulation_alsh_perisco_initial(app, db, admin_client, sample_us
     assert r.status_code == 200
     expected = (15 * jours * 3) * 0.59 + (1 * jours * 3) * 3.90
     assert abs(r.get_json()['total'] - round(expected, 2)) < 0.02
+
+
+def test_perisco_deduction_restant_selon_date_arrete():
+    """PERISCO actualisé : 5 jours déduits avant fin août, 1 jour fin août ou après."""
+    from blueprints.budget import _perisco_deduction_restant
+    assert _perisco_deduction_restant(2026, '2026-06-30') == 5
+    assert _perisco_deduction_restant(2026, '2026-08-30') == 5
+    assert _perisco_deduction_restant(2026, '2026-08-31') == 1
+    assert _perisco_deduction_restant(2026, '2026-09-15') == 1
+
+
+def test_suppression_tranche_bloquee_si_utilisee_par_simulation_ps(app, db, admin_client, sample_users):
+    """Une tranche d'âge référencée par une simulation PS ALSH ne peut être supprimée
+    (les tranches sont partagées avec Analyse ALSH)."""
+    secteur_id = sample_users['secteur_id']
+    with app.app_context():
+        db.execute("INSERT INTO alsh_tranches_age (libelle, ordre) VALUES ('3-5 ans', 1)")
+        tid = db.execute("SELECT id FROM alsh_tranches_age ORDER BY id DESC LIMIT 1").fetchone()['id']
+        db.commit()
+    admin_client.post('/api/budget-previsionnel/ps-simulation', json={
+        'compte_num': '706750', 'annee': 2026, 'type_budget': 'initial',
+        'type_ps': 'alsh_perisco', 'secteur_id': secteur_id,
+        'donnees': {'cellules': [{'tranche_id': tid, 'enfants': 10, 'heures_jour': 3}]}
+    })
+    resp = admin_client.delete(f'/api/alsh/tranches-age/{tid}')
+    assert resp.status_code == 400
+    with app.app_context():
+        still = db.execute("SELECT COUNT(*) FROM alsh_tranches_age WHERE id = ?", (tid,)).fetchone()[0]
+    assert still == 1

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -3,7 +3,9 @@ import json
 import os
 from datetime import datetime
 
-from blueprints.budget import _compute_ps_eaje
+from blueprints.budget import (
+    _compute_ps_eaje, _compute_ps_alsh_extrasco, _compute_ps_alsh_perisco
+)
 
 TEST_SECTOR_TYPE_HIGH_ORDER = 999
 
@@ -316,9 +318,9 @@ def test_api_ps_comptes_crud_directeur(app, db, admin_client):
 
     # Mise à jour du type
     admin_client.post('/api/budget-previsionnel/ps-comptes', json={
-        'compte_num': '706000', 'type_ps': 'alsh'
+        'compte_num': '706000', 'type_ps': 'alsh_extrasco'
     })
-    assert admin_client.get('/api/budget-previsionnel/ps-comptes').get_json()['comptes'] == {'706000': 'alsh'}
+    assert admin_client.get('/api/budget-previsionnel/ps-comptes').get_json()['comptes'] == {'706000': 'alsh_extrasco'}
 
     resp = admin_client.delete('/api/budget-previsionnel/ps-comptes/706000')
     assert resp.status_code == 200
@@ -632,3 +634,125 @@ def test_migration_0043_bascule_mois_eaje_en_reel(app, db, sample_users):
         ).fetchone()
     mois = json.loads(row['donnees'])['mois']
     assert all(m['prev_reel'] == 'reel' for m in mois)
+
+
+# ============================================================
+# Simulateurs PS ALSH (PERISCO / EXTRASCO)
+# ============================================================
+
+def test_api_ps_comptes_accepte_types_alsh(admin_client):
+    """Le paramétrage accepte les deux types ALSH et refuse l'ancien 'alsh'."""
+    for t in ('alsh_perisco', 'alsh_extrasco'):
+        r = admin_client.post('/api/budget-previsionnel/ps-comptes',
+                              json={'compte_num': '7066' + t[-1], 'type_ps': t})
+        assert r.status_code == 200 and r.get_json().get('success') is True
+    r = admin_client.post('/api/budget-previsionnel/ps-comptes',
+                          json={'compte_num': '706999', 'type_ps': 'alsh'})
+    assert r.status_code == 400
+
+
+def test_compute_ps_alsh_extrasco_unitaire():
+    """heures = enfants×jours×heures/jour ; PS = heures×taux×régime ; + complément."""
+    res = _compute_ps_alsh_extrasco({
+        'taux_ps': 0.624, 'taux_compl_inclusif': 3.90, 'taux_regime': 100,
+        'cellules': [{'periode_id': 1, 'tranche_id': 1, 'prev_reel': 'prev',
+                      'enfants': 20, 'heures_jour': 8}],
+        'heures_handicap': 100,
+    }, {1: 10})
+    assert abs(res['total_ps'] - 998.40) < 0.01
+    assert abs(res['compl_inclusif'] - 390.0) < 0.01
+    assert abs(res['total'] - 1388.40) < 0.01
+
+
+def test_compute_ps_alsh_extrasco_mode_reel():
+    """En mode réel, les heures sont saisies directement."""
+    res = _compute_ps_alsh_extrasco({
+        'taux_ps': 0.624, 'taux_regime': 100,
+        'cellules': [{'periode_id': 1, 'tranche_id': 1, 'prev_reel': 'reel',
+                      'enfants': 999, 'heures_jour': 999, 'heures_reel': 500}],
+    }, {1: 10})
+    assert abs(res['total_heures'] - 500) < 0.01
+    assert abs(res['total_ps'] - 312.0) < 0.01
+
+
+def test_compute_ps_alsh_perisco_initial_et_actualise():
+    base = {'taux_ps': 0.59, 'taux_compl_inclusif': 3.90,
+            'cellules': [{'tranche_id': 1, 'enfants': 15, 'heures_jour': 3, 'enfants_handicap': 1}]}
+    ini = _compute_ps_alsh_perisco(base, 33, 0, 'initial')
+    assert abs(ini['total'] - 1262.25) < 0.01
+    actu = _compute_ps_alsh_perisco({
+        **base, 'cellules': [{'tranche_id': 1, 'enfants': 15, 'heures_jour': 3,
+                              'enfants_handicap': 1, 'heures_reel': 800, 'heures_handicap_reel': 50}]
+    }, 33, 10, 'actualise')
+    # 800 + 15*10*3=450 -> 1250h ; PS=737.50 ; handicap 50 + 1*10*3=30 -> 80h ; compl=312 ; total=1049.50
+    assert abs(actu['total'] - 1049.50) < 0.01
+
+
+def _setup_alsh_calendrier(db, annee):
+    """Crée une période de vacances de 2 semaines (10 jours ouvrés) et l'année."""
+    db.execute(
+        "INSERT INTO periodes_vacances (nom, date_debut, date_fin) VALUES (?, ?, ?)",
+        ('Vacances test', f'{annee}-02-09', f'{annee}-02-20')  # lun 9 -> ven 20
+    )
+    pid = db.execute("SELECT id FROM periodes_vacances ORDER BY id DESC LIMIT 1").fetchone()['id']
+    db.execute("INSERT INTO alsh_tranches_age (libelle, ordre) VALUES ('6-8 ans', 1)")
+    tid = db.execute("SELECT id FROM alsh_tranches_age ORDER BY id DESC LIMIT 1").fetchone()['id']
+    db.commit()
+    return pid, tid
+
+
+def test_api_ps_alsh_context(app, db, admin_client):
+    annee = 2026
+    with app.app_context():
+        pid, tid = _setup_alsh_calendrier(db, annee)
+    data = admin_client.get(f'/api/budget-previsionnel/ps-alsh-context?annee={annee}').get_json()
+    periode = next(p for p in data['periodes'] if p['id'] == pid)
+    assert periode['jours_ouvres'] == 10  # 2 semaines pleines, sans férié
+    assert any(t['id'] == tid for t in data['tranches'])
+    assert data['mercredis_count'] > 0
+    assert data['jours_initial'] == max(data['mercredis_count'] - data['mercredis_deduction'], 0)
+
+
+def test_api_ps_simulation_alsh_extrasco_calcule_et_reporte(app, db, admin_client, sample_users):
+    secteur_id = sample_users['secteur_id']
+    annee = 2026
+    with app.app_context():
+        pid, tid = _setup_alsh_calendrier(db, annee)
+    donnees = {
+        'taux_ps': 0.624, 'taux_compl_inclusif': 3.90, 'taux_regime': 100,
+        'heures_handicap': 100,
+        'cellules': [{'periode_id': pid, 'tranche_id': tid, 'prev_reel': 'prev',
+                      'enfants': 20, 'heures_jour': 8}],
+    }
+    r = admin_client.post('/api/budget-previsionnel/ps-simulation', json={
+        'compte_num': '706600', 'annee': annee, 'type_budget': 'initial',
+        'type_ps': 'alsh_extrasco', 'secteur_id': secteur_id, 'donnees': donnees
+    })
+    assert r.status_code == 200
+    # heures=20*10*8=1600 ; PS=998.40 ; compl=390 ; total=1388.40
+    assert abs(r.get_json()['total'] - 1388.40) < 0.01
+    row = db.execute('''
+        SELECT valeur_def FROM budget_prev_saisies
+        WHERE type_budget='initial' AND annee=? AND secteur_id=? AND compte_num='706600'
+    ''', (annee, secteur_id)).fetchone()
+    assert row is not None and abs(row['valeur_def'] - 1388.40) < 0.01
+
+
+def test_api_ps_simulation_alsh_perisco_initial(app, db, admin_client, sample_users):
+    secteur_id = sample_users['secteur_id']
+    annee = 2026
+    with app.app_context():
+        _setup_alsh_calendrier(db, annee)
+        tid = db.execute("SELECT id FROM alsh_tranches_age ORDER BY id DESC LIMIT 1").fetchone()['id']
+        # jours_initial dépend du calendrier réel ; on le récupère via le contexte
+    ctx = admin_client.get(f'/api/budget-previsionnel/ps-alsh-context?annee={annee}').get_json()
+    jours = ctx['jours_initial']
+    donnees = {'taux_ps': 0.59, 'taux_compl_inclusif': 3.90,
+               'cellules': [{'tranche_id': tid, 'enfants': 15, 'heures_jour': 3, 'enfants_handicap': 1}]}
+    r = admin_client.post('/api/budget-previsionnel/ps-simulation', json={
+        'compte_num': '706700', 'annee': annee, 'type_budget': 'initial',
+        'type_ps': 'alsh_perisco', 'secteur_id': secteur_id, 'donnees': donnees
+    })
+    assert r.status_code == 200
+    expected = (15 * jours * 3) * 0.59 + (1 * jours * 3) * 3.90
+    assert abs(r.get_json()['total'] - round(expected, 2)) < 0.02


### PR DESCRIPTION
## Résumé

Ajoute les deux simulateurs **PS ALSH** au budget prévisionnel, dans la continuité du simulateur EAJE. Même logique de persistance : une simulation est attachée au **compte + année + secteur + type de budget**, recalculée côté serveur et reportée sur la valeur définitive du compte.

### Paramétrage des comptes PS
- Le type unique « ALSH » est scindé en **ALSH Périscolaire** et **ALSH Extrascolaire**.
- Migration **0044** : reconstruit la contrainte `CHECK` de `budget_ps_comptes` et remappe les comptes `alsh` existants vers `alsh_extrasco`.

### Tranches d'âge partagées
- Réutilisent la table `alsh_tranches_age` (partagées avec **Analyse ALSH**), gérables directement depuis le simulateur (ajout/suppression).

### Simulateur EXTRASCO
- Tableau **période de vacances × tranche d'âge**. Les périodes et les **jours ouvrés** sont déduits du calendrier (`periodes_vacances` + jours fériés).
- Par cellule : `Prévisionnel` (enfants/jour × jours × heures/jour) ou `Réel` (heures saisies). `PS = heures × taux PS × taux régime`.
- Complément inclusif (bonus handicap) sur les heures d'enfants en situation de handicap. **Total à reporter = PS + complément**.
- Paramètres : taux PS (déf. 0,624), taux complément inclusif (déf. 3,90), taux régime (déf. 100 %).

### Simulateur PERISCO
- Une période annuelle = **mercredis scolaires − 7** (fermetures + reprise), × tranche d'âge.
- **Budget initial** : prévisionnel `enfants × jours × heures/jour`.
- **Budget actualisé** : réel saisi à ce jour + prévisionnel sur le **reste de l'année** (mercredis après la date d'arrêté).
- `PS = heures × taux PS` ; complément inclusif idem. Paramètres : taux PS (déf. 0,59), taux complément inclusif (déf. 3,90).

### Choix d'interprétation (à confirmer)
- **Taux de régime général** (EXTRASCO) : appliqué en multiplicateur sur la PS et le complément (cohérent avec l'EAJE ; sans effet à 100 %).
- **Heures handicap EXTRASCO** : une saisie globale annuelle (« à part »), pas par période.
- **PERISCO actualisé** : jours restants = mercredis scolaires strictement après la date d'arrêté (la déduction de 7 reste appliquée au calcul annuel initial). À ajuster si besoin.

### Vérifications
- Calculs **JS et Python alignés** (vérifié : EXTRASCO 1 388,40 € ; PERISCO initial 1 262,25 € ; PERISCO actualisé 1 049,50 €).
- JS validé (`node --check`), migration 0044 appliquée, **554 tests OK** (dont nouveaux tests ALSH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3)_