### PR TITLE
Paie : auto-réparer les colonnes competence/maintien (salariés invisibles)

### DIFF
--- a/database.py
+++ b/database.py
@@ -1616,6 +1616,18 @@ def init_db():
     except sqlite3.OperationalError:
         cursor.execute("ALTER TABLE users ADD COLUMN pesee INTEGER")
 
+    # Migration : ajouter competence si n'existe pas (simulateur de paie)
+    try:
+        cursor.execute("SELECT competence FROM users LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE users ADD COLUMN competence INTEGER")
+
+    # Migration : ajouter maintien si n'existe pas (maintien de salaire)
+    try:
+        cursor.execute("SELECT maintien FROM users LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE users ADD COLUMN maintien REAL DEFAULT 0")
+
     # Migration : ajouter email si n'existe pas
     try:
         cursor.execute("SELECT email FROM users LIMIT 1")

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -1394,9 +1394,17 @@ function openPaieSimulator(compteNum){
     var surl = '/api/budget-previsionnel/paie-simulation?annee=' + ctx.annee + '&secteur_id=' + ctx.secteur_id +
         '&type_budget=' + encodeURIComponent(ctx.type_budget);
     Promise.all([
-        fetch(curl).then(r => r.json()).catch(function(){ return {employes:[], mercredis_dates:[], vacances_dates:[]}; }),
+        fetch(curl).then(function(r){ return r.ok ? r.json() : {__error: true}; }).catch(function(){ return {__error: true}; }),
         fetch(surl).then(r => r.json()).then(function(d){ return (d && d.found) ? d.donnees : null; }).catch(function(){ return null; })
     ]).then(function(res){
+        if (res[0] && res[0].__error){
+            document.getElementById('paieSimBody').innerHTML =
+                '<p class="ps-legend" style="color:#b00;">Impossible de charger les salariés. Vérifiez que les mises à jour de la base sont appliquées (Administration → Mises à jour BDD), puis réessayez.</p>';
+            document.getElementById('paieSimFooter').innerHTML =
+                '<button class="btn btn-secondary" type="button" onclick="closePaieSimulator()">Fermer</button>';
+            document.getElementById('paieSimulatorModal').classList.add('open');
+            return;
+        }
         paieSim.context = res[0] || {employes:[], mercredis_dates:[], vacances_dates:[]};
         paieSim.state = mergePaieState(res[1], paieSim.context);
         renderPaieSimulator();

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -996,3 +996,20 @@ def test_paie_maintien_vide_coherent(app, db, admin_client):
     with app.app_context():
         u = db.execute("SELECT maintien FROM users WHERE id=?", (uid,)).fetchone()
     assert abs((u['maintien'] or 0) - 0) < 0.01
+
+
+def test_init_db_reajoute_colonnes_paie_si_absentes(app, db):
+    """init_db ré-ajoute users.competence et users.maintien si elles manquent
+    (auto-réparation au démarrage, sans migration manuelle). Sinon la requête
+    des salariés du simulateur de paie échoue et aucun salarié n'apparaît."""
+    import database
+    with app.app_context():
+        db.execute("ALTER TABLE users DROP COLUMN maintien")
+        db.execute("ALTER TABLE users DROP COLUMN competence")
+        db.commit()
+        cols = [r[1] for r in db.execute("PRAGMA table_info(users)").fetchall()]
+        assert 'maintien' not in cols and 'competence' not in cols
+        database.init_db()
+        cols = [r[1] for r in db.execute("PRAGMA table_info(users)").fetchall()]
+    assert 'maintien' in cols
+    assert 'competence' in cols


### PR DESCRIPTION
## Contexte

Après fusion du maintien de salaire (#169), **plus aucun salarié n'apparaissait** dans le simulateur de paie, sur tous les secteurs, en budget initial comme actualisé.

## Cause

Sur une base de données **existante**, les colonnes `users.competence` (migration 0045) et `users.maintien` (migration 0046) n'existent que si les migrations ont été appliquées. Sans elles, la requête des salariés (`SELECT … competence, maintien …`) échoue avec *no such column*, l'endpoint de contexte renvoie une erreur, et le front-end retombe silencieusement sur une **liste vide** — d'où « aucun salarié » partout.

`init_db()` (exécuté à chaque démarrage) possède déjà des gardes auto-réparatrices pour d'autres colonnes (`pesee`, `email`…), mais **pas** pour `competence` / `maintien`.

## Correctif

- `init_db()` ajoute désormais `users.competence` et `users.maintien` si elles manquent (mêmes gardes `try/except` que les autres). Un **simple redémarrage** suffit donc à réparer la base, sans migration manuelle.
- En complément, le simulateur affiche un **message clair** (« Vérifiez que les mises à jour de la base sont appliquées… ») si le chargement des salariés échoue, au lieu d'une liste vide trompeuse.

## Vérifications
- Reproduction : en supprimant les colonnes puis en relançant `init_db()`, elles sont bien recréées et la requête des salariés refonctionne (test ajouté).
- **575 tests OK**, JS validé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3)_