### PR TITLE
Simulateur de paie (masse salariale) dans le budget prévisionnel

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -734,6 +734,39 @@ def _can_access_budget_previsionnel(profil):
     return False
 
 
+def _secteur_allowed_codes(conn, secteur_id):
+    """Codes (analytiques + comptes du plan) rattachés à un secteur."""
+    allowed = set()
+    if not secteur_id:
+        return allowed
+    for r in conn.execute(
+        'SELECT code_analytique FROM budget_prev_config_codes WHERE secteur_id = ?', (secteur_id,)
+    ).fetchall():
+        c = (r['code_analytique'] or '').strip()
+        if c:
+            allowed.add(c)
+    for r in conn.execute(
+        'SELECT compte_num FROM comptabilite_comptes WHERE secteur_id = ?', (secteur_id,)
+    ).fetchall():
+        c = (r['compte_num'] or '').strip()
+        if c:
+            allowed.add(c)
+    return allowed
+
+
+def _code_allowed(code_analytique, compte_num, allowed_codes):
+    """Une écriture FEC est rattachée au secteur si son code analytique
+    correspond exactement, ou si son compte commence par un code autorisé."""
+    if not allowed_codes:
+        return False
+    code_ana = (code_analytique or '').strip()
+    compte = (compte_num or '').strip()
+    for code in allowed_codes:
+        if code_ana == code or compte.startswith(code):
+            return True
+    return False
+
+
 def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, inflation=0, global_mode=False):
     years = [annee - 2, annee - 1, annee]
     rows = conn.execute('''
@@ -745,28 +778,12 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
 
     allowed_codes = set()
     if secteur_id and not global_mode:
-        cfg = conn.execute(
-            'SELECT code_analytique FROM budget_prev_config_codes WHERE secteur_id = ?',
-            (secteur_id,)
-        ).fetchall()
-        allowed_codes.update((r['code_analytique'] or '').strip() for r in cfg if (r['code_analytique'] or '').strip())
-        from_plan = conn.execute(
-            'SELECT compte_num FROM comptabilite_comptes WHERE secteur_id = ?',
-            (secteur_id,)
-        ).fetchall()
-        allowed_codes.update((r['compte_num'] or '').strip() for r in from_plan if (r['compte_num'] or '').strip())
+        allowed_codes = _secteur_allowed_codes(conn, secteur_id)
 
     def row_allowed(r):
         if global_mode or not secteur_id:
             return True
-        if not allowed_codes:
-            return False
-        code_ana = (r['code_analytique'] or '').strip()
-        compte_num = (r['compte_num'] or '').strip()
-        for code in allowed_codes:
-            if code_ana == code or compte_num.startswith(code):
-                return True
-        return False
+        return _code_allowed(r['code_analytique'], r['compte_num'], allowed_codes)
 
     pcg_rows = conn.execute('SELECT compte_num, libelle FROM plan_comptable_general').fetchall()
     pcg = {r['compte_num']: r['libelle'] for r in pcg_rows}
@@ -1827,12 +1844,18 @@ def _paie_employes_secteur(conn, secteur_id, annee):
     ''', (secteur_id,)).fetchall()
     employes = []
     for u in rows:
+        # Ne retenir que les contrats CDI/CDD qui chevauchent l'année de budget :
+        # commencés au plus tard le 31/12 et finissant au plus tôt le 01/01.
+        # Sinon un contrat saisi pour l'année suivante serait sélectionné en
+        # premier (date_debut la plus récente) puis écarté, faisant disparaître
+        # le salarié alors qu'il a un contrat valide sur l'année.
         contrat = conn.execute('''
             SELECT type_contrat, date_debut, date_fin FROM contrats
             WHERE user_id = ? AND type_contrat IN ('CDI', 'CDD')
+              AND date_debut <= ?
               AND (date_fin IS NULL OR date_fin >= ?)
             ORDER BY date_debut DESC LIMIT 1
-        ''', (u['id'], f'{annee}-01-01')).fetchone()
+        ''', (u['id'], f'{annee}-12-31', f'{annee}-01-01')).fetchone()
         if not contrat:
             continue
         mb, mf = _paie_mois_actifs(contrat['date_debut'], contrat['date_fin'], annee)
@@ -1923,21 +1946,30 @@ def _paie_cee_jours_par_mois(conn, annee, fermetures):
     return result
 
 
-def _paie_reel_641(conn, compte_num, annee):
-    """(last_real_month, montant_reel) du compte brut sur l'année (données FEC)."""
+def _paie_reel_641(conn, secteur_id, compte_num, annee):
+    """(last_real_month, montant_reel) du compte brut sur l'année, restreint au
+    périmètre du secteur (même filtrage que le budget : codes analytiques +
+    comptes rattachés). Évite de compter le réel d'un autre secteur partageant
+    le même compte 641."""
     if not compte_num:
         return 0, 0.0
+    allowed = _secteur_allowed_codes(conn, secteur_id)
     rows = conn.execute('''
-        SELECT mois, COALESCE(SUM(montant), 0) AS m FROM bilan_fec_donnees
-        WHERE compte_num = ? AND annee = ? GROUP BY mois
+        SELECT mois, code_analytique, montant FROM bilan_fec_donnees
+        WHERE compte_num = ? AND annee = ?
     ''', (compte_num, annee)).fetchall()
-    last = 0
-    total = 0.0
+    by_month = {}
     for r in rows:
-        if r['mois'] and 1 <= r['mois'] <= 12:
-            last = max(last, r['mois'])
-            total += float(r['m'] or 0)
-    return last, round(total, 2)
+        if not _code_allowed(r['code_analytique'], compte_num, allowed):
+            continue
+        m = r['mois']
+        if m and 1 <= m <= 12:
+            by_month[m] = by_month.get(m, 0.0) + float(r['montant'] or 0)
+    if not by_month:
+        return 0, 0.0
+    last = max(by_month)
+    total = round(sum(v for m, v in by_month.items() if m <= last), 2)
+    return last, total
 
 
 def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_reel):
@@ -2084,7 +2116,7 @@ def api_paie_context():
         employes = _paie_employes_secteur(conn, secteur_id, annee)
         mercredis, vacances = _paie_cee_dates(conn, annee)
         if type_budget == 'actualise':
-            last_real_month, montant_reel = _paie_reel_641(conn, compte_num, annee)
+            last_real_month, montant_reel = _paie_reel_641(conn, secteur_id, compte_num, annee)
         else:
             last_real_month, montant_reel = 0, 0.0
         return jsonify({
@@ -2155,7 +2187,7 @@ def api_paie_simulation_save():
         employes = _paie_employes_secteur(conn, secteur_id, annee)
         cee_jours = _paie_cee_jours_par_mois(conn, annee, donnees.get('fermetures'))
         if type_budget == 'actualise':
-            last_real_month, montant_reel = _paie_reel_641(conn, compte_num, annee)
+            last_real_month, montant_reel = _paie_reel_641(conn, secteur_id, compte_num, annee)
         else:
             last_real_month, montant_reel = 0, 0.0
         computed = _compute_paie(donnees, employes, cee_jours, last_real_month, montant_reel)

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -819,7 +819,8 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
         n1 = round(vals['N-1'], 2)
         n_full = round(vals['N'], 2)
         nature = 'charges' if compte.startswith('6') else 'produits'
-        is_salary = compte.startswith('63') or compte.startswith('64')
+        # Comptes de personnel répartis au prorata du brut (641), hors 649.
+        is_salary = (compte.startswith('63') or compte.startswith('64')) and not compte.startswith('649')
         n_partiel = round(sum(
             m for month, m in monthly.get(compte, {}).get(annee, {}).items()
             if month <= last_month
@@ -1764,5 +1765,443 @@ def api_ps_simulation_save():
 
         conn.commit()
         return jsonify({'success': True, 'total': total, 'reported': True, 'computed': computed})
+    finally:
+        conn.close()
+
+
+# ============================================================
+# SIMULATEUR DE PAIE (MASSE SALARIALE)
+# ============================================================
+
+PAIE_DEFAULTS = {
+    'salaire_socle': 23000,
+    'valeur_point': 55,
+    'forfait_cee': 70,
+}
+
+
+def _paie_anciennete_annees(date_entree, annee):
+    """Années révolues d'ancienneté au 1er janvier de l'année de budget (floor)."""
+    if not date_entree:
+        return 0
+    try:
+        d = date.fromisoformat(str(date_entree)[:10])
+    except (ValueError, TypeError):
+        return 0
+    ref = date(annee, 1, 1)
+    if d > ref:
+        return 0
+    return max(ref.year - d.year - ((ref.month, ref.day) < (d.month, d.day)), 0)
+
+
+def _paie_mois_actifs(date_debut, date_fin, annee):
+    """(mois_debut, mois_fin) d'activité du contrat dans l'année, ou (None, None)."""
+    try:
+        dd = date.fromisoformat(str(date_debut)[:10]) if date_debut else date(annee, 1, 1)
+    except (ValueError, TypeError):
+        dd = date(annee, 1, 1)
+    df = None
+    if date_fin:
+        try:
+            df = date.fromisoformat(str(date_fin)[:10])
+        except (ValueError, TypeError):
+            df = None
+    if dd.year > annee:
+        return None, None
+    if df and df.year < annee:
+        return None, None
+    mois_debut = dd.month if dd.year == annee else 1
+    mois_fin = df.month if (df and df.year == annee) else 12
+    if mois_debut > mois_fin:
+        return None, None
+    return mois_debut, mois_fin
+
+
+def _paie_employes_secteur(conn, secteur_id, annee):
+    """Salariés actifs du secteur avec un contrat CDI/CDD chevauchant l'année."""
+    rows = conn.execute('''
+        SELECT id, nom, prenom, pesee, competence, date_entree
+        FROM users
+        WHERE actif = 1 AND profil != 'prestataire' AND secteur_id = ?
+        ORDER BY nom, prenom
+    ''', (secteur_id,)).fetchall()
+    employes = []
+    for u in rows:
+        contrat = conn.execute('''
+            SELECT type_contrat, date_debut, date_fin FROM contrats
+            WHERE user_id = ? AND type_contrat IN ('CDI', 'CDD')
+              AND (date_fin IS NULL OR date_fin >= ?)
+            ORDER BY date_debut DESC LIMIT 1
+        ''', (u['id'], f'{annee}-01-01')).fetchone()
+        if not contrat:
+            continue
+        mb, mf = _paie_mois_actifs(contrat['date_debut'], contrat['date_fin'], annee)
+        if mb is None:
+            continue
+        employes.append({
+            'id': u['id'], 'nom': u['nom'], 'prenom': u['prenom'],
+            'pesee': u['pesee'], 'competence': u['competence'],
+            'type_contrat': contrat['type_contrat'],
+            'anciennete': _paie_anciennete_annees(u['date_entree'], annee),
+            'mois_debut': mb, 'mois_fin': mf,
+        })
+    employes.sort(key=lambda e: (0 if e['type_contrat'] == 'CDI' else 1, e['nom'], e['prenom']))
+    return employes
+
+
+def _paie_cee_dates(conn, annee):
+    """(mercredis_scolaires, vacances_ouvres) en dates ISO, hors fériés.
+
+    - mercredis_scolaires : mercredis en période scolaire (hors vacances/fériés)
+    - vacances_ouvres     : jours ouvrés (lun-ven) en vacances scolaires (hors fériés)
+    """
+    feries = {r['date'] for r in conn.execute(
+        'SELECT date FROM jours_feries WHERE annee = ?', (annee,)).fetchall()}
+    jours_vac = set()
+    for pv in conn.execute('''
+        SELECT date_debut, date_fin FROM periodes_vacances
+        WHERE date_debut <= ? AND date_fin >= ?
+    ''', (f'{annee}-12-31', f'{annee}-01-01')).fetchall():
+        try:
+            d0 = max(date.fromisoformat(pv['date_debut']), date(annee, 1, 1))
+            d1 = min(date.fromisoformat(pv['date_fin']), date(annee, 12, 31))
+        except (ValueError, TypeError):
+            continue
+        d = d0
+        while d <= d1:
+            jours_vac.add(d)
+            d += timedelta(days=1)
+    mercredis, vacances = [], []
+    d = date(annee, 1, 1)
+    end = date(annee, 12, 31)
+    while d <= end:
+        if d.weekday() < 5 and d.isoformat() not in feries:
+            if d in jours_vac:
+                vacances.append(d.isoformat())
+            elif d.weekday() == 2:
+                mercredis.append(d.isoformat())
+        d += timedelta(days=1)
+    return mercredis, vacances
+
+
+def _paie_fermetures_set(fermetures, annee):
+    """Ensemble des dates de fermeture de la structure (dans l'année)."""
+    fermees = set()
+    for f in (fermetures or []):
+        if not isinstance(f, dict):
+            continue
+        deb = (f.get('debut') or '').strip()
+        fin = (f.get('fin') or '').strip()
+        if not deb or not fin:
+            continue
+        try:
+            d0 = date.fromisoformat(deb)
+            d1 = date.fromisoformat(fin)
+        except (ValueError, TypeError):
+            continue
+        if d1 < d0:
+            continue
+        d = d0
+        while d <= d1:
+            if d.year == annee:
+                fermees.add(d.isoformat())
+            d += timedelta(days=1)
+    return fermees
+
+
+def _paie_cee_jours_par_mois(conn, annee, fermetures):
+    """{mois: {'mercredis': n, 'vacances': n}} hors périodes de fermeture."""
+    mercredis, vacances = _paie_cee_dates(conn, annee)
+    fermees = _paie_fermetures_set(fermetures, annee)
+    result = {m: {'mercredis': 0, 'vacances': 0} for m in range(1, 13)}
+    for iso in mercredis:
+        if iso not in fermees:
+            result[int(iso[5:7])]['mercredis'] += 1
+    for iso in vacances:
+        if iso not in fermees:
+            result[int(iso[5:7])]['vacances'] += 1
+    return result
+
+
+def _paie_reel_641(conn, compte_num, annee):
+    """(last_real_month, montant_reel) du compte brut sur l'année (données FEC)."""
+    if not compte_num:
+        return 0, 0.0
+    rows = conn.execute('''
+        SELECT mois, COALESCE(SUM(montant), 0) AS m FROM bilan_fec_donnees
+        WHERE compte_num = ? AND annee = ? GROUP BY mois
+    ''', (compte_num, annee)).fetchall()
+    last = 0
+    total = 0.0
+    for r in rows:
+        if r['mois'] and 1 <= r['mois'] <= 12:
+            last = max(last, r['mois'])
+            total += float(r['m'] or 0)
+    return last, round(total, 2)
+
+
+def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_reel):
+    """Calcule le brut par salarié et par mois, le coût CEE et le total annuel.
+
+    Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12.
+    En budget actualisé, seuls les mois > last_real_month sont simulés ; le total
+    intègre le réel (FEC) déjà constaté.
+    """
+    d = donnees or {}
+    socle = _ps_num(d.get('salaire_socle'), PAIE_DEFAULTS['salaire_socle'])
+    point = _ps_num(d.get('valeur_point'), PAIE_DEFAULTS['valeur_point'])
+    forfait_cee = _ps_num(d.get('forfait_cee'), PAIE_DEFAULTS['forfait_cee'])
+    cee_mercredi = _ps_num(d.get('cee_mercredi'))
+    cee_vacances = _ps_num(d.get('cee_vacances'))
+    overrides = d.get('employes') if isinstance(d.get('employes'), dict) else {}
+    ajouts = d.get('ajouts') if isinstance(d.get('ajouts'), list) else []
+
+    start_month = (last_real_month or 0) + 1
+
+    def brut_mensuel(pesee, anciennete, competence):
+        return (socle + (pesee + anciennete + competence) * point) / 12.0
+
+    monthly_totals = {m: 0.0 for m in range(1, 13)}
+    lignes = []
+    for e in employes_base:
+        ov = overrides.get(str(e['id'])) or overrides.get(e['id']) or {}
+        pesee_act = _ps_num(ov.get('pesee'), e['pesee'] or 0)
+        nouv = ov.get('nouvelle_pesee')
+        pesee_eff = _ps_num(nouv) if nouv not in (None, '') else pesee_act
+        anciennete = _ps_num(ov.get('anciennete'), e['anciennete'] or 0)
+        competence = _ps_num(ov.get('competence'), e['competence'] or 0)
+        mois_vals, total_e = {}, 0.0
+        for m in range(max(start_month, e['mois_debut']), e['mois_fin'] + 1):
+            val = brut_mensuel(pesee_eff, anciennete, competence)
+            mois_vals[m] = round(val, 2)
+            monthly_totals[m] += val
+            total_e += val
+        lignes.append({
+            'id': e['id'], 'nom': e['nom'], 'prenom': e['prenom'],
+            'type_contrat': e['type_contrat'], 'pesee_eff': pesee_eff,
+            'anciennete': anciennete, 'competence': competence,
+            'mois': mois_vals, 'total': round(total_e, 2),
+        })
+
+    ajouts_out = []
+    for a in ajouts:
+        if not isinstance(a, dict):
+            continue
+        typ = 'cdd' if a.get('type') == 'cdd' else 'cdi'
+        pesee_eff = _ps_num(a.get('pesee'))
+        anciennete = _ps_num(a.get('anciennete'))
+        competence = _ps_num(a.get('competence'))
+        if typ == 'cdd':
+            mb = int(_ps_num(a.get('mois_debut'), 1)) or 1
+            mf = int(_ps_num(a.get('mois_fin'), 12)) or 12
+        else:
+            mb = int(_ps_num(a.get('mois_embauche'), 1)) or 1
+            mf = 12
+        mb = min(max(mb, 1), 12)
+        mf = min(max(mf, 1), 12)
+        mois_vals, total_a = {}, 0.0
+        for m in range(max(start_month, mb), mf + 1):
+            val = brut_mensuel(pesee_eff, anciennete, competence)
+            mois_vals[m] = round(val, 2)
+            monthly_totals[m] += val
+            total_a += val
+        ajouts_out.append({
+            'type': typ, 'pesee': pesee_eff, 'anciennete': anciennete,
+            'competence': competence, 'mois_debut': mb, 'mois_fin': mf,
+            'mois': mois_vals, 'total': round(total_a, 2),
+        })
+
+    cee_mois = {}
+    for m in range(start_month, 13):
+        cj = cee_jours.get(m) or {'mercredis': 0, 'vacances': 0}
+        cout = (cj['mercredis'] * cee_mercredi + cj['vacances'] * cee_vacances) * forfait_cee
+        cee_mois[m] = round(cout, 2)
+        monthly_totals[m] += cout
+
+    total_simule = sum(monthly_totals[m] for m in range(start_month, 13))
+    return {
+        'lignes': lignes,
+        'ajouts': ajouts_out,
+        'cee_mois': cee_mois,
+        'monthly_totals': {m: round(v, 2) for m, v in monthly_totals.items()},
+        'last_real_month': last_real_month or 0,
+        'montant_reel': round(montant_reel or 0, 2),
+        'total_simule': round(total_simule, 2),
+        'total': round((montant_reel or 0) + total_simule, 2),
+    }
+
+
+def _paie_report_brut(conn, secteur_id, annee, type_budget, brut_compte, total_brut, user_id):
+    """Reporte le brut sur le 641 et répartit 63x/64x (hors 649) au prorata.
+
+    Ratio = compte N-1 / brut N-1 (budget initial) ou réel YTD / brut YTD
+    (budget actualisé). Écrit la valeur définitive dans budget_prev_saisies.
+    """
+    data = _compute_budget_previsionnel(
+        conn=conn, type_budget=type_budget, annee=annee, secteur_id=secteur_id
+    )
+    rows = {r['compte_num']: r for r in data['rows']}
+    actualise = (type_budget == 'actualise')
+    brut_row = rows.get(brut_compte)
+    brut_prev = (brut_row['N'] if actualise else brut_row['N-1']) if brut_row else 0
+
+    reports = {brut_compte: round(total_brut, 2)}
+    for compte, r in rows.items():
+        if compte == brut_compte or not r.get('is_salary'):
+            continue
+        prev = r['N'] if actualise else r['N-1']
+        ratio = (prev / brut_prev) if brut_prev else 0
+        reports[compte] = round(total_brut * ratio, 2)
+
+    now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    for compte, val in reports.items():
+        conn.execute('''
+            INSERT INTO budget_prev_saisies
+            (type_budget, annee, secteur_id, compte_num, valeur_def, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(type_budget, annee, secteur_id, compte_num) DO UPDATE SET
+                valeur_def = excluded.valeur_def,
+                updated_by = excluded.updated_by,
+                updated_at = excluded.updated_at
+        ''', (type_budget, int(annee), int(secteur_id), compte, val, user_id, now))
+    return reports
+
+
+@budget_bp.route('/api/budget-previsionnel/paie-context')
+@login_required
+def api_paie_context():
+    """Contexte du simulateur de paie : salariés du secteur + calendrier CEE."""
+    if session.get('profil') not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    annee = request.args.get('annee', type=int)
+    secteur_id = request.args.get('secteur_id', type=int)
+    compte_num = (request.args.get('compte_num') or '').strip()
+    type_budget = request.args.get('type_budget', 'initial')
+    if not annee or not secteur_id:
+        return jsonify({'error': 'Année et secteur requis'}), 400
+    conn = get_db()
+    try:
+        employes = _paie_employes_secteur(conn, secteur_id, annee)
+        mercredis, vacances = _paie_cee_dates(conn, annee)
+        if type_budget == 'actualise':
+            last_real_month, montant_reel = _paie_reel_641(conn, compte_num, annee)
+        else:
+            last_real_month, montant_reel = 0, 0.0
+        return jsonify({
+            'employes': employes,
+            'mercredis_dates': mercredis,
+            'vacances_dates': vacances,
+            'last_real_month': last_real_month,
+            'montant_reel': montant_reel,
+            'defaults': PAIE_DEFAULTS,
+        })
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/paie-simulation')
+@login_required
+def api_paie_simulation_get():
+    """Récupère la simulation de paie enregistrée (année, secteur, type budget)."""
+    if session.get('profil') not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    annee = request.args.get('annee', type=int)
+    secteur_id = request.args.get('secteur_id', type=int)
+    type_budget = request.args.get('type_budget', 'initial')
+    if not annee or not secteur_id:
+        return jsonify({'error': 'Année et secteur requis'}), 400
+    conn = get_db()
+    try:
+        row = conn.execute('''
+            SELECT donnees, total, updated_at FROM budget_paie_simulations
+            WHERE annee = ? AND secteur_id = ? AND type_budget = ?
+        ''', (annee, secteur_id, type_budget)).fetchone()
+        if not row:
+            return jsonify({'found': False, 'donnees': None})
+        try:
+            donnees = json.loads(row['donnees']) if row['donnees'] else None
+        except (ValueError, TypeError):
+            donnees = None
+        return jsonify({'found': True, 'donnees': donnees, 'total': row['total'],
+                        'updated_at': row['updated_at']})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/paie-simulation', methods=['POST'])
+@login_required
+def api_paie_simulation_save():
+    """Enregistre la simulation de paie et reporte le brut sur le 641 (+ 63x/64x)."""
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+
+    data = request.get_json() or {}
+    annee = data.get('annee')
+    secteur_id = data.get('secteur_id')
+    type_budget = data.get('type_budget')
+    compte_num = (data.get('compte_num') or '').strip()
+    donnees = data.get('donnees') or {}
+    if not isinstance(donnees, dict):
+        donnees = {}
+    if not annee or not secteur_id:
+        return jsonify({'error': 'Année et secteur requis'}), 400
+    if type_budget not in ('initial', 'actualise'):
+        return jsonify({'error': 'Type de budget invalide'}), 400
+
+    conn = get_db()
+    try:
+        employes = _paie_employes_secteur(conn, secteur_id, annee)
+        cee_jours = _paie_cee_jours_par_mois(conn, annee, donnees.get('fermetures'))
+        if type_budget == 'actualise':
+            last_real_month, montant_reel = _paie_reel_641(conn, compte_num, annee)
+        else:
+            last_real_month, montant_reel = 0, 0.0
+        computed = _compute_paie(donnees, employes, cee_jours, last_real_month, montant_reel)
+        total = computed['total']
+
+        # Persister pesée et compétence sur les fiches salariés (mêmes variables
+        # que infos_salaries) à partir des saisies du simulateur.
+        overrides = donnees.get('employes') if isinstance(donnees.get('employes'), dict) else {}
+        emp_ids = {e['id'] for e in employes}
+        for key, ov in overrides.items():
+            if not isinstance(ov, dict):
+                continue
+            try:
+                uid = int(key)
+            except (TypeError, ValueError):
+                continue
+            if uid not in emp_ids:
+                continue
+            pesee = ov.get('pesee')
+            comp = ov.get('competence')
+            conn.execute(
+                'UPDATE users SET pesee = ?, competence = ? WHERE id = ?',
+                (int(pesee) if str(pesee).strip() not in ('', 'None') else None,
+                 int(comp) if str(comp).strip() not in ('', 'None') else None,
+                 uid)
+            )
+
+        conn.execute('''
+            INSERT INTO budget_paie_simulations
+            (annee, secteur_id, type_budget, compte_num, donnees, total, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(annee, secteur_id, type_budget) DO UPDATE SET
+                compte_num = excluded.compte_num,
+                donnees = excluded.donnees,
+                total = excluded.total,
+                updated_by = excluded.updated_by,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (int(annee), int(secteur_id), type_budget, compte_num,
+              json.dumps(donnees), total, user_id))
+
+        reports = {}
+        if compte_num:
+            reports = _paie_report_brut(conn, secteur_id, annee, type_budget,
+                                        compte_num, total, user_id)
+        conn.commit()
+        return jsonify({'success': True, 'total': total, 'computed': computed,
+                        'reports': reports})
     finally:
         conn.close()

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -305,6 +305,8 @@ def modifier_pesee():
     user_id = request.form.get('user_id', type=int)
     pesee_val = request.form.get('pesee', '').strip()
     pesee = int(pesee_val) if pesee_val else None
+    competence_val = request.form.get('competence', '').strip()
+    competence = int(competence_val) if competence_val else None
 
     if not user_id:
         flash("Salarie invalide.", 'error')
@@ -315,7 +317,8 @@ def modifier_pesee():
         conn.close()
         flash("Acces non autorise.", 'error')
         return redirect(url_for('infos_salaries_bp.infos_salaries'))
-    conn.execute('UPDATE users SET pesee = ? WHERE id = ?', (pesee, user_id))
+    conn.execute('UPDATE users SET pesee = ?, competence = ? WHERE id = ?',
+                 (pesee, competence, user_id))
     conn.commit()
     conn.close()
 

--- a/database.py
+++ b/database.py
@@ -217,6 +217,7 @@ def init_db():
             cc_solde REAL DEFAULT 0,
             date_entree TEXT,
             pesee INTEGER,
+            competence INTEGER,
             email TEXT,
             email_notifications_enabled INTEGER DEFAULT 0,
             force_password_change INTEGER DEFAULT 0,
@@ -1473,6 +1474,27 @@ def init_db():
             FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE CASCADE,
             FOREIGN KEY (updated_by) REFERENCES users(id),
             UNIQUE(compte_num, annee, secteur_id, type_budget)
+        )
+    ''')
+
+    # Saisies du simulateur de paie (masse salariale), attachées à l'année, au
+    # secteur et au type de budget. Les données détaillées (paramètres, saisie
+    # par salarié, CEE, ajouts) sont stockées en JSON ; total = brut annuel à
+    # reporter sur le premier compte 641.
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_paie_simulations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            annee INTEGER NOT NULL,
+            secteur_id INTEGER NOT NULL,
+            type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
+            compte_num TEXT,
+            donnees TEXT,
+            total REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE CASCADE,
+            FOREIGN KEY (updated_by) REFERENCES users(id),
+            UNIQUE(annee, secteur_id, type_budget)
         )
     ''')
 

--- a/migrations/0045_simulateur_paie.py
+++ b/migrations/0045_simulateur_paie.py
@@ -1,0 +1,47 @@
+"""
+Migration 0045 : Ajout du simulateur de paie (masse salariale).
+
+- users.competence       : points de compétence (à côté de la pesée ALISFA),
+                           utilisés dans le calcul du brut.
+- budget_paie_simulations : saisies du simulateur de paie, attachées à l'année,
+                           au secteur et au type de budget (initial/actualisé).
+"""
+
+NOM = "Ajout simulateur de paie"
+DESCRIPTION = (
+    "Ajoute la colonne users.competence et la table budget_paie_simulations "
+    "pour le simulateur de masse salariale du budget prévisionnel."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+
+    # Colonne competence sur users (si absente)
+    try:
+        cursor.execute("SELECT competence FROM users LIMIT 1")
+    except Exception:
+        cursor.execute("ALTER TABLE users ADD COLUMN competence INTEGER")
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_paie_simulations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            annee INTEGER NOT NULL,
+            secteur_id INTEGER NOT NULL,
+            type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
+            compte_num TEXT,
+            donnees TEXT,
+            total REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE CASCADE,
+            FOREIGN KEY (updated_by) REFERENCES users(id),
+            UNIQUE(annee, secteur_id, type_budget)
+        )
+    ''')
+
+
+def downgrade(conn):
+    """Supprime la table de simulation (la colonne competence est conservée)."""
+    conn.cursor().execute('DROP TABLE IF EXISTS budget_paie_simulations')

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -328,6 +328,18 @@
     </div>
 </div>
 
+<!-- Simulateur de paie (masse salariale) -->
+<div id="paieSimulatorModal" class="ps-modal-overlay" onclick="if(event.target===this)closePaieSimulator()">
+    <div class="ps-modal" role="dialog" aria-modal="true">
+        <div class="ps-modal-header">
+            <h3 id="paieSimTitle">Simulateur de paie</h3>
+            <button class="modal-close" type="button" onclick="closePaieSimulator()" aria-label="Fermer">&times;</button>
+        </div>
+        <div class="ps-modal-body" id="paieSimBody"></div>
+        <div class="ps-modal-footer" id="paieSimFooter"></div>
+    </div>
+</div>
+
 <script>
 var isReadOnly = {{ 'true' if profil == 'responsable' else 'false' }};
 var canEditPs = {{ 'true' if profil in ['directeur', 'comptable'] else 'false' }};
@@ -455,8 +467,11 @@ function buildTable(rows, labelTemp, labelDef, globalMode){
         const psBtn = (!globalMode && psComptes[r.compte_num])
             ? '<button type="button" class="btn btn-sm btn-secondary bp-ps-btn" data-ps-compte="' + escapeHtml(r.compte_num) + '" title="Ouvrir le simulateur de PS">🧮 PS</button>'
             : '';
+        const paieBtn = (!globalMode && canEditPs && salaryMeta && salaryMeta.salary_brut_account === r.compte_num)
+            ? '<button type="button" class="btn btn-sm btn-secondary bp-ps-btn" data-paie-compte="' + escapeHtml(r.compte_num) + '" title="Ouvrir le simulateur de paie">🧮 Paie</button>'
+            : '';
         html += '<tr' + rowStyle + '>' +
-          '<td>' + escapeHtml(r.compte_num) + '</td><td>' + escapeHtml(r.libelle) + psBtn + '</td>' +
+          '<td>' + escapeHtml(r.compte_num) + '</td><td>' + escapeHtml(r.libelle) + psBtn + paieBtn + '</td>' +
           '<td class="bp-col-num">' + fmt(r['N-2']) + '</td><td class="bp-col-num">' + fmt(r['N-1']) + '</td><td class="bp-col-num">' + fmt(r['N']) + '</td>' +
           '<td class="bp-col-num">' + tempInput + '</td><td class="bp-col-num">' + defInput + '</td><td>' + commentInput + '</td></tr>';
     }
@@ -575,6 +590,9 @@ function bindPsButtons(targetId){
     if (!root) return;
     root.querySelectorAll('button[data-ps-compte]').forEach(function(btn){
         btn.addEventListener('click', function(){ openPsSimulator(this.dataset.psCompte || ''); });
+    });
+    root.querySelectorAll('button[data-paie-compte]').forEach(function(btn){
+        btn.addEventListener('click', function(){ openPaieSimulator(this.dataset.paieCompte || ''); });
     });
 }
 
@@ -1361,10 +1379,277 @@ function savePsSimulator(){
     }).catch(function(){ if (msg) msg.textContent = ''; alert('Erreur réseau lors de l\'enregistrement'); });
 }
 
+// ===================== Simulateur de paie (masse salariale) =====================
+var paieSim = null;  // { ctx, compte, state, context }
+var MOIS_COURT = ['Jan','Fév','Mar','Avr','Mai','Juin','Juil','Août','Sep','Oct','Nov','Déc'];
+
+function openPaieSimulator(compteNum){
+    var ctx = getCurrentBudgetContext();
+    paieSim = {ctx: ctx, compte: compteNum, state: null, context: null};
+    document.getElementById('paieSimTitle').textContent =
+        'Simulateur de paie — ' + (ctx.type_budget === 'actualise' ? 'budget actualisé' : 'budget initial') +
+        ' ' + ctx.annee + ' — compte ' + compteNum;
+    var curl = '/api/budget-previsionnel/paie-context?annee=' + ctx.annee + '&secteur_id=' + ctx.secteur_id +
+        '&compte_num=' + encodeURIComponent(compteNum) + '&type_budget=' + encodeURIComponent(ctx.type_budget);
+    var surl = '/api/budget-previsionnel/paie-simulation?annee=' + ctx.annee + '&secteur_id=' + ctx.secteur_id +
+        '&type_budget=' + encodeURIComponent(ctx.type_budget);
+    Promise.all([
+        fetch(curl).then(r => r.json()).catch(function(){ return {employes:[], mercredis_dates:[], vacances_dates:[]}; }),
+        fetch(surl).then(r => r.json()).then(function(d){ return (d && d.found) ? d.donnees : null; }).catch(function(){ return null; })
+    ]).then(function(res){
+        paieSim.context = res[0] || {employes:[], mercredis_dates:[], vacances_dates:[]};
+        paieSim.state = mergePaieState(res[1], paieSim.context);
+        renderPaieSimulator();
+        recomputePaie();
+        document.getElementById('paieSimulatorModal').classList.add('open');
+    });
+}
+function closePaieSimulator(){ document.getElementById('paieSimulatorModal').classList.remove('open'); paieSim = null; }
+document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && document.getElementById('paieSimulatorModal').classList.contains('open')) closePaieSimulator();
+});
+
+function defaultPaieState(ctx){
+    var def = ctx.defaults || {};
+    var st = {
+        salaire_socle: def.salaire_socle != null ? def.salaire_socle : 23000,
+        valeur_point: def.valeur_point != null ? def.valeur_point : 55,
+        forfait_cee: def.forfait_cee != null ? def.forfait_cee : 70,
+        cee_mercredi: '', cee_vacances: '',
+        fermetures: [{debut:'', fin:''}, {debut:'', fin:''}],
+        employes: {}, ajouts: []
+    };
+    (ctx.employes || []).forEach(function(e){
+        st.employes[e.id] = {
+            pesee: e.pesee != null ? e.pesee : '',
+            nouvelle_pesee: '',
+            anciennete: e.anciennete != null ? e.anciennete : 0,
+            competence: e.competence != null ? e.competence : ''
+        };
+    });
+    return st;
+}
+function mergePaieState(saved, ctx){
+    var st = defaultPaieState(ctx);
+    if (!saved) return st;
+    ['salaire_socle','valeur_point','forfait_cee','cee_mercredi','cee_vacances'].forEach(function(k){
+        if (saved[k] !== undefined && saved[k] !== null) st[k] = saved[k];
+    });
+    if (Array.isArray(saved.fermetures)){
+        for (var i=0;i<2;i++){ if (saved.fermetures[i]) st.fermetures[i] = {debut: saved.fermetures[i].debut||'', fin: saved.fermetures[i].fin||''}; }
+    }
+    if (saved.employes && typeof saved.employes === 'object'){
+        Object.keys(st.employes).forEach(function(id){ if (saved.employes[id]) Object.assign(st.employes[id], saved.employes[id]); });
+    }
+    if (Array.isArray(saved.ajouts)) st.ajouts = saved.ajouts.map(function(a){ return Object.assign({}, a); });
+    return st;
+}
+function paieCeeParMois(ctx, st){
+    var ferm = (st.fermetures || []).filter(function(f){ return f && f.debut && f.fin; });
+    function closed(iso){ return ferm.some(function(f){ return iso >= f.debut && iso <= f.fin; }); }
+    var res = {}; for (var m=1;m<=12;m++) res[m] = {mercredis:0, vacances:0};
+    (ctx.mercredis_dates || []).forEach(function(iso){ if (!closed(iso)) res[parseInt(iso.slice(5,7),10)].mercredis++; });
+    (ctx.vacances_dates || []).forEach(function(iso){ if (!closed(iso)) res[parseInt(iso.slice(5,7),10)].vacances++; });
+    return res;
+}
+function computePaieJS(st, ctx, typeBudget){
+    var socle = psNum(st.salaire_socle, 23000), point = psNum(st.valeur_point, 55), forfait = psNum(st.forfait_cee, 70);
+    var ceeMer = psNum(st.cee_mercredi), ceeVac = psNum(st.cee_vacances);
+    var lastReal = (typeBudget === 'actualise') ? (ctx.last_real_month || 0) : 0;
+    var reel = (typeBudget === 'actualise') ? (ctx.montant_reel || 0) : 0;
+    var start = lastReal + 1;
+    function brut(p,a,c){ return (socle + (p+a+c)*point) / 12; }
+    var monthly = {}; for (var m=1;m<=12;m++) monthly[m] = 0;
+    var lignes = {};
+    (ctx.employes || []).forEach(function(e){
+        var ov = st.employes[e.id] || {};
+        var pAct = psNum(ov.pesee, e.pesee || 0);
+        var pEff = (ov.nouvelle_pesee !== '' && ov.nouvelle_pesee != null) ? psNum(ov.nouvelle_pesee) : pAct;
+        var anc = psNum(ov.anciennete, e.anciennete || 0), comp = psNum(ov.competence, e.competence || 0);
+        var mvals = {}, tot = 0;
+        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp); mvals[m]=v; monthly[m]+=v; tot+=v; }
+        lignes[e.id] = {mois: mvals, total: tot, pesee_eff: pEff};
+    });
+    var ajouts = {};
+    (st.ajouts || []).forEach(function(a, i){
+        var typ = (a.type === 'cdd') ? 'cdd' : 'cdi';
+        var pEff = psNum(a.pesee), anc = psNum(a.anciennete), comp = psNum(a.competence);
+        var mb = (typ==='cdd') ? (parseInt(a.mois_debut,10)||1) : (parseInt(a.mois_embauche,10)||1);
+        var mf = (typ==='cdd') ? (parseInt(a.mois_fin,10)||12) : 12;
+        mb=Math.min(Math.max(mb,1),12); mf=Math.min(Math.max(mf,1),12);
+        var mvals = {}, tot = 0;
+        for (var m=Math.max(start,mb); m<=mf; m++){ var v=brut(pEff,anc,comp); mvals[m]=v; monthly[m]+=v; tot+=v; }
+        ajouts[i] = {mois: mvals, total: tot};
+    });
+    var ceeJours = paieCeeParMois(ctx, st), ceeCout = {};
+    for (var m=start; m<=12; m++){ var cj=ceeJours[m]||{mercredis:0,vacances:0}; var c=(cj.mercredis*ceeMer + cj.vacances*ceeVac)*forfait; ceeCout[m]=c; monthly[m]+=c; }
+    var totalSim = 0; for (var mm=start; mm<=12; mm++) totalSim += monthly[mm];
+    return {lignes:lignes, ajouts:ajouts, ceeJours:ceeJours, ceeCout:ceeCout, monthly:monthly, start:start, lastReal:lastReal, reel:reel, totalSim:totalSim, total: reel + totalSim};
+}
+function paieMonths(){
+    var lastReal = (paieSim.ctx.type_budget === 'actualise') ? (paieSim.context.last_real_month || 0) : 0;
+    var arr = []; for (var m=lastReal+1; m<=12; m++) arr.push(m); return arr;
+}
+function paieInput(attrs, val, step){
+    return '<input class="ps-input" type="number" step="' + (step||'0.01') + '" value="' + psAttr(val) + '" ' + attrs + '>';
+}
+function renderPaieSimulator(){
+    var st = paieSim.state, ctx = paieSim.context, months = paieMonths();
+    var actualise = (paieSim.ctx.type_budget === 'actualise');
+    var monthTh = months.map(function(m){ return '<th class="bp-ps-calc">' + MOIS_COURT[m-1] + '</th>'; }).join('');
+    var html = '<div class="ps-params">' +
+        '<div class="ps-field"><label>Salaire socle (annuel)</label>' + paieInput('data-paie-top="salaire_socle"', st.salaire_socle, '1') + '</div>' +
+        '<div class="ps-field"><label>Valeur du point</label>' + paieInput('data-paie-top="valeur_point"', st.valeur_point, '0.01') + '</div>' +
+        '</div>';
+    html += '<div class="ps-legend">Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12. Colonnes <span class="bp-ps-calc">surlignées</span> = calculées.';
+    if (actualise){
+        html += ' Budget actualisé : seuls les mois après <strong>' + (ctx.last_real_month ? MOIS_COURT[ctx.last_real_month-1] : '—') +
+            '</strong> sont simulés ; réel déjà constaté : <strong>' + fmt(ctx.montant_reel || 0) + ' €</strong>.';
+    }
+    html += '</div>';
+
+    // Salariés en cours de contrat
+    html += '<h4 style="margin:14px 0 6px;color:var(--primary);">Salariés en cours de contrat (secteur)</h4>';
+    if (!(ctx.employes || []).length){
+        html += '<p class="ps-legend">Aucun salarié actif en CDI/CDD rattaché à ce secteur sur l\'année.</p>';
+    } else {
+        html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
+            '<th>Salarié</th><th>Type</th><th>Pesée actuelle</th><th>Nouvelle pesée</th><th>Ancienneté</th><th>Compétence</th>' +
+            monthTh + '<th class="bp-ps-calc">Total</th></tr></thead><tbody>';
+        (ctx.employes || []).forEach(function(e){
+            var ov = st.employes[e.id] || {};
+            html += '<tr><td class="ps-col-mois">' + escapeHtml((e.nom||'') + ' ' + (e.prenom||'')) + '</td>' +
+                '<td>' + escapeHtml(e.type_contrat || '') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="pesee"', ov.pesee, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="nouvelle_pesee"', ov.nouvelle_pesee, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="anciennete"', ov.anciennete, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="competence"', ov.competence, '1') + '</td>' +
+                months.map(function(m){ return '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-' + m + '"></td>'; }).join('') +
+                '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-tot"></td></tr>';
+        });
+        html += '</tbody></table></div>';
+    }
+
+    // Autres salariés (ajouts)
+    html += '<h4 style="margin:14px 0 6px;color:var(--primary);">Autres salariés (ajouts)</h4>';
+    html += '<div style="margin-bottom:6px;display:flex;gap:8px;"><button class="btn btn-sm btn-secondary" type="button" onclick="paieAddAjout(\'cdi\')">+ CDI</button>' +
+        '<button class="btn btn-sm btn-secondary" type="button" onclick="paieAddAjout(\'cdd\')">+ CDD</button></div>';
+    if ((st.ajouts || []).length){
+        html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
+            '<th>Type</th><th>Pesée</th><th>Ancienneté</th><th>Mois début / embauche</th><th>Mois fin (CDD)</th>' +
+            monthTh + '<th class="bp-ps-calc">Total</th><th></th></tr></thead><tbody>';
+        st.ajouts.forEach(function(a, i){
+            var isCdd = (a.type === 'cdd');
+            html += '<tr><td class="ps-col-mois">' + (isCdd ? 'CDD' : 'CDI') + '</td>' +
+                '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="pesee"', a.pesee, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="anciennete"', a.anciennete, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="' + (isCdd ? 'mois_debut' : 'mois_embauche') + '"', isCdd ? a.mois_debut : a.mois_embauche, '1') + '</td>' +
+                '<td>' + (isCdd ? paieInput('data-paie-aj="' + i + '" data-paie-key="mois_fin"', a.mois_fin, '1') : '—') + '</td>' +
+                months.map(function(m){ return '<td class="bp-ps-calc" id="paie-aj-' + i + '-' + m + '"></td>'; }).join('') +
+                '<td class="bp-ps-calc" id="paie-aj-' + i + '-tot"></td>' +
+                '<td><button class="btn btn-sm btn-danger" type="button" onclick="paieRemoveAjout(' + i + ')">×</button></td></tr>';
+        });
+        html += '</tbody></table></div>';
+    }
+
+    // CEE
+    html += '<h4 style="margin:14px 0 6px;color:var(--primary);">Contrats d\'engagement éducatif (CEE)</h4>';
+    html += '<div class="ps-params">' +
+        '<div class="ps-field"><label>Forfait jour brut moyen (€)</label>' + paieInput('data-paie-top="forfait_cee"', st.forfait_cee, '0.01') + '</div>' +
+        '<div class="ps-field"><label>CEE moyen / mercredi périscolaire</label>' + paieInput('data-paie-top="cee_mercredi"', st.cee_mercredi, '0.1') + '</div>' +
+        '<div class="ps-field"><label>CEE moyen / jour de vacances</label>' + paieInput('data-paie-top="cee_vacances"', st.cee_vacances, '0.1') + '</div>' +
+        '</div>';
+    html += '<div class="ps-params"><div class="ps-field"><label>Fermeture 1 — du</label><input class="ps-input" type="date" value="' + psAttr(st.fermetures[0].debut) + '" data-paie-ferm="0" data-paie-key="debut" style="flex:0 0 150px;text-align:left;"></div>' +
+        '<div class="ps-field"><label>au</label><input class="ps-input" type="date" value="' + psAttr(st.fermetures[0].fin) + '" data-paie-ferm="0" data-paie-key="fin" style="flex:0 0 150px;text-align:left;"></div>' +
+        '<div class="ps-field"><label>Fermeture 2 — du</label><input class="ps-input" type="date" value="' + psAttr(st.fermetures[1].debut) + '" data-paie-ferm="1" data-paie-key="debut" style="flex:0 0 150px;text-align:left;"></div>' +
+        '<div class="ps-field"><label>au</label><input class="ps-input" type="date" value="' + psAttr(st.fermetures[1].fin) + '" data-paie-ferm="1" data-paie-key="fin" style="flex:0 0 150px;text-align:left;"></div></div>';
+
+    // Totaux
+    html += '<div class="ps-table-scroll" style="margin-top:14px;"><table class="ps-table"><thead><tr><th>Totaux</th>' + monthTh + '<th class="bp-ps-calc">Année</th></tr></thead><tbody>' +
+        '<tr><td class="ps-col-mois">Coût CEE</td>' + months.map(function(m){ return '<td class="bp-ps-calc" id="paie-cee-' + m + '"></td>'; }).join('') + '<td class="bp-ps-calc" id="paie-cee-tot"></td></tr>' +
+        '<tr><td class="ps-col-mois"><strong>Brut total / mois</strong></td>' + months.map(function(m){ return '<td class="bp-ps-calc" id="paie-mtot-' + m + '"></td>'; }).join('') + '<td class="bp-ps-calc" id="paie-totalsim"></td></tr>' +
+        '</tbody></table></div>';
+
+    var totalLabel = actualise ? 'Total à reporter (réel + simulé)' : 'Total brut annuel à reporter';
+    html += '<div class="ps-total-box"><span>' + totalLabel + ' sur le compte ' + escapeHtml(paieSim.compte) +
+        '</span><strong><span id="paie-total">0,00</span> €</strong></div>';
+
+    document.getElementById('paieSimBody').innerHTML = html;
+    document.getElementById('paieSimFooter').innerHTML =
+        '<span id="paieSaveMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>' +
+        '<button class="btn btn-secondary" type="button" onclick="closePaieSimulator()">Annuler</button>' +
+        '<button class="btn btn-primary" type="button" onclick="savePaieSimulator()">💾 Reporter sur le 641 (et 63x/64x)</button>';
+    bindPaieInputs();
+}
+function bindPaieInputs(){
+    var body = document.getElementById('paieSimBody');
+    if (!body) return;
+    body.querySelectorAll('[data-paie-top]').forEach(function(el){
+        var h = function(){ paieSim.state[this.dataset.paieTop] = this.value; recomputePaie(); };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+    body.querySelectorAll('[data-paie-emp]').forEach(function(el){
+        var h = function(){ var id=this.dataset.paieEmp; (paieSim.state.employes[id] = paieSim.state.employes[id] || {})[this.dataset.paieKey] = this.value; recomputePaie(); };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+    body.querySelectorAll('[data-paie-aj]').forEach(function(el){
+        var h = function(){ var i=parseInt(this.dataset.paieAj,10); paieSim.state.ajouts[i][this.dataset.paieKey] = this.value; recomputePaie(); };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+    body.querySelectorAll('[data-paie-ferm]').forEach(function(el){
+        var h = function(){ var i=parseInt(this.dataset.paieFerm,10); paieSim.state.fermetures[i][this.dataset.paieKey] = this.value; recomputePaie(); };
+        el.addEventListener('input', h); el.addEventListener('change', h);
+    });
+}
+function paieAddAjout(type){
+    paieSim.state.ajouts.push(type === 'cdd'
+        ? {type:'cdd', pesee:'', anciennete:'', competence:0, mois_debut:1, mois_fin:12}
+        : {type:'cdi', pesee:'', anciennete:'', competence:0, mois_embauche:1});
+    renderPaieSimulator(); recomputePaie();
+}
+function paieRemoveAjout(i){ paieSim.state.ajouts.splice(i,1); renderPaieSimulator(); recomputePaie(); }
+function recomputePaie(){
+    if (!paieSim) return;
+    var c = computePaieJS(paieSim.state, paieSim.context, paieSim.ctx.type_budget);
+    var months = paieMonths();
+    (paieSim.context.employes || []).forEach(function(e){
+        var l = c.lignes[e.id] || {mois:{}, total:0};
+        months.forEach(function(m){ psSet('paie-emp-' + e.id + '-' + m, l.mois[m] ? fmt(l.mois[m]) : ''); });
+        psSet('paie-emp-' + e.id + '-tot', fmt(l.total));
+    });
+    (paieSim.state.ajouts || []).forEach(function(a, i){
+        var l = c.ajouts[i] || {mois:{}, total:0};
+        months.forEach(function(m){ psSet('paie-aj-' + i + '-' + m, l.mois[m] ? fmt(l.mois[m]) : ''); });
+        psSet('paie-aj-' + i + '-tot', fmt(l.total));
+    });
+    var ceeTot = 0;
+    months.forEach(function(m){ var v = c.ceeCout[m] || 0; psSet('paie-cee-' + m, fmt(v)); ceeTot += v; });
+    psSet('paie-cee-tot', fmt(ceeTot));
+    months.forEach(function(m){ psSet('paie-mtot-' + m, fmt(c.monthly[m] || 0)); });
+    psSet('paie-totalsim', fmt(c.totalSim));
+    psSet('paie-total', fmt(c.total));
+}
+function savePaieSimulator(){
+    if (!paieSim) return;
+    var ctx = paieSim.ctx;
+    var msg = document.getElementById('paieSaveMsg');
+    if (msg) msg.textContent = 'Enregistrement…';
+    fetch('/api/budget-previsionnel/paie-simulation', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({annee: ctx.annee, secteur_id: ctx.secteur_id, type_budget: ctx.type_budget,
+            compte_num: paieSim.compte, donnees: paieSim.state})
+    }).then(r => r.json()).then(function(data){
+        if (!data.success){ if (msg) msg.textContent = ''; alert(data.error || 'Erreur lors de l\'enregistrement'); return; }
+        var nb = data.reports ? Object.keys(data.reports).length : 1;
+        if (msg) msg.textContent = '✓ Reporté : ' + fmt(data.total) + ' € sur ' + nb + ' compte(s)';
+        chargerBudget();
+    }).catch(function(){ if (msg) msg.textContent = ''; alert('Erreur réseau lors de l\'enregistrement'); });
+}
+
 // Déplace les modales au niveau du <body> : le conteneur .container crée un
 // contexte d'empilement (animation) qui les confinerait sinon sous la barre
 // latérale de gauche (menu). Rattachées au body, elles s'affichent par-dessus.
-['psSimulatorModal', 'psConfigModal'].forEach(function(id){
+['psSimulatorModal', 'psConfigModal', 'paieSimulatorModal'].forEach(function(id){
     var el = document.getElementById(id);
     if (el && el.parentNode !== document.body) document.body.appendChild(el);
 });

--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -80,6 +80,9 @@
             <label for="pesee" style="font-weight: 600; margin: 0;">Pesee ALISFA :</label>
             <input type="number" id="pesee" name="pesee" value="{{ salarie.pesee if salarie.pesee is not none else '' }}"
                    placeholder="Points" style="width: 120px; padding: 6px 10px;" min="0">
+            <label for="competence" style="font-weight: 600; margin: 0;">Points de compétence :</label>
+            <input type="number" id="competence" name="competence" value="{{ salarie.competence if salarie.competence is not none else '' }}"
+                   placeholder="Points" style="width: 120px; padding: 6px 10px;" min="0">
             <button type="submit" class="btn btn-primary btn-sm">Enregistrer</button>
             {% if salarie.pesee is not none %}
             <span style="font-size: 0.85rem; color: var(--gray-500);">{{ salarie.pesee }} pts + SSC</span>

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -885,3 +885,53 @@ def test_budget_649_exclu_du_prorata_salaire(app, db, admin_client):
     assert rows['641000']['is_salary'] is True
     assert rows['649000']['is_salary'] is False
     assert '649000' not in data['salary_ratios']
+
+
+def test_paie_reel_641_restreint_au_secteur(app, db):
+    """Le réel du 641 (budget actualisé) est restreint au périmètre du secteur
+    quand plusieurs secteurs partagent le même compte (P1)."""
+    from blueprints.budget import _paie_reel_641
+    annee = 2026
+    with app.app_context():
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('SA','administratif')")
+        sa = db.execute("SELECT id FROM secteurs WHERE nom='SA'").fetchone()['id']
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('SB','administratif')")
+        sb = db.execute("SELECT id FROM secteurs WHERE nom='SB'").fetchone()['id']
+        db.execute("INSERT INTO budget_prev_config_codes (code_analytique, secteur_id) VALUES ('ANA-A', ?)", (sa,))
+        db.execute("INSERT INTO budget_prev_config_codes (code_analytique, secteur_id) VALUES ('ANA-B', ?)", (sb,))
+        db.execute("INSERT INTO bilan_fec_imports (fichier_nom,annee,nb_ecritures) VALUES ('f',?,1)", (annee,))
+        imp = db.execute("SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1").fetchone()['id']
+        for m in (1, 2, 3):
+            db.execute("INSERT INTO bilan_fec_donnees (compte_num,code_analytique,annee,mois,montant,import_id) "
+                       "VALUES ('641000','ANA-A',?,?,1000,?)", (annee, m, imp))
+        for m in (1, 2, 3, 4, 5, 6):
+            db.execute("INSERT INTO bilan_fec_donnees (compte_num,code_analytique,annee,mois,montant,import_id) "
+                       "VALUES ('641000','ANA-B',?,?,2000,?)", (annee, m, imp))
+        db.commit()
+        la, ta = _paie_reel_641(db, sa, '641000', annee)
+        lb, tb = _paie_reel_641(db, sb, '641000', annee)
+    assert (la, ta) == (3, 3000.0)
+    assert (lb, tb) == (6, 12000.0)
+
+
+def test_paie_employes_ignore_contrat_annee_suivante(app, db):
+    """Un salarié avec un contrat valide sur l'année ET un contrat futur déjà
+    saisi reste pris dans la simulation (P2)."""
+    from blueprints.budget import _paie_employes_secteur
+    annee = 2026
+    with app.app_context():
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('SC','administratif')")
+        sid = db.execute("SELECT id FROM secteurs WHERE nom='SC'").fetchone()['id']
+        db.execute("INSERT INTO users (nom,prenom,login,password,profil,actif,secteur_id,date_entree) "
+                   "VALUES ('X','Y','xy_paie','x','salarie',1,?,?)", (sid, f'{annee-1}-01-01'))
+        uid = db.execute("SELECT id FROM users WHERE login='xy_paie'").fetchone()['id']
+        db.execute("INSERT INTO contrats (user_id,type_contrat,date_debut,date_fin) VALUES (?, 'CDD', ?, ?)",
+                   (uid, f'{annee}-01-01', f'{annee}-12-31'))
+        db.execute("INSERT INTO contrats (user_id,type_contrat,date_debut,date_fin) VALUES (?, 'CDI', ?, NULL)",
+                   (uid, f'{annee+1}-01-01'))
+        db.commit()
+        employes = _paie_employes_secteur(db, sid, annee)
+    e = next((x for x in employes if x['id'] == uid), None)
+    assert e is not None
+    assert e['type_contrat'] == 'CDD'
+    assert e['mois_debut'] == 1 and e['mois_fin'] == 12

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -785,3 +785,103 @@ def test_suppression_tranche_bloquee_si_utilisee_par_simulation_ps(app, db, admi
     with app.app_context():
         still = db.execute("SELECT COUNT(*) FROM alsh_tranches_age WHERE id = ?", (tid,)).fetchone()[0]
     assert still == 1
+
+
+# ============================================================
+# Simulateur de paie (masse salariale)
+# ============================================================
+
+def _setup_paie_secteur(db, annee):
+    """Secteur + 1 CDI actif + comptes 641/645 + FEC N-1 pour le prorata."""
+    db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Paie test','administratif')")
+    sid = db.execute("SELECT id FROM secteurs WHERE nom='Paie test'").fetchone()['id']
+    db.execute("INSERT INTO users (nom,prenom,login,password,profil,actif,secteur_id,date_entree,pesee) "
+               "VALUES ('Doe','Jane','jdoe_paie','x','salarie',1,?,?,0)", (sid, f'{annee-3}-01-01'))
+    uid = db.execute("SELECT id FROM users WHERE login='jdoe_paie'").fetchone()['id']
+    db.execute("INSERT INTO contrats (user_id,type_contrat,date_debut,date_fin) VALUES (?, 'CDI', ?, NULL)",
+               (uid, f'{annee-3}-01-01'))
+    db.execute("INSERT INTO comptabilite_comptes (compte_num,libelle,secteur_id) VALUES ('641000','Brut',?)", (sid,))
+    db.execute("INSERT INTO comptabilite_comptes (compte_num,libelle,secteur_id) VALUES ('645000','Cotis',?)", (sid,))
+    db.execute("INSERT INTO bilan_fec_imports (fichier_nom,annee,nb_ecritures) VALUES ('f',?,2)", (annee - 1,))
+    imp = db.execute("SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1").fetchone()['id']
+    db.execute("INSERT INTO bilan_fec_donnees (compte_num,annee,mois,montant,import_id) VALUES ('641000',?,1,100000,?)", (annee - 1, imp))
+    db.execute("INSERT INTO bilan_fec_donnees (compte_num,annee,mois,montant,import_id) VALUES ('645000',?,1,40000,?)", (annee - 1, imp))
+    db.commit()
+    return sid, uid
+
+
+def test_paie_context_liste_employes(app, db, admin_client):
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    data = admin_client.get(
+        f'/api/budget-previsionnel/paie-context?annee={annee}&secteur_id={sid}&compte_num=641000&type_budget=initial'
+    ).get_json()
+    emp = next(e for e in data['employes'] if e['id'] == uid)
+    assert emp['type_contrat'] == 'CDI'
+    assert emp['anciennete'] == 3
+    assert emp['mois_debut'] == 1 and emp['mois_fin'] == 12
+
+
+def test_paie_simulation_calcule_et_reporte(app, db, admin_client):
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '', 'anciennete': 0, 'competence': 0}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial',
+        'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert abs(data['total'] - 23000.0) < 0.01  # brut annuel = 12 × 23000/12
+    with app.app_context():
+        d641 = db.execute("SELECT valeur_def FROM budget_prev_saisies WHERE compte_num='641000' "
+                          "AND annee=? AND secteur_id=? AND type_budget='initial'", (annee, sid)).fetchone()
+        d645 = db.execute("SELECT valeur_def FROM budget_prev_saisies WHERE compte_num='645000' "
+                          "AND annee=? AND secteur_id=? AND type_budget='initial'", (annee, sid)).fetchone()
+    assert d641 and abs(d641['valeur_def'] - 23000.0) < 0.01
+    # prorata 645 = 23000 × 40000/100000 = 9200
+    assert d645 and abs(d645['valeur_def'] - 9200.0) < 0.01
+
+
+def test_paie_simulation_persiste_pesee_competence(app, db, admin_client):
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'employes': {str(uid): {'pesee': 120, 'competence': 5, 'anciennete': 3, 'nouvelle_pesee': ''}},
+               'ajouts': [], 'fermetures': []}
+    admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': donnees})
+    with app.app_context():
+        u = db.execute("SELECT pesee, competence FROM users WHERE id=?", (uid,)).fetchone()
+    assert u['pesee'] == 120 and u['competence'] == 5
+
+
+def test_paie_simulation_refuse_responsable(resp_client, sample_users):
+    sid = sample_users['secteur_id']
+    r = resp_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': 2026, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': {}})
+    assert r.status_code == 403
+
+
+def test_budget_649_exclu_du_prorata_salaire(app, db, admin_client):
+    """Un compte 649 n'est plus traité comme salaire (exclu du prorata du brut)."""
+    from blueprints.budget import _compute_budget_previsionnel
+    annee = 2026
+    with app.app_context():
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('S649','administratif')")
+        sid = db.execute("SELECT id FROM secteurs WHERE nom='S649'").fetchone()['id']
+        db.execute("INSERT INTO comptabilite_comptes (compte_num,libelle,secteur_id) VALUES ('641000','Brut',?)", (sid,))
+        db.execute("INSERT INTO comptabilite_comptes (compte_num,libelle,secteur_id) VALUES ('649000','Divers',?)", (sid,))
+        db.execute("INSERT INTO bilan_fec_imports (fichier_nom,annee,nb_ecritures) VALUES ('f',?,2)", (annee - 1,))
+        imp = db.execute("SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1").fetchone()['id']
+        db.execute("INSERT INTO bilan_fec_donnees (compte_num,annee,mois,montant,import_id) VALUES ('641000',?,1,100000,?)", (annee - 1, imp))
+        db.execute("INSERT INTO bilan_fec_donnees (compte_num,annee,mois,montant,import_id) VALUES ('649000',?,1,10000,?)", (annee - 1, imp))
+        db.commit()
+        data = _compute_budget_previsionnel(db, 'initial', annee, sid)
+    rows = {r['compte_num']: r for r in data['rows']}
+    assert rows['641000']['is_salary'] is True
+    assert rows['649000']['is_salary'] is False
+    assert '649000' not in data['salary_ratios']


### PR DESCRIPTION
## Résumé

Simulateur de **masse salariale** (la paie = 70-80 % du budget), dans la continuité des simulateurs PS/ALSH. Bouton **🧮 Paie** sur le 1ᵉʳ compte **641** (salaire brut) du budget d'un secteur. Persisté par **année + secteur + type de budget**, recalculé côté serveur et reporté sur le 641.

### Périmètre & paramètres (validés avec toi)
- **Salariés filtrés par secteur** (CDI/CDD actifs rattachés au secteur du budget).
- **Brut mensuel** = `(socle + (pesée + ancienneté + compétence) × valeur du point) / 12` — socle 23 000 €, point 55 par défaut.
- **Ancienneté** = années révolues (floor) depuis la date d'entrée.
- **Compétence** : nouvelle colonne `users.competence`, ajoutée sur la fiche salarié (à côté de la Pesée ALISFA) **et** éditable dans le simulateur (mêmes variables, persistées au report).
- Colonne **« nouvelle pesée »** pour simuler un changement.

### Contenu du simulateur
- **Salariés en cours de contrat** : table mois × salarié + total ; CDD limité à `date_fin` si avant décembre.
- **Ajouts** : CDI (pesée, ancienneté, mois d'embauche) et CDD (pesée, ancienneté, mois début/fin), compétence 0.
- **CEE** : forfait jour (déf. 70 €), CEE moyen/mercredi périscolaire, CEE moyen/jour de vacances, **2 périodes de fermeture**. Coût mensuel = (mercredis scolaires + **jours ouvrés lun–ven** de vacances, hors fériés et hors fermeture) × forfait, calendrier en base.
- **Brut total** par mois et sur l'année.

### Report
- Bouton **« Reporter sur le 641 (et 63x/64x) »** : écrit le brut total en **valeur définitive** du 641, puis répartit les autres comptes **63x/64x (hors 649)** au prorata — ratio **N‑1** (budget initial) ou **réel YTD** (budget actualisé). Les comptes **649** sont désormais exclus du prorata du brut.

### Budget actualisé
- Seuls les **mois absents en base** (FEC du 641) sont simulés ; le total = **réel constaté + simulé** ; prorata basé sur le réel de l'année en cours.

### Vérifications
- Calculs **JS = Python** (CDI 28 775 € · actualisé 64 387,50 € · CEE 140 € · CEE fermeture → 0 €).
- Migration **0045** (`users.competence` + `budget_paie_simulations`), JS validé (`node --check`), **569 tests OK** (dont nouveaux tests paie + exclusion 649).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3)_