### PR TITLE
Paie : ancienneté/prorata basés sur le contrat + proratisation temps partiel

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1797,12 +1797,16 @@ PAIE_DEFAULTS = {
 }
 
 
-def _paie_anciennete_annees(date_entree, annee):
-    """Années révolues d'ancienneté au 1er janvier de l'année de budget (floor)."""
-    if not date_entree:
+def _paie_anciennete_annees(date_ref, annee):
+    """Années révolues d'ancienneté au 1er janvier de l'année de budget (floor).
+
+    La date de référence est la date de début du contrat en cours de validité
+    (c'est le contrat qui compte, pas users.date_entree saisie à la création).
+    """
+    if not date_ref:
         return 0
     try:
-        d = date.fromisoformat(str(date_entree)[:10])
+        d = date.fromisoformat(str(date_ref)[:10])
     except (ValueError, TypeError):
         return 0
     ref = date(annee, 1, 1)
@@ -1854,7 +1858,7 @@ def _paie_employes_secteur(conn, secteur_id, annee):
 
     if inclut_direction:
         rows = conn.execute('''
-            SELECT id, nom, prenom, pesee, competence, maintien, date_entree
+            SELECT id, nom, prenom, pesee, competence, maintien
             FROM users
             WHERE actif = 1 AND profil != 'prestataire'
               AND (secteur_id = ? OR profil = 'directeur')
@@ -1863,7 +1867,7 @@ def _paie_employes_secteur(conn, secteur_id, annee):
     else:
         # Hors secteur administratif principal : la direction n'apparaît pas.
         rows = conn.execute('''
-            SELECT id, nom, prenom, pesee, competence, maintien, date_entree
+            SELECT id, nom, prenom, pesee, competence, maintien
             FROM users
             WHERE actif = 1 AND profil != 'prestataire' AND profil != 'directeur'
               AND secteur_id = ?
@@ -1893,7 +1897,7 @@ def _paie_employes_secteur(conn, secteur_id, annee):
             'pesee': u['pesee'], 'competence': u['competence'],
             'maintien': u['maintien'] if u['maintien'] is not None else 0,
             'type_contrat': contrat['type_contrat'],
-            'anciennete': _paie_anciennete_annees(u['date_entree'], annee),
+            'anciennete': _paie_anciennete_annees(contrat['date_debut'], annee),
             'mois_debut': mb, 'mois_fin': mf,
         })
     employes.sort(key=lambda e: (0 if e['type_contrat'] == 'CDI' else 1, e['nom'], e['prenom']))

--- a/blueprints/variables_paie.py
+++ b/blueprints/variables_paie.py
@@ -365,6 +365,15 @@ def cloturer_conges():
     # d'embauche en cours de mois. C'est le contrat qui compte.
     # Un contrat dont date_fin est exactement le dernier jour est exclu : les
     # conges acquis sont soldes en paie, les compteurs doivent repasser a zero.
+    #
+    # Cas multi-contrats (RARE) : si un salarie a plusieurs contrats encore
+    # actifs en fin de mois, on retient le PLUS ANCIEN en cours de validite
+    # (MIN(date_debut)) -> choix metier deliberé, favorable au salarie (mois
+    # plein plutot qu'un prorata sur le contrat le plus recent).
+    # Limite connue laissee de cote : en toute rigueur chaque contrat a son
+    # propre solde de conges et ceux-ci devraient se CUMULER (un solde par
+    # contrat). Ce n'est pas gere ici (cas exceptionnel, chantier a part). Si on
+    # revient un jour dessus, c'est le point a reprendre.
     dernier_du_mois_str = date(annee, mois, jours_dans_mois).strftime('%Y-%m-%d')
     contrat_debut = {
         row['user_id']: row['date_debut'] for row in conn.execute(

--- a/blueprints/variables_paie.py
+++ b/blueprints/variables_paie.py
@@ -349,7 +349,7 @@ def cloturer_conges():
 
     # Salaries actifs hors directeur et prestataire
     salaries = conn.execute('''
-        SELECT id, date_entree, cp_acquis, cp_a_prendre, cp_pris, cc_solde
+        SELECT id, cp_acquis, cp_a_prendre, cp_pris, cc_solde
         FROM users
         WHERE actif = 1 AND profil NOT IN ('directeur', 'prestataire')
     ''').fetchall()
@@ -359,17 +359,22 @@ def cloturer_conges():
     # Mois d'acquisition CC : octobre (10) a mai (5)
     mois_cc = mois in (10, 11, 12, 1, 2, 3, 4, 5)
 
-    # Salaries avec un contrat se poursuivant apres le dernier jour du mois.
+    # Salaries avec un contrat se poursuivant apres le dernier jour du mois, et
+    # la date de debut de ce contrat : c'est elle (et non users.date_entree,
+    # saisie a la creation et plus fiable) qui sert de reference pour le prorata
+    # d'embauche en cours de mois. C'est le contrat qui compte.
     # Un contrat dont date_fin est exactement le dernier jour est exclu : les
     # conges acquis sont soldes en paie, les compteurs doivent repasser a zero.
     dernier_du_mois_str = date(annee, mois, jours_dans_mois).strftime('%Y-%m-%d')
-    ids_avec_contrat = {
-        row['user_id'] for row in conn.execute(
-            '''SELECT DISTINCT user_id FROM contrats
-               WHERE date_debut <= ? AND (date_fin IS NULL OR date_fin > ?)''',
+    contrat_debut = {
+        row['user_id']: row['date_debut'] for row in conn.execute(
+            '''SELECT user_id, MIN(date_debut) AS date_debut FROM contrats
+               WHERE date_debut <= ? AND (date_fin IS NULL OR date_fin > ?)
+               GROUP BY user_id''',
             (dernier_du_mois_str, dernier_du_mois_str)
         ).fetchall()
     }
+    ids_avec_contrat = set(contrat_debut.keys())
 
     nb_traites = 0
     nb_resets = 0
@@ -382,7 +387,7 @@ def cloturer_conges():
             cp_a_prendre = sal['cp_a_prendre'] or 0
             cp_pris = sal['cp_pris'] or 0
             cc_solde = sal['cc_solde'] or 0
-            date_entree = sal['date_entree']
+            date_debut_contrat = contrat_debut.get(uid)
 
             # Sans contrat actif le dernier jour du mois : remise a zero des soldes
             if uid not in ids_avec_contrat:
@@ -395,11 +400,12 @@ def cloturer_conges():
                 details.append({'user_id': uid, 'reset_sans_contrat': True})
                 continue
 
-            # Calculer le prorata si embauche en cours de mois
+            # Calculer le prorata si embauche en cours de mois (= date de debut
+            # du contrat en cours, et non plus users.date_entree)
             prorata = 1.0
-            if date_entree:
+            if date_debut_contrat:
                 try:
-                    d_entree = datetime.strptime(date_entree, '%Y-%m-%d').date()
+                    d_entree = datetime.strptime(str(date_debut_contrat)[:10], '%Y-%m-%d').date()
                     premier_du_mois = date(annee, mois, 1)
                     dernier_du_mois = date(annee, mois, jours_dans_mois)
                     # Si l'entree est dans ce mois

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1013,3 +1013,41 @@ def test_init_db_reajoute_colonnes_paie_si_absentes(app, db):
         cols = [r[1] for r in db.execute("PRAGMA table_info(users)").fetchall()]
     assert 'maintien' in cols
     assert 'competence' in cols
+
+
+def test_paie_anciennete_depuis_contrat_directeur_sans_date_entree(app, db):
+    """L'ancienneté vient de la date de début du contrat, pas de users.date_entree.
+    Un directeur sans date_entree mais avec un contrat a une ancienneté correcte."""
+    from blueprints.budget import _paie_employes_secteur
+    annee = 2026
+    with app.app_context():
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Admin','administratif')")
+        sid = db.execute("SELECT id FROM secteurs WHERE nom='Admin'").fetchone()['id']
+        db.execute("INSERT INTO users (nom,prenom,login,password,profil,actif,secteur_id,date_entree) "
+                   "VALUES ('Dir','X','dir_anc','x','directeur',1,NULL,NULL)")
+        did = db.execute("SELECT id FROM users WHERE login='dir_anc'").fetchone()['id']
+        db.execute("INSERT INTO contrats (user_id,type_contrat,date_debut,date_fin) VALUES (?, 'CDI', ?, NULL)",
+                   (did, f'{annee-4}-01-01'))
+        db.commit()
+        employes = _paie_employes_secteur(db, sid, annee)
+    e = next(x for x in employes if x['id'] == did)
+    assert e['anciennete'] == 4
+
+
+def test_paie_anciennete_cdd_depuis_son_contrat(app, db):
+    """Pour un CDD, l'ancienneté est calculée depuis le début de SON contrat,
+    en ignorant une date_entree plus ancienne."""
+    from blueprints.budget import _paie_employes_secteur
+    annee = 2026
+    with app.app_context():
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Op','creche')")
+        sid = db.execute("SELECT id FROM secteurs WHERE nom='Op'").fetchone()['id']
+        db.execute("INSERT INTO users (nom,prenom,login,password,profil,actif,secteur_id,date_entree) "
+                   "VALUES ('C','D','cdd_anc','x','salarie',1,?,?)", (sid, f'{annee-6}-01-01'))
+        uid = db.execute("SELECT id FROM users WHERE login='cdd_anc'").fetchone()['id']
+        db.execute("INSERT INTO contrats (user_id,type_contrat,date_debut,date_fin) VALUES (?, 'CDD', ?, ?)",
+                   (uid, f'{annee}-01-01', f'{annee}-08-31'))
+        db.commit()
+        employes = _paie_employes_secteur(db, sid, annee)
+    e = next(x for x in employes if x['id'] == uid)
+    assert e['anciennete'] == 0  # depuis le contrat (cette année), pas 6 (date_entree)

--- a/tests/test_variables_paie.py
+++ b/tests/test_variables_paie.py
@@ -424,6 +424,28 @@ class TestClotureCongesSansContrat:
             row = self._get_soldes(db, uid)
             assert abs(row['cp_acquis'] - round(25.0 / 12.0, 6)) < 0.001
 
+    def test_prorata_depuis_date_contrat_pas_date_entree(self, comptable_client, app, db, sample_users):
+        """Le prorata d'embauche en cours de mois utilise la date de début du
+        contrat, et non users.date_entree (qui n'est plus fiable)."""
+        uid = sample_users['salarie_id']
+        with app.app_context():
+            self._set_soldes(db, uid, cp_acquis=0, cp_a_prendre=0, cp_pris=0, cc_solde=0)
+            # date_entree volontairement ancienne : doit être ignorée
+            db.execute("UPDATE users SET date_entree = '2020-01-01' WHERE id = ?", (uid,))
+            db.commit()
+            self._add_contrat(db, uid, '2026-06-15')  # contrat démarrant en cours de mois
+
+        resp = comptable_client.post('/variables_paie/cloturer_conges', data={
+            'mois': '6', 'annee': '2026',
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+        with app.app_context():
+            row = self._get_soldes(db, uid)
+        # Juin = 30 jours ; du 15 au 30 = 16 jours -> prorata 16/30 (pas 1)
+        attendu = round(25.0 / 12.0 * (16 / 30), 6)
+        assert abs(row['cp_acquis'] - attendu) < 0.001
+
     def test_deux_salaries_un_avec_un_sans_contrat(self, comptable_client, app, db, sample_users):
         """Salarie avec contrat actif acquiert, salarie sans contrat est remis a zero."""
         uid_avec = sample_users['salarie_id']


### PR DESCRIPTION
Deux améliorations du simulateur de paie, basées sur le **contrat** (la donnée fiable).

## 1. Ancienneté & prorata congés basés sur le contrat (plus sur `date_entree`)

`users.date_entree` (saisie à la création) n'est plus fiable — les directeurs créés via `creer_user` n'en ont pas, d'où une ancienneté de 0. C'est désormais **le contrat qui fait foi** (`date_entree` conservé pour référence, plus utilisé dans les calculs).

- **Simulateur de paie** : ancienneté calculée depuis la **date de début du contrat** CDI/CDD de l'année.
- **Clôture des congés** (`variables_paie`) : prorata d'embauche en cours de mois basé sur la **date de début du contrat actif** en fin de mois (le plus ancien en cours de validité — choix métier documenté pour le cas rare multi-contrats).

## 2. Proratisation du brut selon le temps de travail (temps partiel)

Le brut était calculé comme si tout le monde était à **temps plein (35 h)**. Le temps de travail figure sur le contrat (`contrats.temps_hebdo`) :
- Brut mensuel **proratisé** par `temps_hebdo / temps plein` (35 h par défaut, **paramétrable**). Le **maintien** (montant fixe) n'est pas proratisé.
- Temps hebdo repris du contrat, affiché en **colonne éditable** (salariés en base + ajouts) ; non renseigné = temps plein.

## Vérifications
- Directeur sans `date_entree` + contrat il y a 4 ans → ancienneté **4** ; CDD → depuis son contrat.
- Clôture : contrat au 15/06 → prorata **16/30**.
- Temps partiel : 28 h → `23000 × 28/35 = 18400` ; sans temps hebdo → temps plein.
- Calculs **JS = Python**, **581 tests OK**, JS validé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3