### PR TITLE
Paie : proratiser le brut selon le temps de travail (temps partiel)

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1794,6 +1794,7 @@ PAIE_DEFAULTS = {
     'salaire_socle': 23000,
     'valeur_point': 55,
     'forfait_cee': 70,
+    'temps_plein': 35,  # heures hebdomadaires de référence (temps plein)
 }
 
 
@@ -1881,7 +1882,7 @@ def _paie_employes_secteur(conn, secteur_id, annee):
         # premier (date_debut la plus récente) puis écarté, faisant disparaître
         # le salarié alors qu'il a un contrat valide sur l'année.
         contrat = conn.execute('''
-            SELECT type_contrat, date_debut, date_fin FROM contrats
+            SELECT type_contrat, date_debut, date_fin, temps_hebdo FROM contrats
             WHERE user_id = ? AND type_contrat IN ('CDI', 'CDD')
               AND date_debut <= ?
               AND (date_fin IS NULL OR date_fin >= ?)
@@ -1896,6 +1897,7 @@ def _paie_employes_secteur(conn, secteur_id, annee):
             'id': u['id'], 'nom': u['nom'], 'prenom': u['prenom'],
             'pesee': u['pesee'], 'competence': u['competence'],
             'maintien': u['maintien'] if u['maintien'] is not None else 0,
+            'temps_hebdo': contrat['temps_hebdo'],
             'type_contrat': contrat['type_contrat'],
             'anciennete': _paie_anciennete_annees(contrat['date_debut'], annee),
             'mois_debut': mb, 'mois_fin': mf,
@@ -2007,7 +2009,9 @@ def _paie_reel_641(conn, secteur_id, compte_num, annee):
 def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_reel):
     """Calcule le brut par salarié et par mois, le coût CEE et le total annuel.
 
-    Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12.
+    Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12,
+    proratisé selon le temps de travail (temps_hebdo / temps plein de référence)
+    pour les salariés à temps partiel, puis + maintien (montant fixe non proratisé).
     En budget actualisé, seuls les mois > last_real_month sont simulés ; le total
     intègre le réel (FEC) déjà constaté.
     """
@@ -2015,6 +2019,7 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
     socle = _ps_num(d.get('salaire_socle'), PAIE_DEFAULTS['salaire_socle'])
     point = _ps_num(d.get('valeur_point'), PAIE_DEFAULTS['valeur_point'])
     forfait_cee = _ps_num(d.get('forfait_cee'), PAIE_DEFAULTS['forfait_cee'])
+    temps_plein = _ps_num(d.get('temps_plein'), PAIE_DEFAULTS['temps_plein'])
     cee_mercredi = _ps_num(d.get('cee_mercredi'))
     cee_vacances = _ps_num(d.get('cee_vacances'))
     overrides = d.get('employes') if isinstance(d.get('employes'), dict) else {}
@@ -2024,6 +2029,10 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
 
     def brut_mensuel(pesee, anciennete, competence):
         return (socle + (pesee + anciennete + competence) * point) / 12.0
+
+    def ratio_temps(temps_hebdo):
+        # Temps inconnu ou non renseigné => temps plein (ratio 1).
+        return (temps_hebdo / temps_plein) if (temps_hebdo and temps_hebdo > 0 and temps_plein) else 1.0
 
     def override_num(ov, key, db_value):
         # Champ présent (même vide) => saisie (vide = 0, cohérent avec la
@@ -2042,9 +2051,10 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         anciennete = override_num(ov, 'anciennete', e['anciennete'])
         competence = override_num(ov, 'competence', e['competence'])
         maintien = override_num(ov, 'maintien', e.get('maintien'))
+        ratio = ratio_temps(override_num(ov, 'temps_hebdo', e.get('temps_hebdo')))
         mois_vals, total_e = {}, 0.0
         for m in range(max(start_month, e['mois_debut']), e['mois_fin'] + 1):
-            val = brut_mensuel(pesee_eff, anciennete, competence) + maintien
+            val = brut_mensuel(pesee_eff, anciennete, competence) * ratio + maintien
             mois_vals[m] = round(val, 2)
             monthly_totals[m] += val
             total_e += val
@@ -2064,6 +2074,7 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         anciennete = _ps_num(a.get('anciennete'))
         competence = _ps_num(a.get('competence'))
         maintien = _ps_num(a.get('maintien'))
+        ratio = ratio_temps(_ps_num(a.get('temps_hebdo'), temps_plein))
         if typ == 'cdd':
             mb = int(_ps_num(a.get('mois_debut'), 1)) or 1
             mf = int(_ps_num(a.get('mois_fin'), 12)) or 12
@@ -2074,7 +2085,7 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         mf = min(max(mf, 1), 12)
         mois_vals, total_a = {}, 0.0
         for m in range(max(start_month, mb), mf + 1):
-            val = brut_mensuel(pesee_eff, anciennete, competence) + maintien
+            val = brut_mensuel(pesee_eff, anciennete, competence) * ratio + maintien
             mois_vals[m] = round(val, 2)
             monthly_totals[m] += val
             total_a += val

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -1423,6 +1423,7 @@ function defaultPaieState(ctx){
         salaire_socle: def.salaire_socle != null ? def.salaire_socle : 23000,
         valeur_point: def.valeur_point != null ? def.valeur_point : 55,
         forfait_cee: def.forfait_cee != null ? def.forfait_cee : 70,
+        temps_plein: def.temps_plein != null ? def.temps_plein : 35,
         cee_mercredi: '', cee_vacances: '',
         fermetures: [{debut:'', fin:''}, {debut:'', fin:''}],
         employes: {}, ajouts: []
@@ -1433,7 +1434,8 @@ function defaultPaieState(ctx){
             nouvelle_pesee: '',
             anciennete: e.anciennete != null ? e.anciennete : 0,
             competence: e.competence != null ? e.competence : '',
-            maintien: e.maintien != null ? e.maintien : 0
+            maintien: e.maintien != null ? e.maintien : 0,
+            temps_hebdo: e.temps_hebdo != null ? e.temps_hebdo : ''
         };
     });
     return st;
@@ -1441,7 +1443,7 @@ function defaultPaieState(ctx){
 function mergePaieState(saved, ctx){
     var st = defaultPaieState(ctx);
     if (!saved) return st;
-    ['salaire_socle','valeur_point','forfait_cee','cee_mercredi','cee_vacances'].forEach(function(k){
+    ['salaire_socle','valeur_point','forfait_cee','temps_plein','cee_mercredi','cee_vacances'].forEach(function(k){
         if (saved[k] !== undefined && saved[k] !== null) st[k] = saved[k];
     });
     if (Array.isArray(saved.fermetures)){
@@ -1463,11 +1465,14 @@ function paieCeeParMois(ctx, st){
 }
 function computePaieJS(st, ctx, typeBudget){
     var socle = psNum(st.salaire_socle, 23000), point = psNum(st.valeur_point, 55), forfait = psNum(st.forfait_cee, 70);
+    var tplein = psNum(st.temps_plein, 35);
     var ceeMer = psNum(st.cee_mercredi), ceeVac = psNum(st.cee_vacances);
     var lastReal = (typeBudget === 'actualise') ? (ctx.last_real_month || 0) : 0;
     var reel = (typeBudget === 'actualise') ? (ctx.montant_reel || 0) : 0;
     var start = lastReal + 1;
     function brut(p,a,c){ return (socle + (p+a+c)*point) / 12; }
+    // Temps inconnu/0 => temps plein (ratio 1).
+    function ratioTemps(th){ return (th && th > 0 && tplein) ? th/tplein : 1; }
     // Champ surchargé présent (même vide) => saisie (vide = 0) ; absent => fiche.
     function ovNum(ov, key, dbVal){ return (ov && Object.prototype.hasOwnProperty.call(ov, key)) ? psNum(ov[key], 0) : psNum(dbVal, 0); }
     var monthly = {}; for (var m=1;m<=12;m++) monthly[m] = 0;
@@ -1478,19 +1483,21 @@ function computePaieJS(st, ctx, typeBudget){
         var pEff = (ov.nouvelle_pesee !== '' && ov.nouvelle_pesee != null) ? psNum(ov.nouvelle_pesee) : pAct;
         var anc = ovNum(ov, 'anciennete', e.anciennete), comp = ovNum(ov, 'competence', e.competence);
         var maint = ovNum(ov, 'maintien', e.maintien);
+        var ratio = ratioTemps(ovNum(ov, 'temps_hebdo', e.temps_hebdo));
         var mvals = {}, tot = 0;
-        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
+        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp)*ratio+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
         lignes[e.id] = {mois: mvals, total: tot, pesee_eff: pEff};
     });
     var ajouts = {};
     (st.ajouts || []).forEach(function(a, i){
         var typ = (a.type === 'cdd') ? 'cdd' : 'cdi';
         var pEff = psNum(a.pesee), anc = psNum(a.anciennete), comp = psNum(a.competence), maint = psNum(a.maintien);
+        var ratioA = ratioTemps(psNum(a.temps_hebdo, tplein));
         var mb = (typ==='cdd') ? (parseInt(a.mois_debut,10)||1) : (parseInt(a.mois_embauche,10)||1);
         var mf = (typ==='cdd') ? (parseInt(a.mois_fin,10)||12) : 12;
         mb=Math.min(Math.max(mb,1),12); mf=Math.min(Math.max(mf,1),12);
         var mvals = {}, tot = 0;
-        for (var m=Math.max(start,mb); m<=mf; m++){ var v=brut(pEff,anc,comp)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
+        for (var m=Math.max(start,mb); m<=mf; m++){ var v=brut(pEff,anc,comp)*ratioA+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
         ajouts[i] = {mois: mvals, total: tot};
     });
     var ceeJours = paieCeeParMois(ctx, st), ceeCout = {};
@@ -1512,8 +1519,9 @@ function renderPaieSimulator(){
     var html = '<div class="ps-params">' +
         '<div class="ps-field"><label>Salaire socle (annuel)</label>' + paieInput('data-paie-top="salaire_socle"', st.salaire_socle, '1') + '</div>' +
         '<div class="ps-field"><label>Valeur du point</label>' + paieInput('data-paie-top="valeur_point"', st.valeur_point, '0.01') + '</div>' +
+        '<div class="ps-field"><label>Temps plein (h/sem.)</label>' + paieInput('data-paie-top="temps_plein"', st.temps_plein, '0.5') + '</div>' +
         '</div>';
-    html += '<div class="ps-legend">Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12. Colonnes <span class="bp-ps-calc">surlignées</span> = calculées.';
+    html += '<div class="ps-legend">Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12, au prorata du temps de travail (temps hebdo / temps plein). Colonnes <span class="bp-ps-calc">surlignées</span> = calculées.';
     if (actualise){
         html += ' Budget actualisé : seuls les mois après <strong>' + (ctx.last_real_month ? MOIS_COURT[ctx.last_real_month-1] : '—') +
             '</strong> sont simulés ; réel déjà constaté : <strong>' + fmt(ctx.montant_reel || 0) + ' €</strong>.';
@@ -1526,12 +1534,13 @@ function renderPaieSimulator(){
         html += '<p class="ps-legend">Aucun salarié actif en CDI/CDD rattaché à ce secteur sur l\'année.</p>';
     } else {
         html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
-            '<th>Salarié</th><th>Type</th><th>Pesée actuelle</th><th>Nouvelle pesée</th><th>Ancienneté</th><th>Compétence</th><th>Maintien €/mois</th>' +
+            '<th>Salarié</th><th>Type</th><th>Temps hebdo</th><th>Pesée actuelle</th><th>Nouvelle pesée</th><th>Ancienneté</th><th>Compétence</th><th>Maintien €/mois</th>' +
             monthTh + '<th class="bp-ps-calc">Total</th></tr></thead><tbody>';
         (ctx.employes || []).forEach(function(e){
             var ov = st.employes[e.id] || {};
             html += '<tr><td class="ps-col-mois">' + escapeHtml((e.nom||'') + ' ' + (e.prenom||'')) + '</td>' +
                 '<td>' + escapeHtml(e.type_contrat || '') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="temps_hebdo"', ov.temps_hebdo, '0.5') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="pesee"', ov.pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="nouvelle_pesee"', ov.nouvelle_pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="anciennete"', ov.anciennete, '1') + '</td>' +
@@ -1549,11 +1558,12 @@ function renderPaieSimulator(){
         '<button class="btn btn-sm btn-secondary" type="button" onclick="paieAddAjout(\'cdd\')">+ CDD</button></div>';
     if ((st.ajouts || []).length){
         html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
-            '<th>Type</th><th>Pesée</th><th>Ancienneté</th><th>Maintien €/mois</th><th>Mois début / embauche</th><th>Mois fin (CDD)</th>' +
+            '<th>Type</th><th>Temps hebdo</th><th>Pesée</th><th>Ancienneté</th><th>Maintien €/mois</th><th>Mois début / embauche</th><th>Mois fin (CDD)</th>' +
             monthTh + '<th class="bp-ps-calc">Total</th><th></th></tr></thead><tbody>';
         st.ajouts.forEach(function(a, i){
             var isCdd = (a.type === 'cdd');
             html += '<tr><td class="ps-col-mois">' + (isCdd ? 'CDD' : 'CDI') + '</td>' +
+                '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="temps_hebdo"', a.temps_hebdo, '0.5') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="pesee"', a.pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="anciennete"', a.anciennete, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="maintien"', a.maintien, '0.01') + '</td>' +
@@ -1617,8 +1627,8 @@ function bindPaieInputs(){
 }
 function paieAddAjout(type){
     paieSim.state.ajouts.push(type === 'cdd'
-        ? {type:'cdd', pesee:'', anciennete:'', competence:0, maintien:0, mois_debut:1, mois_fin:12}
-        : {type:'cdi', pesee:'', anciennete:'', competence:0, maintien:0, mois_embauche:1});
+        ? {type:'cdd', temps_hebdo:'', pesee:'', anciennete:'', competence:0, maintien:0, mois_debut:1, mois_fin:12}
+        : {type:'cdi', temps_hebdo:'', pesee:'', anciennete:'', competence:0, maintien:0, mois_embauche:1});
     renderPaieSimulator(); recomputePaie();
 }
 function paieRemoveAjout(i){ paieSim.state.ajouts.splice(i,1); renderPaieSimulator(); recomputePaie(); }

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1051,3 +1051,48 @@ def test_paie_anciennete_cdd_depuis_son_contrat(app, db):
         employes = _paie_employes_secteur(db, sid, annee)
     e = next(x for x in employes if x['id'] == uid)
     assert e['anciennete'] == 0  # depuis le contrat (cette année), pas 6 (date_entree)
+
+
+def test_paie_employes_recupere_temps_hebdo_du_contrat(app, db):
+    """Le temps de travail hebdomadaire est repris du contrat."""
+    from blueprints.budget import _paie_employes_secteur
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        db.execute("UPDATE contrats SET temps_hebdo = 28 WHERE user_id = ?", (uid,))
+        db.commit()
+        employes = _paie_employes_secteur(db, sid, annee)
+    e = next(x for x in employes if x['id'] == uid)
+    assert e['temps_hebdo'] == 28
+
+
+def test_paie_simulation_proratise_temps_partiel(app, db, admin_client):
+    """Le brut d'un salarié à temps partiel est proratisé (temps hebdo / temps plein)."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        db.execute("UPDATE contrats SET temps_hebdo = 28 WHERE user_id = ?", (uid,))
+        db.commit()
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55, 'temps_plein': 35,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '', 'anciennete': 0,
+                                       'competence': 0, 'maintien': 0, 'temps_hebdo': 28}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    assert abs(r.get_json()['total'] - 18400.0) < 0.01  # 23000 × 28/35
+
+
+def test_paie_temps_hebdo_absent_temps_plein(app, db, admin_client):
+    """Sans temps hebdo renseigné, le salarié est considéré à temps plein."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)  # contrat sans temps_hebdo (NULL)
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55, 'temps_plein': 35,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '', 'anciennete': 0,
+                                       'competence': 0, 'maintien': 0, 'temps_hebdo': ''}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    assert abs(r.get_json()['total'] - 23000.0) < 0.01


### PR DESCRIPTION
Le brut était calculé comme si tous les salariés étaient à temps plein (35 h). Le temps de travail figure sur le contrat (contrats.temps_hebdo) : le brut mensuel est désormais proratisé par temps_hebdo / temps plein de référence (35 h par défaut, paramétrable). Le maintien de salaire (montant fixe) n'est pas proratisé.

- Le temps hebdo est repris du contrat en cours et affiché en colonne éditable (salariés en base et ajouts) ; un temps non renseigné = temps plein.
- Nouveau paramètre « Temps plein (h/sem.) » (défaut 35).

Calculs JS et Python alignés (28 h → 23000 × 28/35 = 18400).


Claude-Session: https://claude.ai/code/session_01LKuG2NuTAStyMD8wyTqaL3