### PR TITLE
Paie : direction rattachée au secteur administratif + maintien de salaire

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1835,13 +1835,40 @@ def _paie_mois_actifs(date_debut, date_fin, annee):
 
 
 def _paie_employes_secteur(conn, secteur_id, annee):
-    """Salariés actifs du secteur avec un contrat CDI/CDD chevauchant l'année."""
-    rows = conn.execute('''
-        SELECT id, nom, prenom, pesee, competence, date_entree
-        FROM users
-        WHERE actif = 1 AND profil != 'prestataire' AND secteur_id = ?
-        ORDER BY nom, prenom
-    ''', (secteur_id,)).fetchall()
+    """Salariés actifs du secteur avec un contrat CDI/CDD chevauchant l'année.
+
+    La direction (profil 'directeur'), généralement sans secteur opérationnel,
+    est rattachée au secteur administratif (et n'apparaît que là). Pour éviter
+    tout double comptage si plusieurs secteurs sont de type 'administratif',
+    la direction n'est incluse que dans le secteur administratif principal
+    (le plus petit id).
+    """
+    sect = conn.execute('SELECT type_secteur FROM secteurs WHERE id = ?', (secteur_id,)).fetchone()
+    is_admin = bool(sect) and (sect['type_secteur'] == 'administratif')
+    inclut_direction = False
+    if is_admin:
+        primary = conn.execute(
+            "SELECT MIN(id) AS mid FROM secteurs WHERE type_secteur = 'administratif'"
+        ).fetchone()
+        inclut_direction = bool(primary) and (primary['mid'] == secteur_id)
+
+    if inclut_direction:
+        rows = conn.execute('''
+            SELECT id, nom, prenom, pesee, competence, maintien, date_entree
+            FROM users
+            WHERE actif = 1 AND profil != 'prestataire'
+              AND (secteur_id = ? OR profil = 'directeur')
+            ORDER BY nom, prenom
+        ''', (secteur_id,)).fetchall()
+    else:
+        # Hors secteur administratif principal : la direction n'apparaît pas.
+        rows = conn.execute('''
+            SELECT id, nom, prenom, pesee, competence, maintien, date_entree
+            FROM users
+            WHERE actif = 1 AND profil != 'prestataire' AND profil != 'directeur'
+              AND secteur_id = ?
+            ORDER BY nom, prenom
+        ''', (secteur_id,)).fetchall()
     employes = []
     for u in rows:
         # Ne retenir que les contrats CDI/CDD qui chevauchent l'année de budget :
@@ -1864,6 +1891,7 @@ def _paie_employes_secteur(conn, secteur_id, annee):
         employes.append({
             'id': u['id'], 'nom': u['nom'], 'prenom': u['prenom'],
             'pesee': u['pesee'], 'competence': u['competence'],
+            'maintien': u['maintien'] if u['maintien'] is not None else 0,
             'type_contrat': contrat['type_contrat'],
             'anciennete': _paie_anciennete_annees(u['date_entree'], annee),
             'mois_debut': mb, 'mois_fin': mf,
@@ -2002,16 +2030,17 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         pesee_eff = _ps_num(nouv) if nouv not in (None, '') else pesee_act
         anciennete = _ps_num(ov.get('anciennete'), e['anciennete'] or 0)
         competence = _ps_num(ov.get('competence'), e['competence'] or 0)
+        maintien = _ps_num(ov.get('maintien'), e.get('maintien') or 0)
         mois_vals, total_e = {}, 0.0
         for m in range(max(start_month, e['mois_debut']), e['mois_fin'] + 1):
-            val = brut_mensuel(pesee_eff, anciennete, competence)
+            val = brut_mensuel(pesee_eff, anciennete, competence) + maintien
             mois_vals[m] = round(val, 2)
             monthly_totals[m] += val
             total_e += val
         lignes.append({
             'id': e['id'], 'nom': e['nom'], 'prenom': e['prenom'],
             'type_contrat': e['type_contrat'], 'pesee_eff': pesee_eff,
-            'anciennete': anciennete, 'competence': competence,
+            'anciennete': anciennete, 'competence': competence, 'maintien': maintien,
             'mois': mois_vals, 'total': round(total_e, 2),
         })
 
@@ -2023,6 +2052,7 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         pesee_eff = _ps_num(a.get('pesee'))
         anciennete = _ps_num(a.get('anciennete'))
         competence = _ps_num(a.get('competence'))
+        maintien = _ps_num(a.get('maintien'))
         if typ == 'cdd':
             mb = int(_ps_num(a.get('mois_debut'), 1)) or 1
             mf = int(_ps_num(a.get('mois_fin'), 12)) or 12
@@ -2033,13 +2063,13 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         mf = min(max(mf, 1), 12)
         mois_vals, total_a = {}, 0.0
         for m in range(max(start_month, mb), mf + 1):
-            val = brut_mensuel(pesee_eff, anciennete, competence)
+            val = brut_mensuel(pesee_eff, anciennete, competence) + maintien
             mois_vals[m] = round(val, 2)
             monthly_totals[m] += val
             total_a += val
         ajouts_out.append({
             'type': typ, 'pesee': pesee_eff, 'anciennete': anciennete,
-            'competence': competence, 'mois_debut': mb, 'mois_fin': mf,
+            'competence': competence, 'maintien': maintien, 'mois_debut': mb, 'mois_fin': mf,
             'mois': mois_vals, 'total': round(total_a, 2),
         })
 
@@ -2208,10 +2238,12 @@ def api_paie_simulation_save():
                 continue
             pesee = ov.get('pesee')
             comp = ov.get('competence')
+            maint = ov.get('maintien')
             conn.execute(
-                'UPDATE users SET pesee = ?, competence = ? WHERE id = ?',
-                (int(pesee) if str(pesee).strip() not in ('', 'None') else None,
-                 int(comp) if str(comp).strip() not in ('', 'None') else None,
+                'UPDATE users SET pesee = ?, competence = ?, maintien = ? WHERE id = ?',
+                (int(float(pesee)) if str(pesee).strip() not in ('', 'None') else None,
+                 int(float(comp)) if str(comp).strip() not in ('', 'None') else None,
+                 float(maint) if str(maint).strip() not in ('', 'None') else 0,
                  uid)
             )
 

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -2021,16 +2021,23 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
     def brut_mensuel(pesee, anciennete, competence):
         return (socle + (pesee + anciennete + competence) * point) / 12.0
 
+    def override_num(ov, key, db_value):
+        # Champ présent (même vide) => saisie (vide = 0, cohérent avec la
+        # persistance sur la fiche) ; champ absent => valeur de la fiche.
+        if isinstance(ov, dict) and key in ov:
+            return _ps_num(ov.get(key), 0)
+        return _ps_num(db_value, 0)
+
     monthly_totals = {m: 0.0 for m in range(1, 13)}
     lignes = []
     for e in employes_base:
         ov = overrides.get(str(e['id'])) or overrides.get(e['id']) or {}
-        pesee_act = _ps_num(ov.get('pesee'), e['pesee'] or 0)
+        pesee_act = override_num(ov, 'pesee', e['pesee'])
         nouv = ov.get('nouvelle_pesee')
         pesee_eff = _ps_num(nouv) if nouv not in (None, '') else pesee_act
-        anciennete = _ps_num(ov.get('anciennete'), e['anciennete'] or 0)
-        competence = _ps_num(ov.get('competence'), e['competence'] or 0)
-        maintien = _ps_num(ov.get('maintien'), e.get('maintien') or 0)
+        anciennete = override_num(ov, 'anciennete', e['anciennete'])
+        competence = override_num(ov, 'competence', e['competence'])
+        maintien = override_num(ov, 'maintien', e.get('maintien'))
         mois_vals, total_e = {}, 0.0
         for m in range(max(start_month, e['mois_debut']), e['mois_fin'] + 1):
             val = brut_mensuel(pesee_eff, anciennete, competence) + maintien

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -307,6 +307,8 @@ def modifier_pesee():
     pesee = int(pesee_val) if pesee_val else None
     competence_val = request.form.get('competence', '').strip()
     competence = int(competence_val) if competence_val else None
+    maintien_val = request.form.get('maintien', '').strip()
+    maintien = float(maintien_val) if maintien_val else 0
 
     if not user_id:
         flash("Salarie invalide.", 'error')
@@ -317,8 +319,8 @@ def modifier_pesee():
         conn.close()
         flash("Acces non autorise.", 'error')
         return redirect(url_for('infos_salaries_bp.infos_salaries'))
-    conn.execute('UPDATE users SET pesee = ?, competence = ? WHERE id = ?',
-                 (pesee, competence, user_id))
+    conn.execute('UPDATE users SET pesee = ?, competence = ?, maintien = ? WHERE id = ?',
+                 (pesee, competence, maintien, user_id))
     conn.commit()
     conn.close()
 

--- a/database.py
+++ b/database.py
@@ -218,6 +218,7 @@ def init_db():
             date_entree TEXT,
             pesee INTEGER,
             competence INTEGER,
+            maintien REAL DEFAULT 0,
             email TEXT,
             email_notifications_enabled INTEGER DEFAULT 0,
             force_password_change INTEGER DEFAULT 0,

--- a/migrations/0046_maintien_salaire.py
+++ b/migrations/0046_maintien_salaire.py
@@ -1,0 +1,24 @@
+"""
+Migration 0046 : Ajout du maintien de salaire.
+
+Certains salariés disposent d'un « maintien » de salaire (mis en place lors du
+changement de mode de calcul des salaires). Ce montant mensuel s'ajoute au brut
+dans le simulateur de paie. Colonne users.maintien (défaut 0).
+"""
+
+NOM = "Ajout maintien de salaire"
+DESCRIPTION = "Ajoute la colonne users.maintien (montant mensuel ajouté au brut)."
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SELECT maintien FROM users LIMIT 1")
+    except Exception:
+        cursor.execute("ALTER TABLE users ADD COLUMN maintien REAL DEFAULT 0")
+
+
+def downgrade(conn):
+    """Pas de downgrade (la colonne est conservée)."""
+    conn.commit()

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -1424,7 +1424,8 @@ function defaultPaieState(ctx){
             pesee: e.pesee != null ? e.pesee : '',
             nouvelle_pesee: '',
             anciennete: e.anciennete != null ? e.anciennete : 0,
-            competence: e.competence != null ? e.competence : ''
+            competence: e.competence != null ? e.competence : '',
+            maintien: e.maintien != null ? e.maintien : 0
         };
     });
     return st;
@@ -1466,19 +1467,20 @@ function computePaieJS(st, ctx, typeBudget){
         var pAct = psNum(ov.pesee, e.pesee || 0);
         var pEff = (ov.nouvelle_pesee !== '' && ov.nouvelle_pesee != null) ? psNum(ov.nouvelle_pesee) : pAct;
         var anc = psNum(ov.anciennete, e.anciennete || 0), comp = psNum(ov.competence, e.competence || 0);
+        var maint = psNum(ov.maintien, e.maintien || 0);
         var mvals = {}, tot = 0;
-        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp); mvals[m]=v; monthly[m]+=v; tot+=v; }
+        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
         lignes[e.id] = {mois: mvals, total: tot, pesee_eff: pEff};
     });
     var ajouts = {};
     (st.ajouts || []).forEach(function(a, i){
         var typ = (a.type === 'cdd') ? 'cdd' : 'cdi';
-        var pEff = psNum(a.pesee), anc = psNum(a.anciennete), comp = psNum(a.competence);
+        var pEff = psNum(a.pesee), anc = psNum(a.anciennete), comp = psNum(a.competence), maint = psNum(a.maintien);
         var mb = (typ==='cdd') ? (parseInt(a.mois_debut,10)||1) : (parseInt(a.mois_embauche,10)||1);
         var mf = (typ==='cdd') ? (parseInt(a.mois_fin,10)||12) : 12;
         mb=Math.min(Math.max(mb,1),12); mf=Math.min(Math.max(mf,1),12);
         var mvals = {}, tot = 0;
-        for (var m=Math.max(start,mb); m<=mf; m++){ var v=brut(pEff,anc,comp); mvals[m]=v; monthly[m]+=v; tot+=v; }
+        for (var m=Math.max(start,mb); m<=mf; m++){ var v=brut(pEff,anc,comp)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
         ajouts[i] = {mois: mvals, total: tot};
     });
     var ceeJours = paieCeeParMois(ctx, st), ceeCout = {};
@@ -1514,7 +1516,7 @@ function renderPaieSimulator(){
         html += '<p class="ps-legend">Aucun salarié actif en CDI/CDD rattaché à ce secteur sur l\'année.</p>';
     } else {
         html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
-            '<th>Salarié</th><th>Type</th><th>Pesée actuelle</th><th>Nouvelle pesée</th><th>Ancienneté</th><th>Compétence</th>' +
+            '<th>Salarié</th><th>Type</th><th>Pesée actuelle</th><th>Nouvelle pesée</th><th>Ancienneté</th><th>Compétence</th><th>Maintien €/mois</th>' +
             monthTh + '<th class="bp-ps-calc">Total</th></tr></thead><tbody>';
         (ctx.employes || []).forEach(function(e){
             var ov = st.employes[e.id] || {};
@@ -1524,6 +1526,7 @@ function renderPaieSimulator(){
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="nouvelle_pesee"', ov.nouvelle_pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="anciennete"', ov.anciennete, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="competence"', ov.competence, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="maintien"', ov.maintien, '0.01') + '</td>' +
                 months.map(function(m){ return '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-' + m + '"></td>'; }).join('') +
                 '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-tot"></td></tr>';
         });
@@ -1536,13 +1539,14 @@ function renderPaieSimulator(){
         '<button class="btn btn-sm btn-secondary" type="button" onclick="paieAddAjout(\'cdd\')">+ CDD</button></div>';
     if ((st.ajouts || []).length){
         html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
-            '<th>Type</th><th>Pesée</th><th>Ancienneté</th><th>Mois début / embauche</th><th>Mois fin (CDD)</th>' +
+            '<th>Type</th><th>Pesée</th><th>Ancienneté</th><th>Maintien €/mois</th><th>Mois début / embauche</th><th>Mois fin (CDD)</th>' +
             monthTh + '<th class="bp-ps-calc">Total</th><th></th></tr></thead><tbody>';
         st.ajouts.forEach(function(a, i){
             var isCdd = (a.type === 'cdd');
             html += '<tr><td class="ps-col-mois">' + (isCdd ? 'CDD' : 'CDI') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="pesee"', a.pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="anciennete"', a.anciennete, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="maintien"', a.maintien, '0.01') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="' + (isCdd ? 'mois_debut' : 'mois_embauche') + '"', isCdd ? a.mois_debut : a.mois_embauche, '1') + '</td>' +
                 '<td>' + (isCdd ? paieInput('data-paie-aj="' + i + '" data-paie-key="mois_fin"', a.mois_fin, '1') : '—') + '</td>' +
                 months.map(function(m){ return '<td class="bp-ps-calc" id="paie-aj-' + i + '-' + m + '"></td>'; }).join('') +
@@ -1603,8 +1607,8 @@ function bindPaieInputs(){
 }
 function paieAddAjout(type){
     paieSim.state.ajouts.push(type === 'cdd'
-        ? {type:'cdd', pesee:'', anciennete:'', competence:0, mois_debut:1, mois_fin:12}
-        : {type:'cdi', pesee:'', anciennete:'', competence:0, mois_embauche:1});
+        ? {type:'cdd', pesee:'', anciennete:'', competence:0, maintien:0, mois_debut:1, mois_fin:12}
+        : {type:'cdi', pesee:'', anciennete:'', competence:0, maintien:0, mois_embauche:1});
     renderPaieSimulator(); recomputePaie();
 }
 function paieRemoveAjout(i){ paieSim.state.ajouts.splice(i,1); renderPaieSimulator(); recomputePaie(); }

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -1460,14 +1460,16 @@ function computePaieJS(st, ctx, typeBudget){
     var reel = (typeBudget === 'actualise') ? (ctx.montant_reel || 0) : 0;
     var start = lastReal + 1;
     function brut(p,a,c){ return (socle + (p+a+c)*point) / 12; }
+    // Champ surchargé présent (même vide) => saisie (vide = 0) ; absent => fiche.
+    function ovNum(ov, key, dbVal){ return (ov && Object.prototype.hasOwnProperty.call(ov, key)) ? psNum(ov[key], 0) : psNum(dbVal, 0); }
     var monthly = {}; for (var m=1;m<=12;m++) monthly[m] = 0;
     var lignes = {};
     (ctx.employes || []).forEach(function(e){
         var ov = st.employes[e.id] || {};
-        var pAct = psNum(ov.pesee, e.pesee || 0);
+        var pAct = ovNum(ov, 'pesee', e.pesee);
         var pEff = (ov.nouvelle_pesee !== '' && ov.nouvelle_pesee != null) ? psNum(ov.nouvelle_pesee) : pAct;
-        var anc = psNum(ov.anciennete, e.anciennete || 0), comp = psNum(ov.competence, e.competence || 0);
-        var maint = psNum(ov.maintien, e.maintien || 0);
+        var anc = ovNum(ov, 'anciennete', e.anciennete), comp = ovNum(ov, 'competence', e.competence);
+        var maint = ovNum(ov, 'maintien', e.maintien);
         var mvals = {}, tot = 0;
         for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
         lignes[e.id] = {mois: mvals, total: tot, pesee_eff: pEff};

--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -83,6 +83,9 @@
             <label for="competence" style="font-weight: 600; margin: 0;">Points de compétence :</label>
             <input type="number" id="competence" name="competence" value="{{ salarie.competence if salarie.competence is not none else '' }}"
                    placeholder="Points" style="width: 120px; padding: 6px 10px;" min="0">
+            <label for="maintien" style="font-weight: 600; margin: 0;">Maintien de salaire (€/mois) :</label>
+            <input type="number" id="maintien" name="maintien" step="0.01" value="{{ salarie.maintien if salarie.maintien is not none else '' }}"
+                   placeholder="0" style="width: 120px; padding: 6px 10px;" min="0">
             <button type="submit" class="btn btn-primary btn-sm">Enregistrer</button>
             {% if salarie.pesee is not none %}
             <span style="font-size: 0.85rem; color: var(--gray-500);">{{ salarie.pesee }} pts + SSC</span>

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -975,3 +975,24 @@ def test_paie_maintien_ajoute_au_brut(app, db, admin_client):
     with app.app_context():
         u = db.execute("SELECT maintien FROM users WHERE id=?", (uid,)).fetchone()
     assert abs(u['maintien'] - 100) < 0.01
+
+
+def test_paie_maintien_vide_coherent(app, db, admin_client):
+    """Maintien vidé dans le simulateur : report ET fiche utilisent 0 (et non
+    l'ancienne valeur), de façon cohérente (revue P2)."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        db.execute("UPDATE users SET maintien = 200 WHERE id = ?", (uid,))
+        db.commit()
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '', 'anciennete': 0,
+                                       'competence': 0, 'maintien': ''}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    assert abs(r.get_json()['total'] - 23000.0) < 0.01  # maintien vidé -> 0
+    with app.app_context():
+        u = db.execute("SELECT maintien FROM users WHERE id=?", (uid,)).fetchone()
+    assert abs((u['maintien'] or 0) - 0) < 0.01

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -935,3 +935,43 @@ def test_paie_employes_ignore_contrat_annee_suivante(app, db):
     assert e is not None
     assert e['type_contrat'] == 'CDD'
     assert e['mois_debut'] == 1 and e['mois_fin'] == 12
+
+
+def test_paie_direction_rattachee_au_secteur_administratif(app, db):
+    """La direction (profil directeur) apparaît dans le secteur administratif
+    principal, et pas dans un secteur opérationnel."""
+    from blueprints.budget import _paie_employes_secteur
+    annee = 2026
+    with app.app_context():
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Admin','administratif')")
+        admin_sid = db.execute("SELECT id FROM secteurs WHERE nom='Admin'").fetchone()['id']
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Creche','creche')")
+        op_sid = db.execute("SELECT id FROM secteurs WHERE nom='Creche'").fetchone()['id']
+        db.execute("INSERT INTO users (nom,prenom,login,password,profil,actif,secteur_id,date_entree) "
+                   "VALUES ('Dir','Ecteur','dir_paie','x','directeur',1,NULL,?)", (f'{annee-5}-01-01',))
+        did = db.execute("SELECT id FROM users WHERE login='dir_paie'").fetchone()['id']
+        db.execute("INSERT INTO contrats (user_id,type_contrat,date_debut,date_fin) VALUES (?, 'CDI', ?, NULL)",
+                   (did, f'{annee-5}-01-01'))
+        db.commit()
+        admin_emps = _paie_employes_secteur(db, admin_sid, annee)
+        op_emps = _paie_employes_secteur(db, op_sid, annee)
+    assert any(e['id'] == did for e in admin_emps)
+    assert not any(e['id'] == did for e in op_emps)
+
+
+def test_paie_maintien_ajoute_au_brut(app, db, admin_client):
+    """Le maintien de salaire s'ajoute au brut mensuel et est persisté sur la fiche."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '', 'anciennete': 0,
+                                       'competence': 0, 'maintien': 100}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    assert abs(r.get_json()['total'] - 24200.0) < 0.01  # 23000 + 12 × 100
+    with app.app_context():
+        u = db.execute("SELECT maintien FROM users WHERE id=?", (uid,)).fetchone()
+    assert abs(u['maintien'] - 100) < 0.01


### PR DESCRIPTION
## Résumé

Deux ajustements du simulateur de paie demandés après test :

### 1. Direction rattachée au secteur administratif
Les salariés de profil **directeur** (généralement sans secteur opérationnel) n'apparaissaient dans aucun simulateur de paie. Ils sont désormais inclus dans le **secteur administratif principal** (le plus petit id parmi les secteurs de type `administratif`) et **uniquement là** — pas de double comptage si un directeur a aussi un secteur, et ils ne polluent pas les secteurs opérationnels.

### 2. Maintien de salaire
Certains salariés ont un **maintien** de salaire (mis en place lors du changement de mode de calcul). Ajouté :
- Colonne **`users.maintien`** (défaut 0, migration **0046**).
- Champ éditable sur la fiche **`infos_salaries`** (à côté de la pesée / compétence).
- Colonne éditable directement dans les **tableaux du simulateur** (salariés en base **et** ajouts CDI/CDD).
- Ce montant **s'ajoute au brut mensuel** : `brut = (socle + (pesée + ancienneté + compétence) × point) / 12 + maintien`.
- Persisté sur la fiche salarié au moment du report (comme la pesée et la compétence).

### Vérifications
- Calculs **JS = Python** (maintien 100 €/mois → +1 200 €/an, ex. 24 200 € ; override simulateur OK).
- JS validé (`node --check`), migration 0046 appliquée, **573 tests OK** (nouveaux : direction→administratif, maintien ajouté + persisté).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3)_