### PR TITLE
Module Bilan action + délégation des réservations de salle récurrentes

### DIFF
--- a/app.py
+++ b/app.py
@@ -242,6 +242,7 @@ from blueprints.generation_contrats import generation_contrats_bp
 from blueprints.comptabilite_analytique import comptabilite_analytique_bp
 from blueprints.plan_comptable_general import plan_comptable_general_bp
 from blueprints.bilan_secteurs import bilan_secteurs_bp
+from blueprints.bilan_action import bilan_action_bp
 from blueprints.alsh import alsh_bp
 from blueprints.mise_a_jour import mise_a_jour_bp
 from blueprints.rh_statistiques import rh_statistiques_bp
@@ -295,6 +296,7 @@ app.register_blueprint(generation_contrats_bp)
 app.register_blueprint(comptabilite_analytique_bp)
 app.register_blueprint(plan_comptable_general_bp)
 app.register_blueprint(bilan_secteurs_bp)
+app.register_blueprint(bilan_action_bp)
 app.register_blueprint(alsh_bp)
 app.register_blueprint(mise_a_jour_bp)
 app.register_blueprint(rh_statistiques_bp)

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -8,7 +8,10 @@ from flask import Blueprint, render_template, request, redirect, url_for, sessio
 from werkzeug.security import generate_password_hash
 from datetime import datetime
 from database import get_db
-from blueprints.delegations import MISSIONS, MISSIONS_MAP, save_delegation
+from blueprints.delegations import (
+    MISSIONS, MISSIONS_MAP, save_delegation,
+    get_salle_recurrence_user_ids, save_salle_recurrence_delegations,
+)
 from utils import login_required, validate_password_strength
 from access_log import (journaliser_action, ACTION_CREATION_USER,
                         ACTION_MODIF_USER, ACTION_STATUT_USER)
@@ -61,6 +64,23 @@ def delegations():
         if request.method == 'POST':
             if session.get('profil') != 'directeur':
                 flash('Seule la direction peut modifier les délégations.', 'error')
+                return redirect(url_for('admin_bp.delegations'))
+
+            # Délégation des réservations de salle récurrentes (multi-salariés).
+            if request.form.get('form_type') == 'salle_recurrence':
+                selected = [int(x) for x in request.form.getlist('salle_recurrence_users') if x.isdigit()]
+                valides = []
+                if selected:
+                    placeholders = ','.join('?' * len(selected))
+                    rows = conn.execute(
+                        f'''SELECT id FROM users
+                            WHERE id IN ({placeholders}) AND actif = 1
+                              AND profil IN ('salarie', 'responsable')''',
+                        selected
+                    ).fetchall()
+                    valides = [r['id'] for r in rows]
+                save_salle_recurrence_delegations(valides, session['user_id'])
+                flash('Les autorisations de réservation récurrente ont été enregistrées.', 'success')
                 return redirect(url_for('admin_bp.delegations'))
 
             mission_key = request.form.get('mission_key')
@@ -128,6 +148,7 @@ def delegations():
         'delegations.html',
         missions=missions,
         salaries=salaries,
+        salle_recurrence_user_ids=get_salle_recurrence_user_ids(),
         peut_modifier=session.get('profil') == 'directeur',
     )
 

--- a/blueprints/bilan_action.py
+++ b/blueprints/bilan_action.py
@@ -1,0 +1,817 @@
+"""
+Blueprint bilan_action_bp - Bilan action (budget prévisionnel et réalisé).
+
+Contrairement à la page « Bilan secteurs/actions » (bilan_secteurs_bp) qui est
+une photo de la comptabilité détaillée sur une année clôturée avec récupération
+analytique, cette page sert à CONSTRUIRE le budget prévisionnel d'une action et
+à construire/vérifier son réalisé avant la clôture.
+
+Fonctionnement :
+- Sélection d'une action (définie dans le plan comptable analytique) et d'une année.
+- Enregistrement par action / année / onglet (prévisionnel, réalisé).
+- Onglet PRÉVISIONNEL en 3 parties :
+    1. Comptes de charges 60xxxx / 61xxxx / 62xxxx (sections séparées) et comptes
+       de produits (70xxxx, 74xxxx, autres) : liste déroulante des comptes, ajout
+       de lignes avec montant et commentaire.
+    2. Salaires : liste des salariés sous contrat sur l'année (simulateur de paie,
+       même principe que budget_previsionnel) ; coût brut au prorata des heures
+       passées sur l'action, salaire chargé et taxe sur salaire (calcul simplifié).
+    3. Taux de logistique (site1/site2/global, partagé avec bilan_secteurs) et
+       bénévoles (liste déroulante + temps + commentaire).
+- Onglet RÉALISÉ : reprend le réalisé comptable (import BI) en comparatif avec le
+  prévisionnel, reporte salaires et taux de logistique (modifiables) et bénévoles.
+- Export PDF (bilan simplifié + récap salariés + bénévoles) pour les deux onglets.
+  Les salaires sont regroupés : 641100 (brut), 645100 (charges sociales),
+  631100 (taxe sur salaires).
+
+Accès : directeur et comptable (comme Budget prévisionnel).
+"""
+import io
+import json
+from datetime import date
+
+from flask import (Blueprint, render_template, request, redirect,
+                   url_for, session, flash, jsonify, make_response)
+
+from database import get_db
+from utils import login_required
+# Réutilise les paramètres et calculs de paie du simulateur (source unique).
+from blueprints.budget import PAIE_DEFAULTS, _paie_anciennete_annees
+
+bilan_action_bp = Blueprint('bilan_action_bp', __name__)
+
+# Taux par défaut (modifiables dans l'interface).
+TAUX_CHARGE_DEFAUT = 27.0   # charges patronales : coût brut + 27 %
+TAUX_TAXE_DEFAUT = 4.25     # taxe sur les salaires (taux de base simplifié)
+
+# Comptes utilisés pour regrouper la masse salariale dans le bilan.
+COMPTE_BRUT = '641100'      # rémunérations brutes
+COMPTE_TAXE = '631100'      # taxe sur les salaires
+COMPTE_CHARGES = '645100'   # charges de sécurité sociale
+
+ONGLETS = ('previsionnel', 'realise')
+
+NOMS_CATEGORIES = {
+    '60': 'Achats', '61': 'Services extérieurs', '62': 'Autres services ext.',
+    '63': 'Impôts et taxes', '64': 'Charges de personnel',
+    '65': 'Autres charges de gestion', '66': 'Charges financières',
+    '67': 'Charges exceptionnelles', '68': 'Dotations amort.',
+    '70': 'Ventes/prestations', '71': 'Production stockée',
+    '72': 'Production immobilisée', '73': 'Produits nets partiels',
+    '74': 'Subventions', '75': 'Autres produits de gestion',
+    '76': 'Produits financiers', '77': 'Produits exceptionnels',
+    '78': 'Reprises amort.', '79': 'Transferts de charges',
+}
+
+
+# ── Permissions ───────────────────────────────────────────────────────────────
+
+def _peut_acceder():
+    return session.get('profil') in ('directeur', 'comptable')
+
+
+def _peut_modifier():
+    return session.get('profil') in ('directeur', 'comptable')
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _num(value, default=0.0):
+    """Convertit une valeur saisie (str/None) en float, avec valeur par défaut."""
+    try:
+        if value is None or value == '':
+            return float(default)
+        if isinstance(value, str):
+            value = value.replace(',', '.')
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _fmt(n):
+    """Formate un nombre en style français : 1 234,56."""
+    return f'{n:,.2f}'.replace(',', '\xa0').replace('.', ',')
+
+
+def _get_libelles_pcg(conn):
+    """Retourne un dict {compte_num: libelle} depuis le plan comptable général."""
+    rows = conn.execute('SELECT compte_num, libelle FROM plan_comptable_general').fetchall()
+    return {row['compte_num']: row['libelle'] for row in rows}
+
+
+def _calc_salarie(s, params):
+    """Calcule la paie d'un salarié pour l'action à partir de ses paramètres.
+
+    Brut mensuel (même formule que le simulateur de paie) :
+        (socle + (pesée + ancienneté + compétence) * point) / 12 * ratio_temps
+        + maintien
+    Coût brut sur l'action (taux horaire annuel) :
+        coût brut = (brut mensuel * 12) / (temps hebdo * 52) * heures sur l'action
+    Charges sociales = coût brut * taux chargé (ex. 27 %).
+    Taxe sur salaire = coût brut * taux taxe (ex. 4,25 %, calcul simplifié).
+    """
+    socle = _num(params.get('socle'), PAIE_DEFAULTS['salaire_socle'])
+    point = _num(params.get('point'), PAIE_DEFAULTS['valeur_point'])
+    temps_plein = _num(params.get('temps_plein'), PAIE_DEFAULTS['temps_plein']) or 35.0
+
+    temps_hebdo = _num(s.get('temps_hebdo'), temps_plein)
+    if temps_hebdo <= 0:
+        temps_hebdo = temps_plein
+    pesee = _num(s.get('pesee'))
+    anciennete = _num(s.get('anciennete'))
+    competence = _num(s.get('competence'))
+    maintien = _num(s.get('maintien'))
+    heures = _num(s.get('heures_action'))
+    taux_charge = _num(s.get('taux_charge'), TAUX_CHARGE_DEFAUT)
+    taux_taxe = _num(s.get('taux_taxe'), TAUX_TAXE_DEFAUT)
+
+    ratio = (temps_hebdo / temps_plein) if temps_plein else 1.0
+    brut_mensuel = (socle + (pesee + anciennete + competence) * point) / 12.0 * ratio + maintien
+    heures_annuelles = temps_hebdo * 52.0
+    taux_horaire = (brut_mensuel * 12.0 / heures_annuelles) if heures_annuelles else 0.0
+    cout_brut = taux_horaire * heures
+    charges_sociales = cout_brut * taux_charge / 100.0
+    salaire_charge = cout_brut + charges_sociales
+    taxe = cout_brut * taux_taxe / 100.0
+
+    return {
+        'brut_mensuel': round(brut_mensuel, 2),
+        'taux_horaire': round(taux_horaire, 4),
+        'cout_brut': round(cout_brut, 2),
+        'charges_sociales': round(charges_sociales, 2),
+        'salaire_charge': round(salaire_charge, 2),
+        'taxe': round(taxe, 2),
+    }
+
+
+def _employes_actifs_annee(conn, annee):
+    """Salariés avec un contrat CDI/CDD valide sur l'année concernée.
+
+    - Année passée ou en cours : tout contrat chevauchant l'année (même terminé).
+    - Année à venir (> année courante) : uniquement les contrats actifs aujourd'hui.
+    On retient le contrat le plus récent par salarié.
+    """
+    today = date.today()
+    if annee > today.year:
+        start = end = today.isoformat()
+    else:
+        start = f'{annee}-01-01'
+        end = f'{annee}-12-31'
+
+    rows = conn.execute('''
+        SELECT u.id, u.nom, u.prenom, u.pesee, u.competence, u.maintien,
+               c.type_contrat, c.date_debut, c.date_fin, c.temps_hebdo
+        FROM users u
+        JOIN contrats c ON c.user_id = u.id
+        WHERE c.type_contrat IN ('CDI', 'CDD')
+          AND (u.profil IS NULL OR u.profil != 'prestataire')
+          AND c.date_debut <= ?
+          AND (c.date_fin IS NULL OR c.date_fin >= ?)
+        ORDER BY u.nom, u.prenom, c.date_debut DESC
+    ''', (end, start)).fetchall()
+
+    seen = {}
+    for r in rows:
+        if r['id'] not in seen:  # premier = contrat le plus récent (ORDER BY date_debut DESC)
+            seen[r['id']] = r
+
+    employes = []
+    for u in seen.values():
+        employes.append({
+            'user_id': u['id'],
+            'nom': u['nom'] or '',
+            'prenom': u['prenom'] or '',
+            'pesee': u['pesee'] if u['pesee'] is not None else 0,
+            'competence': u['competence'] if u['competence'] is not None else 0,
+            'maintien': u['maintien'] if u['maintien'] is not None else 0,
+            'temps_hebdo': u['temps_hebdo'],
+            'type_contrat': u['type_contrat'],
+            'anciennete': _paie_anciennete_annees(u['date_debut'], annee),
+        })
+    employes.sort(key=lambda e: (e['nom'], e['prenom']))
+    return employes
+
+
+def _realise_compta(conn, action_id, annee):
+    """Charges (6x) et produits (7x) réalisés depuis le FEC, regroupés par compte,
+    pour les comptes rattachés à l'action dans le plan comptable analytique."""
+    rows = conn.execute('''
+        SELECT d.compte_num, d.libelle, SUM(d.montant) AS montant
+        FROM bilan_fec_donnees d
+        WHERE d.annee = ?
+          AND EXISTS (
+              SELECT 1 FROM comptabilite_comptes c
+              WHERE c.action_id = ?
+                AND (d.compte_num LIKE c.compte_num || '%'
+                     OR d.code_analytique = c.compte_num)
+          )
+        GROUP BY d.compte_num, d.libelle
+        ORDER BY d.compte_num
+    ''', (annee, action_id)).fetchall()
+
+    pcg = _get_libelles_pcg(conn)
+    charges, produits = {}, {}
+    for d in rows:
+        compte = d['compte_num']
+        if not compte:
+            continue
+        cat = compte[:2]
+        montant = d['montant'] or 0
+        libelle = pcg.get(compte) or d['libelle'] or compte
+        # On se limite aux charges 60/61/62 et aux produits 7x, à l'image de la
+        # Partie 1 du prévisionnel. Les charges de personnel (64x), la taxe sur
+        # salaires (63x) et la logistique sont gérées séparément (section salaires
+        # reportée du prévisionnel, taux de logistique) pour éviter un double
+        # comptage avec le réalisé comptable importé.
+        if cat in ('60', '61', '62'):
+            target = charges
+        elif compte[0] == '7':
+            target = produits
+        else:
+            continue
+        target.setdefault(cat, {'comptes': {}, 'total': 0})
+        target[cat]['comptes'].setdefault(compte, {'libelle': libelle, 'total': 0})
+        target[cat]['comptes'][compte]['total'] += montant
+        target[cat]['total'] += montant
+
+    for groupe in (charges, produits):
+        for cat in groupe.values():
+            cat['total'] = round(cat['total'], 2)
+            for c in cat['comptes'].values():
+                c['total'] = round(c['total'], 2)
+    return charges, produits
+
+
+def _taux_logistique_val(conn, annee, selection):
+    """Valeur (%) du taux de logistique sélectionné pour l'année."""
+    row = conn.execute(
+        'SELECT * FROM bilan_taux_logistique WHERE annee = ?', (annee,)
+    ).fetchone()
+    if not row:
+        return 0.0
+    if selection == 'site1':
+        return row['taux_site1'] or 0.0
+    if selection == 'site2':
+        return row['taux_site2'] or 0.0
+    return row['taux_global'] or 0.0
+
+
+def _summary(conn, donnees, annee, action_id, onglet):
+    """Calcule l'ensemble des totaux d'un onglet (source de vérité serveur).
+
+    Charges totales = comptes (60/61/62) + masse salariale chargée
+    (coût brut + charges sociales + taxe). La logistique s'applique sur ce total.
+    """
+    donnees = donnees or {}
+    params = donnees.get('salaire_params') or {}
+
+    # --- Salaires ---
+    salaries_out = []
+    tot_brut = tot_charges_soc = tot_taxe = 0.0
+    for s in (donnees.get('salaries') or []):
+        calc = _calc_salarie(s, params)
+        tot_brut += calc['cout_brut']
+        tot_charges_soc += calc['charges_sociales']
+        tot_taxe += calc['taxe']
+        out = dict(s)
+        out.update(calc)
+        salaries_out.append(out)
+    masse_salariale = tot_brut + tot_charges_soc + tot_taxe
+
+    # --- Comptes de charges / produits ---
+    if onglet == 'realise':
+        charges_cat, produits_cat = _realise_compta(conn, action_id, annee)
+        charges_comptes = sum(c['total'] for c in charges_cat.values())
+        produits_total = sum(p['total'] for p in produits_cat.values())
+        for m in (donnees.get('comptes_manuels') or []):
+            montant = _num(m.get('montant'))
+            num = str(m.get('compte_num') or '')
+            if num[:1] == '7':
+                produits_total += montant
+            else:
+                charges_comptes += montant
+    else:
+        charges_comptes = 0.0
+        for key in ('charges_60', 'charges_61', 'charges_62'):
+            for ligne in (donnees.get(key) or []):
+                charges_comptes += _num(ligne.get('montant'))
+        produits_total = sum(_num(ligne.get('montant')) for ligne in (donnees.get('produits') or []))
+
+    charges_comptes = round(charges_comptes, 2)
+    produits_total = round(produits_total, 2)
+
+    # --- Logistique ---
+    selection = (donnees.get('logistique') or {}).get('selection', 'global')
+    taux_val = _taux_logistique_val(conn, annee, selection)
+    total_charges = round(charges_comptes + masse_salariale, 2)   # base de la logistique
+    logistique = round(total_charges * taux_val / 100.0, 2)
+    resultat_sans = round(produits_total - total_charges, 2)
+    resultat_avec = round(produits_total - total_charges - logistique, 2)
+
+    return {
+        'salaries': salaries_out,
+        'total_brut': round(tot_brut, 2),
+        'total_charges_sociales': round(tot_charges_soc, 2),
+        'total_taxe': round(tot_taxe, 2),
+        'masse_salariale': round(masse_salariale, 2),
+        'charges_comptes': charges_comptes,
+        'produits_total': produits_total,
+        'taux_selection': selection,
+        'taux_logistique': taux_val,
+        'logistique': logistique,
+        'total_charges': total_charges,
+        'total_produits': produits_total,
+        'resultat_sans': resultat_sans,
+        'resultat_avec': resultat_avec,
+    }
+
+
+# ── Page principale ───────────────────────────────────────────────────────────
+
+@bilan_action_bp.route('/bilan-action')
+@login_required
+def bilan_action():
+    """Affiche la page Bilan action."""
+    if not _peut_acceder():
+        flash('Accès non autorisé.', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    conn = get_db()
+    try:
+        actions = conn.execute(
+            'SELECT id, nom FROM comptabilite_actions ORDER BY nom'
+        ).fetchall()
+        annee_courante = date.today().year
+        annees = list(range(annee_courante + 1, annee_courante - 5, -1))
+        return render_template(
+            'bilan_action.html',
+            actions=actions,
+            annees=annees,
+            annee_courante=annee_courante,
+        )
+    finally:
+        conn.close()
+
+
+# ── API : contexte (salariés, bénévoles, taux, comptes) ───────────────────────
+
+@bilan_action_bp.route('/api/bilan-action/contexte')
+@login_required
+def api_contexte():
+    if not _peut_acceder():
+        return jsonify({'error': 'Accès non autorisé.'}), 403
+    annee = request.args.get('annee', type=int)
+    if not annee:
+        return jsonify({'error': 'Année requise.'}), 400
+
+    conn = get_db()
+    try:
+        employes = _employes_actifs_annee(conn, annee)
+        benevoles = [dict(r) for r in conn.execute(
+            'SELECT id, nom FROM benevoles ORDER BY nom'
+        ).fetchall()]
+        taux_row = conn.execute(
+            'SELECT * FROM bilan_taux_logistique WHERE annee = ?', (annee,)
+        ).fetchone()
+        taux = {
+            'taux_site1': taux_row['taux_site1'] if taux_row else 0,
+            'taux_site2': taux_row['taux_site2'] if taux_row else 0,
+            'taux_global': taux_row['taux_global'] if taux_row else 0,
+        }
+        import_existe = conn.execute(
+            'SELECT COUNT(*) AS n FROM bilan_fec_imports WHERE annee = ?', (annee,)
+        ).fetchone()['n'] > 0
+        comptes_pcg = [dict(r) for r in conn.execute(
+            'SELECT compte_num, libelle FROM plan_comptable_general ORDER BY compte_num'
+        ).fetchall()]
+        return jsonify({
+            'employes': employes,
+            'benevoles': benevoles,
+            'taux': taux,
+            'import_existe': import_existe,
+            'comptes_pcg': comptes_pcg,
+            'defaults': {
+                'socle': PAIE_DEFAULTS['salaire_socle'],
+                'point': PAIE_DEFAULTS['valeur_point'],
+                'temps_plein': PAIE_DEFAULTS['temps_plein'],
+                'taux_charge': TAUX_CHARGE_DEFAUT,
+                'taux_taxe': TAUX_TAXE_DEFAUT,
+            },
+            'comptes_salaire': {
+                'brut': COMPTE_BRUT, 'taxe': COMPTE_TAXE, 'charges': COMPTE_CHARGES,
+            },
+        })
+    finally:
+        conn.close()
+
+
+# ── API : chargement des données d'un onglet ──────────────────────────────────
+
+@bilan_action_bp.route('/api/bilan-action/donnees')
+@login_required
+def api_donnees():
+    if not _peut_acceder():
+        return jsonify({'error': 'Accès non autorisé.'}), 403
+    annee = request.args.get('annee', type=int)
+    action_id = request.args.get('action_id', type=int)
+    onglet = request.args.get('onglet', 'previsionnel')
+    if not annee or not action_id:
+        return jsonify({'error': 'Action et année requises.'}), 400
+    if onglet not in ONGLETS:
+        onglet = 'previsionnel'
+
+    conn = get_db()
+    try:
+        row = conn.execute(
+            'SELECT donnees FROM bilan_action_data WHERE action_id = ? AND annee = ? AND onglet = ?',
+            (action_id, annee, onglet)
+        ).fetchone()
+        donnees = json.loads(row['donnees']) if row and row['donnees'] else None
+
+        # Le réalisé reprend le prévisionnel (salaires, logistique, comparatif).
+        previsionnel = None
+        if onglet == 'realise':
+            prev_row = conn.execute(
+                'SELECT donnees FROM bilan_action_data WHERE action_id = ? AND annee = ? AND onglet = ?',
+                (action_id, annee, 'previsionnel')
+            ).fetchone()
+            previsionnel = json.loads(prev_row['donnees']) if prev_row and prev_row['donnees'] else None
+
+        summary = _summary(conn, donnees, annee, action_id, onglet) if donnees else None
+        return jsonify({
+            'found': donnees is not None,
+            'donnees': donnees,
+            'previsionnel': previsionnel,
+            'summary': summary,
+        })
+    finally:
+        conn.close()
+
+
+# ── API : sauvegarde d'un onglet ──────────────────────────────────────────────
+
+@bilan_action_bp.route('/api/bilan-action/save', methods=['POST'])
+@login_required
+def api_save():
+    if not _peut_modifier():
+        return jsonify({'error': 'Accès non autorisé.'}), 403
+    data = request.get_json(silent=True) or {}
+    annee = data.get('annee')
+    action_id = data.get('action_id')
+    onglet = data.get('onglet', 'previsionnel')
+    donnees = data.get('donnees') or {}
+    try:
+        annee = int(annee)
+        action_id = int(action_id)
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Action et année requises.'}), 400
+    if onglet not in ONGLETS:
+        return jsonify({'error': 'Onglet invalide.'}), 400
+
+    conn = get_db()
+    try:
+        action = conn.execute(
+            'SELECT id FROM comptabilite_actions WHERE id = ?', (action_id,)
+        ).fetchone()
+        if not action:
+            return jsonify({'error': 'Action introuvable.'}), 404
+
+        summary = _summary(conn, donnees, annee, action_id, onglet)
+        conn.execute('''
+            INSERT INTO bilan_action_data
+                (action_id, annee, onglet, donnees, total_charges, total_produits, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(action_id, annee, onglet) DO UPDATE SET
+                donnees = excluded.donnees,
+                total_charges = excluded.total_charges,
+                total_produits = excluded.total_produits,
+                updated_by = excluded.updated_by,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (action_id, annee, onglet, json.dumps(donnees, ensure_ascii=False),
+              summary['total_charges'], summary['total_produits'],
+              session.get('user_id')))
+        conn.commit()
+        return jsonify({'success': True, 'summary': summary})
+    finally:
+        conn.close()
+
+
+# ── API : réalisé comptable (import BI) ───────────────────────────────────────
+
+@bilan_action_bp.route('/api/bilan-action/realise-compta')
+@login_required
+def api_realise_compta():
+    if not _peut_acceder():
+        return jsonify({'error': 'Accès non autorisé.'}), 403
+    annee = request.args.get('annee', type=int)
+    action_id = request.args.get('action_id', type=int)
+    if not annee or not action_id:
+        return jsonify({'error': 'Action et année requises.'}), 400
+
+    conn = get_db()
+    try:
+        import_existe = conn.execute(
+            'SELECT COUNT(*) AS n FROM bilan_fec_imports WHERE annee = ?', (annee,)
+        ).fetchone()['n'] > 0
+        if not import_existe:
+            return jsonify({'import_existe': False, 'charges': {}, 'produits': {}})
+        charges, produits = _realise_compta(conn, action_id, annee)
+        return jsonify({
+            'import_existe': True,
+            'charges': charges,
+            'produits': produits,
+        })
+    finally:
+        conn.close()
+
+
+# ── API : taux de logistique (valeurs partagées par année) ────────────────────
+
+@bilan_action_bp.route('/api/bilan-action/taux-logistique', methods=['POST'])
+@login_required
+def api_taux_logistique():
+    if not _peut_modifier():
+        return jsonify({'error': 'Accès non autorisé.'}), 403
+    data = request.get_json(silent=True) or {}
+    annee = data.get('annee')
+    try:
+        annee = int(annee)
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Année requise.'}), 400
+
+    conn = get_db()
+    try:
+        # Met à jour les valeurs (partagées avec bilan_secteurs) sans toucher à
+        # la sélection propre à la page bilan_secteurs (taux_selectionne).
+        conn.execute('''
+            INSERT INTO bilan_taux_logistique (annee, taux_site1, taux_site2, taux_global)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(annee) DO UPDATE SET
+                taux_site1 = excluded.taux_site1,
+                taux_site2 = excluded.taux_site2,
+                taux_global = excluded.taux_global,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (annee, _num(data.get('taux_site1')), _num(data.get('taux_site2')),
+              _num(data.get('taux_global'))))
+        conn.commit()
+        return jsonify({'success': True})
+    finally:
+        conn.close()
+
+
+# ── API : export PDF ──────────────────────────────────────────────────────────
+
+@bilan_action_bp.route('/api/bilan-action/export-pdf')
+@login_required
+def api_export_pdf():
+    if not _peut_acceder():
+        flash('Accès non autorisé.', 'error')
+        return redirect(url_for('bilan_action_bp.bilan_action'))
+    annee = request.args.get('annee', type=int)
+    action_id = request.args.get('action_id', type=int)
+    onglet = request.args.get('onglet', 'previsionnel')
+    if onglet not in ONGLETS:
+        onglet = 'previsionnel'
+    if not annee or not action_id:
+        flash('Action et année requises.', 'error')
+        return redirect(url_for('bilan_action_bp.bilan_action'))
+
+    conn = get_db()
+    try:
+        row = conn.execute(
+            'SELECT donnees FROM bilan_action_data WHERE action_id = ? AND annee = ? AND onglet = ?',
+            (action_id, annee, onglet)
+        ).fetchone()
+        donnees = json.loads(row['donnees']) if row and row['donnees'] else {}
+        action = conn.execute(
+            'SELECT nom FROM comptabilite_actions WHERE id = ?', (action_id,)
+        ).fetchone()
+        action_nom = action['nom'] if action else f'#{action_id}'
+
+        summary = _summary(conn, donnees, annee, action_id, onglet)
+
+        # Détail des comptes pour le bilan simplifié.
+        charges_cat, produits_cat = _bilan_categories(conn, donnees, summary, annee, action_id, onglet)
+
+        pdf_bytes = _build_pdf(action_nom, annee, onglet, donnees, summary,
+                               charges_cat, produits_cat)
+        response = make_response(pdf_bytes)
+        response.headers['Content-Type'] = 'application/pdf'
+        filename = f'bilan_action_{action_id}_{annee}_{onglet}.pdf'
+        response.headers['Content-Disposition'] = f'attachment; filename={filename}'
+        return response
+    finally:
+        conn.close()
+
+
+def _bilan_categories(conn, donnees, summary, annee, action_id, onglet):
+    """Construit les catégories charges/produits (style bilan_secteurs) pour le PDF,
+    en intégrant les lignes de salaires (641100 / 645100 / 631100)."""
+    charges, produits = {}, {}
+
+    def _add(groupe, compte, libelle, montant):
+        if not compte:
+            return
+        cat = str(compte)[:2]
+        groupe.setdefault(cat, {'comptes': {}, 'total': 0})
+        groupe[cat]['comptes'].setdefault(compte, {'libelle': libelle, 'total': 0})
+        groupe[cat]['comptes'][compte]['total'] += montant
+        groupe[cat]['total'] += montant
+
+    pcg = _get_libelles_pcg(conn)
+
+    if onglet == 'realise':
+        rc, rp = _realise_compta(conn, action_id, annee)
+        charges, produits = rc, rp
+        for m in (donnees.get('comptes_manuels') or []):
+            num = str(m.get('compte_num') or '')
+            lib = m.get('libelle') or pcg.get(num) or num
+            montant = _num(m.get('montant'))
+            _add(produits if num[:1] == '7' else charges, num, lib, montant)
+    else:
+        for key in ('charges_60', 'charges_61', 'charges_62'):
+            for ligne in (donnees.get(key) or []):
+                num = str(ligne.get('compte_num') or '')
+                lib = ligne.get('libelle') or pcg.get(num) or num
+                _add(charges, num, lib, _num(ligne.get('montant')))
+        for ligne in (donnees.get('produits') or []):
+            num = str(ligne.get('compte_num') or '')
+            lib = ligne.get('libelle') or pcg.get(num) or num
+            _add(produits, num, lib, _num(ligne.get('montant')))
+
+    # Lignes de salaires regroupées.
+    if summary['total_brut']:
+        _add(charges, COMPTE_BRUT, 'Rémunérations brutes', summary['total_brut'])
+    if summary['total_charges_sociales']:
+        _add(charges, COMPTE_CHARGES, 'Charges de sécurité sociale', summary['total_charges_sociales'])
+    if summary['total_taxe']:
+        _add(charges, COMPTE_TAXE, 'Taxe sur les salaires', summary['total_taxe'])
+
+    for groupe in (charges, produits):
+        for cat in groupe.values():
+            cat['total'] = round(cat['total'], 2)
+            for c in cat['comptes'].values():
+                c['total'] = round(c['total'], 2)
+    return charges, produits
+
+
+def _build_pdf(action_nom, annee, onglet, donnees, summary, charges, produits):
+    """Génère le PDF : bilan simplifié + récap salariés + récap bénévoles."""
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib import colors
+    from reportlab.lib.units import cm
+    from reportlab.platypus import (SimpleDocTemplate, Table as RLTable,
+                                    TableStyle, Paragraph, Spacer, PageBreak)
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.enums import TA_CENTER
+
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(buffer, pagesize=A4,
+                            topMargin=1.5 * cm, bottomMargin=1.5 * cm,
+                            leftMargin=1.5 * cm, rightMargin=1.5 * cm)
+    elements = []
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle('T', parent=styles['Heading1'],
+                                 alignment=TA_CENTER, fontSize=14, spaceAfter=6)
+    subtitle_style = ParagraphStyle('S', parent=styles['Normal'],
+                                    alignment=TA_CENTER, fontSize=10, spaceAfter=14)
+    section_style = ParagraphStyle('Sec', parent=styles['Heading2'],
+                                   fontSize=12, spaceAfter=6, spaceBefore=12)
+    normal = styles['Normal']
+
+    libelle_onglet = 'Prévisionnel' if onglet == 'previsionnel' else 'Réalisé'
+    elements.append(Paragraph('BILAN ACTION', title_style))
+    elements.append(Paragraph(
+        f'Action : {action_nom} — Année {annee} — {libelle_onglet}', subtitle_style))
+
+    def _section(categories, label, color_header):
+        elements.append(Paragraph(label, section_style))
+        if not categories:
+            elements.append(Paragraph('Aucune donnée.', normal))
+            return
+        data = [['Compte', 'Libellé', 'Montant']]
+        cat_rows = []
+        for cat_code in sorted(categories.keys()):
+            cat = categories[cat_code]
+            cat_name = NOMS_CATEGORIES.get(cat_code, f'Catégorie {cat_code}')
+            cat_rows.append(len(data))
+            data.append([f'{cat_code} - {cat_name}', '', _fmt(cat['total']) + ' €'])
+            for cpt_num in sorted(cat['comptes'].keys()):
+                cpt = cat['comptes'][cpt_num]
+                data.append([f'   {cpt_num}', cpt['libelle'], _fmt(cpt['total']) + ' €'])
+        t = RLTable(data, colWidths=[4 * cm, 9 * cm, 4 * cm], repeatRows=1)
+        style_cmds = [
+            ('BACKGROUND', (0, 0), (-1, 0), color_header),
+            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+            ('FONTSIZE', (0, 0), (-1, 0), 9),
+            ('BOTTOMPADDING', (0, 0), (-1, 0), 6),
+            ('TOPPADDING', (0, 0), (-1, 0), 6),
+            ('FONTSIZE', (0, 1), (-1, -1), 8),
+            ('TOPPADDING', (0, 1), (-1, -1), 3),
+            ('BOTTOMPADDING', (0, 1), (-1, -1), 3),
+            ('ALIGN', (2, 0), (2, -1), 'RIGHT'),
+            ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
+            ('BOX', (0, 0), (-1, -1), 1, colors.black),
+        ]
+        for ri in cat_rows:
+            style_cmds.append(('FONTNAME', (0, ri), (-1, ri), 'Helvetica-Bold'))
+            style_cmds.append(('BACKGROUND', (0, ri), (-1, ri), colors.HexColor('#F0F0F0')))
+        t.setStyle(TableStyle(style_cmds))
+        elements.append(t)
+
+    _section(charges, 'Charges', colors.HexColor('#C0392B'))
+    _section(produits, 'Produits', colors.HexColor('#27AE60'))
+
+    # Résumé.
+    elements.append(Spacer(1, 0.5 * cm))
+    summary_data = [
+        ['Total charges (comptes + salaires)', _fmt(summary['total_charges']) + ' €'],
+        ['Total produits', _fmt(summary['total_produits']) + ' €'],
+        [f"Logistique ({_fmt(summary['taux_logistique'])} % — {summary['taux_selection']})",
+         _fmt(summary['logistique']) + ' €'],
+        ['Résultat sans logistique', _fmt(summary['resultat_sans']) + ' €'],
+        ['Résultat avec logistique', _fmt(summary['resultat_avec']) + ' €'],
+    ]
+    summary_t = RLTable(summary_data, colWidths=[11 * cm, 6 * cm])
+    summary_t.setStyle(TableStyle([
+        ('FONTNAME', (0, 0), (-1, -1), 'Helvetica-Bold'),
+        ('FONTSIZE', (0, 0), (-1, -1), 10),
+        ('ALIGN', (1, 0), (1, -1), 'RIGHT'),
+        ('TOPPADDING', (0, 0), (-1, -1), 4),
+        ('BOTTOMPADDING', (0, 0), (-1, -1), 4),
+        ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
+        ('BOX', (0, 0), (-1, -1), 1, colors.black),
+        ('BACKGROUND', (0, 3), (-1, 4), colors.HexColor('#FFF9C4')),
+    ]))
+    elements.append(summary_t)
+
+    # Page récap salariés.
+    salaries = summary.get('salaries') or []
+    if salaries:
+        elements.append(PageBreak())
+        elements.append(Paragraph('Récapitulatif des salariés', section_style))
+        data = [['Salarié', 'Temps hebdo', 'Brut mensuel', 'Heures action',
+                 'Coût brut', 'Charges soc.', 'Taxe', 'Salaire chargé']]
+        for s in salaries:
+            nom = (str(s.get('nom') or '') + ' ' + str(s.get('prenom') or '')).strip() or 'Salarié'
+            data.append([
+                nom,
+                _fmt(_num(s.get('temps_hebdo'))),
+                _fmt(s.get('brut_mensuel', 0)),
+                _fmt(_num(s.get('heures_action'))),
+                _fmt(s.get('cout_brut', 0)),
+                _fmt(s.get('charges_sociales', 0)),
+                _fmt(s.get('taxe', 0)),
+                _fmt(s.get('salaire_charge', 0)),
+            ])
+        data.append(['TOTAL', '', '', '',
+                     _fmt(summary['total_brut']),
+                     _fmt(summary['total_charges_sociales']),
+                     _fmt(summary['total_taxe']),
+                     _fmt(round(summary['total_brut'] + summary['total_charges_sociales'], 2))])
+        t = RLTable(data, repeatRows=1)
+        t.setStyle(TableStyle([
+            ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#34495E')),
+            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+            ('FONTNAME', (0, -1), (-1, -1), 'Helvetica-Bold'),
+            ('BACKGROUND', (0, -1), (-1, -1), colors.HexColor('#F0F0F0')),
+            ('FONTSIZE', (0, 0), (-1, -1), 7.5),
+            ('ALIGN', (1, 0), (-1, -1), 'RIGHT'),
+            ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
+            ('TOPPADDING', (0, 0), (-1, -1), 3),
+            ('BOTTOMPADDING', (0, 0), (-1, -1), 3),
+        ]))
+        elements.append(t)
+
+    # Page récap bénévoles.
+    benevoles = donnees.get('benevoles') or []
+    if benevoles:
+        elements.append(PageBreak())
+        elements.append(Paragraph('Récapitulatif des bénévoles', section_style))
+        data = [['Bénévole', 'Heures', 'Commentaire']]
+        total_h = 0.0
+        for b in benevoles:
+            h = _num(b.get('heures'))
+            total_h += h
+            data.append([b.get('nom') or 'Bénévole', _fmt(h), b.get('commentaire') or ''])
+        data.append(['TOTAL', _fmt(total_h), ''])
+        t = RLTable(data, colWidths=[6 * cm, 3 * cm, 8 * cm], repeatRows=1)
+        t.setStyle(TableStyle([
+            ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor('#16A085')),
+            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+            ('FONTNAME', (0, -1), (-1, -1), 'Helvetica-Bold'),
+            ('BACKGROUND', (0, -1), (-1, -1), colors.HexColor('#F0F0F0')),
+            ('FONTSIZE', (0, 0), (-1, -1), 8),
+            ('ALIGN', (1, 0), (1, -1), 'RIGHT'),
+            ('GRID', (0, 0), (-1, -1), 0.5, colors.grey),
+            ('TOPPADDING', (0, 0), (-1, -1), 3),
+            ('BOTTOMPADDING', (0, 0), (-1, -1), 3),
+        ]))
+        elements.append(t)
+
+    doc.build(elements)
+    buffer.seek(0)
+    return buffer.getvalue()

--- a/blueprints/delegations.py
+++ b/blueprints/delegations.py
@@ -67,3 +67,50 @@ def save_delegation(mission_key, delegated_user_id, delegated_by_user_id):
         conn.commit()
     finally:
         conn.close()
+
+
+# ── Délégation : réservations de salle récurrentes ─────────────────────────────
+# Par défaut, seuls les responsables (et la direction) peuvent créer des
+# récurrences. La direction peut déléguer ce droit à un ou plusieurs salariés.
+
+def get_salle_recurrence_user_ids():
+    """Retourne la liste des IDs des salariés autorisés à créer des récurrences."""
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            'SELECT user_id FROM delegations_salles_recurrence'
+        ).fetchall()
+        return [row['user_id'] for row in rows]
+    finally:
+        conn.close()
+
+
+def user_peut_recurrence_salle(user_id):
+    """Indique si un salarié dispose de la délégation des récurrences de salle."""
+    if not user_id:
+        return False
+    conn = get_db()
+    try:
+        row = conn.execute(
+            'SELECT 1 FROM delegations_salles_recurrence WHERE user_id = ?',
+            (user_id,)
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def save_salle_recurrence_delegations(user_ids, granted_by):
+    """Remplace l'ensemble des salariés autorisés à créer des récurrences."""
+    conn = get_db()
+    try:
+        conn.execute('DELETE FROM delegations_salles_recurrence')
+        for uid in user_ids:
+            conn.execute(
+                'INSERT OR IGNORE INTO delegations_salles_recurrence (user_id, granted_by) '
+                'VALUES (?, ?)',
+                (uid, granted_by)
+            )
+        conn.commit()
+    finally:
+        conn.close()

--- a/blueprints/salles.py
+++ b/blueprints/salles.py
@@ -21,8 +21,15 @@ def _est_admin():
 
 
 def _peut_creer_recurrence():
-    """Verifie si l'utilisateur peut creer des recurrences."""
-    return _est_admin() or session.get('profil') == 'responsable'
+    """Verifie si l'utilisateur peut creer des recurrences.
+
+    Par defaut : direction/comptable et responsables. La direction peut aussi
+    deleguer ce droit a des salaries via la page Delegation.
+    """
+    if _est_admin() or session.get('profil') == 'responsable':
+        return True
+    from blueprints.delegations import user_peut_recurrence_salle
+    return user_peut_recurrence_salle(session.get('user_id'))
 
 
 def _get_dates_exclues(conn, date_debut_str, date_fin_str, exclure_vacances, exclure_feries):

--- a/database.py
+++ b/database.py
@@ -1344,6 +1344,26 @@ def init_db():
         )
     ''')
 
+    # Bilan action : budget previsionnel et realise d'une action analytique
+    # (un enregistrement par action / annee / onglet ; etat complet en JSON)
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS bilan_action_data (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            action_id INTEGER NOT NULL,
+            annee INTEGER NOT NULL,
+            onglet TEXT NOT NULL DEFAULT 'previsionnel'
+                CHECK(onglet IN ('previsionnel', 'realise')),
+            donnees TEXT,
+            total_charges REAL DEFAULT 0,
+            total_produits REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(action_id, annee, onglet),
+            FOREIGN KEY (action_id) REFERENCES comptabilite_actions(id) ON DELETE CASCADE,
+            FOREIGN KEY (updated_by) REFERENCES users(id)
+        )
+    ''')
+
     # ===== Table types de secteur (migration 0027) =====
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS types_secteur (

--- a/database.py
+++ b/database.py
@@ -889,6 +889,19 @@ def init_db():
         )
     ''')
 
+    # Délégation : salariés autorisés à créer des réservations de salle
+    # récurrentes (par défaut réservé aux responsables / direction).
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS delegations_salles_recurrence (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL UNIQUE,
+            granted_by INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (granted_by) REFERENCES users(id)
+        )
+    ''')
+
     # ===== Module CSE (migration 0040) =====
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS cse_membres (

--- a/migrations/0047_bilan_action.py
+++ b/migrations/0047_bilan_action.py
@@ -1,0 +1,52 @@
+"""
+Migration 0047 : Ajout du module Bilan action.
+
+Construction du budget prévisionnel et du réalisé d'une action analytique,
+par action et par année, avec deux onglets (prévisionnel / réalisé).
+
+- bilan_action_data : un enregistrement par (action, année, onglet). L'état
+  complet de l'onglet (comptes de charges 60/61/62, produits, salariés avec
+  paramètres de paie, sélection du taux de logistique, bénévoles, commentaires)
+  est sérialisé en JSON dans la colonne `donnees`. Les totaux sont mis en cache
+  pour un accès rapide.
+
+Les taux de logistique restent stockés dans `bilan_taux_logistique` (partagés
+avec la page Bilan secteurs). Le réalisé comptable est lu depuis
+`bilan_fec_donnees` (import BI).
+"""
+
+NOM = "Ajout module bilan action"
+DESCRIPTION = (
+    "Ajoute la table bilan_action_data (budget prévisionnel et réalisé d'une "
+    "action analytique, par action / année / onglet)."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS bilan_action_data (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            action_id INTEGER NOT NULL,
+            annee INTEGER NOT NULL,
+            onglet TEXT NOT NULL DEFAULT 'previsionnel'
+                CHECK(onglet IN ('previsionnel', 'realise')),
+            donnees TEXT,
+            total_charges REAL DEFAULT 0,
+            total_produits REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(action_id, annee, onglet),
+            FOREIGN KEY (action_id) REFERENCES comptabilite_actions(id) ON DELETE CASCADE,
+            FOREIGN KEY (updated_by) REFERENCES users(id)
+        )
+    ''')
+
+
+def downgrade(conn):
+    """Suppression de la table du module bilan action."""
+    cursor = conn.cursor()
+    cursor.execute('DROP TABLE IF EXISTS bilan_action_data')
+    conn.commit()

--- a/migrations/0048_delegation_recurrence_salles.py
+++ b/migrations/0048_delegation_recurrence_salles.py
@@ -1,0 +1,35 @@
+"""
+Migration 0048 : Délégation des réservations de salle récurrentes.
+
+Par défaut, seuls les responsables (et la direction) peuvent créer des
+réservations de salle récurrentes. Cette table permet à la direction de
+déléguer ce droit à un ou plusieurs salariés, depuis la page Délégation.
+"""
+
+NOM = "Délégation récurrences de salle"
+DESCRIPTION = (
+    "Ajoute la table delegations_salles_recurrence (salariés autorisés à créer "
+    "des réservations de salle récurrentes)."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS delegations_salles_recurrence (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL UNIQUE,
+            granted_by INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (granted_by) REFERENCES users(id)
+        )
+    ''')
+
+
+def downgrade(conn):
+    """Suppression de la table de délégation des récurrences."""
+    cursor = conn.cursor()
+    cursor.execute('DROP TABLE IF EXISTS delegations_salles_recurrence')
+    conn.commit()

--- a/templates/base.html
+++ b/templates/base.html
@@ -88,6 +88,7 @@
                     <a href="{{ url_for('subventions_bp.gestion_subventions') }}">📋 Subventions</a>
                     <a href="{{ url_for('tresorerie_bp.tresorerie') }}">📈 Trésorerie</a>
                     <a href="{{ url_for('bilan_secteurs_bp.bilan_secteurs') }}">📊 Bilan secteurs/actions</a>
+                    <a href="{{ url_for('bilan_action_bp.bilan_action') }}">🎯 Bilan action</a>
                     <a href="{{ url_for('alsh_bp.analyse_alsh') }}">🏕️ Analyse ALSH</a>
                 </div>
             </div>
@@ -205,6 +206,7 @@
                     <a href="{{ url_for('subventions_bp.gestion_subventions') }}">📋 Subventions</a>
                     <a href="{{ url_for('tresorerie_bp.tresorerie') }}">📈 Trésorerie</a>
                     <a href="{{ url_for('bilan_secteurs_bp.bilan_secteurs') }}">📊 Bilan secteurs/actions</a>
+                    <a href="{{ url_for('bilan_action_bp.bilan_action') }}">🎯 Bilan action</a>
                     <a href="{{ url_for('alsh_bp.analyse_alsh') }}">🏕️ Analyse ALSH</a>
                 </div>
             </div>

--- a/templates/bilan_action.html
+++ b/templates/bilan_action.html
@@ -1,0 +1,596 @@
+{% extends "base.html" %}
+{% block title %}Bilan action - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="page-header" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:10px;">
+    <h2>🎯 Bilan action</h2>
+    <div id="actionButtons" style="display:none;gap:8px;flex-wrap:wrap;">
+        <span id="saveStatus" class="muted" style="align-self:center;"></span>
+        <button class="btn btn-primary" onclick="sauvegarder(true)">💾 Enregistrer</button>
+        <button class="btn btn-secondary" onclick="exporterPdf()">📄 Export PDF</button>
+    </div>
+</div>
+
+<div class="info-box">
+    ℹ️ La création d'une action se fait sur la page
+    <a href="{{ url_for('comptabilite_analytique_bp.plan_comptable_analytique') }}">Plan comptable analytique</a>.
+    Les enregistrements se font par action et par année.
+</div>
+
+{# ── Sélecteurs action / année ── #}
+<div style="display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap;margin:16px 0;">
+    <div class="form-group" style="margin:0;">
+        <label>Action</label>
+        <select id="selAction" class="form-select" onchange="onSelection()" style="min-width:220px;">
+            <option value="">— Sélectionner une action —</option>
+            {% for a in actions %}
+            <option value="{{ a.id }}">{{ a.nom }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="form-group" style="margin:0;">
+        <label>Année</label>
+        <select id="selAnnee" class="form-select" onchange="onSelection()">
+            {% for a in annees %}
+            <option value="{{ a }}" {% if a == annee_courante %}selected{% endif %}>{{ a }}</option>
+            {% endfor %}
+        </select>
+    </div>
+</div>
+
+{% if not actions %}
+<div class="muted" style="padding:16px 0;">
+    Aucune action n'est définie. Créez-en une sur la page
+    <a href="{{ url_for('comptabilite_analytique_bp.plan_comptable_analytique') }}">Plan comptable analytique</a>.
+</div>
+{% endif %}
+
+<div id="infoSelect" class="muted" style="padding:20px 0;text-align:center;">
+    Sélectionnez une action et une année pour construire le budget.
+</div>
+
+<div id="mainContainer" style="display:none;">
+    <div class="tabs">
+        <button class="tab-btn active" data-onglet="previsionnel" onclick="switchOnglet('previsionnel')">📘 Prévisionnel</button>
+        <button class="tab-btn" data-onglet="realise" onclick="switchOnglet('realise')">📊 Réalisé</button>
+    </div>
+    <div id="pane-previsionnel" class="pane"></div>
+    <div id="pane-realise" class="pane" style="display:none;"></div>
+</div>
+
+<datalist id="dl60"></datalist>
+<datalist id="dl61"></datalist>
+<datalist id="dl62"></datalist>
+<datalist id="dl7"></datalist>
+<datalist id="dlAll"></datalist>
+
+<div id="toast" style="display:none;position:fixed;bottom:20px;right:20px;background:#27AE60;color:#fff;padding:10px 16px;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.2);z-index:9999;"></div>
+
+<style>
+.tabs{display:flex;gap:4px;border-bottom:2px solid var(--border,#e3e6ea);margin:8px 0 16px;}
+.tab-btn{padding:10px 18px;border:none;background:transparent;cursor:pointer;font-size:1em;border-bottom:3px solid transparent;color:var(--text,#333);}
+.tab-btn.active{border-bottom-color:var(--primary,#2c7be5);font-weight:bold;color:var(--primary,#2c7be5);}
+.card{background:var(--card-bg,#fff);border:1px solid var(--border,#e3e6ea);border-radius:10px;padding:16px;margin-bottom:16px;}
+.card h4{margin:0 0 12px;}
+.part-title{font-size:1.1em;font-weight:bold;margin:22px 0 8px;color:var(--primary,#2c7be5);border-left:4px solid var(--primary,#2c7be5);padding-left:8px;}
+.muted{color:var(--text-muted,#888);font-size:.9em;}
+.tright{text-align:right;}
+.btn-sm{padding:5px 10px;font-size:.9em;}
+.btn-del{background:transparent;border:none;color:var(--danger,#dc3545);cursor:pointer;font-size:1em;line-height:1;}
+.bilan-table input.form-control{padding:4px 6px;height:auto;}
+.sal-table th{font-size:.78em;white-space:nowrap;}
+.sal-table td{padding:4px 6px;}
+.sal-table input{width:80px;}
+.info-box{background:#eaf3ff;border:1px solid #b6d4fe;border-radius:8px;padding:10px 14px;margin:12px 0;}
+.summary-row{display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid var(--border,#eee);}
+.summary-row.total{font-weight:bold;font-size:1.05em;border-bottom:2px solid var(--border,#ccc);}
+.pos{color:var(--success,#27AE60);font-weight:bold;}
+.neg{color:var(--danger,#dc3545);font-weight:bold;}
+</style>
+
+<script>
+var URL_IMPORT_BI = "{{ url_for('import_bi_bp.import_bi') }}";
+
+var CTX = null;
+var STATE = {previsionnel: null, realise: null};
+var PREV_FOR_REAL = null;     // snapshot du prévisionnel pour le comparatif réalisé
+var REAL_COMPTA = null;       // données comptables réalisées (import BI)
+var currentOnglet = 'previsionnel';
+
+// ── Utilitaires ──────────────────────────────────────────────────────────────
+function num(v, def){
+    var d = (def === undefined) ? 0 : (parseFloat(def) || 0);
+    if(v === undefined || v === null || v === '') return d;
+    if(typeof v === 'string') v = v.replace(',', '.');
+    var n = parseFloat(v);
+    return isNaN(n) ? d : n;
+}
+function fmt(n){ return (n || 0).toLocaleString('fr-FR', {minimumFractionDigits:2, maximumFractionDigits:2}); }
+function esc(s){ return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
+function attr(s){ return esc(s); }
+function setTxt(id, v){ var el = document.getElementById(id); if(el) el.textContent = v; }
+function setHtml(id, v){ var el = document.getElementById(id); if(el) el.innerHTML = v; }
+function gv(id){ var el = document.getElementById(id); return el ? el.value : ''; }
+function toast(msg){ var t = document.getElementById('toast'); t.textContent = msg; t.style.display = 'block'; setTimeout(function(){ t.style.display = 'none'; }, 2000); }
+
+function emptyPrev(){ return {charges_60:[], charges_61:[], charges_62:[], produits:[], salaries:[], salaire_params:{}, logistique:{selection:'global'}, benevoles:[]}; }
+function emptyReal(){ return {comptes_commentaires:{}, comptes_manuels:[], salaries:[], salaire_params:{}, logistique:{selection:'global'}, benevoles:[]}; }
+
+function ensureParams(o){
+    o.salaire_params = o.salaire_params || {};
+    var p = o.salaire_params;
+    if(p.socle == null || p.socle === '') p.socle = CTX.defaults.socle;
+    if(p.point == null || p.point === '') p.point = CTX.defaults.point;
+    if(p.temps_plein == null || p.temps_plein === '') p.temps_plein = CTX.defaults.temps_plein;
+}
+function mergePrev(d){ var b = emptyPrev(); if(d) Object.assign(b, d); ensureParams(b); b.logistique = b.logistique || {selection:'global'}; if(!b.logistique.selection) b.logistique.selection = 'global'; return b; }
+function mergeReal(d){ var b = emptyReal(); if(d) Object.assign(b, d); ensureParams(b); b.logistique = b.logistique || {selection:'global'}; if(!b.logistique.selection) b.logistique.selection = 'global'; b.comptes_commentaires = b.comptes_commentaires || {}; return b; }
+function prefillRealise(prev){
+    var b = emptyReal();
+    b.salaries = JSON.parse(JSON.stringify(prev.salaries || []));
+    b.salaire_params = Object.assign({}, prev.salaire_params || {});
+    b.logistique = {selection: (prev.logistique || {}).selection || 'global'};
+    b.benevoles = JSON.parse(JSON.stringify(prev.benevoles || []));
+    ensureParams(b);
+    return b;
+}
+
+// ── Calcul de paie (miroir du serveur) ───────────────────────────────────────
+function calcSalarie(s, params){
+    var socle = num(params.socle, CTX.defaults.socle);
+    var point = num(params.point, CTX.defaults.point);
+    var tp = num(params.temps_plein, CTX.defaults.temps_plein) || 35;
+    var th = num(s.temps_hebdo, tp); if(th <= 0) th = tp;
+    var pesee = num(s.pesee), anc = num(s.anciennete), comp = num(s.competence), maint = num(s.maintien);
+    var heures = num(s.heures_action);
+    var tc = num(s.taux_charge, CTX.defaults.taux_charge);
+    var tt = num(s.taux_taxe, CTX.defaults.taux_taxe);
+    var ratio = tp ? th / tp : 1;
+    var brutm = (socle + (pesee + anc + comp) * point) / 12 * ratio + maint;
+    var ha = th * 52;
+    var txh = ha ? brutm * 12 / ha : 0;
+    var coutb = txh * heures;
+    var chs = coutb * tc / 100;
+    var salc = coutb + chs;
+    var taxe = coutb * tt / 100;
+    return {brutm:brutm, coutb:coutb, chs:chs, salc:salc, taxe:taxe};
+}
+function sumCat(o){ var s = 0; for(var k in (o || {})) s += (o[k].total || 0); return s; }
+
+// ── Sélection action/année ───────────────────────────────────────────────────
+function onSelection(){
+    var action = gv('selAction'), annee = gv('selAnnee');
+    if(!action || !annee){
+        document.getElementById('mainContainer').style.display = 'none';
+        document.getElementById('actionButtons').style.display = 'none';
+        document.getElementById('infoSelect').style.display = 'block';
+        return;
+    }
+    loadAll(action, annee);
+}
+
+function loadAll(action_id, annee){
+    fetch('/api/bilan-action/contexte?annee=' + annee)
+    .then(function(r){ return r.json(); })
+    .then(function(ctx){
+        if(ctx.error){ alert(ctx.error); return; }
+        CTX = ctx;
+        CTX.comptesMap = {};
+        (ctx.comptes_pcg || []).forEach(function(c){ CTX.comptesMap[c.compte_num] = c.libelle; });
+        CTX.taux = {
+            taux_site1: num(ctx.taux.taux_site1),
+            taux_site2: num(ctx.taux.taux_site2),
+            taux_global: num(ctx.taux.taux_global)
+        };
+        populateDatalists();
+        return Promise.all([
+            fetch('/api/bilan-action/donnees?action_id=' + action_id + '&annee=' + annee + '&onglet=previsionnel').then(function(r){ return r.json(); }),
+            fetch('/api/bilan-action/donnees?action_id=' + action_id + '&annee=' + annee + '&onglet=realise').then(function(r){ return r.json(); })
+        ]);
+    })
+    .then(function(res){
+        if(!res) return;
+        var dp = res[0], dr = res[1];
+        STATE.previsionnel = mergePrev(dp.donnees);
+        PREV_FOR_REAL = dr.previsionnel || dp.donnees || JSON.parse(JSON.stringify(STATE.previsionnel));
+        if(dr.found){ STATE.realise = mergeReal(dr.donnees); }
+        else { STATE.realise = prefillRealise(STATE.previsionnel); }
+        REAL_COMPTA = null;
+        document.getElementById('mainContainer').style.display = 'block';
+        document.getElementById('actionButtons').style.display = 'flex';
+        document.getElementById('infoSelect').style.display = 'none';
+        renderPane('previsionnel');
+        renderPane('realise');
+        showCurrent();
+    })
+    .catch(function(){ alert('Erreur réseau.'); });
+}
+
+function populateDatalists(){
+    function f(id, pred){
+        var el = document.getElementById(id); if(!el) return;
+        el.innerHTML = (CTX.comptes_pcg || []).filter(function(c){ return pred(c.compte_num); })
+            .map(function(c){ return '<option value="' + attr(c.compte_num) + '">' + attr(c.compte_num + ' — ' + c.libelle) + '</option>'; }).join('');
+    }
+    f('dl60', function(n){ return n.indexOf('60') === 0; });
+    f('dl61', function(n){ return n.indexOf('61') === 0; });
+    f('dl62', function(n){ return n.indexOf('62') === 0; });
+    f('dl7', function(n){ return n.indexOf('7') === 0; });
+    f('dlAll', function(){ return true; });
+}
+
+function switchOnglet(o){
+    currentOnglet = o;
+    document.querySelectorAll('.tab-btn').forEach(function(b){ b.classList.toggle('active', b.dataset.onglet === o); });
+    showCurrent();
+}
+function showCurrent(){
+    document.getElementById('pane-previsionnel').style.display = (currentOnglet === 'previsionnel') ? 'block' : 'none';
+    document.getElementById('pane-realise').style.display = (currentOnglet === 'realise') ? 'block' : 'none';
+}
+
+// ── Rendu d'un onglet ────────────────────────────────────────────────────────
+function renderPane(onglet){
+    if(onglet === 'previsionnel') renderPrev(); else renderRealise();
+    refreshComputed(onglet);
+}
+function partTitle(t){ return '<div class="part-title">' + t + '</div>'; }
+
+function renderPrev(){
+    var h = '';
+    h += partTitle('Partie 1 — Comptes comptables');
+    h += sectionComptes('previsionnel', 'charges_60', '60xxxx — Achats', 'dl60');
+    h += sectionComptes('previsionnel', 'charges_61', '61xxxx — Services extérieurs', 'dl61');
+    h += sectionComptes('previsionnel', 'charges_62', '62xxxx — Autres services extérieurs', 'dl62');
+    h += sectionComptes('previsionnel', 'produits', 'Produits (70xxxx, 74xxxx, autres 71xxxx…)', 'dl7');
+    h += partTitle('Partie 2 — Salaires');
+    h += salaryBlock('previsionnel');
+    h += partTitle('Partie 3 — Logistique & bénévoles');
+    h += logistiqueBlock('previsionnel');
+    h += benevolesBlock('previsionnel');
+    h += summaryBlock('previsionnel');
+    document.getElementById('pane-previsionnel').innerHTML = h;
+}
+
+function renderRealise(){
+    var h = '';
+    h += partTitle('Partie 1 — Réalisé comptable');
+    h += '<div class="card"><button class="btn btn-primary btn-sm" onclick="lancerBilan()">▶️ Lancer / actualiser le bilan</button>'
+       + '<div id="realiseComptaZone" style="margin-top:12px;">' + renderComptaCompare() + '</div></div>';
+    h += partTitle('Partie 2 — Salaires (reportés du prévisionnel, modifiables)');
+    h += salaryBlock('realise');
+    h += partTitle('Partie 3 — Logistique & bénévoles');
+    h += logistiqueBlock('realise');
+    h += benevolesBlock('realise');
+    h += summaryBlock('realise');
+    document.getElementById('pane-realise').innerHTML = h;
+}
+
+// ── Partie 1 : comptes (prévisionnel) ────────────────────────────────────────
+function sectionComptes(onglet, key, titre, dl){
+    var arr = STATE[onglet][key] || [];
+    var rows = arr.map(function(l, i){
+        return '<tr>'
+            + '<td><input list="' + dl + '" class="form-control" value="' + attr(l.compte_num) + '" oninput="updateRow(\'' + onglet + '\',\'' + key + '\',' + i + ',\'compte_num\',this.value);autoLib(\'' + onglet + '\',\'' + key + '\',' + i + ',this.value)"></td>'
+            + '<td><input id="lib_' + onglet + '_' + key + '_' + i + '" class="form-control" value="' + attr(l.libelle) + '" oninput="updateRow(\'' + onglet + '\',\'' + key + '\',' + i + ',\'libelle\',this.value)"></td>'
+            + '<td><input type="number" step="0.01" class="form-control tright" value="' + (l.montant == null ? '' : l.montant) + '" oninput="updateRow(\'' + onglet + '\',\'' + key + '\',' + i + ',\'montant\',this.value)"></td>'
+            + '<td><input class="form-control" value="' + attr(l.commentaire) + '" oninput="updateRow(\'' + onglet + '\',\'' + key + '\',' + i + ',\'commentaire\',this.value)"></td>'
+            + '<td><button class="btn-del" onclick="delRow(\'' + onglet + '\',\'' + key + '\',' + i + ')">✕</button></td>'
+            + '</tr>';
+    }).join('');
+    return '<div class="card bilan-table"><h4>' + titre + '</h4>'
+        + '<table class="data-table"><thead><tr><th style="width:18%">Compte</th><th>Libellé</th><th style="width:15%">Montant</th><th>Commentaire</th><th></th></tr></thead>'
+        + '<tbody>' + (rows || '<tr><td colspan="5" class="muted">Aucune ligne.</td></tr>') + '</tbody>'
+        + '<tfoot><tr><td colspan="2" class="tright"><b>Sous-total</b></td><td class="tright"><b><span id="sub_' + onglet + '_' + key + '">0,00</span> €</b></td><td colspan="2"></td></tr></tfoot></table>'
+        + '<button class="btn btn-secondary btn-sm" onclick="addRow(\'' + onglet + '\',\'' + key + '\')">+ Ajouter un compte</button></div>';
+}
+
+function autoLib(onglet, key, i, n){
+    var lib = CTX.comptesMap[n];
+    if(lib){
+        STATE[onglet][key][i].libelle = lib;
+        var el = document.getElementById('lib_' + onglet + '_' + key + '_' + i);
+        if(el) el.value = lib;
+    }
+}
+
+// ── Partie 2 : salaires ──────────────────────────────────────────────────────
+function salaryBlock(onglet){
+    var d = STATE[onglet];
+    var p = d.salaire_params || {};
+    var opts = '<option value="">— Choisir un salarié —</option>';
+    (CTX.employes || []).forEach(function(e){ opts += '<option value="' + e.user_id + '">' + esc(e.nom + ' ' + e.prenom) + ' (' + e.type_contrat + ')</option>'; });
+    var rows = (d.salaries || []).map(function(s, i){ return salaryRow(onglet, s, i); }).join('');
+    return '<div class="card"><h4>Masse salariale</h4>'
+        + '<div style="display:flex;gap:16px;flex-wrap:wrap;margin-bottom:10px;align-items:flex-end;">'
+        + '<div class="form-group" style="margin:0;"><label>Salaire socle (annuel)</label><input type="number" step="1" class="form-control" style="width:120px;" value="' + (p.socle == null ? '' : p.socle) + '" oninput="updateParam(\'' + onglet + '\',\'socle\',this.value)"></div>'
+        + '<div class="form-group" style="margin:0;"><label>Valeur du point</label><input type="number" step="0.01" class="form-control" style="width:110px;" value="' + (p.point == null ? '' : p.point) + '" oninput="updateParam(\'' + onglet + '\',\'point\',this.value)"></div>'
+        + '<div class="form-group" style="margin:0;"><label>Temps plein (h/sem.)</label><input type="number" step="0.5" class="form-control" style="width:110px;" value="' + (p.temps_plein == null ? '' : p.temps_plein) + '" oninput="updateParam(\'' + onglet + '\',\'temps_plein\',this.value)"></div>'
+        + '</div>'
+        + '<div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;margin-bottom:10px;">'
+        + '<div class="form-group" style="margin:0;"><label>Ajouter un salarié</label><select id="selSal_' + onglet + '" class="form-select">' + opts + '</select></div>'
+        + '<button class="btn btn-secondary btn-sm" onclick="addSalarie(\'' + onglet + '\')">+ Salarié de la liste</button>'
+        + '<button class="btn btn-secondary btn-sm" onclick="addSalarieManuel(\'' + onglet + '\')">+ Salarié manuel</button>'
+        + '</div>'
+        + '<div style="overflow-x:auto;"><table class="data-table sal-table"><thead><tr>'
+        + '<th>Salarié</th><th>Temps hebdo</th><th>Pesée</th><th>Anc.</th><th>Comp.</th><th>Maintien</th>'
+        + '<th>Brut mensuel</th><th>Heures action</th><th>Coût brut<br>(641100)</th><th>Taux chargé %</th>'
+        + '<th>Charges soc.<br>(645100)</th><th>Taxe %</th><th>Taxe<br>(631100)</th><th>Salaire chargé</th><th></th>'
+        + '</tr></thead><tbody>' + (rows || '<tr><td colspan="15" class="muted">Aucun salarié.</td></tr>') + '</tbody>'
+        + '<tfoot><tr><td colspan="8" class="tright"><b>Totaux</b></td>'
+        + '<td class="tright"><b><span id="tot_' + onglet + '_brut">0,00</span></b></td><td></td>'
+        + '<td class="tright"><b><span id="tot_' + onglet + '_chs">0,00</span></b></td><td></td>'
+        + '<td class="tright"><b><span id="tot_' + onglet + '_taxe">0,00</span></b></td>'
+        + '<td class="tright"><b><span id="tot_' + onglet + '_salc">0,00</span></b></td><td></td></tr></tfoot></table></div></div>';
+}
+
+function salaryRow(onglet, s, i){
+    var nameCell = s.user_id
+        ? esc((s.nom || '') + (s.prenom ? (' ' + s.prenom) : ''))
+        : '<input class="form-control" value="' + attr(s.nom) + '" style="min-width:110px;" oninput="updateRow(\'' + onglet + '\',\'salaries\',' + i + ',\'nom\',this.value)">';
+    function inp(field, step){ var v = s[field]; return '<input type="number" step="' + (step || '0.01') + '" class="form-control tright" value="' + (v == null ? '' : v) + '" oninput="updateRow(\'' + onglet + '\',\'salaries\',' + i + ',\'' + field + '\',this.value)">'; }
+    return '<tr><td>' + nameCell + '</td>'
+        + '<td>' + inp('temps_hebdo', '0.5') + '</td>'
+        + '<td>' + inp('pesee', '1') + '</td>'
+        + '<td>' + inp('anciennete', '1') + '</td>'
+        + '<td>' + inp('competence', '1') + '</td>'
+        + '<td>' + inp('maintien', '0.01') + '</td>'
+        + '<td class="tright"><span id="c_' + onglet + '_brutm_' + i + '">0,00</span></td>'
+        + '<td>' + inp('heures_action', '1') + '</td>'
+        + '<td class="tright"><span id="c_' + onglet + '_coutb_' + i + '">0,00</span></td>'
+        + '<td>' + inp('taux_charge', '0.1') + '</td>'
+        + '<td class="tright"><span id="c_' + onglet + '_chs_' + i + '">0,00</span></td>'
+        + '<td>' + inp('taux_taxe', '0.01') + '</td>'
+        + '<td class="tright"><span id="c_' + onglet + '_taxe_' + i + '">0,00</span></td>'
+        + '<td class="tright"><span id="c_' + onglet + '_salc_' + i + '">0,00</span></td>'
+        + '<td><button class="btn-del" onclick="delRow(\'' + onglet + '\',\'salaries\',' + i + ')">✕</button></td></tr>';
+}
+
+function addSalarie(onglet){
+    var sel = document.getElementById('selSal_' + onglet);
+    var uid = sel ? sel.value : '';
+    if(!uid) return;
+    var emp = (CTX.employes || []).find(function(e){ return String(e.user_id) === String(uid); });
+    if(!emp) return;
+    if((STATE[onglet].salaries || []).some(function(s){ return String(s.user_id) === String(uid); })){ alert('Ce salarié est déjà ajouté.'); return; }
+    STATE[onglet].salaries.push({
+        user_id: emp.user_id, nom: emp.nom, prenom: emp.prenom,
+        temps_hebdo: emp.temps_hebdo, pesee: emp.pesee, anciennete: emp.anciennete,
+        competence: emp.competence, maintien: emp.maintien, heures_action: '',
+        taux_charge: CTX.defaults.taux_charge, taux_taxe: CTX.defaults.taux_taxe
+    });
+    renderPane(onglet);
+}
+function addSalarieManuel(onglet){
+    var n = (STATE[onglet].salaries || []).filter(function(s){ return !s.user_id; }).length + 1;
+    STATE[onglet].salaries.push({
+        user_id: null, nom: 'Salarié ' + n, prenom: '',
+        temps_hebdo: CTX.defaults.temps_plein, pesee: '', anciennete: '', competence: '', maintien: '',
+        heures_action: '', taux_charge: CTX.defaults.taux_charge, taux_taxe: CTX.defaults.taux_taxe
+    });
+    renderPane(onglet);
+}
+function updateParam(onglet, field, val){ STATE[onglet].salaire_params[field] = val; refreshComputed(onglet); }
+
+// ── Partie 3 : logistique ────────────────────────────────────────────────────
+function logistiqueBlock(onglet){
+    var sel = (STATE[onglet].logistique || {}).selection || 'global';
+    function radio(val, label){ return '<label><input type="radio" name="taux_' + onglet + '" value="' + val + '" ' + (sel === val ? 'checked' : '') + ' onchange="setTauxSel(\'' + onglet + '\',\'' + val + '\')"> ' + label + '</label>'; }
+    function input(site){ return '<input type="number" step="0.01" id="tx_' + site + '_' + onglet + '" class="form-control" style="width:110px;margin-top:4px;" value="' + (CTX.taux['taux_' + site] || '') + '" oninput="onTauxInput(\'' + site + '\',this.value)">'; }
+    return '<div class="card"><h4>🏗️ Taux de logistique <span class="muted">(valeurs partagées avec Bilan secteurs, par année)</span></h4>'
+        + '<div style="display:flex;gap:24px;flex-wrap:wrap;">'
+        + '<div class="form-group" style="margin:0;">' + radio('site1', 'Site 1') + '<br>' + input('site1') + '</div>'
+        + '<div class="form-group" style="margin:0;">' + radio('site2', 'Site 2') + '<br>' + input('site2') + '</div>'
+        + '<div class="form-group" style="margin:0;">' + radio('global', 'Global') + '<br>' + input('global') + '</div>'
+        + '</div><div id="logiCalc_' + onglet + '" class="muted" style="margin-top:12px;"></div></div>';
+}
+var _tauxTimer = null;
+function onTauxInput(site, val){
+    CTX.taux['taux_' + site] = num(val);
+    ['previsionnel', 'realise'].forEach(function(o){ var el = document.getElementById('tx_' + site + '_' + o); if(el && el.value !== val) el.value = val; });
+    refreshComputed('previsionnel'); refreshComputed('realise');
+    clearTimeout(_tauxTimer); _tauxTimer = setTimeout(saveTaux, 600);
+}
+function saveTaux(){
+    var annee = parseInt(gv('selAnnee'), 10);
+    if(!annee) return;
+    fetch('/api/bilan-action/taux-logistique', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({annee:annee, taux_site1:CTX.taux.taux_site1, taux_site2:CTX.taux.taux_site2, taux_global:CTX.taux.taux_global})
+    });
+}
+function setTauxSel(onglet, val){ STATE[onglet].logistique.selection = val; refreshComputed(onglet); }
+
+// ── Partie 3 : bénévoles ─────────────────────────────────────────────────────
+function benevolesBlock(onglet){
+    var arr = STATE[onglet].benevoles || [];
+    var opts = '<option value="">— Choisir un bénévole —</option>';
+    (CTX.benevoles || []).forEach(function(b){ opts += '<option value="' + b.id + '">' + esc(b.nom) + '</option>'; });
+    var rows = arr.map(function(b, i){
+        var nameCell = b.benevole_id
+            ? esc(b.nom)
+            : '<input class="form-control" value="' + attr(b.nom) + '" oninput="updateRow(\'' + onglet + '\',\'benevoles\',' + i + ',\'nom\',this.value)">';
+        return '<tr><td>' + nameCell + '</td>'
+            + '<td><input type="number" step="0.5" class="form-control tright" value="' + (b.heures == null ? '' : b.heures) + '" oninput="updateRow(\'' + onglet + '\',\'benevoles\',' + i + ',\'heures\',this.value)"></td>'
+            + '<td><input class="form-control" value="' + attr(b.commentaire) + '" oninput="updateRow(\'' + onglet + '\',\'benevoles\',' + i + ',\'commentaire\',this.value)"></td>'
+            + '<td><button class="btn-del" onclick="delRow(\'' + onglet + '\',\'benevoles\',' + i + ')">✕</button></td></tr>';
+    }).join('');
+    return '<div class="card"><h4>🤝 Bénévoles</h4>'
+        + '<div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;margin-bottom:10px;">'
+        + '<div class="form-group" style="margin:0;"><label>Ajouter un bénévole</label><select id="selBen_' + onglet + '" class="form-select">' + opts + '</select></div>'
+        + '<button class="btn btn-secondary btn-sm" onclick="addBenevole(\'' + onglet + '\')">+ De la liste</button>'
+        + '<button class="btn btn-secondary btn-sm" onclick="addBenevoleManuel(\'' + onglet + '\')">+ Manuel</button>'
+        + '</div><table class="data-table"><thead><tr><th>Bénévole</th><th style="width:15%">Heures</th><th>Commentaire</th><th></th></tr></thead>'
+        + '<tbody>' + (rows || '<tr><td colspan="4" class="muted">Aucun bénévole.</td></tr>') + '</tbody>'
+        + '<tfoot><tr><td class="tright"><b>Total heures</b></td><td class="tright"><b><span id="benh_' + onglet + '">0</span></b></td><td colspan="2"></td></tr></tfoot></table></div>';
+}
+function addBenevole(onglet){
+    var sel = document.getElementById('selBen_' + onglet);
+    var id = sel ? sel.value : '';
+    if(!id) return;
+    var b = (CTX.benevoles || []).find(function(x){ return String(x.id) === String(id); });
+    if(!b) return;
+    STATE[onglet].benevoles.push({benevole_id: b.id, nom: b.nom, heures: '', commentaire: ''});
+    renderPane(onglet);
+}
+function addBenevoleManuel(onglet){
+    STATE[onglet].benevoles.push({benevole_id: null, nom: '', heures: '', commentaire: ''});
+    renderPane(onglet);
+}
+
+// ── Synthèse ─────────────────────────────────────────────────────────────────
+function summaryBlock(onglet){ return '<div class="card"><h4>📈 Synthèse</h4><div id="summary_' + onglet + '"></div></div>'; }
+
+function refreshComputed(onglet){
+    var d = STATE[onglet];
+    if(onglet === 'previsionnel'){
+        ['charges_60', 'charges_61', 'charges_62', 'produits'].forEach(function(k){
+            var s = 0; (d[k] || []).forEach(function(l){ s += num(l.montant); });
+            setTxt('sub_' + onglet + '_' + k, fmt(s));
+        });
+    }
+    var params = d.salaire_params || {};
+    var tb = 0, tcs = 0, tt = 0, tsalc = 0;
+    (d.salaries || []).forEach(function(s, i){
+        var c = calcSalarie(s, params);
+        tb += c.coutb; tcs += c.chs; tt += c.taxe; tsalc += c.salc;
+        setTxt('c_' + onglet + '_brutm_' + i, fmt(c.brutm));
+        setTxt('c_' + onglet + '_coutb_' + i, fmt(c.coutb));
+        setTxt('c_' + onglet + '_chs_' + i, fmt(c.chs));
+        setTxt('c_' + onglet + '_taxe_' + i, fmt(c.taxe));
+        setTxt('c_' + onglet + '_salc_' + i, fmt(c.salc));
+    });
+    setTxt('tot_' + onglet + '_brut', fmt(tb));
+    setTxt('tot_' + onglet + '_chs', fmt(tcs));
+    setTxt('tot_' + onglet + '_taxe', fmt(tt));
+    setTxt('tot_' + onglet + '_salc', fmt(tsalc));
+    var masse = tb + tcs + tt;
+
+    var bh = 0; (d.benevoles || []).forEach(function(b){ bh += num(b.heures); });
+    setTxt('benh_' + onglet, bh.toLocaleString('fr-FR'));
+
+    var chComptes = 0, prod = 0;
+    if(onglet === 'realise'){
+        if(REAL_COMPTA && REAL_COMPTA.import_existe){ chComptes += sumCat(REAL_COMPTA.charges); prod += sumCat(REAL_COMPTA.produits); }
+        (d.comptes_manuels || []).forEach(function(m){ var v = num(m.montant); if(String(m.compte_num || '')[0] === '7') prod += v; else chComptes += v; });
+    } else {
+        ['charges_60', 'charges_61', 'charges_62'].forEach(function(k){ (d[k] || []).forEach(function(l){ chComptes += num(l.montant); }); });
+        (d.produits || []).forEach(function(l){ prod += num(l.montant); });
+    }
+
+    var sel = (d.logistique || {}).selection || 'global';
+    var tauxVal = num(CTX.taux['taux_' + sel]);
+    var totalCharges = chComptes + masse;
+    var logi = totalCharges * tauxVal / 100;
+    setHtml('logiCalc_' + onglet, 'Base = charges comptables ' + fmt(chComptes) + ' € + masse salariale chargée ' + fmt(masse) + ' € = <b>' + fmt(totalCharges) + ' €</b><br>Charges de logistique = ' + fmt(totalCharges) + ' € × ' + fmt(tauxVal) + ' % (' + sel + ') = <b>' + fmt(logi) + ' €</b>');
+
+    var resSans = prod - totalCharges, resAvec = prod - totalCharges - logi;
+    function r(label, val, cls){ return '<div class="summary-row ' + (cls || '') + '"><span>' + label + '</span><span>' + val + ' €</span></div>'; }
+    function rcol(label, val){ var c = val >= 0 ? 'pos' : 'neg'; return '<div class="summary-row total"><span>' + label + '</span><span class="' + c + '">' + fmt(val) + ' €</span></div>'; }
+    var html = r('Charges comptables (60/61/62)', fmt(chComptes))
+        + r('Masse salariale chargée (641100 + 645100 + 631100)', fmt(masse))
+        + r('<b>Total charges</b>', fmt(totalCharges), 'total')
+        + r('Total produits', fmt(prod))
+        + r('Logistique (' + fmt(tauxVal) + ' % — ' + sel + ')', fmt(logi))
+        + rcol('Résultat sans logistique', resSans)
+        + rcol('Résultat avec logistique', resAvec);
+    setHtml('summary_' + onglet, html);
+}
+
+// ── Réalisé : comparatif comptable ───────────────────────────────────────────
+function prevComptesMap(){
+    var map = {};
+    var p = PREV_FOR_REAL;
+    if(!p) return map;
+    ['charges_60', 'charges_61', 'charges_62', 'produits'].forEach(function(k){
+        (p[k] || []).forEach(function(l){
+            var n = l.compte_num; if(!n) return;
+            if(!map[n]) map[n] = {libelle: l.libelle || '', montant: 0};
+            map[n].montant += num(l.montant);
+        });
+    });
+    return map;
+}
+function renderComptaCompare(){
+    if(!REAL_COMPTA){ return '<p class="muted">Cliquez sur « Lancer le bilan » pour charger le réalisé comptable.</p>'; }
+    if(!REAL_COMPTA.import_existe){ return '<p class="muted">⚠️ Aucun import BI pour cette année. <a href="' + URL_IMPORT_BI + '">Effectuer l\'import BI</a>, puis relancez le bilan.</p>'; }
+    var prevMap = prevComptesMap();
+    var realMap = {};
+    ['charges', 'produits'].forEach(function(g){
+        var o = REAL_COMPTA[g] || {};
+        for(var cat in o){ for(var n in o[cat].comptes){ realMap[n] = {libelle: o[cat].comptes[n].libelle, montant: o[cat].comptes[n].total}; } }
+    });
+    var nums = Object.keys(prevMap).concat(Object.keys(realMap)).filter(function(v, idx, self){ return self.indexOf(v) === idx; }).sort();
+    var rows = nums.map(function(n){
+        var p = prevMap[n] ? prevMap[n].montant : 0;
+        var rr = realMap[n] ? realMap[n].montant : 0;
+        var lib = (realMap[n] && realMap[n].libelle) || (prevMap[n] && prevMap[n].libelle) || n;
+        var ecart = rr - p;
+        var com = (STATE.realise.comptes_commentaires || {})[n] || '';
+        return '<tr><td>' + esc(n) + '</td><td>' + esc(lib) + '</td><td class="tright">' + fmt(p) + '</td><td class="tright">' + fmt(rr) + '</td>'
+            + '<td class="tright ' + (ecart >= 0 ? 'pos' : 'neg') + '">' + fmt(ecart) + '</td>'
+            + '<td><input class="form-control" value="' + attr(com) + '" oninput="setComment(\'' + attr(n) + '\',this.value)"></td></tr>';
+    }).join('');
+    var man = (STATE.realise.comptes_manuels || []).map(function(m, i){
+        return '<tr><td><input list="dlAll" class="form-control" value="' + attr(m.compte_num) + '" oninput="updateRow(\'realise\',\'comptes_manuels\',' + i + ',\'compte_num\',this.value)"></td>'
+            + '<td><input class="form-control" value="' + attr(m.libelle) + '" oninput="updateRow(\'realise\',\'comptes_manuels\',' + i + ',\'libelle\',this.value)"></td>'
+            + '<td colspan="2"><input type="number" step="0.01" class="form-control tright" value="' + (m.montant == null ? '' : m.montant) + '" oninput="updateRow(\'realise\',\'comptes_manuels\',' + i + ',\'montant\',this.value)"></td><td></td>'
+            + '<td style="display:flex;gap:4px;"><input class="form-control" value="' + attr(m.commentaire) + '" oninput="updateRow(\'realise\',\'comptes_manuels\',' + i + ',\'commentaire\',this.value)"><button class="btn-del" onclick="delCompteManuel(' + i + ')">✕</button></td></tr>';
+    }).join('');
+    return '<table class="data-table bilan-table"><thead><tr><th>Compte</th><th>Libellé</th><th class="tright">Prévu</th><th class="tright">Réalisé</th><th class="tright">Écart</th><th>Commentaire</th></tr></thead>'
+        + '<tbody>' + (rows || '<tr><td colspan="6" class="muted">Aucun compte rattaché à l\'action.</td></tr>') + '</tbody>'
+        + (man ? '<tbody><tr><td colspan="6"><b>Comptes ajoutés manuellement</b></td></tr>' + man + '</tbody>' : '')
+        + '</table><button class="btn btn-secondary btn-sm" onclick="addCompteManuel()" style="margin-top:8px;">+ Ajouter un compte</button>';
+}
+function setComment(n, val){ STATE.realise.comptes_commentaires[n] = val; }
+function addCompteManuel(){ STATE.realise.comptes_manuels.push({compte_num:'', libelle:'', montant:'', commentaire:''}); document.getElementById('realiseComptaZone').innerHTML = renderComptaCompare(); refreshComputed('realise'); }
+function delCompteManuel(i){ STATE.realise.comptes_manuels.splice(i, 1); document.getElementById('realiseComptaZone').innerHTML = renderComptaCompare(); refreshComputed('realise'); }
+
+function lancerBilan(){
+    var action_id = gv('selAction'), annee = gv('selAnnee');
+    if(!action_id || !annee) return;
+    fetch('/api/bilan-action/realise-compta?action_id=' + action_id + '&annee=' + annee)
+    .then(function(r){ return r.json(); })
+    .then(function(d){
+        if(d.error){ alert(d.error); return; }
+        REAL_COMPTA = d;
+        document.getElementById('realiseComptaZone').innerHTML = renderComptaCompare();
+        refreshComputed('realise');
+    })
+    .catch(function(){ alert('Erreur réseau.'); });
+}
+
+// ── Mutations génériques ─────────────────────────────────────────────────────
+function updateRow(onglet, key, i, field, val){
+    if(!STATE[onglet][key] || !STATE[onglet][key][i]) return;
+    STATE[onglet][key][i][field] = val;
+    refreshComputed(onglet);
+}
+function addRow(onglet, key){ STATE[onglet][key].push({compte_num:'', libelle:'', montant:'', commentaire:''}); renderPane(onglet); }
+function delRow(onglet, key, i){ STATE[onglet][key].splice(i, 1); renderPane(onglet); }
+
+// ── Sauvegarde / export ──────────────────────────────────────────────────────
+function sauvegarder(showMsg){
+    var action_id = parseInt(gv('selAction'), 10), annee = parseInt(gv('selAnnee'), 10);
+    if(!action_id || !annee) return Promise.resolve();
+    setTxt('saveStatus', 'Enregistrement…');
+    return fetch('/api/bilan-action/save', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({action_id:action_id, annee:annee, onglet:currentOnglet, donnees:STATE[currentOnglet]})
+    }).then(function(r){ return r.json(); }).then(function(d){
+        setTxt('saveStatus', '');
+        if(d.error){ alert(d.error); return d; }
+        if(currentOnglet === 'previsionnel'){ PREV_FOR_REAL = JSON.parse(JSON.stringify(STATE.previsionnel)); }
+        if(showMsg) toast('✓ Enregistré');
+        return d;
+    }).catch(function(){ setTxt('saveStatus', ''); alert('Erreur réseau lors de l\'enregistrement.'); });
+}
+function exporterPdf(){
+    var action_id = gv('selAction'), annee = gv('selAnnee');
+    if(!action_id || !annee) return;
+    sauvegarder(false).then(function(){
+        window.open('/api/bilan-action/export-pdf?action_id=' + action_id + '&annee=' + annee + '&onglet=' + currentOnglet, '_blank');
+    });
+}
+</script>
+{% endblock %}

--- a/templates/bilan_action.html
+++ b/templates/bilan_action.html
@@ -159,6 +159,7 @@ function sumCat(o){ var s = 0; for(var k in (o || {})) s += (o[k].total || 0); r
 
 // ── Sélection action/année ───────────────────────────────────────────────────
 function onSelection(){
+    flushTaux();  // persiste un taux édité pour l'année courante avant de changer de sélection
     var action = gv('selAction'), annee = gv('selAnnee');
     if(!action || !annee){
         document.getElementById('mainContainer').style.display = 'none';
@@ -385,19 +386,27 @@ function logistiqueBlock(onglet){
         + '</div><div id="logiCalc_' + onglet + '" class="muted" style="margin-top:12px;"></div></div>';
 }
 var _tauxTimer = null;
+var _tauxPending = null;   // snapshot {annee, taux_site1, taux_site2, taux_global} à enregistrer
 function onTauxInput(site, val){
     CTX.taux['taux_' + site] = num(val);
     ['previsionnel', 'realise'].forEach(function(o){ var el = document.getElementById('tx_' + site + '_' + o); if(el && el.value !== val) el.value = val; });
     refreshComputed('previsionnel'); refreshComputed('realise');
-    clearTimeout(_tauxTimer); _tauxTimer = setTimeout(saveTaux, 600);
+    // Capture l'année ET les taux au moment de l'édition : un changement d'année
+    // ou un enregistrement déclenché ensuite ne doit pas écrire le taux sur la
+    // mauvaise année (le callback débouncé s'exécute plus tard).
+    _tauxPending = {annee: parseInt(gv('selAnnee'), 10), taux_site1: CTX.taux.taux_site1, taux_site2: CTX.taux.taux_site2, taux_global: CTX.taux.taux_global};
+    clearTimeout(_tauxTimer); _tauxTimer = setTimeout(flushTaux, 600);
 }
-function saveTaux(){
-    var annee = parseInt(gv('selAnnee'), 10);
-    if(!annee) return;
-    fetch('/api/bilan-action/taux-logistique', {
+// Enregistre immédiatement le taux en attente (snapshot) ; renvoie une promesse
+// pour pouvoir attendre l'écriture avant une sauvegarde / un export PDF.
+function flushTaux(){
+    clearTimeout(_tauxTimer); _tauxTimer = null;
+    if(!_tauxPending || !_tauxPending.annee){ _tauxPending = null; return Promise.resolve(); }
+    var p = _tauxPending; _tauxPending = null;
+    return fetch('/api/bilan-action/taux-logistique', {
         method:'POST', headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({annee:annee, taux_site1:CTX.taux.taux_site1, taux_site2:CTX.taux.taux_site2, taux_global:CTX.taux.taux_global})
-    });
+        body: JSON.stringify({annee:p.annee, taux_site1:p.taux_site1, taux_site2:p.taux_site2, taux_global:p.taux_global})
+    }).then(function(r){ return r.json(); }).catch(function(){});
 }
 function setTauxSel(onglet, val){ STATE[onglet].logistique.selection = val; refreshComputed(onglet); }
 
@@ -574,9 +583,12 @@ function sauvegarder(showMsg){
     var action_id = parseInt(gv('selAction'), 10), annee = parseInt(gv('selAnnee'), 10);
     if(!action_id || !annee) return Promise.resolve();
     setTxt('saveStatus', 'Enregistrement…');
-    return fetch('/api/bilan-action/save', {
-        method:'POST', headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({action_id:action_id, annee:annee, onglet:currentOnglet, donnees:STATE[currentOnglet]})
+    // Le résumé serveur lit les taux en base : on écrit d'abord un éventuel taux en attente.
+    return flushTaux().then(function(){
+        return fetch('/api/bilan-action/save', {
+            method:'POST', headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({action_id:action_id, annee:annee, onglet:currentOnglet, donnees:STATE[currentOnglet]})
+        });
     }).then(function(r){ return r.json(); }).then(function(d){
         setTxt('saveStatus', '');
         if(d.error){ alert(d.error); return d; }

--- a/templates/delegations.html
+++ b/templates/delegations.html
@@ -22,6 +22,18 @@
         font-weight: 600;
         color: var(--gray-900);
     }
+    .recurrence-users {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+        gap: 8px 16px;
+    }
+    .recurrence-user {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 400;
+    }
+    .recurrence-user input { width: auto; margin: 0; }
 </style>
 
 <div class="delegations-page">
@@ -64,6 +76,41 @@
             </form>
         </div>
         {% endfor %}
+
+        <div class="delegation-card">
+            <h2>Réservation de salle récurrente</h2>
+            <p class="delegation-meta">
+                Par défaut, seuls les responsables (et la direction) peuvent créer des réservations
+                de salle récurrentes. Cochez les salariés autorisés à créer des récurrences.
+            </p>
+
+            <form method="POST" action="{{ url_for('admin_bp.delegations') }}">
+                <input type="hidden" name="form_type" value="salle_recurrence">
+
+                <div class="form-group">
+                    <div class="recurrence-users">
+                        {% for user in salaries %}
+                        <label class="recurrence-user">
+                            <input type="checkbox" name="salle_recurrence_users" value="{{ user.id }}"
+                                   {% if user.id in salle_recurrence_user_ids %}checked{% endif %}
+                                   {% if not peut_modifier %}disabled{% endif %}>
+                            {{ user.prenom }} {{ user.nom }}{% if user.profil == 'responsable' %} — Responsable{% endif %}
+                        </label>
+                        {% endfor %}
+                        {% if not salaries %}
+                        <p class="delegation-meta">Aucun salarié disponible.</p>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="form-actions">
+                    <a href="{{ url_for('dashboard_bp.dashboard') }}" class="btn btn-secondary">Retour</a>
+                    {% if peut_modifier %}
+                    <button type="submit" class="btn btn-primary">Enregistrer les autorisations</button>
+                    {% endif %}
+                </div>
+            </form>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/tests/test_bilan_action.py
+++ b/tests/test_bilan_action.py
@@ -1,0 +1,179 @@
+"""
+Tests du module Bilan action (blueprints/bilan_action.py).
+
+Couvre : accès, contexte (salariés/bénévoles/taux/défauts), sauvegarde et
+rechargement par action/année/onglet, calcul de la masse salariale et de la
+logistique, partage du taux de logistique avec bilan_secteurs, message en
+l'absence d'import BI, et export PDF.
+"""
+import json
+
+import pytest
+
+from database import get_db
+
+
+def _make_action(app, nom='Action Test'):
+    with app.app_context():
+        conn = get_db()
+        cur = conn.execute("INSERT INTO comptabilite_actions (nom) VALUES (?)", (nom,))
+        conn.commit()
+        aid = cur.lastrowid
+        conn.close()
+        return aid
+
+
+def test_page_accessible_directeur(admin_client):
+    r = admin_client.get('/bilan-action')
+    assert r.status_code == 200
+    assert 'Bilan action' in r.get_data(as_text=True)
+
+
+def test_page_refuse_salarie(auth_client):
+    # Un salarié ne doit pas accéder à la page (redirection vers le dashboard).
+    r = auth_client.get('/bilan-action', follow_redirects=False)
+    assert r.status_code in (301, 302)
+
+
+def test_contexte_defaults(admin_client):
+    r = admin_client.get('/api/bilan-action/contexte?annee=2025')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data['defaults']['socle'] == 23000
+    assert data['defaults']['point'] == 55
+    assert data['defaults']['temps_plein'] == 35
+    assert data['defaults']['taux_charge'] == 27.0
+    assert data['defaults']['taux_taxe'] == 4.25
+    assert data['comptes_salaire'] == {'brut': '641100', 'taxe': '631100', 'charges': '645100'}
+    assert data['import_existe'] is False
+
+
+def test_contexte_employe_sous_contrat(admin_client, app, sample_users):
+    # Un salarié avec un CDI en cours doit apparaître dans la liste.
+    with app.app_context():
+        conn = get_db()
+        conn.execute(
+            "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin, temps_hebdo) "
+            "VALUES (?, 'CDI', '2015-01-01', NULL, 35)",
+            (sample_users['salarie_id'],)
+        )
+        conn.commit()
+        conn.close()
+
+    r = admin_client.get('/api/bilan-action/contexte?annee=2025')
+    data = r.get_json()
+    ids = [e['user_id'] for e in data['employes']]
+    assert sample_users['salarie_id'] in ids
+
+
+def test_save_and_load_previsionnel(admin_client, app):
+    action_id = _make_action(app)
+    # Fixer un taux de logistique global de 10 % pour l'année.
+    admin_client.post('/api/bilan-action/taux-logistique', json={
+        'annee': 2025, 'taux_site1': 0, 'taux_site2': 0, 'taux_global': 10,
+    })
+
+    donnees = {
+        'charges_60': [{'compte_num': '601000', 'libelle': 'Achats', 'montant': 1000, 'commentaire': ''}],
+        'charges_61': [], 'charges_62': [],
+        'produits': [{'compte_num': '706000', 'libelle': 'Prestations', 'montant': 5000, 'commentaire': ''}],
+        'salaries': [{
+            'user_id': None, 'nom': 'Salarié 1', 'prenom': '',
+            'temps_hebdo': 35, 'pesee': 100, 'anciennete': 0, 'competence': 0, 'maintien': 0,
+            'heures_action': 100, 'taux_charge': 27, 'taux_taxe': 4.25,
+        }],
+        'salaire_params': {'socle': 23000, 'point': 55, 'temps_plein': 35},
+        'logistique': {'selection': 'global'},
+        'benevoles': [{'benevole_id': None, 'nom': 'Paul', 'heures': 10, 'commentaire': 'aide'}],
+    }
+    r = admin_client.post('/api/bilan-action/save', json={
+        'action_id': action_id, 'annee': 2025, 'onglet': 'previsionnel', 'donnees': donnees,
+    })
+    assert r.status_code == 200
+    s = r.get_json()['summary']
+
+    # Masse salariale : coût brut = 28500/1820*100 ≈ 1565.93
+    assert s['total_brut'] == pytest.approx(1565.93, abs=0.02)
+    assert s['total_charges_sociales'] == pytest.approx(422.80, abs=0.02)
+    assert s['total_taxe'] == pytest.approx(66.55, abs=0.02)
+    assert s['charges_comptes'] == pytest.approx(1000.0, abs=0.01)
+    assert s['produits_total'] == pytest.approx(5000.0, abs=0.01)
+    # Total charges = comptes + masse salariale chargée
+    assert s['total_charges'] == pytest.approx(1000 + 1565.93 + 422.80 + 66.55, abs=0.05)
+    assert s['taux_logistique'] == pytest.approx(10.0, abs=0.01)
+    assert s['logistique'] == pytest.approx(s['total_charges'] * 0.10, abs=0.02)
+    assert s['resultat_sans'] == pytest.approx(5000 - s['total_charges'], abs=0.02)
+    assert s['resultat_avec'] == pytest.approx(s['resultat_sans'] - s['logistique'], abs=0.02)
+
+    # Rechargement.
+    r2 = admin_client.get(f'/api/bilan-action/donnees?action_id={action_id}&annee=2025&onglet=previsionnel')
+    d2 = r2.get_json()
+    assert d2['found'] is True
+    assert d2['donnees']['charges_60'][0]['compte_num'] == '601000'
+    assert d2['summary']['total_charges'] == pytest.approx(s['total_charges'], abs=0.01)
+
+
+def test_taux_logistique_partage_avec_bilan_secteurs(admin_client, app):
+    admin_client.post('/api/bilan-action/taux-logistique', json={
+        'annee': 2027, 'taux_site1': 5, 'taux_site2': 7.5, 'taux_global': 12,
+    })
+    with app.app_context():
+        conn = get_db()
+        row = conn.execute('SELECT * FROM bilan_taux_logistique WHERE annee = 2027').fetchone()
+        conn.close()
+    assert row is not None
+    assert row['taux_site1'] == pytest.approx(5)
+    assert row['taux_site2'] == pytest.approx(7.5)
+    assert row['taux_global'] == pytest.approx(12)
+
+
+def test_realise_compta_sans_import(admin_client, app):
+    action_id = _make_action(app, 'Action Réalisé')
+    r = admin_client.get(f'/api/bilan-action/realise-compta?action_id={action_id}&annee=2025')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data['import_existe'] is False
+
+
+def test_realise_reporte_previsionnel(admin_client, app):
+    action_id = _make_action(app, 'Action Report')
+    donnees = {
+        'charges_60': [], 'charges_61': [], 'charges_62': [], 'produits': [],
+        'salaries': [{'user_id': None, 'nom': 'Salarié 1', 'temps_hebdo': 35,
+                      'pesee': 50, 'anciennete': 0, 'competence': 0, 'maintien': 0,
+                      'heures_action': 50, 'taux_charge': 27, 'taux_taxe': 4.25}],
+        'salaire_params': {'socle': 23000, 'point': 55, 'temps_plein': 35},
+        'logistique': {'selection': 'global'},
+        'benevoles': [],
+    }
+    admin_client.post('/api/bilan-action/save', json={
+        'action_id': action_id, 'annee': 2025, 'onglet': 'previsionnel', 'donnees': donnees,
+    })
+    # Le réalisé (non encore enregistré) renvoie le prévisionnel pour report.
+    r = admin_client.get(f'/api/bilan-action/donnees?action_id={action_id}&annee=2025&onglet=realise')
+    d = r.get_json()
+    assert d['found'] is False
+    assert d['previsionnel'] is not None
+    assert d['previsionnel']['salaries'][0]['nom'] == 'Salarié 1'
+
+
+def test_export_pdf(admin_client, app):
+    action_id = _make_action(app, 'Action PDF')
+    donnees = {
+        'charges_60': [{'compte_num': '601000', 'libelle': 'Achats', 'montant': 1000, 'commentaire': ''}],
+        'charges_61': [], 'charges_62': [],
+        'produits': [{'compte_num': '706000', 'libelle': 'Prestations', 'montant': 5000, 'commentaire': ''}],
+        'salaries': [{'user_id': None, 'nom': 'Salarié 1', 'temps_hebdo': 35,
+                      'pesee': 100, 'anciennete': 0, 'competence': 0, 'maintien': 0,
+                      'heures_action': 100, 'taux_charge': 27, 'taux_taxe': 4.25}],
+        'salaire_params': {'socle': 23000, 'point': 55, 'temps_plein': 35},
+        'logistique': {'selection': 'global'},
+        'benevoles': [{'benevole_id': None, 'nom': 'Paul', 'heures': 10, 'commentaire': ''}],
+    }
+    admin_client.post('/api/bilan-action/save', json={
+        'action_id': action_id, 'annee': 2025, 'onglet': 'previsionnel', 'donnees': donnees,
+    })
+    r = admin_client.get(f'/api/bilan-action/export-pdf?action_id={action_id}&annee=2025&onglet=previsionnel')
+    assert r.status_code == 200
+    assert r.headers['Content-Type'] == 'application/pdf'
+    assert r.get_data()[:4] == b'%PDF'

--- a/tests/test_delegation_recurrence_salles.py
+++ b/tests/test_delegation_recurrence_salles.py
@@ -1,0 +1,125 @@
+"""
+Tests de la délégation des réservations de salle récurrentes.
+
+Par défaut, seuls la direction/comptable et les responsables peuvent créer des
+récurrences. La direction peut déléguer ce droit à des salariés depuis la page
+Délégation.
+"""
+from database import get_db
+
+
+def _login(c, login, password):
+    return c.post('/login', data={'login': login, 'password': password}, follow_redirects=True)
+
+
+def _make_salle(app, nom='Salle Test'):
+    with app.app_context():
+        conn = get_db()
+        cur = conn.execute("INSERT INTO salles (nom, active) VALUES (?, 1)", (nom,))
+        conn.commit()
+        sid = cur.lastrowid
+        conn.close()
+        return sid
+
+
+def _recurrence_form(salle_id):
+    return {
+        'salle_id': salle_id,
+        'titre_rec': 'Atelier hebdo',
+        'description_rec': '',
+        'jour_semaine': 0,            # Lundi
+        'heure_debut_rec': '09:00',
+        'heure_fin_rec': '10:00',
+        'date_debut_rec': '2025-01-06',
+        'date_fin_rec': '2025-01-27',
+        'exclure_vacances': '',
+        'exclure_feries': '',
+    }
+
+
+def _count_recurrences(app):
+    with app.app_context():
+        conn = get_db()
+        n = conn.execute('SELECT COUNT(*) AS n FROM recurrences_salles').fetchone()['n']
+        conn.close()
+        return n
+
+
+def test_salarie_sans_delegation_ne_peut_pas_creer_recurrence(app, sample_users):
+    salle_id = _make_salle(app)
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    sal.post('/salles/recurrence', data=_recurrence_form(salle_id), follow_redirects=True)
+    assert _count_recurrences(app) == 0
+
+
+def test_directeur_delegue_puis_salarie_peut_creer(app, sample_users):
+    salle_id = _make_salle(app)
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    # Déléguer la récurrence au salarié.
+    admin.post('/delegations', data={
+        'form_type': 'salle_recurrence',
+        'salle_recurrence_users': [sample_users['salarie_id']],
+    }, follow_redirects=True)
+
+    with app.app_context():
+        conn = get_db()
+        row = conn.execute(
+            'SELECT user_id FROM delegations_salles_recurrence WHERE user_id = ?',
+            (sample_users['salarie_id'],)
+        ).fetchone()
+        conn.close()
+    assert row is not None
+
+    # Le salarié délégué peut désormais créer une récurrence.
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    sal.post('/salles/recurrence', data=_recurrence_form(salle_id), follow_redirects=True)
+    assert _count_recurrences(app) == 1
+
+
+def test_retrait_delegation(app, sample_users):
+    salle_id = _make_salle(app)
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    admin.post('/delegations', data={
+        'form_type': 'salle_recurrence',
+        'salle_recurrence_users': [sample_users['salarie_id']],
+    }, follow_redirects=True)
+    # Retrait : aucune case cochée.
+    admin.post('/delegations', data={'form_type': 'salle_recurrence'}, follow_redirects=True)
+
+    with app.app_context():
+        conn = get_db()
+        n = conn.execute('SELECT COUNT(*) AS n FROM delegations_salles_recurrence').fetchone()['n']
+        conn.close()
+    assert n == 0
+
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    sal.post('/salles/recurrence', data=_recurrence_form(salle_id), follow_redirects=True)
+    assert _count_recurrences(app) == 0
+
+
+def test_comptable_ne_peut_pas_deleguer(app, sample_users):
+    admin = app.test_client()
+    compta = app.test_client()
+    _login(compta, 'compta_test', 'compta123')
+    compta.post('/delegations', data={
+        'form_type': 'salle_recurrence',
+        'salle_recurrence_users': [sample_users['salarie_id']],
+    }, follow_redirects=True)
+    with app.app_context():
+        conn = get_db()
+        n = conn.execute('SELECT COUNT(*) AS n FROM delegations_salles_recurrence').fetchone()['n']
+        conn.close()
+    assert n == 0
+
+
+def test_page_delegations_affiche_section_recurrence(app, sample_users):
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    r = admin.get('/delegations')
+    assert r.status_code == 200
+    assert 'Réservation de salle récurrente' in r.get_data(as_text=True)


### PR DESCRIPTION
## Objectif

Nouvelle page **Bilan action** (menu *Financier*) pour **construire le budget prévisionnel** d'une action analytique et **construire/vérifier son réalisé avant clôture** — complémentaire de *Bilan secteurs* (photo de la compta clôturée).

## Fonctionnement (Bilan action)

- Sélection d'une **action** (définie sur *Plan comptable analytique*, lien rappelé) et d'une **année**. Enregistrement par **action / année / onglet**.
- **2 onglets : Prévisionnel et Réalisé.**

### Onglet Prévisionnel — 3 parties
1. **Comptes** : sections 60xxxx, 61xxxx, 62xxxx et produits (70/74/71…), listes déroulantes + montant + commentaire.
2. **Salaires** : salariés sous contrat sur l'année (simulateur de paie : pesée/ancienneté/compétence/maintien → brut mensuel ; heures sur l'action → coût brut ; taux chargé ; taxe sur salaire). Ajout de salariés hors liste.
3. **Logistique** (site1/site2/global, partagé avec *Bilan secteurs*) + **bénévoles**.

### Onglet Réalisé
Réalisé comptable (import BI) en comparatif prévu/réalisé/écart + commentaire (message si aucun import) ; salaires et logistique reportés du prévisionnel et modifiables ; bénévoles.

### Export PDF (les deux onglets)
Bilan simplifié + récap salariés + récap bénévoles. Salaires regroupés : **641100** (brut), **645100** (charges sociales), **631100** (taxe).

## Choix par défaut (ajustables)

| Point | Choix |
|---|---|
| Coût brut / heures | taux horaire annuel = brut mensuel × 12 ÷ (temps hebdo × 52) ; heures = total annuel |
| Base logistique | charges 60/61/62 + masse salariale chargée |
| Taxe sur salaire | taux unique 4,25 % paramétrable (631100) |
| Accès | directeur + comptable |

Le réalisé importé est restreint aux charges 60/61/62 et produits 7x (les salaires sont gérés à part) pour éviter un double comptage.

## Mises à jour suite à la review

- **Correctif review (Codex, P2)** : le taux de logistique débouncé est désormais capturé (snapshot année + taux) à la saisie et `flushTaux()` est appelé avant tout changement de sélection et avant chaque sauvegarde / export PDF → plus de risque d'écriture sur la mauvaise année ou d'omission dans le PDF.
- **Délégation des réservations de salle récurrentes** : par défaut seuls la direction/comptable et les responsables peuvent créer des récurrences ; la direction peut désormais déléguer ce droit à un ou plusieurs **salariés** depuis la page *Délégation* (nouvelle table `delegations_salles_recurrence`, migration 0048, gate `_peut_creer_recurrence()` ouvert aux délégués).

## Détails techniques

- Tables : `bilan_action_data` (migration 0047), `delegations_salles_recurrence` (migration 0048) + schéma `database.py`.
- Blueprint `bilan_action_bp` ; réutilise `PAIE_DEFAULTS`/calcul d'ancienneté du simulateur, le taux partagé (`bilan_taux_logistique`) et les données FEC (`bilan_fec_donnees`).
- Helpers de délégation dans `delegations.py`, route `admin_bp.delegations` (multi-salariés), carte UI dans `delegations.html`.

## Vérification

- Suite complète : **595 tests au vert** (581 existants + 9 `test_bilan_action.py` + 5 `test_delegation_recurrence_salles.py`).
- JS du template validé (`node --check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNitQPDr9owxSjKpcg4wbt