### PR TITLE
Planificateur de tâches (Time Blocking) dans Mon espace

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Taches recurrentes (quotidien / hebdomadaire / mensuel) placees la ou il reste de la place
 - Suivi depuis le calendrier : marquer effectuee, reporter, planifier la fin d'une tache, modifier, supprimer
 - Code couleur selon la proximite de l'echeance ; vues jour / semaine / mois avec navigation simple
-- Horaires de travail configurables par jour de la semaine
+- Horaires de travail repris automatiquement du planning theorique du salarie (menu « Mon planning ») : aucune ressaisie (horaires par defaut si aucun planning n'est defini)
 
 ### Notifications par email
 - Envoi de notifications via Gmail (SMTP)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Exclusion automatique des vacances et jours feries
 - Calendrier visuel des reservations
 
+### Planificateur de taches (Time Blocking)
+- Gestionnaire de taches personnel inspire de FlowSavvy (epure), accessible depuis le menu **Mon espace** (reserve au comptable en phase de test)
+- Planning strictement prive : chaque utilisateur ne voit que ses propres taches (meme la direction n'y a pas acces)
+- Ajout de taches (duree estimee, echeance optionnelle, priorite, preference matin / apres-midi, possibilite de decoupage) et d'evenements fixes (rendez-vous, reunions)
+- Organisation automatique du planning par optimisation sous contraintes (moteur integre) : equilibrage de la charge par jour, micro-pauses sur les journees chargees, respect des horaires de travail, blocage prioritaire des evenements fixes, repartition des longues missions sur plusieurs jours
+- Bouton **Replanifier** et replanification automatique a chaque ajout
+- Taches recurrentes (quotidien / hebdomadaire / mensuel) placees la ou il reste de la place
+- Suivi depuis le calendrier : marquer effectuee, reporter, planifier la fin d'une tache, modifier, supprimer
+- Code couleur selon la proximite de l'echeance ; vues jour / semaine / mois avec navigation simple
+- Horaires de travail configurables par jour de la semaine
+
 ### Notifications par email
 - Envoi de notifications via Gmail (SMTP)
 - Notifications automatiques sur les demandes de recuperation (creation, validation, refus)
@@ -220,10 +231,12 @@ CS-PILOT/
 │   ├── benevoles.py           # Gestion des benevoles
 │   ├── salles.py              # Reservations de salles
 │   ├── cse.py                 # CSE (membres, messages, budget, bilan)
+│   ├── planificateur.py       # Planificateur de taches (Time Blocking)
 │   ├── parametres.py          # Parametres personnels
 │   ├── api_keys.py            # Gestion des cles API
 │   └── notifications.py       # Notifications email
 │
+├── planificateur_engine.py    # Moteur d'optimisation du planificateur (pur)
 ├── migrations/                # Fichiers de migration SQL
 ├── templates/                 # Templates HTML (Jinja2)
 ├── static/                    # CSS, JS, images

--- a/app.py
+++ b/app.py
@@ -254,6 +254,7 @@ from blueprints.indicateurs_financiers import indicateurs_financiers_bp
 from blueprints.import_bi import import_bi_bp
 from blueprints.commandes_salaries import commandes_salaries_bp
 from blueprints.cse import cse_bp
+from blueprints.planificateur import planificateur_bp
 
 app.register_blueprint(auth)
 app.register_blueprint(dashboard_bp)
@@ -306,6 +307,7 @@ app.register_blueprint(indicateurs_financiers_bp)
 app.register_blueprint(import_bi_bp)
 app.register_blueprint(commandes_salaries_bp)
 app.register_blueprint(cse_bp)
+app.register_blueprint(planificateur_bp)
 
 
 # ==================== Context Processors ====================

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -37,12 +37,10 @@ PRIORITES_VALIDES = ('basse', 'normale', 'haute')
 PREFERENCES_VALIDES = ('aucune', 'matin', 'apres_midi')
 FREQUENCES_VALIDES = ('quotidien', 'hebdomadaire', 'mensuel')
 
-# Horaires de travail par defaut (lundi-vendredi).
-HORAIRE_DEFAUT = {
-    'matin_debut': '09:00', 'matin_fin': '12:30',
-    'aprem_debut': '13:30', 'aprem_fin': '17:30',
-}
-JOURS_LABELS = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche']
+# Horaires de travail par defaut (lundi-vendredi), utilises uniquement si le
+# salarie n'a aucun planning theorique defini (menu « Mon planning »).
+HORAIRE_DEFAUT_INTERVALLES = [(540, 750), (810, 1050)]  # 09:00-12:30 / 13:30-17:30
+JOURS_NOMS_PLANNING = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi']
 
 
 # ── Controle d'acces ───────────────────────────────────────────────────────
@@ -72,51 +70,50 @@ def _uid():
     return session.get('user_id')
 
 
-# ── Helpers horaires ───────────────────────────────────────────────────────
+# ── Helpers horaires (repris du planning theorique) ────────────────────────
 
-def _seed_horaires_defaut(conn, user_id):
-    """Cree les horaires par defaut (lun-ven 9h-12h30 / 13h30-17h30)."""
-    for j in range(7):
-        actif = 1 if j < 5 else 0
-        conn.execute(
-            '''INSERT OR IGNORE INTO planif_horaires
-               (user_id, jour_semaine, actif, matin_debut, matin_fin, aprem_debut, aprem_fin)
-               VALUES (?, ?, ?, ?, ?, ?, ?)''',
-            (user_id, j, actif, HORAIRE_DEFAUT['matin_debut'], HORAIRE_DEFAUT['matin_fin'],
-             HORAIRE_DEFAUT['aprem_debut'], HORAIRE_DEFAUT['aprem_fin'])
-        )
-    conn.commit()
+def _horaires_par_date(conn, user_id, debut, fin):
+    """Construit {date_str: [(deb_min, fin_min), ...]} pour l'horizon.
 
+    Les horaires de travail proviennent du planning theorique du salarie
+    (table planning_theorique, alimentee par le menu « Mon planning ») : ils
+    n'ont donc pas a etre ressaisis. Le planning peut varier selon la periode
+    (scolaire / vacances) et l'alternance, d'ou une resolution par date via les
+    helpers existants.
 
-def _charger_horaires_rows(conn, user_id):
-    """Retourne les 7 lignes d'horaires de l'utilisateur (cree les defauts au besoin)."""
-    rows = conn.execute(
-        'SELECT * FROM planif_horaires WHERE user_id = ? ORDER BY jour_semaine',
-        (user_id,)
-    ).fetchall()
-    if len(rows) < 7:
-        _seed_horaires_defaut(conn, user_id)
-        rows = conn.execute(
-            'SELECT * FROM planif_horaires WHERE user_id = ? ORDER BY jour_semaine',
-            (user_id,)
-        ).fetchall()
-    return rows
+    Si le salarie n'a aucun planning, un horaire par defaut est applique
+    (lundi-vendredi 09:00-12:30 / 13:30-17:30) afin que le planificateur reste
+    utilisable immediatement.
+    """
+    from utils import get_planning_valide_a_date, get_type_periode
 
+    a_un_planning = conn.execute(
+        'SELECT 1 FROM planning_theorique WHERE user_id = ? LIMIT 1', (user_id,)
+    ).fetchone()
 
-def _horaires_moteur(conn, user_id):
-    """Construit le dict {jour_semaine: [(deb_min, fin_min), ...]} pour le moteur."""
     horaires = {}
-    for r in _charger_horaires_rows(conn, user_id):
-        if not r['actif']:
-            continue
-        intervalles = []
-        for deb, fin in ((r['matin_debut'], r['matin_fin']),
-                         (r['aprem_debut'], r['aprem_fin'])):
-            dm, fm = moteur._to_min(deb), moteur._to_min(fin)
-            if dm is not None and fm is not None and fm > dm:
-                intervalles.append((dm, fm))
-        if intervalles:
-            horaires[r['jour_semaine']] = intervalles
+    d = debut
+    while d <= fin:
+        # Le planning theorique ne couvre que le lundi au vendredi.
+        if d.weekday() < 5:
+            date_str = d.isoformat()
+            if not a_un_planning:
+                horaires[date_str] = list(HORAIRE_DEFAUT_INTERVALLES)
+            else:
+                planning = get_planning_valide_a_date(
+                    user_id, get_type_periode(date_str), date_str
+                )
+                if planning:
+                    jn = JOURS_NOMS_PLANNING[d.weekday()]
+                    intervalles = []
+                    for col_d, col_f in ((f'{jn}_matin_debut', f'{jn}_matin_fin'),
+                                         (f'{jn}_aprem_debut', f'{jn}_aprem_fin')):
+                        dm, fm = moteur._to_min(planning[col_d]), moteur._to_min(planning[col_f])
+                        if dm is not None and fm is not None and fm > dm:
+                            intervalles.append((dm, fm))
+                    if intervalles:
+                        horaires[date_str] = intervalles
+        d += timedelta(days=1)
     return horaires
 
 
@@ -184,28 +181,23 @@ def _ensure_occurrence(conn, rec, anchor, fenetre_debut, fenetre_fin, today):
     )
 
 
-def _generer_occurrences(conn, user_id, today, fin):
-    """Materialise les occurrences des recurrences actives sur l'horizon."""
+def _generer_occurrences(conn, user_id, today, fin, horaires):
+    """Materialise les occurrences des recurrences actives sur l'horizon.
+
+    `horaires` ({date_str: [...]}) sert a ne pas creer d'occurrence quotidienne
+    un jour non travaille (qui ne pourrait jamais etre placee).
+    """
     recurrences = conn.execute(
         'SELECT * FROM planif_recurrences WHERE user_id = ? AND active = 1',
         (user_id,)
     ).fetchall()
-
-    # Jours ouvres de l'utilisateur (pour ne pas creer d'occurrence quotidienne
-    # un jour non travaille, qui ne pourrait jamais etre placee).
-    actifs = {r['jour_semaine'] for r in conn.execute(
-        'SELECT jour_semaine FROM planif_horaires WHERE user_id = ? AND actif = 1',
-        (user_id,)
-    ).fetchall()}
-    if not actifs:
-        actifs = {0, 1, 2, 3, 4}
 
     for rec in recurrences:
         freq = rec['frequence']
         if freq == 'quotidien':
             d = today
             while d <= fin:
-                if d.weekday() in actifs:
+                if d.isoformat() in horaires:
                     _ensure_occurrence(conn, rec, d.isoformat(), d, d, today)
                 d += timedelta(days=1)
 
@@ -247,9 +239,9 @@ def _replanifier(conn, user_id):
     today = date.today()
     fin = today + timedelta(days=HORIZON_JOURS)
 
-    # S'assurer que les horaires existent (jours ouvres) avant de generer les
-    # occurrences recurrentes, qui s'appuient dessus.
-    _charger_horaires_rows(conn, user_id)
+    # Horaires de travail repris du planning theorique du salarie.
+    horaires = _horaires_par_date(conn, user_id, today, fin)
+    feries = _jours_feries_set(conn, today, fin)
 
     # Nettoyer les occurrences recurrentes passees jamais realisees (une reunion
     # quotidienne manquee hier n'est pas reportee a aujourd'hui).
@@ -263,10 +255,7 @@ def _replanifier(conn, user_id):
         conn.execute('DELETE FROM planif_blocs WHERE tache_id = ?', (occ['id'],))
         conn.execute('DELETE FROM planif_taches WHERE id = ?', (occ['id'],))
 
-    _generer_occurrences(conn, user_id, today, fin)
-
-    horaires = _horaires_moteur(conn, user_id)
-    feries = _jours_feries_set(conn, today, fin)
+    _generer_occurrences(conn, user_id, today, fin, horaires)
 
     # Creneaux deja occupes a conserver : evenements fixes (verrouilles) et
     # blocs deja realises, a partir d'aujourd'hui.
@@ -435,7 +424,9 @@ def planificateur():
             vue = 'semaine'
         date_ref = _valide_date(request.args.get('date')) or date.today().isoformat()
 
-        horaires_rows = _charger_horaires_rows(conn, user_id)
+        a_un_planning = conn.execute(
+            'SELECT 1 FROM planning_theorique WHERE user_id = ? LIMIT 1', (user_id,)
+        ).fetchone() is not None
         recurrences = conn.execute(
             'SELECT * FROM planif_recurrences WHERE user_id = ? AND active = 1 ORDER BY id DESC',
             (user_id,)
@@ -461,10 +452,9 @@ def planificateur():
         return render_template(
             'planificateur.html',
             vue=vue, date_ref=date_ref,
-            horaires=[dict(r) for r in horaires_rows],
             recurrences=[dict(r) for r in recurrences],
             taches_non_placees=[dict(r) for r in taches_non_placees],
-            jours_labels=JOURS_LABELS,
+            a_un_planning=a_un_planning,
         )
     finally:
         conn.close()
@@ -473,13 +463,19 @@ def planificateur():
 @planificateur_bp.route('/planificateur/api/blocs')
 @planif_required
 def api_blocs():
-    """Retourne les blocs (JSON) sur un intervalle de dates."""
+    """Retourne les blocs et les horaires de travail (JSON) sur un intervalle."""
     conn = get_db()
     try:
+        user_id = _uid()
         debut = _valide_date(request.args.get('debut')) or date.today().isoformat()
         fin = _valide_date(request.args.get('fin')) or debut
-        blocs = _serialiser_blocs(conn, _uid(), debut, fin)
-        return jsonify({'ok': True, 'blocs': blocs})
+        blocs = _serialiser_blocs(conn, user_id, debut, fin)
+        # Horaires de travail (par date) pour afficher les plages travaillees.
+        horaires_min = _horaires_par_date(
+            conn, user_id, date.fromisoformat(debut), date.fromisoformat(fin)
+        )
+        horaires = {k: [[d, f] for (d, f) in v] for k, v in horaires_min.items()}
+        return jsonify({'ok': True, 'blocs': blocs, 'horaires': horaires})
     finally:
         conn.close()
 
@@ -797,42 +793,6 @@ def api_replanifier():
     conn = get_db()
     try:
         non_planifie = _replanifier(conn, _uid())
-        return jsonify({'ok': True, 'non_planifie': non_planifie})
-    finally:
-        conn.close()
-
-
-@planificateur_bp.route('/planificateur/api/horaires', methods=['POST'])
-@planif_required
-def api_horaires():
-    """Enregistre les horaires de travail (7 jours) puis replanifie."""
-    data = _lire_payload()
-    jours = data.get('jours') if request.is_json else None
-    conn = get_db()
-    try:
-        user_id = _uid()
-        _charger_horaires_rows(conn, user_id)  # s'assure que les 7 lignes existent
-        for j in range(7):
-            if jours is not None:
-                cfg = jours[j] if j < len(jours) else {}
-                actif = 1 if cfg.get('actif') in (1, '1', True, 'true', 'on') else 0
-                md = _valide_heure(cfg.get('matin_debut'))
-                mf = _valide_heure(cfg.get('matin_fin'))
-                ad = _valide_heure(cfg.get('aprem_debut'))
-                af = _valide_heure(cfg.get('aprem_fin'))
-            else:
-                actif = 1 if request.form.get(f'actif_{j}') else 0
-                md = _valide_heure(request.form.get(f'matin_debut_{j}'))
-                mf = _valide_heure(request.form.get(f'matin_fin_{j}'))
-                ad = _valide_heure(request.form.get(f'aprem_debut_{j}'))
-                af = _valide_heure(request.form.get(f'aprem_fin_{j}'))
-            conn.execute(
-                '''UPDATE planif_horaires SET actif = ?, matin_debut = ?, matin_fin = ?,
-                   aprem_debut = ?, aprem_fin = ? WHERE user_id = ? AND jour_semaine = ?''',
-                (actif, md, mf, ad, af, user_id, j)
-            )
-        conn.commit()
-        non_planifie = _replanifier(conn, user_id)
         return jsonify({'ok': True, 'non_planifie': non_planifie})
     finally:
         conn.close()

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -1,0 +1,910 @@
+"""
+Blueprint planificateur_bp.
+
+Gestionnaire de taches avec planification automatique par Time Blocking,
+inspire de FlowSavvy. Le moteur d'optimisation (placement glouton + equilibrage
+de charge) vit dans le module pur `planificateur_engine`.
+
+Confidentialite : le planning est strictement personnel. Toutes les requetes
+sont filtrees par `user_id = session['user_id']` et aucune route n'expose le
+planning d'un autre utilisateur (meme la direction n'y a pas acces).
+
+Acces (phase 1) : reserve au profil comptable, pour la phase de test.
+"""
+import calendar
+import logging
+from datetime import date, datetime, timedelta
+from functools import wraps
+
+from flask import (Blueprint, render_template, request, redirect, url_for,
+                   session, flash, jsonify)
+
+from database import get_db
+from utils import login_required
+import planificateur_engine as moteur
+
+logger = logging.getLogger(__name__)
+
+planificateur_bp = Blueprint('planificateur_bp', __name__)
+
+# Profils autorises a acceder au planificateur (phase 1 : comptable uniquement).
+PROFILS_AUTORISES = ('comptable',)
+
+# Horizon de planification (jours a partir d'aujourd'hui).
+HORIZON_JOURS = 60
+
+PRIORITES_VALIDES = ('basse', 'normale', 'haute')
+PREFERENCES_VALIDES = ('aucune', 'matin', 'apres_midi')
+FREQUENCES_VALIDES = ('quotidien', 'hebdomadaire', 'mensuel')
+
+# Horaires de travail par defaut (lundi-vendredi).
+HORAIRE_DEFAUT = {
+    'matin_debut': '09:00', 'matin_fin': '12:30',
+    'aprem_debut': '13:30', 'aprem_fin': '17:30',
+}
+JOURS_LABELS = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche']
+
+
+# ── Controle d'acces ───────────────────────────────────────────────────────
+
+def planif_required(f):
+    """Connexion requise + profil autorise pour le planificateur."""
+    @wraps(f)
+    @login_required
+    def wrapper(*args, **kwargs):
+        if session.get('profil') not in PROFILS_AUTORISES:
+            if '/api/' in request.path or _veut_json():
+                return jsonify({'ok': False, 'erreur': 'Acces refuse.'}), 403
+            flash("Le planificateur n'est pas accessible pour votre profil.", 'error')
+            return redirect(url_for('dashboard_bp.dashboard'))
+        return f(*args, **kwargs)
+    return wrapper
+
+
+def _veut_json():
+    """Vrai si le client attend une reponse JSON (appel fetch)."""
+    return (request.accept_mimetypes.best == 'application/json'
+            or request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+            or request.is_json)
+
+
+def _uid():
+    return session.get('user_id')
+
+
+# ── Helpers horaires ───────────────────────────────────────────────────────
+
+def _seed_horaires_defaut(conn, user_id):
+    """Cree les horaires par defaut (lun-ven 9h-12h30 / 13h30-17h30)."""
+    for j in range(7):
+        actif = 1 if j < 5 else 0
+        conn.execute(
+            '''INSERT OR IGNORE INTO planif_horaires
+               (user_id, jour_semaine, actif, matin_debut, matin_fin, aprem_debut, aprem_fin)
+               VALUES (?, ?, ?, ?, ?, ?, ?)''',
+            (user_id, j, actif, HORAIRE_DEFAUT['matin_debut'], HORAIRE_DEFAUT['matin_fin'],
+             HORAIRE_DEFAUT['aprem_debut'], HORAIRE_DEFAUT['aprem_fin'])
+        )
+    conn.commit()
+
+
+def _charger_horaires_rows(conn, user_id):
+    """Retourne les 7 lignes d'horaires de l'utilisateur (cree les defauts au besoin)."""
+    rows = conn.execute(
+        'SELECT * FROM planif_horaires WHERE user_id = ? ORDER BY jour_semaine',
+        (user_id,)
+    ).fetchall()
+    if len(rows) < 7:
+        _seed_horaires_defaut(conn, user_id)
+        rows = conn.execute(
+            'SELECT * FROM planif_horaires WHERE user_id = ? ORDER BY jour_semaine',
+            (user_id,)
+        ).fetchall()
+    return rows
+
+
+def _horaires_moteur(conn, user_id):
+    """Construit le dict {jour_semaine: [(deb_min, fin_min), ...]} pour le moteur."""
+    horaires = {}
+    for r in _charger_horaires_rows(conn, user_id):
+        if not r['actif']:
+            continue
+        intervalles = []
+        for deb, fin in ((r['matin_debut'], r['matin_fin']),
+                         (r['aprem_debut'], r['aprem_fin'])):
+            dm, fm = moteur._to_min(deb), moteur._to_min(fin)
+            if dm is not None and fm is not None and fm > dm:
+                intervalles.append((dm, fm))
+        if intervalles:
+            horaires[r['jour_semaine']] = intervalles
+    return horaires
+
+
+def _jours_feries_set(conn, debut, fin):
+    """Ensemble des jours feries (chaines 'YYYY-MM-DD') dans l'intervalle."""
+    try:
+        rows = conn.execute(
+            'SELECT date FROM jours_feries WHERE date >= ? AND date <= ?',
+            (debut.isoformat(), fin.isoformat())
+        ).fetchall()
+        return {r['date'] for r in rows}
+    except Exception:
+        return set()
+
+
+# ── Generation des occurrences de taches recurrentes ───────────────────────
+
+def _dernier_jour_mois(annee, mois):
+    return calendar.monthrange(annee, mois)[1]
+
+
+def _ajouter_mois(d, n):
+    """Premier jour du mois decale de n mois."""
+    mois = d.month - 1 + n
+    annee = d.year + mois // 12
+    mois = mois % 12 + 1
+    return date(annee, mois, 1)
+
+
+def _ensure_occurrence(conn, rec, anchor, fenetre_debut, fenetre_fin, today):
+    """Cree une occurrence de tache pour une recurrence si elle n'existe pas."""
+    # Borner par les dates de validite de la recurrence.
+    rec_debut = rec['date_debut']
+    rec_fin = rec['date_fin']
+    if rec_debut and fenetre_fin.isoformat() < rec_debut:
+        return
+    if rec_fin and fenetre_debut.isoformat() > rec_fin:
+        return
+    if rec_debut and fenetre_debut.isoformat() < rec_debut:
+        fenetre_debut = date.fromisoformat(rec_debut)
+    if rec_fin and fenetre_fin.isoformat() > rec_fin:
+        fenetre_fin = date.fromisoformat(rec_fin)
+    if fenetre_debut < today:
+        fenetre_debut = today
+    if fenetre_fin < fenetre_debut:
+        return
+
+    existe = conn.execute(
+        'SELECT id FROM planif_taches WHERE recurrence_id = ? AND occurrence_jour = ?',
+        (rec['id'], anchor)
+    ).fetchone()
+    if existe:
+        return
+
+    conn.execute(
+        '''INSERT INTO planif_taches
+           (user_id, type, titre, description, duree_min, deadline, date_min,
+            priorite, preference, secable, duree_min_bloc, statut,
+            recurrence_id, occurrence_jour)
+           VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire', ?, ?)''',
+        (rec['user_id'], rec['titre'], rec['description'], rec['duree_min'],
+         fenetre_fin.isoformat(), fenetre_debut.isoformat(), rec['priorite'],
+         rec['preference'], rec['secable'], rec['duree_min_bloc'],
+         rec['id'], anchor)
+    )
+
+
+def _generer_occurrences(conn, user_id, today, fin):
+    """Materialise les occurrences des recurrences actives sur l'horizon."""
+    recurrences = conn.execute(
+        'SELECT * FROM planif_recurrences WHERE user_id = ? AND active = 1',
+        (user_id,)
+    ).fetchall()
+
+    # Jours ouvres de l'utilisateur (pour ne pas creer d'occurrence quotidienne
+    # un jour non travaille, qui ne pourrait jamais etre placee).
+    actifs = {r['jour_semaine'] for r in conn.execute(
+        'SELECT jour_semaine FROM planif_horaires WHERE user_id = ? AND actif = 1',
+        (user_id,)
+    ).fetchall()}
+    if not actifs:
+        actifs = {0, 1, 2, 3, 4}
+
+    for rec in recurrences:
+        freq = rec['frequence']
+        if freq == 'quotidien':
+            d = today
+            while d <= fin:
+                if d.weekday() in actifs:
+                    _ensure_occurrence(conn, rec, d.isoformat(), d, d, today)
+                d += timedelta(days=1)
+
+        elif freq == 'hebdomadaire':
+            lundi = today - timedelta(days=today.weekday())
+            while lundi <= fin:
+                semaine_fin = min(lundi + timedelta(days=6), fin)
+                if rec['jour_semaine'] is not None:
+                    cible = lundi + timedelta(days=int(rec['jour_semaine']))
+                    if today <= cible <= fin:
+                        _ensure_occurrence(conn, rec, lundi.isoformat(), cible, cible, today)
+                else:
+                    _ensure_occurrence(conn, rec, lundi.isoformat(),
+                                       max(lundi, today), semaine_fin, today)
+                lundi += timedelta(days=7)
+
+        elif freq == 'mensuel':
+            cur = date(today.year, today.month, 1)
+            while cur <= fin:
+                dernier = _dernier_jour_mois(cur.year, cur.month)
+                mois_fin = date(cur.year, cur.month, dernier)
+                if rec['jour_mois']:
+                    jour = min(int(rec['jour_mois']), dernier)
+                    cible = date(cur.year, cur.month, jour)
+                    if today <= cible <= fin:
+                        _ensure_occurrence(conn, rec, cur.isoformat(), cible, cible, today)
+                else:
+                    _ensure_occurrence(conn, rec, cur.isoformat(),
+                                       max(cur, today), min(mois_fin, fin), today)
+                cur = _ajouter_mois(cur, 1)
+    conn.commit()
+
+
+# ── Replanification ────────────────────────────────────────────────────────
+
+def _replanifier(conn, user_id):
+    """Recalcule le planning des taches sur l'horizon. Retourne la liste des
+    taches non planifiees (chacune enrichie de son titre)."""
+    today = date.today()
+    fin = today + timedelta(days=HORIZON_JOURS)
+
+    # S'assurer que les horaires existent (jours ouvres) avant de generer les
+    # occurrences recurrentes, qui s'appuient dessus.
+    _charger_horaires_rows(conn, user_id)
+
+    # Nettoyer les occurrences recurrentes passees jamais realisees (une reunion
+    # quotidienne manquee hier n'est pas reportee a aujourd'hui).
+    perimees = conn.execute(
+        '''SELECT id FROM planif_taches
+           WHERE user_id = ? AND recurrence_id IS NOT NULL AND statut = 'a_faire'
+             AND deadline IS NOT NULL AND deadline < ?''',
+        (user_id, today.isoformat())
+    ).fetchall()
+    for occ in perimees:
+        conn.execute('DELETE FROM planif_blocs WHERE tache_id = ?', (occ['id'],))
+        conn.execute('DELETE FROM planif_taches WHERE id = ?', (occ['id'],))
+
+    _generer_occurrences(conn, user_id, today, fin)
+
+    horaires = _horaires_moteur(conn, user_id)
+    feries = _jours_feries_set(conn, today, fin)
+
+    # Creneaux deja occupes a conserver : evenements fixes (verrouilles) et
+    # blocs deja realises, a partir d'aujourd'hui.
+    rows = conn.execute(
+        '''SELECT date, heure_debut, heure_fin FROM planif_blocs
+           WHERE user_id = ? AND date >= ? AND (verrouille = 1 OR statut = 'fait')''',
+        (user_id, today.isoformat())
+    ).fetchall()
+    occupes = {}
+    for r in rows:
+        occupes.setdefault(r['date'], []).append(
+            (moteur._to_min(r['heure_debut']), moteur._to_min(r['heure_fin']))
+        )
+
+    # Supprimer les blocs futurs replanifiables (ni verrouilles ni realises).
+    conn.execute(
+        '''DELETE FROM planif_blocs
+           WHERE user_id = ? AND date >= ? AND verrouille = 0 AND statut != 'fait' ''',
+        (user_id, today.isoformat())
+    )
+
+    # Charger les taches a planifier (hors evenements fixes).
+    taches_rows = conn.execute(
+        '''SELECT * FROM planif_taches
+           WHERE user_id = ? AND type = 'tache' AND statut = 'a_faire' ''',
+        (user_id,)
+    ).fetchall()
+
+    taches = []
+    titres = {}
+    for t in taches_rows:
+        done = conn.execute(
+            "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs "
+            "WHERE tache_id = ? AND statut = 'fait'",
+            (t['id'],)
+        ).fetchone()['s']
+        restant = int(t['duree_min']) - int(done or 0)
+        if restant <= 0:
+            conn.execute("UPDATE planif_taches SET statut = 'fait' WHERE id = ?", (t['id'],))
+            continue
+        dmin = t['date_min'] or today.isoformat()
+        if dmin < today.isoformat():
+            dmin = today.isoformat()
+        titres[t['id']] = t['titre']
+        taches.append({
+            'id': t['id'], 'titre': t['titre'], 'duree_min': restant,
+            'deadline': t['deadline'], 'priorite': t['priorite'],
+            'preference': t['preference'], 'secable': bool(t['secable']),
+            'duree_min_bloc': t['duree_min_bloc'],
+            'est_recurrente': t['recurrence_id'] is not None,
+            'date_min': dmin,
+        })
+
+    resultat = moteur.planifier(taches, occupes, horaires, today, fin, feries)
+
+    for b in resultat['blocs']:
+        conn.execute(
+            '''INSERT INTO planif_blocs
+               (tache_id, user_id, date, heure_debut, heure_fin, duree_min, statut, verrouille)
+               VALUES (?, ?, ?, ?, ?, ?, 'planifie', 0)''',
+            (b['tache_id'], user_id, b['date'], b['heure_debut'], b['heure_fin'], b['duree_min'])
+        )
+    conn.commit()
+
+    non_planifie = []
+    for np in resultat['non_planifie']:
+        non_planifie.append({**np, 'titre': titres.get(np['tache_id'], '')})
+    return non_planifie
+
+
+# ── Synchronisation des blocs d'evenements fixes ───────────────────────────
+
+def _sync_bloc_evenement(conn, tache):
+    """(Re)cree le bloc verrouille correspondant a un evenement fixe."""
+    conn.execute('DELETE FROM planif_blocs WHERE tache_id = ?', (tache['id'],))
+    if not (tache['date_fixe'] and tache['heure_debut'] and tache['heure_fin']):
+        return
+    dm = moteur._to_min(tache['heure_debut'])
+    fm = moteur._to_min(tache['heure_fin'])
+    duree = (fm - dm) if (dm is not None and fm is not None) else 0
+    statut = 'fait' if tache['statut'] == 'fait' else 'planifie'
+    conn.execute(
+        '''INSERT INTO planif_blocs
+           (tache_id, user_id, date, heure_debut, heure_fin, duree_min, statut, verrouille)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 1)''',
+        (tache['id'], tache['user_id'], tache['date_fixe'], tache['heure_debut'],
+         tache['heure_fin'], max(duree, 0), statut)
+    )
+
+
+# ── Serialisation ──────────────────────────────────────────────────────────
+
+def _serialiser_blocs(conn, user_id, debut, fin):
+    """Retourne la liste JSON des blocs (avec infos de la tache) sur l'intervalle."""
+    rows = conn.execute(
+        '''SELECT b.id, b.tache_id, b.date, b.heure_debut, b.heure_fin, b.duree_min,
+                  b.statut AS bloc_statut, b.verrouille,
+                  t.titre, t.type, t.description, t.priorite, t.preference,
+                  t.deadline, t.secable, t.statut AS tache_statut, t.couleur,
+                  t.recurrence_id, t.duree_min AS tache_duree_min, t.duree_min_bloc
+           FROM planif_blocs b
+           JOIN planif_taches t ON b.tache_id = t.id
+           WHERE b.user_id = ? AND b.date >= ? AND b.date <= ?
+           ORDER BY b.date, b.heure_debut''',
+        (user_id, debut, fin)
+    ).fetchall()
+    today = date.today()
+    blocs = []
+    for r in rows:
+        urgence = moteur.niveau_urgence(r['deadline'], today, r['bloc_statut'])
+        blocs.append({
+            'id': r['id'], 'tache_id': r['tache_id'], 'date': r['date'],
+            'heure_debut': r['heure_debut'], 'heure_fin': r['heure_fin'],
+            'duree_min': r['duree_min'], 'statut': r['bloc_statut'],
+            'verrouille': bool(r['verrouille']), 'titre': r['titre'],
+            'type': r['type'], 'description': r['description'] or '',
+            'priorite': r['priorite'], 'preference': r['preference'],
+            'deadline': r['deadline'], 'secable': bool(r['secable']),
+            'tache_statut': r['tache_statut'], 'couleur': r['couleur'] or '',
+            'urgence': urgence, 'recurrente': r['recurrence_id'] is not None,
+            'tache_duree_min': r['tache_duree_min'], 'duree_min_bloc': r['duree_min_bloc'],
+        })
+    return blocs
+
+
+# ── Validation des entrees ─────────────────────────────────────────────────
+
+def _parse_int(valeur, defaut=0, mini=None, maxi=None):
+    try:
+        n = int(valeur)
+    except (TypeError, ValueError):
+        return defaut
+    if mini is not None:
+        n = max(mini, n)
+    if maxi is not None:
+        n = min(maxi, n)
+    return n
+
+
+def _valide_date(valeur):
+    if not valeur:
+        return None
+    try:
+        return date.fromisoformat(valeur).isoformat()
+    except (TypeError, ValueError):
+        return None
+
+
+def _valide_heure(valeur):
+    if moteur._to_min(valeur) is None:
+        return None
+    return valeur
+
+
+# ── Routes : page principale ───────────────────────────────────────────────
+
+@planificateur_bp.route('/planificateur')
+@planif_required
+def planificateur():
+    """Page principale du planificateur (calendrier + panneaux de gestion)."""
+    conn = get_db()
+    try:
+        user_id = _uid()
+        vue = request.args.get('vue', 'semaine')
+        if vue not in ('jour', 'semaine', 'mois'):
+            vue = 'semaine'
+        date_ref = _valide_date(request.args.get('date')) or date.today().isoformat()
+
+        horaires_rows = _charger_horaires_rows(conn, user_id)
+        recurrences = conn.execute(
+            'SELECT * FROM planif_recurrences WHERE user_id = ? AND active = 1 ORDER BY id DESC',
+            (user_id,)
+        ).fetchall()
+
+        # Taches sans bloc futur planifie = non placees (indicateur persistant).
+        today = date.today().isoformat()
+        # Les occurrences recurrentes sont exclues : elles sont placees « au
+        # mieux, la ou il reste de la place » et leur absence n'est pas une
+        # anomalie a signaler.
+        taches_non_placees = conn.execute(
+            '''SELECT t.* FROM planif_taches t
+               WHERE t.user_id = ? AND t.type = 'tache' AND t.statut = 'a_faire'
+                 AND t.recurrence_id IS NULL
+                 AND NOT EXISTS (
+                     SELECT 1 FROM planif_blocs b
+                     WHERE b.tache_id = t.id AND b.date >= ?
+                 )
+               ORDER BY t.deadline IS NULL, t.deadline''',
+            (user_id, today)
+        ).fetchall()
+
+        return render_template(
+            'planificateur.html',
+            vue=vue, date_ref=date_ref,
+            horaires=[dict(r) for r in horaires_rows],
+            recurrences=[dict(r) for r in recurrences],
+            taches_non_placees=[dict(r) for r in taches_non_placees],
+            jours_labels=JOURS_LABELS,
+        )
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/blocs')
+@planif_required
+def api_blocs():
+    """Retourne les blocs (JSON) sur un intervalle de dates."""
+    conn = get_db()
+    try:
+        debut = _valide_date(request.args.get('debut')) or date.today().isoformat()
+        fin = _valide_date(request.args.get('fin')) or debut
+        blocs = _serialiser_blocs(conn, _uid(), debut, fin)
+        return jsonify({'ok': True, 'blocs': blocs})
+    finally:
+        conn.close()
+
+
+# ── Routes : taches et evenements ──────────────────────────────────────────
+
+def _lire_payload():
+    """Lit les donnees du formulaire ou du corps JSON."""
+    if request.is_json:
+        return request.get_json(silent=True) or {}
+    return request.form
+
+
+@planificateur_bp.route('/planificateur/api/tache', methods=['POST'])
+@planif_required
+def api_creer_tache():
+    """Cree une tache ou un evenement fixe puis replanifie."""
+    data = _lire_payload()
+    conn = get_db()
+    try:
+        user_id = _uid()
+        type_item = data.get('type', 'tache')
+        titre = (data.get('titre') or '').strip()
+        description = (data.get('description') or '').strip()
+        if not titre:
+            return jsonify({'ok': False, 'erreur': 'Le titre est obligatoire.'}), 400
+
+        if type_item == 'evenement':
+            date_fixe = _valide_date(data.get('date_fixe'))
+            heure_debut = _valide_heure(data.get('heure_debut'))
+            heure_fin = _valide_heure(data.get('heure_fin'))
+            if not (date_fixe and heure_debut and heure_fin):
+                return jsonify({'ok': False, 'erreur': 'Date et horaires de l\'evenement requis.'}), 400
+            if moteur._to_min(heure_fin) <= moteur._to_min(heure_debut):
+                return jsonify({'ok': False, 'erreur': 'L\'heure de fin doit suivre l\'heure de debut.'}), 400
+            cur = conn.execute(
+                '''INSERT INTO planif_taches
+                   (user_id, type, titre, description, date_fixe, heure_debut, heure_fin,
+                    duree_min, statut)
+                   VALUES (?, 'evenement', ?, ?, ?, ?, ?, ?, 'a_faire')''',
+                (user_id, titre, description, date_fixe, heure_debut, heure_fin,
+                 moteur._to_min(heure_fin) - moteur._to_min(heure_debut))
+            )
+            tache = conn.execute('SELECT * FROM planif_taches WHERE id = ?',
+                                 (cur.lastrowid,)).fetchone()
+            _sync_bloc_evenement(conn, tache)
+            conn.commit()
+        else:
+            duree_min = _parse_int(data.get('duree_min'), 60, mini=5, maxi=24 * 60)
+            deadline = _valide_date(data.get('deadline'))
+            priorite = data.get('priorite') if data.get('priorite') in PRIORITES_VALIDES else 'normale'
+            preference = data.get('preference') if data.get('preference') in PREFERENCES_VALIDES else 'aucune'
+            secable = 1 if str(data.get('secable')) in ('1', 'true', 'on', 'True') else 0
+            duree_min_bloc = _parse_int(data.get('duree_min_bloc'), 30, mini=5, maxi=duree_min)
+            conn.execute(
+                '''INSERT INTO planif_taches
+                   (user_id, type, titre, description, duree_min, deadline,
+                    priorite, preference, secable, duree_min_bloc, statut)
+                   VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire')''',
+                (user_id, titre, description, duree_min, deadline, priorite,
+                 preference, secable, duree_min_bloc)
+            )
+            conn.commit()
+
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+def _get_tache_proprietaire(conn, tache_id, user_id):
+    return conn.execute(
+        'SELECT * FROM planif_taches WHERE id = ? AND user_id = ?',
+        (tache_id, user_id)
+    ).fetchone()
+
+
+@planificateur_bp.route('/planificateur/api/tache/<int:tache_id>', methods=['POST'])
+@planif_required
+def api_modifier_tache(tache_id):
+    """Modifie une tache ou un evenement existant."""
+    data = _lire_payload()
+    conn = get_db()
+    try:
+        user_id = _uid()
+        tache = _get_tache_proprietaire(conn, tache_id, user_id)
+        if not tache:
+            return jsonify({'ok': False, 'erreur': 'Tache introuvable.'}), 404
+
+        titre = (data.get('titre') or tache['titre']).strip()
+        description = (data.get('description') or '').strip()
+
+        if tache['type'] == 'evenement':
+            date_fixe = _valide_date(data.get('date_fixe')) or tache['date_fixe']
+            heure_debut = _valide_heure(data.get('heure_debut')) or tache['heure_debut']
+            heure_fin = _valide_heure(data.get('heure_fin')) or tache['heure_fin']
+            if moteur._to_min(heure_fin) <= moteur._to_min(heure_debut):
+                return jsonify({'ok': False, 'erreur': 'Horaires invalides.'}), 400
+            conn.execute(
+                '''UPDATE planif_taches SET titre = ?, description = ?, date_fixe = ?,
+                   heure_debut = ?, heure_fin = ?, duree_min = ?, updated_at = CURRENT_TIMESTAMP
+                   WHERE id = ?''',
+                (titre, description, date_fixe, heure_debut, heure_fin,
+                 moteur._to_min(heure_fin) - moteur._to_min(heure_debut), tache_id)
+            )
+            maj = conn.execute('SELECT * FROM planif_taches WHERE id = ?', (tache_id,)).fetchone()
+            _sync_bloc_evenement(conn, maj)
+            conn.commit()
+        else:
+            duree_min = _parse_int(data.get('duree_min'), tache['duree_min'], mini=5, maxi=24 * 60)
+            deadline = _valide_date(data.get('deadline'))
+            priorite = data.get('priorite') if data.get('priorite') in PRIORITES_VALIDES else tache['priorite']
+            preference = data.get('preference') if data.get('preference') in PREFERENCES_VALIDES else tache['preference']
+            secable = 1 if str(data.get('secable')) in ('1', 'true', 'on', 'True') else 0
+            duree_min_bloc = _parse_int(data.get('duree_min_bloc'), tache['duree_min_bloc'], mini=5, maxi=duree_min)
+            conn.execute(
+                '''UPDATE planif_taches SET titre = ?, description = ?, duree_min = ?,
+                   deadline = ?, priorite = ?, preference = ?, secable = ?,
+                   duree_min_bloc = ?, updated_at = CURRENT_TIMESTAMP
+                   WHERE id = ?''',
+                (titre, description, duree_min, deadline, priorite, preference,
+                 secable, duree_min_bloc, tache_id)
+            )
+            conn.commit()
+
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/tache/<int:tache_id>/supprimer', methods=['POST'])
+@planif_required
+def api_supprimer_tache(tache_id):
+    """Supprime une tache et ses blocs."""
+    conn = get_db()
+    try:
+        user_id = _uid()
+        tache = _get_tache_proprietaire(conn, tache_id, user_id)
+        if not tache:
+            return jsonify({'ok': False, 'erreur': 'Tache introuvable.'}), 404
+        # Suppression manuelle des blocs enfants (FK CASCADE non actif sur cette base).
+        conn.execute('DELETE FROM planif_blocs WHERE tache_id = ?', (tache_id,))
+        conn.execute('DELETE FROM planif_taches WHERE id = ?', (tache_id,))
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/tache/<int:tache_id>/statut', methods=['POST'])
+@planif_required
+def api_statut_tache(tache_id):
+    """Change le statut d'une tache (fait / a_faire / annule)."""
+    data = _lire_payload()
+    statut = data.get('statut')
+    if statut not in ('fait', 'a_faire', 'annule'):
+        return jsonify({'ok': False, 'erreur': 'Statut invalide.'}), 400
+    conn = get_db()
+    try:
+        user_id = _uid()
+        tache = _get_tache_proprietaire(conn, tache_id, user_id)
+        if not tache:
+            return jsonify({'ok': False, 'erreur': 'Tache introuvable.'}), 404
+
+        conn.execute('UPDATE planif_taches SET statut = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+                     (statut, tache_id))
+        if statut == 'fait':
+            # Marquer ses blocs futurs comme realises (ils restent en place).
+            conn.execute(
+                "UPDATE planif_blocs SET statut = 'fait' WHERE tache_id = ? AND date >= ?",
+                (tache_id, date.today().isoformat())
+            )
+        elif statut in ('a_faire', 'annule'):
+            if tache['type'] == 'evenement':
+                maj = conn.execute('SELECT * FROM planif_taches WHERE id = ?', (tache_id,)).fetchone()
+                _sync_bloc_evenement(conn, maj)
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/tache/<int:tache_id>/reporter', methods=['POST'])
+@planif_required
+def api_reporter_tache(tache_id):
+    """Reporte une tache : la replanifie a partir d'une date donnee (ou demain)."""
+    data = _lire_payload()
+    conn = get_db()
+    try:
+        user_id = _uid()
+        tache = _get_tache_proprietaire(conn, tache_id, user_id)
+        if not tache:
+            return jsonify({'ok': False, 'erreur': 'Tache introuvable.'}), 404
+
+        nouveau_min = _valide_date(data.get('date_min'))
+        if not nouveau_min:
+            nouveau_min = (date.today() + timedelta(days=1)).isoformat()
+        conn.execute(
+            'UPDATE planif_taches SET date_min = ?, statut = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+            (nouveau_min, 'a_faire', tache_id)
+        )
+        # Liberer les blocs non realises de cette tache avant de replanifier.
+        conn.execute(
+            "DELETE FROM planif_blocs WHERE tache_id = ? AND statut != 'fait'",
+            (tache_id,)
+        )
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/tache/<int:tache_id>/terminer_partiel', methods=['POST'])
+@planif_required
+def api_terminer_partiel(tache_id):
+    """Marque la progression actuelle comme faite et cree une nouvelle tache
+    pour planifier la fin (le reste de la duree estimee)."""
+    data = _lire_payload()
+    conn = get_db()
+    try:
+        user_id = _uid()
+        tache = _get_tache_proprietaire(conn, tache_id, user_id)
+        if not tache or tache['type'] != 'tache':
+            return jsonify({'ok': False, 'erreur': 'Tache introuvable.'}), 404
+
+        minutes_faites = _parse_int(data.get('minutes_faites'), 0, mini=0, maxi=int(tache['duree_min']))
+        restant = int(tache['duree_min']) - minutes_faites
+        # La tache courante est consideree terminee pour la partie deja faite.
+        conn.execute("UPDATE planif_taches SET statut = 'fait', updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                     (tache_id,))
+        conn.execute("UPDATE planif_blocs SET statut = 'fait' WHERE tache_id = ?", (tache_id,))
+
+        if restant > 0:
+            conn.execute(
+                '''INSERT INTO planif_taches
+                   (user_id, type, titre, description, duree_min, deadline,
+                    priorite, preference, secable, duree_min_bloc, statut)
+                   VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire')''',
+                (user_id, (tache['titre'] + ' (suite)')[:200], tache['description'],
+                 restant, tache['deadline'], tache['priorite'], tache['preference'],
+                 tache['secable'], tache['duree_min_bloc'])
+            )
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+# ── Routes : blocs ─────────────────────────────────────────────────────────
+
+@planificateur_bp.route('/planificateur/api/bloc/<int:bloc_id>/statut', methods=['POST'])
+@planif_required
+def api_statut_bloc(bloc_id):
+    """Bascule un bloc entre planifie et fait (depuis le calendrier)."""
+    data = _lire_payload()
+    statut = data.get('statut', 'fait')
+    if statut not in ('fait', 'planifie'):
+        return jsonify({'ok': False, 'erreur': 'Statut invalide.'}), 400
+    conn = get_db()
+    try:
+        user_id = _uid()
+        bloc = conn.execute('SELECT * FROM planif_blocs WHERE id = ? AND user_id = ?',
+                            (bloc_id, user_id)).fetchone()
+        if not bloc:
+            return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
+        conn.execute('UPDATE planif_blocs SET statut = ? WHERE id = ?', (statut, bloc_id))
+
+        # Si tous les blocs de la tache sont faits, marquer la tache faite.
+        if statut == 'fait':
+            reste = conn.execute(
+                "SELECT COUNT(*) AS n FROM planif_blocs WHERE tache_id = ? AND statut != 'fait'",
+                (bloc['tache_id'],)
+            ).fetchone()['n']
+            if reste == 0:
+                conn.execute("UPDATE planif_taches SET statut = 'fait' WHERE id = ?",
+                             (bloc['tache_id'],))
+        else:
+            conn.execute("UPDATE planif_taches SET statut = 'a_faire' WHERE id = ?",
+                         (bloc['tache_id'],))
+        conn.commit()
+        return jsonify({'ok': True})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/bloc/<int:bloc_id>/supprimer', methods=['POST'])
+@planif_required
+def api_supprimer_bloc(bloc_id):
+    """Supprime un bloc precis (libere le creneau)."""
+    conn = get_db()
+    try:
+        user_id = _uid()
+        bloc = conn.execute('SELECT * FROM planif_blocs WHERE id = ? AND user_id = ?',
+                            (bloc_id, user_id)).fetchone()
+        if not bloc:
+            return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
+        conn.execute('DELETE FROM planif_blocs WHERE id = ?', (bloc_id,))
+        conn.commit()
+        return jsonify({'ok': True})
+    finally:
+        conn.close()
+
+
+# ── Routes : replanification, horaires, recurrences ────────────────────────
+
+@planificateur_bp.route('/planificateur/api/replanifier', methods=['POST'])
+@planif_required
+def api_replanifier():
+    """Replanifie l'ensemble des taches."""
+    conn = get_db()
+    try:
+        non_planifie = _replanifier(conn, _uid())
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/horaires', methods=['POST'])
+@planif_required
+def api_horaires():
+    """Enregistre les horaires de travail (7 jours) puis replanifie."""
+    data = _lire_payload()
+    jours = data.get('jours') if request.is_json else None
+    conn = get_db()
+    try:
+        user_id = _uid()
+        _charger_horaires_rows(conn, user_id)  # s'assure que les 7 lignes existent
+        for j in range(7):
+            if jours is not None:
+                cfg = jours[j] if j < len(jours) else {}
+                actif = 1 if cfg.get('actif') in (1, '1', True, 'true', 'on') else 0
+                md = _valide_heure(cfg.get('matin_debut'))
+                mf = _valide_heure(cfg.get('matin_fin'))
+                ad = _valide_heure(cfg.get('aprem_debut'))
+                af = _valide_heure(cfg.get('aprem_fin'))
+            else:
+                actif = 1 if request.form.get(f'actif_{j}') else 0
+                md = _valide_heure(request.form.get(f'matin_debut_{j}'))
+                mf = _valide_heure(request.form.get(f'matin_fin_{j}'))
+                ad = _valide_heure(request.form.get(f'aprem_debut_{j}'))
+                af = _valide_heure(request.form.get(f'aprem_fin_{j}'))
+            conn.execute(
+                '''UPDATE planif_horaires SET actif = ?, matin_debut = ?, matin_fin = ?,
+                   aprem_debut = ?, aprem_fin = ? WHERE user_id = ? AND jour_semaine = ?''',
+                (actif, md, mf, ad, af, user_id, j)
+            )
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/recurrence', methods=['POST'])
+@planif_required
+def api_creer_recurrence():
+    """Cree une tache recurrente puis replanifie."""
+    data = _lire_payload()
+    conn = get_db()
+    try:
+        user_id = _uid()
+        titre = (data.get('titre') or '').strip()
+        if not titre:
+            return jsonify({'ok': False, 'erreur': 'Le titre est obligatoire.'}), 400
+        frequence = data.get('frequence') if data.get('frequence') in FREQUENCES_VALIDES else 'hebdomadaire'
+        duree_min = _parse_int(data.get('duree_min'), 30, mini=5, maxi=24 * 60)
+        priorite = data.get('priorite') if data.get('priorite') in PRIORITES_VALIDES else 'normale'
+        preference = data.get('preference') if data.get('preference') in PREFERENCES_VALIDES else 'aucune'
+        secable = 1 if str(data.get('secable')) in ('1', 'true', 'on', 'True') else 0
+        duree_min_bloc = _parse_int(data.get('duree_min_bloc'), 30, mini=5, maxi=duree_min)
+        jour_semaine = data.get('jour_semaine')
+        jour_semaine = _parse_int(jour_semaine, None, mini=0, maxi=6) if jour_semaine not in (None, '', 'null') else None
+        jour_mois = data.get('jour_mois')
+        jour_mois = _parse_int(jour_mois, None, mini=1, maxi=28) if jour_mois not in (None, '', 'null') else None
+        date_debut = _valide_date(data.get('date_debut')) or date.today().isoformat()
+        date_fin = _valide_date(data.get('date_fin'))
+
+        conn.execute(
+            '''INSERT INTO planif_recurrences
+               (user_id, titre, description, duree_min, priorite, preference, secable,
+                duree_min_bloc, frequence, jour_semaine, jour_mois, date_debut, date_fin, active)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)''',
+            (user_id, titre, (data.get('description') or '').strip(), duree_min, priorite,
+             preference, secable, duree_min_bloc, frequence, jour_semaine, jour_mois,
+             date_debut, date_fin)
+        )
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/recurrence/<int:rec_id>/supprimer', methods=['POST'])
+@planif_required
+def api_supprimer_recurrence(rec_id):
+    """Supprime une recurrence et ses occurrences (et leurs blocs, en cascade)."""
+    conn = get_db()
+    try:
+        user_id = _uid()
+        rec = conn.execute('SELECT id FROM planif_recurrences WHERE id = ? AND user_id = ?',
+                           (rec_id, user_id)).fetchone()
+        if not rec:
+            return jsonify({'ok': False, 'erreur': 'Recurrence introuvable.'}), 404
+        # Supprimer les occurrences non realisees et leurs blocs (FK CASCADE inactif).
+        a_faire = conn.execute(
+            "SELECT id FROM planif_taches WHERE recurrence_id = ? AND statut = 'a_faire'",
+            (rec_id,)
+        ).fetchall()
+        for occ in a_faire:
+            conn.execute('DELETE FROM planif_blocs WHERE tache_id = ?', (occ['id'],))
+            conn.execute('DELETE FROM planif_taches WHERE id = ?', (occ['id'],))
+        # Detacher les occurrences deja realisees (conservees comme historique).
+        conn.execute(
+            'UPDATE planif_taches SET recurrence_id = NULL WHERE recurrence_id = ?',
+            (rec_id,)
+        )
+        conn.execute('DELETE FROM planif_recurrences WHERE id = ?', (rec_id,))
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -707,10 +707,14 @@ def api_terminer_partiel(tache_id):
 
         minutes_faites = _parse_int(data.get('minutes_faites'), 0, mini=0, maxi=int(tache['duree_min']))
         restant = int(tache['duree_min']) - minutes_faites
-        # La tache courante est consideree terminee pour la partie deja faite.
+        # La tache courante est cloturee. On conserve ses blocs deja realises
+        # (historique) et on LIBERE ses creneaux futurs non realises : le reste
+        # est replanifie via une nouvelle tache « suite ». Marquer ces creneaux
+        # futurs comme « faits » surevaluerait le travail accompli et
+        # consommerait deux fois la capacite (bloc fige + tache suite).
         conn.execute("UPDATE planif_taches SET statut = 'fait', updated_at = CURRENT_TIMESTAMP WHERE id = ?",
                      (tache_id,))
-        conn.execute("UPDATE planif_blocs SET statut = 'fait' WHERE tache_id = ?", (tache_id,))
+        conn.execute("DELETE FROM planif_blocs WHERE tache_id = ? AND statut != 'fait'", (tache_id,))
 
         if restant > 0:
             conn.execute(
@@ -748,13 +752,20 @@ def api_statut_bloc(bloc_id):
             return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
         conn.execute('UPDATE planif_blocs SET statut = ? WHERE id = ?', (statut, bloc_id))
 
-        # Si tous les blocs de la tache sont faits, marquer la tache faite.
+        # La tache n'est consideree faite que si le temps realise couvre la duree
+        # estimee. Une tache sous-planifiee (capacite insuffisante : moins de
+        # blocs que sa duree) ne doit pas etre cloturee en laissant tomber son
+        # reliquat lorsque ses quelques blocs visibles sont coches.
         if statut == 'fait':
-            reste = conn.execute(
-                "SELECT COUNT(*) AS n FROM planif_blocs WHERE tache_id = ? AND statut != 'fait'",
+            tache = conn.execute(
+                "SELECT duree_min FROM planif_taches WHERE id = ?", (bloc['tache_id'],)
+            ).fetchone()
+            fait_min = conn.execute(
+                "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs "
+                "WHERE tache_id = ? AND statut = 'fait'",
                 (bloc['tache_id'],)
-            ).fetchone()['n']
-            if reste == 0:
+            ).fetchone()['s']
+            if tache and int(fait_min) >= int(tache['duree_min']):
                 conn.execute("UPDATE planif_taches SET statut = 'fait' WHERE id = ?",
                              (bloc['tache_id'],))
         else:
@@ -777,6 +788,15 @@ def api_supprimer_bloc(bloc_id):
                             (bloc_id, user_id)).fetchone()
         if not bloc:
             return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
+        # Un creneau verrouille correspond a un evenement fixe : le supprimer
+        # seul laisserait l'evenement en base sans occuper son horaire (des
+        # taches pourraient s'y planifier). On passe par la suppression / la
+        # modification de l'evenement lui-meme.
+        if bloc['verrouille']:
+            return jsonify({
+                'ok': False,
+                'erreur': "Ce créneau correspond à un événement fixe : supprimez ou modifiez l'événement."
+            }), 400
         conn.execute('DELETE FROM planif_blocs WHERE id = ?', (bloc_id,))
         conn.commit()
         return jsonify({'ok': True})

--- a/database.py
+++ b/database.py
@@ -1606,22 +1606,6 @@ def init_db():
     ''')
     cursor.execute('CREATE INDEX IF NOT EXISTS idx_planif_blocs_user_date ON planif_blocs(user_id, date)')
 
-    # Horaires de travail par salarie et par jour de la semaine.
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS planif_horaires (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            jour_semaine INTEGER NOT NULL,
-            actif INTEGER DEFAULT 1,
-            matin_debut TEXT,
-            matin_fin TEXT,
-            aprem_debut TEXT,
-            aprem_fin TEXT,
-            UNIQUE(user_id, jour_semaine),
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        )
-    ''')
-
     # ===== Table de suivi des migrations de schema =====
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/database.py
+++ b/database.py
@@ -1532,6 +1532,96 @@ def init_db():
         )
     ''')
 
+    # ===== Tables module Planificateur de taches / Time Blocking (migration 0049) =====
+
+    # Definitions des taches recurrentes (generent des occurrences de taches).
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_recurrences (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            titre TEXT NOT NULL,
+            description TEXT DEFAULT '',
+            duree_min INTEGER DEFAULT 30,
+            priorite TEXT DEFAULT 'normale',
+            preference TEXT DEFAULT 'aucune',
+            secable INTEGER DEFAULT 0,
+            duree_min_bloc INTEGER DEFAULT 30,
+            frequence TEXT NOT NULL DEFAULT 'hebdomadaire',
+            jour_semaine INTEGER,
+            jour_mois INTEGER,
+            date_debut TEXT NOT NULL,
+            date_fin TEXT,
+            active INTEGER DEFAULT 1,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    ''')
+
+    # Taches et evenements fixes (rendez-vous, reunions) a planifier.
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_taches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            type TEXT NOT NULL DEFAULT 'tache',
+            titre TEXT NOT NULL,
+            description TEXT DEFAULT '',
+            couleur TEXT DEFAULT '',
+            duree_min INTEGER DEFAULT 60,
+            deadline TEXT,
+            date_min TEXT,
+            priorite TEXT DEFAULT 'normale',
+            preference TEXT DEFAULT 'aucune',
+            secable INTEGER DEFAULT 1,
+            duree_min_bloc INTEGER DEFAULT 30,
+            date_fixe TEXT,
+            heure_debut TEXT,
+            heure_fin TEXT,
+            statut TEXT DEFAULT 'a_faire',
+            recurrence_id INTEGER,
+            occurrence_jour TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (recurrence_id) REFERENCES planif_recurrences(id) ON DELETE CASCADE
+        )
+    ''')
+    cursor.execute('CREATE INDEX IF NOT EXISTS idx_planif_taches_user ON planif_taches(user_id, statut)')
+
+    # Blocs de temps calcules par le moteur (le planning concret).
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_blocs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tache_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            date TEXT NOT NULL,
+            heure_debut TEXT NOT NULL,
+            heure_fin TEXT NOT NULL,
+            duree_min INTEGER NOT NULL,
+            statut TEXT DEFAULT 'planifie',
+            verrouille INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (tache_id) REFERENCES planif_taches(id) ON DELETE CASCADE,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    ''')
+    cursor.execute('CREATE INDEX IF NOT EXISTS idx_planif_blocs_user_date ON planif_blocs(user_id, date)')
+
+    # Horaires de travail par salarie et par jour de la semaine.
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_horaires (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            jour_semaine INTEGER NOT NULL,
+            actif INTEGER DEFAULT 1,
+            matin_debut TEXT,
+            matin_fin TEXT,
+            aprem_debut TEXT,
+            aprem_fin TEXT,
+            UNIQUE(user_id, jour_semaine),
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    ''')
+
     # ===== Table de suivi des migrations de schema =====
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/migrations/0049_module_planificateur.py
+++ b/migrations/0049_module_planificateur.py
@@ -4,8 +4,10 @@ Migration 0049 : Module Planificateur de taches (Time Blocking).
 Ajoute les tables du gestionnaire de taches inspire de FlowSavvy :
 - planif_recurrences : definitions des taches recurrentes ;
 - planif_taches      : taches et evenements fixes (rendez-vous, reunions) ;
-- planif_blocs       : blocs de temps calcules par le moteur d'optimisation ;
-- planif_horaires    : horaires de travail par salarie et par jour.
+- planif_blocs       : blocs de temps calcules par le moteur d'optimisation.
+
+Les horaires de travail ne sont pas redemandes : ils sont repris du planning
+theorique du salarie (table planning_theorique, menu « Mon planning »).
 
 Le planning est strictement prive : chaque utilisateur ne voit que ses
 propres taches et blocs (aucun acces transversal, meme pour la direction).
@@ -13,9 +15,9 @@ propres taches et blocs (aucun acces transversal, meme pour la direction).
 
 NOM = "Module Planificateur de taches"
 DESCRIPTION = (
-    "Ajoute les tables planif_recurrences, planif_taches, planif_blocs et "
-    "planif_horaires pour le gestionnaire de taches avec planification "
-    "automatique (Time Blocking)."
+    "Ajoute les tables planif_recurrences, planif_taches et planif_blocs pour "
+    "le gestionnaire de taches avec planification automatique (Time Blocking). "
+    "Les horaires de travail sont repris du planning theorique."
 )
 
 
@@ -96,21 +98,6 @@ def upgrade(conn):
         'CREATE INDEX IF NOT EXISTS idx_planif_blocs_user_date ON planif_blocs(user_id, date)'
     )
 
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS planif_horaires (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER NOT NULL,
-            jour_semaine INTEGER NOT NULL,
-            actif INTEGER DEFAULT 1,
-            matin_debut TEXT,
-            matin_fin TEXT,
-            aprem_debut TEXT,
-            aprem_fin TEXT,
-            UNIQUE(user_id, jour_semaine),
-            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-        )
-    ''')
-
     conn.commit()
 
 
@@ -120,5 +107,4 @@ def downgrade(conn):
     cursor.execute('DROP TABLE IF EXISTS planif_blocs')
     cursor.execute('DROP TABLE IF EXISTS planif_taches')
     cursor.execute('DROP TABLE IF EXISTS planif_recurrences')
-    cursor.execute('DROP TABLE IF EXISTS planif_horaires')
     conn.commit()

--- a/migrations/0049_module_planificateur.py
+++ b/migrations/0049_module_planificateur.py
@@ -1,0 +1,124 @@
+"""
+Migration 0049 : Module Planificateur de taches (Time Blocking).
+
+Ajoute les tables du gestionnaire de taches inspire de FlowSavvy :
+- planif_recurrences : definitions des taches recurrentes ;
+- planif_taches      : taches et evenements fixes (rendez-vous, reunions) ;
+- planif_blocs       : blocs de temps calcules par le moteur d'optimisation ;
+- planif_horaires    : horaires de travail par salarie et par jour.
+
+Le planning est strictement prive : chaque utilisateur ne voit que ses
+propres taches et blocs (aucun acces transversal, meme pour la direction).
+"""
+
+NOM = "Module Planificateur de taches"
+DESCRIPTION = (
+    "Ajoute les tables planif_recurrences, planif_taches, planif_blocs et "
+    "planif_horaires pour le gestionnaire de taches avec planification "
+    "automatique (Time Blocking)."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_recurrences (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            titre TEXT NOT NULL,
+            description TEXT DEFAULT '',
+            duree_min INTEGER DEFAULT 30,
+            priorite TEXT DEFAULT 'normale',
+            preference TEXT DEFAULT 'aucune',
+            secable INTEGER DEFAULT 0,
+            duree_min_bloc INTEGER DEFAULT 30,
+            frequence TEXT NOT NULL DEFAULT 'hebdomadaire',
+            jour_semaine INTEGER,
+            jour_mois INTEGER,
+            date_debut TEXT NOT NULL,
+            date_fin TEXT,
+            active INTEGER DEFAULT 1,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    ''')
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_taches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            type TEXT NOT NULL DEFAULT 'tache',
+            titre TEXT NOT NULL,
+            description TEXT DEFAULT '',
+            couleur TEXT DEFAULT '',
+            duree_min INTEGER DEFAULT 60,
+            deadline TEXT,
+            date_min TEXT,
+            priorite TEXT DEFAULT 'normale',
+            preference TEXT DEFAULT 'aucune',
+            secable INTEGER DEFAULT 1,
+            duree_min_bloc INTEGER DEFAULT 30,
+            date_fixe TEXT,
+            heure_debut TEXT,
+            heure_fin TEXT,
+            statut TEXT DEFAULT 'a_faire',
+            recurrence_id INTEGER,
+            occurrence_jour TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (recurrence_id) REFERENCES planif_recurrences(id) ON DELETE CASCADE
+        )
+    ''')
+    cursor.execute(
+        'CREATE INDEX IF NOT EXISTS idx_planif_taches_user ON planif_taches(user_id, statut)'
+    )
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_blocs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tache_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            date TEXT NOT NULL,
+            heure_debut TEXT NOT NULL,
+            heure_fin TEXT NOT NULL,
+            duree_min INTEGER NOT NULL,
+            statut TEXT DEFAULT 'planifie',
+            verrouille INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (tache_id) REFERENCES planif_taches(id) ON DELETE CASCADE,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    ''')
+    cursor.execute(
+        'CREATE INDEX IF NOT EXISTS idx_planif_blocs_user_date ON planif_blocs(user_id, date)'
+    )
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS planif_horaires (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            jour_semaine INTEGER NOT NULL,
+            actif INTEGER DEFAULT 1,
+            matin_debut TEXT,
+            matin_fin TEXT,
+            aprem_debut TEXT,
+            aprem_fin TEXT,
+            UNIQUE(user_id, jour_semaine),
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+    ''')
+
+    conn.commit()
+
+
+def downgrade(conn):
+    """Annule la migration."""
+    cursor = conn.cursor()
+    cursor.execute('DROP TABLE IF EXISTS planif_blocs')
+    cursor.execute('DROP TABLE IF EXISTS planif_taches')
+    cursor.execute('DROP TABLE IF EXISTS planif_recurrences')
+    cursor.execute('DROP TABLE IF EXISTS planif_horaires')
+    conn.commit()

--- a/planificateur_engine.py
+++ b/planificateur_engine.py
@@ -1,0 +1,378 @@
+"""
+Moteur d'optimisation du planificateur de taches (Time Blocking).
+
+Module *pur* (sans acces base de donnees) : il recoit des structures de
+donnees simples et retourne le placement calcule. Cela le rend facilement
+testable et permettrait de brancher un autre solveur (ex: OR-Tools) plus tard
+sans toucher au reste de l'application.
+
+Principe general (heuristique de placement glouton + equilibrage de charge) :
+
+1. On reconstruit, pour chaque jour de l'horizon, les creneaux libres a partir
+   des horaires de travail du salarie, desquels on retire les evenements fixes
+   (rendez-vous, reunions) et les blocs deja realises ou verrouilles.
+2. On traite les taches par ordre d'urgence : echeance la plus proche d'abord,
+   puis priorite, puis duree. Les taches recurrentes sont placees en dernier,
+   « la ou il reste de la place ».
+3. Pour chaque tache, on choisit a chaque etape le jour le moins charge de sa
+   fenetre (equilibrage), en respectant la preference matin / apres-midi.
+4. Les longues missions secables sont reparties sur plusieurs jours, avec des
+   blocs ni trop petits (>= duree_min_bloc) ni demesures.
+5. A l'interieur d'une journee, on intercale des respirations : 5 min par heure
+   les journees chargees, 15 min toutes les 2 h les journees normales. Les
+   pauses sont de simples « trous » dans le planning (espace laisse libre).
+"""
+from datetime import date, timedelta
+import math
+
+# Poids de tri des priorites (plus petit = traite en premier).
+PRIORITE_POIDS = {'haute': 0, 'normale': 1, 'basse': 2}
+
+# Seuil (minutes de travail disponibles dans la journee) au-dela duquel la
+# journee est consideree « chargee » et beneficie de micro-pauses rapprochees.
+SEUIL_JOURNEE_CHARGEE = 360  # 6 h
+
+# Regime de respiration : (intervalle de travail continu, duree de pause) en min.
+PAUSE_JOURNEE_CHARGEE = (60, 5)    # 5 min toutes les heures
+PAUSE_JOURNEE_NORMALE = (120, 15)  # 15 min toutes les 2 h
+
+# En dessous de cette duree, une tache secable n'est pas fragmentee sur
+# plusieurs jours (cela n'aurait pas de sens de la repartir).
+SEUIL_FRAGMENTATION = 90  # 1 h 30
+
+# Cible indicative de travail par jour pour une longue mission repartie.
+CIBLE_PAR_JOUR = 120  # 2 h
+
+# Plafond de minutes qu'une seule tache peut consommer sur une journee, pour
+# eviter qu'une grosse mission ne sature un jour au detriment des autres.
+PLAFOND_TACHE_PAR_JOUR = 240  # 4 h
+
+
+def _to_min(hhmm):
+    """'HH:MM' -> minutes depuis minuit (None si invalide)."""
+    if not hhmm:
+        return None
+    try:
+        h, m = hhmm.split(':')
+        return int(h) * 60 + int(m)
+    except (ValueError, AttributeError):
+        return None
+
+
+def _to_hhmm(minutes):
+    """minutes depuis minuit -> 'HH:MM'."""
+    minutes = int(round(minutes))
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+def _normaliser_intervalles(intervalles):
+    """Trie et fusionne une liste d'intervalles (debut, fin) en minutes."""
+    propres = sorted((d, f) for d, f in intervalles if d is not None and f is not None and f > d)
+    fusionnes = []
+    for deb, fin in propres:
+        if fusionnes and deb <= fusionnes[-1][1]:
+            fusionnes[-1] = (fusionnes[-1][0], max(fusionnes[-1][1], fin))
+        else:
+            fusionnes.append((deb, fin))
+    return fusionnes
+
+
+def _soustraire(libres, occupes):
+    """Retire les intervalles `occupes` des intervalles `libres`.
+
+    Retourne la liste des segments restants (debut, fin), tries.
+    """
+    occupes = _normaliser_intervalles(occupes)
+    resultat = []
+    for deb, fin in _normaliser_intervalles(libres):
+        courant = deb
+        for o_deb, o_fin in occupes:
+            if o_fin <= courant or o_deb >= fin:
+                continue
+            if o_deb > courant:
+                resultat.append((courant, min(o_deb, fin)))
+            courant = max(courant, o_fin)
+            if courant >= fin:
+                break
+        if courant < fin:
+            resultat.append((courant, fin))
+    return [(d, f) for d, f in resultat if f > d]
+
+
+class _PlanJour:
+    """Gere le placement des blocs sur une journee donnee."""
+
+    def __init__(self, jour, segments_libres):
+        self.jour = jour  # objet date
+        # Chaque segment : dict avec curseur de remplissage et compteur de
+        # travail continu (remis a zero a chaque nouveau segment = pause
+        # naturelle : pause dejeuner, evenement fixe, etc.).
+        self.segments = [
+            {'deb': d, 'fin': f, 'curseur': d, 'continu': 0}
+            for d, f in segments_libres if f > d
+        ]
+        self.capacite = sum(f - d for d, f in segments_libres if f > d)
+        self.charge = 0  # minutes de taches deja placees
+        if self.capacite >= SEUIL_JOURNEE_CHARGEE:
+            self.intervalle_pause, self.duree_pause = PAUSE_JOURNEE_CHARGEE
+        else:
+            self.intervalle_pause, self.duree_pause = PAUSE_JOURNEE_NORMALE
+
+    def _segments_ordonnes(self, preference):
+        """Ordonne les segments selon la preference matin / apres-midi."""
+        segs = [s for s in self.segments if s['curseur'] < s['fin']]
+        if preference == 'matin':
+            segs.sort(key=lambda s: s['curseur'])
+        elif preference == 'apres_midi':
+            # Apres-midi d'abord (segments commencant a 12h ou plus tard).
+            segs.sort(key=lambda s: (s['curseur'] < 720, s['curseur']))
+        else:
+            segs.sort(key=lambda s: s['curseur'])
+        return segs
+
+    def placer_bloc_entier(self, duree, preference):
+        """Place une tache non secable en un seul bloc contigu.
+
+        Retourne (deb, fin) en minutes si reussi, sinon None.
+        """
+        for seg in self._segments_ordonnes(preference):
+            curseur = seg['curseur']
+            continu = seg['continu']
+            # Pause prealable si le travail continu impose une respiration.
+            if continu >= self.intervalle_pause:
+                curseur += self.duree_pause
+                continu = 0
+            if seg['fin'] - curseur >= duree:
+                deb, fin = curseur, curseur + duree
+                seg['curseur'] = fin
+                # On force une respiration apres une longue session.
+                seg['continu'] = self.intervalle_pause
+                self.charge += duree
+                return (deb, fin)
+        return None
+
+    def placer_secable(self, minutes_voulues, preference):
+        """Place jusqu'a `minutes_voulues` minutes en intercalant des pauses.
+
+        Retourne (liste_de_blocs, minutes_placees).
+        """
+        blocs = []
+        restant = minutes_voulues
+        for seg in self._segments_ordonnes(preference):
+            while restant > 0 and seg['curseur'] < seg['fin']:
+                if seg['continu'] >= self.intervalle_pause:
+                    if seg['fin'] - seg['curseur'] <= self.duree_pause:
+                        break  # plus de place pour pause + travail
+                    seg['curseur'] += self.duree_pause
+                    seg['continu'] = 0
+                run = min(
+                    seg['fin'] - seg['curseur'],
+                    self.intervalle_pause - seg['continu'],
+                    restant,
+                )
+                if run <= 0:
+                    break
+                deb, fin = seg['curseur'], seg['curseur'] + run
+                blocs.append((deb, fin))
+                seg['curseur'] = fin
+                seg['continu'] += run
+                restant -= run
+        placees = minutes_voulues - restant
+        self.charge += placees
+        return blocs, placees
+
+    def capacite_restante(self):
+        return sum(s['fin'] - s['curseur'] for s in self.segments)
+
+
+def niveau_urgence(deadline, jour_ref, statut='a_faire'):
+    """Niveau d'urgence d'une tache selon la proximite de l'echeance.
+
+    Retourne l'un de : 'fait', 'retard', 'urgent', 'proche', 'a_venir',
+    'sans_echeance'. Utilise pour le code couleur du calendrier.
+    """
+    if statut == 'fait':
+        return 'fait'
+    if not deadline:
+        return 'sans_echeance'
+    if isinstance(deadline, str):
+        try:
+            deadline = date.fromisoformat(deadline)
+        except ValueError:
+            return 'sans_echeance'
+    jours = (deadline - jour_ref).days
+    if jours < 0:
+        return 'retard'
+    if jours <= 1:
+        return 'urgent'
+    if jours <= 3:
+        return 'proche'
+    return 'a_venir'
+
+
+def _cle_tri_tache(tache, horizon_fin):
+    """Cle de tri d'une tache : echeance, puis priorite, puis duree."""
+    deadline = tache.get('deadline') or horizon_fin
+    if isinstance(deadline, str):
+        try:
+            deadline = date.fromisoformat(deadline)
+        except ValueError:
+            deadline = horizon_fin
+    # Les taches sans echeance passent apres celles qui en ont une.
+    sans_echeance = 0 if tache.get('deadline') else 1
+    priorite = PRIORITE_POIDS.get(tache.get('priorite', 'normale'), 1)
+    return (sans_echeance, deadline, priorite, -int(tache.get('duree_min', 0)))
+
+
+def _taille_chunk(duree, min_bloc, nb_jours_dispo, secable):
+    """Determine la taille cible d'un bloc journalier pour une tache."""
+    if not secable or duree <= SEUIL_FRAGMENTATION:
+        return duree
+    jours_souhaites = max(1, math.ceil(duree / CIBLE_PAR_JOUR))
+    jours_souhaites = min(jours_souhaites, max(1, nb_jours_dispo))
+    cible = math.ceil(duree / jours_souhaites)
+    cible = max(min_bloc, min(cible, PLAFOND_TACHE_PAR_JOUR))
+    return cible
+
+
+def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
+              jours_feries=None):
+    """Calcule le placement des taches sur l'horizon donne.
+
+    Args:
+        taches: liste de dicts, chacun contenant :
+            id, titre, duree_min (int), deadline (date|str|None),
+            priorite ('haute'|'normale'|'basse'),
+            preference ('matin'|'apres_midi'|'aucune'),
+            secable (bool), duree_min_bloc (int),
+            est_recurrente (bool, optionnel),
+            date_min (date|str|None, optionnel : pas avant ce jour).
+        occupes_par_date: dict 'YYYY-MM-DD' -> liste de (deb_min, fin_min)
+            deja occupes (evenements fixes, blocs realises / verrouilles).
+        horaires: dict jour_semaine (0=lundi..6=dimanche) -> liste de
+            (deb_min, fin_min) representant les horaires de travail.
+        date_debut, date_fin: objets date delimitant l'horizon (inclus).
+        jours_feries: ensemble de chaines 'YYYY-MM-DD' a ne pas planifier.
+
+    Returns:
+        dict {
+            'blocs': [ {tache_id, date, heure_debut, heure_fin, duree_min} ],
+            'non_planifie': [ {tache_id, minutes_restantes, raison} ],
+        }
+    """
+    jours_feries = jours_feries or set()
+    occupes_par_date = occupes_par_date or {}
+
+    # 1. Construire les journees et leurs creneaux libres.
+    jours = {}
+    d = date_debut
+    while d <= date_fin:
+        date_str = d.isoformat()
+        if date_str not in jours_feries:
+            work = horaires.get(d.weekday(), [])
+            if work:
+                libres = _soustraire(work, occupes_par_date.get(date_str, []))
+                if libres:
+                    jours[date_str] = _PlanJour(d, libres)
+        d += timedelta(days=1)
+
+    # 2. Trier les taches : prioritaires (par urgence) puis recurrentes.
+    prioritaires = [t for t in taches if not t.get('est_recurrente')]
+    recurrentes = [t for t in taches if t.get('est_recurrente')]
+    prioritaires.sort(key=lambda t: _cle_tri_tache(t, date_fin))
+
+    blocs_resultat = []
+    non_planifie = []
+
+    def _jours_fenetre(tache):
+        """Journees candidates pour une tache, dans sa fenetre [date_min, deadline]."""
+        dmin = tache.get('date_min')
+        if isinstance(dmin, str):
+            dmin = date.fromisoformat(dmin) if dmin else None
+        deadline = tache.get('deadline')
+        if isinstance(deadline, str):
+            try:
+                deadline = date.fromisoformat(deadline)
+            except ValueError:
+                deadline = None
+        candidats = []
+        for date_str, pj in jours.items():
+            if dmin and pj.jour < dmin:
+                continue
+            if deadline and pj.jour > deadline:
+                continue
+            candidats.append(pj)
+        return candidats
+
+    def _placer_tache(tache):
+        duree = int(tache.get('duree_min', 0))
+        if duree <= 0:
+            return
+        secable = bool(tache.get('secable', True))
+        min_bloc = max(5, int(tache.get('duree_min_bloc') or 30))
+        preference = tache.get('preference', 'aucune')
+        candidats = _jours_fenetre(tache)
+
+        if not candidats:
+            non_planifie.append({
+                'tache_id': tache['id'], 'minutes_restantes': duree,
+                'raison': 'aucun creneau disponible avant l\'echeance',
+            })
+            return
+
+        if not secable:
+            # Bloc unique : essayer chaque jour, du moins charge au plus charge.
+            for pj in sorted(candidats, key=lambda p: (p.charge, p.jour)):
+                pos = pj.placer_bloc_entier(duree, preference)
+                if pos:
+                    blocs_resultat.append({
+                        'tache_id': tache['id'], 'date': pj.jour.isoformat(),
+                        'heure_debut': _to_hhmm(pos[0]), 'heure_fin': _to_hhmm(pos[1]),
+                        'duree_min': duree,
+                    })
+                    return
+            non_planifie.append({
+                'tache_id': tache['id'], 'minutes_restantes': duree,
+                'raison': 'aucun creneau contigu assez long (tache non secable)',
+            })
+            return
+
+        # Tache secable : repartir en respectant l'equilibrage de charge.
+        restant = duree
+        chunk = _taille_chunk(duree, min_bloc, len(candidats), secable)
+        epuises = set()
+        while restant > 0:
+            dispo = [p for p in candidats
+                     if id(p) not in epuises and p.capacite_restante() > 0]
+            if not dispo:
+                break
+            pj = min(dispo, key=lambda p: (p.charge, p.jour))
+            voulu = min(restant, chunk)
+            # Sur le dernier reliquat, ne pas exiger le chunk plein.
+            blocs, places = pj.placer_secable(voulu, preference)
+            if places <= 0:
+                epuises.add(id(pj))
+                continue
+            for deb, fin in blocs:
+                blocs_resultat.append({
+                    'tache_id': tache['id'], 'date': pj.jour.isoformat(),
+                    'heure_debut': _to_hhmm(deb), 'heure_fin': _to_hhmm(fin),
+                    'duree_min': fin - deb,
+                })
+            restant -= places
+            if pj.capacite_restante() <= 0:
+                epuises.add(id(pj))
+
+        if restant > 0:
+            non_planifie.append({
+                'tache_id': tache['id'], 'minutes_restantes': restant,
+                'raison': 'capacite insuffisante sur l\'horizon',
+            })
+
+    for tache in prioritaires:
+        _placer_tache(tache)
+    # Les taches recurrentes remplissent l'espace restant.
+    for tache in recurrentes:
+        _placer_tache(tache)
+
+    return {'blocs': blocs_resultat, 'non_planifie': non_planifie}

--- a/planificateur_engine.py
+++ b/planificateur_engine.py
@@ -249,8 +249,10 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
             date_min (date|str|None, optionnel : pas avant ce jour).
         occupes_par_date: dict 'YYYY-MM-DD' -> liste de (deb_min, fin_min)
             deja occupes (evenements fixes, blocs realises / verrouilles).
-        horaires: dict jour_semaine (0=lundi..6=dimanche) -> liste de
-            (deb_min, fin_min) representant les horaires de travail.
+        horaires: dict 'YYYY-MM-DD' -> liste de (deb_min, fin_min) representant
+            les horaires de travail de ce jour. Les horaires peuvent varier d'un
+            jour a l'autre (periode scolaire / vacances, semaines alternees),
+            c'est pourquoi ils sont indexes par date et non par jour de semaine.
         date_debut, date_fin: objets date delimitant l'horizon (inclus).
         jours_feries: ensemble de chaines 'YYYY-MM-DD' a ne pas planifier.
 
@@ -269,7 +271,7 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
     while d <= date_fin:
         date_str = d.isoformat()
         if date_str not in jours_feries:
-            work = horaires.get(d.weekday(), [])
+            work = horaires.get(date_str, [])
             if work:
                 libres = _soustraire(work, occupes_par_date.get(date_str, []))
                 if libres:

--- a/templates/base.html
+++ b/templates/base.html
@@ -145,6 +145,7 @@
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('dashboard_comptable_bp.dashboard_comptable') }}">📊 Tableau de bord</a>
                     <a href="{{ url_for('dashboard_direction_bp.dashboard_direction') }}">🏢 Vue Direction</a>
+                    <a href="{{ url_for('planificateur_bp.planificateur') }}">🗓️ Planificateur</a>
                     <a href="{{ url_for('validation_bp.vue_mensuelle') }}">📅 Vue mensuelle</a>
                     <a href="{{ url_for('validation_bp.vue_calendrier') }}">📆 Vue calendrier</a>
                     <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -558,8 +558,14 @@
       act+='<button class="btn btn-secondary" data-act="fin">✂️ Planifier la fin</button>';
     }
     act+='<button class="btn btn-secondary" data-act="modifier">✏️ Modifier</button>';
-    act+='<button class="btn btn-secondary" data-act="bloc_suppr">🗑 Supprimer ce créneau</button>';
-    act+='<button class="btn btn-danger" data-act="tache_suppr">🗑 Supprimer la tâche</button>';
+    // Pour un evenement fixe, le creneau ne peut pas etre supprime seul (il
+    // bloque l'horaire) : on supprime l'evenement entier.
+    if(b.type!=='evenement'){
+      act+='<button class="btn btn-secondary" data-act="bloc_suppr">🗑 Supprimer ce créneau</button>';
+      act+='<button class="btn btn-danger" data-act="tache_suppr">🗑 Supprimer la tâche</button>';
+    }else{
+      act+='<button class="btn btn-danger" data-act="tache_suppr">🗑 Supprimer l\'événement</button>';
+    }
     act+='</div>';
     document.getElementById('detailCorps').innerHTML = corps+act;
     document.querySelectorAll('#detailCorps [data-act]').forEach(btn=>{

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -7,7 +7,7 @@
 {
   "vue": {{ vue|tojson }},
   "date": {{ date_ref|tojson }},
-  "horaires": {{ horaires|tojson }},
+  "a_un_planning": {{ a_un_planning|tojson }},
   "recurrences": {{ recurrences|tojson }},
   "taches_non_placees": {{ taches_non_placees|tojson }}
 }
@@ -23,7 +23,6 @@
     <div class="planif-actions">
       <button class="btn btn-primary" id="btnAjouter">➕ Ajouter</button>
       <button class="btn btn-secondary" id="btnReplan">↻ Replanifier</button>
-      <button class="btn btn-secondary" id="btnHoraires">⏰ Horaires</button>
       <button class="btn btn-secondary" id="btnRecur">🔁 Récurrences</button>
     </div>
   </div>
@@ -52,6 +51,12 @@
     <span class="lg"><i class="sw u-sans_echeance"></i> Sans échéance</span>
     <span class="lg"><i class="sw evenement"></i> Rendez-vous / réunion</span>
   </div>
+
+  <p class="planif-hint">
+    ⏰ Les tâches sont planifiées dans vos horaires de travail issus de
+    <a href="{{ url_for('planning_bp.planning_theorique') }}">Mon planning</a>.
+    {% if not a_un_planning %}<strong>Aucun planning défini : des horaires par défaut (lun.–ven. 9h–12h30 / 13h30–17h30) sont utilisés.</strong>{% endif %}
+  </p>
 
   <div id="planifCal" class="planif-cal"></div>
 </div>
@@ -146,28 +151,6 @@
         <div class="actions" style="display:flex;gap:.5rem;justify-content:flex-end;margin-top:.5rem;">
           <button type="button" class="btn btn-secondary" onclick="planifFermerModales()">Annuler</button>
           <button type="submit" class="btn btn-primary" id="btnSubmitTache">Enregistrer</button>
-        </div>
-      </form>
-    </div>
-  </div>
-</div>
-
-{# ── Modale Horaires de travail ── #}
-<div class="modal-overlay planif-modal" id="modalHoraires" style="display:none;" onclick="if(event.target===this)planifFermerModales()">
-  <div class="modal-content">
-    <div class="modal-header">
-      <h3>⏰ Horaires de travail</h3>
-      <button class="modal-close" type="button" onclick="planifFermerModales()" aria-label="Fermer">&times;</button>
-    </div>
-    <div style="padding:0 1.5rem 1.5rem;">
-      <p style="color:var(--gray-500);margin:.25rem 0 1rem;font-size:.9rem;">
-        Le moteur ne planifie vos tâches qu'à l'intérieur de ces horaires. La pause déjeuner correspond au trou entre le matin et l'après-midi.
-      </p>
-      <form id="formHoraires">
-        <div class="planif-horaires-grid" id="horairesGrid"></div>
-        <div class="actions" style="display:flex;gap:.5rem;justify-content:flex-end;margin-top:1rem;">
-          <button type="button" class="btn btn-secondary" onclick="planifFermerModales()">Annuler</button>
-          <button type="submit" class="btn btn-primary">Enregistrer & replanifier</button>
         </div>
       </form>
     </div>
@@ -333,11 +316,8 @@
 .planif-tabs{display:flex;gap:.5rem;margin:.5rem 0 1rem;}
 .planif-tabs button{flex:1;border:1px solid var(--gray-300);background:var(--card-bg,#fff);color:var(--gray-700);padding:.5rem;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;}
 .planif-tabs button.active{background:var(--primary);color:#fff;border-color:var(--primary);}
-.planif-horaires-grid{display:flex;flex-direction:column;gap:.4rem;}
-.planif-hday{display:grid;grid-template-columns:1.4fr repeat(4,1fr);gap:.4rem;align-items:center;}
-.planif-hday label.jr{font-weight:600;display:flex;align-items:center;gap:.4rem;}
-.planif-hday input[type=time]{width:100%;}
-.planif-hday.off input[type=time]{opacity:.4;}
+.planif-hint{font-size:.82rem;color:var(--gray-500);margin:0 0 .75rem;}
+.planif-hint a{color:var(--primary);font-weight:600;}
 .planif-recur-liste{display:flex;flex-direction:column;gap:.4rem;max-height:180px;overflow-y:auto;}
 .planif-recur-item{display:flex;justify-content:space-between;align-items:center;gap:.5rem;padding:.5rem .6rem;border:1px solid var(--gray-200,#eee);border-radius:var(--radius-sm);font-size:.85rem;}
 .planif-detail-line{margin:.3rem 0;color:var(--gray-700);}
@@ -378,6 +358,7 @@
 
   const state = { vue: DATA.vue || 'semaine', date: DATA.date || isoToday() };
   let blocsCache = [];
+  let horairesCache = {};
 
   // ── Helpers dates ──
   function isoToday(){ const d=new Date(); return iso(d); }
@@ -422,20 +403,19 @@
   }
 
   // ── Plage horaire affichée ──
+  // horairesCache : { 'YYYY-MM-DD': [[deb_min, fin_min], ...] } (issu du planning)
   function plageMinutes(){
     let mn=8*60, mx=18*60;
-    (DATA.horaires||[]).forEach(h=>{
-      if(!h.actif) return;
-      [h.matin_debut, h.aprem_debut].forEach(v=>{ const m=hhmm2min(v); if(m!=null) mn=Math.min(mn,m); });
-      [h.matin_fin, h.aprem_fin].forEach(v=>{ const m=hhmm2min(v); if(m!=null) mx=Math.max(mx,m); });
+    Object.values(horairesCache).forEach(intervalles=>{
+      intervalles.forEach(iv=>{ mn=Math.min(mn,iv[0]); mx=Math.max(mx,iv[1]); });
     });
     blocsCache.forEach(b=>{ const d=hhmm2min(b.heure_debut), f=hhmm2min(b.heure_fin); if(d!=null)mn=Math.min(mn,d); if(f!=null)mx=Math.max(mx,f); });
-    mn = Math.max(0, Math.floor(mn/60)*60 - 0);
+    mn = Math.max(0, Math.floor(mn/60)*60);
     mx = Math.min(1440, Math.ceil(mx/60)*60);
     if(mx-mn < 240){ mx = Math.min(1440, mn+240); }
     return [mn, mx];
   }
-  function horaireJour(js){ return (DATA.horaires||[]).find(h=>h.jour_semaine===js); }
+  function horaireJour(dateStr){ return horairesCache[dateStr] || null; }
 
   // ── Chargement + rendu ──
   function rangeFetch(){
@@ -451,7 +431,8 @@
     try{
       const j = await apiGet('{{ url_for("planificateur_bp.api_blocs") }}?debut='+deb+'&fin='+fin);
       blocsCache = (j && j.blocs) ? j.blocs : [];
-    }catch(e){ blocsCache=[]; }
+      horairesCache = (j && j.horaires) ? j.horaires : {};
+    }catch(e){ blocsCache=[]; horairesCache={}; }
     rendre();
   }
   function rendre(){
@@ -486,14 +467,11 @@
       cols+='<div class="planif-col" data-jour="'+jr+'">';
       cols+='<div class="planif-colhead'+(est_today?' today':'')+'">'+JOURS_COURT[js]+'<span class="num">'+parse(jr).getDate()+'</span></div>';
       cols+='<div class="planif-colbody" style="position:relative;height:'+hauteur+'px;">';
-      // bandes horaires de travail
-      const h=horaireJour(js);
-      if(h && h.actif){
-        [[h.matin_debut,h.matin_fin],[h.aprem_debut,h.aprem_fin]].forEach(iv=>{
-          const d=hhmm2min(iv[0]), f=hhmm2min(iv[1]);
-          if(d!=null && f!=null && f>d){ cols+='<div class="planif-workband" style="top:'+((d-mn)*PX_MIN)+'px;height:'+((f-d)*PX_MIN)+'px;"></div>'; }
-        });
-      }
+      // bandes horaires de travail (issues du planning, par date)
+      (horaireJour(jr)||[]).forEach(iv=>{
+        const d=iv[0], f=iv[1];
+        if(f>d){ cols+='<div class="planif-workband" style="top:'+((d-mn)*PX_MIN)+'px;height:'+((f-d)*PX_MIN)+'px;"></div>'; }
+      });
       for(let hh=Math.ceil(mn/60)*60; hh<=mx; hh+=60){ cols+='<div class="planif-hourline" style="top:'+((hh-mn)*PX_MIN)+'px;"></div>'; }
       if(est_today){ const now=new Date().getHours()*60+new Date().getMinutes(); if(now>=mn&&now<=mx){ cols+='<div class="planif-now" style="top:'+((now-mn)*PX_MIN)+'px;"></div>'; } }
       // blocs
@@ -683,41 +661,6 @@
     }catch(err){ toast(err.message,'err'); }
   }
 
-  // ── Horaires ──
-  function construireHoraires(){
-    const grid=document.getElementById('horairesGrid');
-    let html='';
-    for(let j=0;j<7;j++){
-      const h=horaireJour(j)||{actif:j<5,matin_debut:'09:00',matin_fin:'12:30',aprem_debut:'13:30',aprem_fin:'17:30'};
-      html+='<div class="planif-hday'+(h.actif?'':' off')+'" data-j="'+j+'">'
-        +'<label class="jr"><input type="checkbox" class="h_actif" '+(h.actif?'checked':'')+'> '+JOURS[j]+'</label>'
-        +'<input type="time" class="h_md" value="'+(h.matin_debut||'')+'">'
-        +'<input type="time" class="h_mf" value="'+(h.matin_fin||'')+'">'
-        +'<input type="time" class="h_ad" value="'+(h.aprem_debut||'')+'">'
-        +'<input type="time" class="h_af" value="'+(h.aprem_fin||'')+'">'
-        +'</div>';
-    }
-    grid.innerHTML=html;
-    grid.querySelectorAll('.h_actif').forEach(cb=>cb.addEventListener('change',()=>cb.closest('.planif-hday').classList.toggle('off',!cb.checked)));
-  }
-  async function soumettreHoraires(e){
-    e.preventDefault();
-    const jours=[];
-    document.querySelectorAll('#horairesGrid .planif-hday').forEach(row=>{
-      jours.push({ actif:row.querySelector('.h_actif').checked?1:0,
-        matin_debut:row.querySelector('.h_md').value, matin_fin:row.querySelector('.h_mf').value,
-        aprem_debut:row.querySelector('.h_ad').value, aprem_fin:row.querySelector('.h_af').value });
-    });
-    try{
-      const res=await apiPost('{{ url_for("planificateur_bp.api_horaires") }}',{jours});
-      DATA.horaires = jours.map((c,j)=>({jour_semaine:j, actif:c.actif, matin_debut:c.matin_debut, matin_fin:c.matin_fin, aprem_debut:c.aprem_debut, aprem_fin:c.aprem_fin}));
-      planifFermerModales();
-      toast('✓ Horaires enregistrés','ok');
-      montrerNonPlanifie(res.non_planifie);
-      await charger();
-    }catch(err){ toast(err.message,'err'); }
-  }
-
   // ── Récurrences ──
   function construireRecur(){
     const liste=document.getElementById('recurListe');
@@ -787,11 +730,9 @@
     try{ const res=await apiPost('{{ url_for("planificateur_bp.api_replanifier") }}',{}); toast('✓ Planning recalculé','ok'); montrerNonPlanifie(res.non_planifie); await charger(); }
     catch(e){ toast(e.message,'err'); }
   });
-  document.getElementById('btnHoraires').addEventListener('click', ()=>{ construireHoraires(); ouvrir('modalHoraires'); });
   document.getElementById('btnRecur').addEventListener('click', ()=>{ construireRecur(); ouvrir('modalRecur'); });
   document.getElementById('ajTabs').addEventListener('click', e=>{ if(e.target.dataset.type) setType(e.target.dataset.type); });
   document.getElementById('formTache').addEventListener('submit', soumettreTache);
-  document.getElementById('formHoraires').addEventListener('submit', soumettreHoraires);
   document.getElementById('formRecur').addEventListener('submit', soumettreRecur);
   document.getElementById('r_frequence').addEventListener('change', majChampsFreq);
   document.getElementById('t_secable').addEventListener('change', e=>{ document.getElementById('grpMinBloc').style.display=e.target.checked?'':'none'; });

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -1,0 +1,812 @@
+{% extends "base.html" %}
+
+{% block title %}Planificateur - CS-PILOT{% endblock %}
+
+{% block content %}
+<script type="application/json" id="planif-data">
+{
+  "vue": {{ vue|tojson }},
+  "date": {{ date_ref|tojson }},
+  "horaires": {{ horaires|tojson }},
+  "recurrences": {{ recurrences|tojson }},
+  "taches_non_placees": {{ taches_non_placees|tojson }}
+}
+</script>
+
+<div class="planif" id="planif">
+
+  <div class="planif-head">
+    <div>
+      <h1 style="margin-bottom:.2rem;">🗓️ Planificateur</h1>
+      <p class="subtitle" style="margin:0;">Organisez vos tâches automatiquement par Time Blocking — votre planning, privé et optimisé.</p>
+    </div>
+    <div class="planif-actions">
+      <button class="btn btn-primary" id="btnAjouter">➕ Ajouter</button>
+      <button class="btn btn-secondary" id="btnReplan">↻ Replanifier</button>
+      <button class="btn btn-secondary" id="btnHoraires">⏰ Horaires</button>
+      <button class="btn btn-secondary" id="btnRecur">🔁 Récurrences</button>
+    </div>
+  </div>
+
+  <div class="planif-toolbar">
+    <div class="planif-views" id="planifViews">
+      <button data-vue="jour">Jour</button>
+      <button data-vue="semaine">Semaine</button>
+      <button data-vue="mois">Mois</button>
+    </div>
+    <div class="planif-nav">
+      <button class="planif-navbtn" id="navPrev" aria-label="Précédent">‹</button>
+      <button class="planif-navbtn" id="navToday">Aujourd'hui</button>
+      <button class="planif-navbtn" id="navNext" aria-label="Suivant">›</button>
+      <span class="planif-navlabel" id="navLabel"></span>
+    </div>
+  </div>
+
+  <div id="planifAlertes"></div>
+
+  <div class="planif-legend">
+    <span class="lg"><i class="sw u-retard"></i> En retard</span>
+    <span class="lg"><i class="sw u-urgent"></i> Échéance imminente</span>
+    <span class="lg"><i class="sw u-proche"></i> Échéance proche</span>
+    <span class="lg"><i class="sw u-a_venir"></i> À venir</span>
+    <span class="lg"><i class="sw u-sans_echeance"></i> Sans échéance</span>
+    <span class="lg"><i class="sw evenement"></i> Rendez-vous / réunion</span>
+  </div>
+
+  <div id="planifCal" class="planif-cal"></div>
+</div>
+
+{# ── Modale Ajouter / Modifier une tâche ou un événement ── #}
+<div class="modal-overlay planif-modal" id="modalAjouter" style="display:none;" onclick="if(event.target===this)planifFermerModales()">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 id="modalAjouterTitre">Ajouter</h3>
+      <button class="modal-close" type="button" onclick="planifFermerModales()" aria-label="Fermer">&times;</button>
+    </div>
+    <div style="padding:0 1.5rem 1.5rem;">
+      <div class="planif-tabs" id="ajTabs">
+        <button type="button" class="active" data-type="tache">📝 Tâche</button>
+        <button type="button" data-type="evenement">📌 Événement fixe</button>
+      </div>
+
+      <form id="formTache">
+        <input type="hidden" id="t_id" value="">
+        <div class="form-group">
+          <label for="t_titre">Titre *</label>
+          <input type="text" id="t_titre" maxlength="200" required>
+        </div>
+
+        {# Champs Tâche #}
+        <div id="champsTache">
+          <div class="planif-row">
+            <div class="form-group">
+              <label>Durée estimée</label>
+              <div class="planif-duree">
+                <input type="number" id="t_heures" min="0" max="23" value="1"> h
+                <input type="number" id="t_minutes" min="0" max="59" step="5" value="0"> min
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="t_deadline">Échéance (optionnel)</label>
+              <input type="date" id="t_deadline">
+            </div>
+          </div>
+          <div class="planif-row">
+            <div class="form-group">
+              <label for="t_priorite">Priorité</label>
+              <select id="t_priorite">
+                <option value="basse">Basse</option>
+                <option value="normale" selected>Normale</option>
+                <option value="haute">Haute</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="t_preference">Préférence</label>
+              <select id="t_preference">
+                <option value="aucune" selected>Aucune</option>
+                <option value="matin">Matin</option>
+                <option value="apres_midi">Après-midi</option>
+              </select>
+            </div>
+          </div>
+          <div class="planif-row">
+            <div class="form-group" style="flex:0 0 auto;">
+              <label class="planif-check"><input type="checkbox" id="t_secable" checked> Peut être découpée</label>
+            </div>
+            <div class="form-group" id="grpMinBloc">
+              <label for="t_min_bloc">Bloc minimum (min)</label>
+              <input type="number" id="t_min_bloc" min="5" step="5" value="30">
+            </div>
+          </div>
+        </div>
+
+        {# Champs Événement #}
+        <div id="champsEvenement" style="display:none;">
+          <div class="form-group">
+            <label for="e_date">Date *</label>
+            <input type="date" id="e_date">
+          </div>
+          <div class="planif-row">
+            <div class="form-group">
+              <label for="e_debut">Heure début *</label>
+              <input type="time" id="e_debut">
+            </div>
+            <div class="form-group">
+              <label for="e_fin">Heure fin *</label>
+              <input type="time" id="e_fin">
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="t_description">Description (optionnel)</label>
+          <textarea id="t_description" rows="2" maxlength="1000"></textarea>
+        </div>
+
+        <div class="actions" style="display:flex;gap:.5rem;justify-content:flex-end;margin-top:.5rem;">
+          <button type="button" class="btn btn-secondary" onclick="planifFermerModales()">Annuler</button>
+          <button type="submit" class="btn btn-primary" id="btnSubmitTache">Enregistrer</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+{# ── Modale Horaires de travail ── #}
+<div class="modal-overlay planif-modal" id="modalHoraires" style="display:none;" onclick="if(event.target===this)planifFermerModales()">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3>⏰ Horaires de travail</h3>
+      <button class="modal-close" type="button" onclick="planifFermerModales()" aria-label="Fermer">&times;</button>
+    </div>
+    <div style="padding:0 1.5rem 1.5rem;">
+      <p style="color:var(--gray-500);margin:.25rem 0 1rem;font-size:.9rem;">
+        Le moteur ne planifie vos tâches qu'à l'intérieur de ces horaires. La pause déjeuner correspond au trou entre le matin et l'après-midi.
+      </p>
+      <form id="formHoraires">
+        <div class="planif-horaires-grid" id="horairesGrid"></div>
+        <div class="actions" style="display:flex;gap:.5rem;justify-content:flex-end;margin-top:1rem;">
+          <button type="button" class="btn btn-secondary" onclick="planifFermerModales()">Annuler</button>
+          <button type="submit" class="btn btn-primary">Enregistrer & replanifier</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+{# ── Modale Récurrences ── #}
+<div class="modal-overlay planif-modal" id="modalRecur" style="display:none;" onclick="if(event.target===this)planifFermerModales()">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3>🔁 Tâches récurrentes</h3>
+      <button class="modal-close" type="button" onclick="planifFermerModales()" aria-label="Fermer">&times;</button>
+    </div>
+    <div style="padding:0 1.5rem 1.5rem;">
+      <p style="color:var(--gray-500);margin:.25rem 0 1rem;font-size:.9rem;">
+        Les tâches récurrentes sont placées en priorité là où il reste de la place, selon la fréquence choisie.
+      </p>
+      <div id="recurListe" class="planif-recur-liste"></div>
+      <hr style="border:none;border-top:1px solid var(--gray-300);margin:1rem 0;">
+      <form id="formRecur">
+        <div class="form-group">
+          <label for="r_titre">Titre *</label>
+          <input type="text" id="r_titre" maxlength="200" required>
+        </div>
+        <div class="planif-row">
+          <div class="form-group">
+            <label for="r_frequence">Fréquence</label>
+            <select id="r_frequence">
+              <option value="quotidien">Tous les jours</option>
+              <option value="hebdomadaire" selected>Une fois par semaine</option>
+              <option value="mensuel">Une fois par mois</option>
+            </select>
+          </div>
+          <div class="form-group" id="grpJourSem">
+            <label for="r_jour_sem">Jour</label>
+            <select id="r_jour_sem">
+              <option value="">Au mieux</option>
+              <option value="0">Lundi</option><option value="1">Mardi</option>
+              <option value="2">Mercredi</option><option value="3">Jeudi</option>
+              <option value="4">Vendredi</option><option value="5">Samedi</option>
+              <option value="6">Dimanche</option>
+            </select>
+          </div>
+          <div class="form-group" id="grpJourMois" style="display:none;">
+            <label for="r_jour_mois">Jour du mois</label>
+            <input type="number" id="r_jour_mois" min="1" max="28" placeholder="Au mieux">
+          </div>
+        </div>
+        <div class="planif-row">
+          <div class="form-group">
+            <label>Durée</label>
+            <div class="planif-duree">
+              <input type="number" id="r_heures" min="0" max="23" value="0"> h
+              <input type="number" id="r_minutes" min="0" max="59" step="5" value="30"> min
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="r_priorite">Priorité</label>
+            <select id="r_priorite">
+              <option value="basse">Basse</option>
+              <option value="normale" selected>Normale</option>
+              <option value="haute">Haute</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="r_preference">Préférence</label>
+            <select id="r_preference">
+              <option value="aucune" selected>Aucune</option>
+              <option value="matin">Matin</option>
+              <option value="apres_midi">Après-midi</option>
+            </select>
+          </div>
+        </div>
+        <div class="planif-row">
+          <div class="form-group"><label for="r_debut">À partir du</label><input type="date" id="r_debut"></div>
+          <div class="form-group"><label for="r_fin">Jusqu'au (optionnel)</label><input type="date" id="r_fin"></div>
+        </div>
+        <div class="actions" style="display:flex;justify-content:flex-end;margin-top:.5rem;">
+          <button type="submit" class="btn btn-primary">➕ Ajouter la récurrence</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+{# ── Modale Détail d'un bloc ── #}
+<div class="modal-overlay planif-modal" id="modalDetail" style="display:none;" onclick="if(event.target===this)planifFermerModales()">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 id="detailTitre">Détail</h3>
+      <button class="modal-close" type="button" onclick="planifFermerModales()" aria-label="Fermer">&times;</button>
+    </div>
+    <div style="padding:0 1.5rem 1.5rem;" id="detailCorps"></div>
+  </div>
+</div>
+
+<div id="planifToasts" class="planif-toasts"></div>
+
+<style>
+.planif-head{display:flex;justify-content:space-between;align-items:flex-start;gap:1rem;flex-wrap:wrap;margin-bottom:1rem;}
+.planif-actions{display:flex;gap:.5rem;flex-wrap:wrap;}
+.planif-toolbar{display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;margin-bottom:1rem;}
+.planif-views{display:inline-flex;border:1px solid var(--gray-300);border-radius:var(--radius-md);overflow:hidden;}
+.planif-views button{border:none;background:var(--card-bg,#fff);color:var(--gray-700);padding:.5rem 1rem;cursor:pointer;font-weight:600;font-size:.9rem;}
+.planif-views button.active{background:var(--primary);color:#fff;}
+.planif-nav{display:flex;align-items:center;gap:.4rem;}
+.planif-navbtn{border:1px solid var(--gray-300);background:var(--card-bg,#fff);color:var(--gray-700);border-radius:var(--radius-sm);padding:.4rem .7rem;cursor:pointer;font-weight:600;}
+.planif-navbtn:hover{background:var(--gray-100);}
+.planif-navlabel{font-weight:700;color:var(--gray-900);margin-left:.5rem;text-transform:capitalize;}
+.planif-legend{display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:.75rem;font-size:.8rem;color:var(--gray-500);}
+.planif-legend .lg{display:inline-flex;align-items:center;gap:.35rem;}
+.planif-legend .sw{width:14px;height:14px;border-radius:3px;display:inline-block;}
+
+/* Code couleur selon la proximité de l'échéance */
+.u-retard{background:#fde2e2;border-color:#bf4444;}
+.u-urgent{background:#ffe6d2;border-color:#d97706;}
+.u-proche{background:#fdf2cf;border-color:#ba7a2a;}
+.u-a_venir{background:#dcefe1;border-color:#3f8a60;}
+.u-sans_echeance{background:#e4ebf3;border-color:#5b6b7d;}
+.evenement{background:#e7e1f7;border-color:#6d28d9;}
+
+.planif-cal{border:1px solid var(--gray-300);border-radius:var(--radius-md);overflow:hidden;background:var(--card-bg,#fff);}
+
+/* Vue semaine / jour : grille temporelle */
+.planif-grid{display:flex;max-height:70vh;overflow-y:auto;}
+.planif-gutter{flex:0 0 52px;border-right:1px solid var(--gray-200,#eee);position:relative;}
+.planif-gutter .hh{position:absolute;right:4px;font-size:.7rem;color:var(--gray-500);transform:translateY(-50%);}
+.planif-cols{display:flex;flex:1;}
+.planif-col{flex:1;position:relative;border-right:1px solid var(--gray-200,#eee);}
+.planif-col:last-child{border-right:none;}
+.planif-colhead{position:sticky;top:0;z-index:3;background:var(--card-bg,#fff);border-bottom:1px solid var(--gray-300);text-align:center;padding:.35rem 0;font-size:.8rem;font-weight:600;color:var(--gray-700);}
+.planif-colhead.today{color:var(--primary);}
+.planif-colhead .num{display:block;font-size:1.1rem;font-weight:700;color:var(--gray-900);}
+.planif-colhead.today .num{color:var(--primary);}
+.planif-hourline{position:absolute;left:0;right:0;border-top:1px solid var(--gray-200,#eee);}
+.planif-workband{position:absolute;left:0;right:0;background:rgba(47,93,80,0.06);}
+.planif-now{position:absolute;left:0;right:0;border-top:2px solid #e11d48;z-index:2;}
+
+.planif-bloc{position:absolute;left:3px;right:3px;border-left:4px solid;border-radius:5px;padding:2px 5px;font-size:.74rem;overflow:hidden;cursor:pointer;box-shadow:var(--shadow-sm);z-index:1;color:#1f2937;}
+.planif-bloc:hover{box-shadow:var(--shadow-md);filter:brightness(0.97);}
+.planif-bloc .bt{font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.planif-bloc .bh{opacity:.8;font-size:.68rem;}
+.planif-bloc.fait{opacity:.5;}
+.planif-bloc.fait .bt{text-decoration:line-through;}
+.planif-bloc .ic{font-size:.66rem;}
+
+/* Vue mois */
+.planif-month{display:grid;grid-template-columns:repeat(7,1fr);}
+.planif-month .mh{text-align:center;font-weight:600;font-size:.78rem;color:var(--gray-500);padding:.4rem 0;border-bottom:1px solid var(--gray-300);}
+.planif-day{min-height:96px;border:1px solid var(--gray-200,#eee);padding:3px;display:flex;flex-direction:column;gap:2px;}
+.planif-day.out{background:var(--gray-100);opacity:.6;}
+.planif-day .dn{font-size:.78rem;font-weight:600;color:var(--gray-700);cursor:pointer;align-self:flex-start;border-radius:4px;padding:0 4px;}
+.planif-day.today .dn{background:var(--primary);color:#fff;}
+.planif-chip{font-size:.68rem;border-left:3px solid;border-radius:3px;padding:1px 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer;}
+.planif-chip.fait{opacity:.5;text-decoration:line-through;}
+.planif-more{font-size:.66rem;color:var(--gray-500);cursor:pointer;}
+
+.planif-row{display:flex;gap:.75rem;flex-wrap:wrap;}
+.planif-row .form-group{flex:1;min-width:120px;}
+.planif-duree{display:flex;align-items:center;gap:.35rem;}
+.planif-duree input{width:64px;}
+.planif-check{display:flex;align-items:center;gap:.4rem;font-weight:600;cursor:pointer;}
+.planif-tabs{display:flex;gap:.5rem;margin:.5rem 0 1rem;}
+.planif-tabs button{flex:1;border:1px solid var(--gray-300);background:var(--card-bg,#fff);color:var(--gray-700);padding:.5rem;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;}
+.planif-tabs button.active{background:var(--primary);color:#fff;border-color:var(--primary);}
+.planif-horaires-grid{display:flex;flex-direction:column;gap:.4rem;}
+.planif-hday{display:grid;grid-template-columns:1.4fr repeat(4,1fr);gap:.4rem;align-items:center;}
+.planif-hday label.jr{font-weight:600;display:flex;align-items:center;gap:.4rem;}
+.planif-hday input[type=time]{width:100%;}
+.planif-hday.off input[type=time]{opacity:.4;}
+.planif-recur-liste{display:flex;flex-direction:column;gap:.4rem;max-height:180px;overflow-y:auto;}
+.planif-recur-item{display:flex;justify-content:space-between;align-items:center;gap:.5rem;padding:.5rem .6rem;border:1px solid var(--gray-200,#eee);border-radius:var(--radius-sm);font-size:.85rem;}
+.planif-detail-line{margin:.3rem 0;color:var(--gray-700);}
+.planif-detail-actions{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem;}
+.planif-detail-actions .btn{font-size:.82rem;padding:.4rem .7rem;}
+.planif-alerte{background:#fdf2cf;border:1px solid #ba7a2a;color:#7a5314;border-radius:var(--radius-sm);padding:.6rem .8rem;margin-bottom:1rem;font-size:.88rem;}
+.planif-toasts{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;gap:.5rem;z-index:10000;}
+.planif-toast{background:var(--gray-900);color:#fff;padding:.7rem 1rem;border-radius:var(--radius-sm);box-shadow:var(--shadow-lg);font-size:.85rem;max-width:340px;animation:planifIn .2s ease;}
+.planif-toast.err{background:#7f1d1d;}
+.planif-toast.ok{background:#14532d;}
+@keyframes planifIn{from{opacity:0;transform:translateY(8px);}to{opacity:1;transform:none;}}
+
+[data-theme="dark"] .u-retard{background:#4c1d1d;border-color:#f87171;color:#fecaca;}
+[data-theme="dark"] .u-urgent{background:#4a2c10;border-color:#fb923c;color:#fed7aa;}
+[data-theme="dark"] .u-proche{background:#473a13;border-color:#fbbf24;color:#fde68a;}
+[data-theme="dark"] .u-a_venir{background:#0f3d2a;border-color:#34d399;color:#a7f3d0;}
+[data-theme="dark"] .u-sans_echeance{background:#27313b;border-color:#94a3b8;color:#cbd5e1;}
+[data-theme="dark"] .evenement{background:#2e2348;border-color:#a78bfa;color:#ddd6fe;}
+[data-theme="dark"] .planif-bloc{color:#e5e7eb;}
+[data-theme="dark"] .planif-workband{background:rgba(255,255,255,0.04);}
+
+@media (max-width:640px){
+  .planif-toolbar{flex-direction:column;align-items:stretch;}
+  .planif-navlabel{margin-left:0;}
+  .planif-day{min-height:70px;}
+}
+</style>
+
+<script>
+(function(){
+  "use strict";
+  const DATA = JSON.parse(document.getElementById('planif-data').textContent);
+  const CSRF = (document.querySelector('meta[name=csrf-token]')||{}).content || '';
+  const JOURS = ['Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi','Dimanche'];
+  const JOURS_COURT = ['Lun','Mar','Mer','Jeu','Ven','Sam','Dim'];
+  const MOIS = ['janvier','février','mars','avril','mai','juin','juillet','août','septembre','octobre','novembre','décembre'];
+  const PX_MIN = 0.8; // pixels par minute
+
+  const state = { vue: DATA.vue || 'semaine', date: DATA.date || isoToday() };
+  let blocsCache = [];
+
+  // ── Helpers dates ──
+  function isoToday(){ const d=new Date(); return iso(d); }
+  function iso(d){ return d.getFullYear()+'-'+String(d.getMonth()+1).padStart(2,'0')+'-'+String(d.getDate()).padStart(2,'0'); }
+  function parse(s){ const p=s.split('-'); return new Date(+p[0], +p[1]-1, +p[2]); }
+  function addDays(s,n){ const d=parse(s); d.setDate(d.getDate()+n); return iso(d); }
+  function weekday(s){ return (parse(s).getDay()+6)%7; } // 0=lundi
+  function monday(s){ return addDays(s, -weekday(s)); }
+  function fmtFR(s){ const d=parse(s); return d.getDate()+' '+MOIS[d.getMonth()]+' '+d.getFullYear(); }
+  function min2hhmm(m){ m=Math.round(m); return String(Math.floor(m/60)).padStart(2,'0')+':'+String(m%60).padStart(2,'0'); }
+  function hhmm2min(s){ if(!s)return null; const p=s.split(':'); return (+p[0])*60+(+p[1]); }
+  function dureeTxt(m){ const h=Math.floor(m/60), mm=m%60; return (h?h+' h':'')+(mm?(h?' ':'')+mm+' min':(h?'':'0 min')); }
+  function esc(s){ return (s||'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+
+  // ── API ──
+  async function apiPost(url, data){
+    const r = await fetch(url, {method:'POST', headers:{
+      'Content-Type':'application/json','X-CSRFToken':CSRF,'X-Requested-With':'XMLHttpRequest'
+    }, body: JSON.stringify(data||{})});
+    let j; try{ j = await r.json(); }catch(e){ j = {ok:false, erreur:'Réponse invalide du serveur'}; }
+    if(!r.ok || !j.ok){ throw new Error(j.erreur || 'Erreur ('+r.status+')'); }
+    return j;
+  }
+  async function apiGet(url){
+    const r = await fetch(url, {headers:{'X-Requested-With':'XMLHttpRequest'}});
+    return r.json();
+  }
+
+  function toast(msg, type){
+    const c = document.getElementById('planifToasts');
+    const t = document.createElement('div');
+    t.className = 'planif-toast '+(type||'');
+    t.textContent = msg;
+    c.appendChild(t);
+    setTimeout(()=>{ t.style.opacity='0'; setTimeout(()=>t.remove(),300); }, 4200);
+  }
+  function montrerNonPlanifie(np){
+    if(np && np.length){
+      const titres = np.map(x=>x.titre||'tâche').slice(0,4).join(', ');
+      toast('⚠️ '+np.length+' élément(s) non planifié(s) (capacité ou échéance) : '+titres, 'err');
+    }
+  }
+
+  // ── Plage horaire affichée ──
+  function plageMinutes(){
+    let mn=8*60, mx=18*60;
+    (DATA.horaires||[]).forEach(h=>{
+      if(!h.actif) return;
+      [h.matin_debut, h.aprem_debut].forEach(v=>{ const m=hhmm2min(v); if(m!=null) mn=Math.min(mn,m); });
+      [h.matin_fin, h.aprem_fin].forEach(v=>{ const m=hhmm2min(v); if(m!=null) mx=Math.max(mx,m); });
+    });
+    blocsCache.forEach(b=>{ const d=hhmm2min(b.heure_debut), f=hhmm2min(b.heure_fin); if(d!=null)mn=Math.min(mn,d); if(f!=null)mx=Math.max(mx,f); });
+    mn = Math.max(0, Math.floor(mn/60)*60 - 0);
+    mx = Math.min(1440, Math.ceil(mx/60)*60);
+    if(mx-mn < 240){ mx = Math.min(1440, mn+240); }
+    return [mn, mx];
+  }
+  function horaireJour(js){ return (DATA.horaires||[]).find(h=>h.jour_semaine===js); }
+
+  // ── Chargement + rendu ──
+  function rangeFetch(){
+    if(state.vue==='jour') return [state.date, state.date];
+    if(state.vue==='semaine'){ const m=monday(state.date); return [m, addDays(m,6)]; }
+    // mois : grille du lundi avant le 1er au dimanche après la fin
+    const d=parse(state.date); const first=iso(new Date(d.getFullYear(),d.getMonth(),1));
+    const last=iso(new Date(d.getFullYear(),d.getMonth()+1,0));
+    return [monday(first), addDays(monday(last),6)];
+  }
+  async function charger(){
+    const [deb,fin]=rangeFetch();
+    try{
+      const j = await apiGet('{{ url_for("planificateur_bp.api_blocs") }}?debut='+deb+'&fin='+fin);
+      blocsCache = (j && j.blocs) ? j.blocs : [];
+    }catch(e){ blocsCache=[]; }
+    rendre();
+  }
+  function rendre(){
+    document.querySelectorAll('#planifViews button').forEach(b=>b.classList.toggle('active', b.dataset.vue===state.vue));
+    majLabel();
+    const cal = document.getElementById('planifCal');
+    if(state.vue==='mois') cal.innerHTML = rendreMois();
+    else cal.innerHTML = rendreGrille(state.vue==='jour'? [state.date] : joursSemaine());
+    brancherBlocs();
+  }
+  function majLabel(){
+    let txt='';
+    if(state.vue==='jour') txt = JOURS[weekday(state.date)]+' '+fmtFR(state.date);
+    else if(state.vue==='semaine'){ const m=monday(state.date); txt='Semaine du '+fmtFR(m); }
+    else { const d=parse(state.date); txt=MOIS[d.getMonth()]+' '+d.getFullYear(); }
+    document.getElementById('navLabel').textContent = txt;
+  }
+  function joursSemaine(){ const m=monday(state.date); return [0,1,2,3,4,5,6].map(i=>addDays(m,i)); }
+
+  function rendreGrille(jours){
+    const [mn,mx]=plageMinutes();
+    const hauteur=(mx-mn)*PX_MIN;
+    let gutter='<div class="planif-gutter" style="height:'+(hauteur+28)+'px;">';
+    gutter+='<div style="height:28px;"></div>';
+    for(let h=Math.ceil(mn/60)*60; h<=mx; h+=60){ gutter+='<div class="hh" style="top:'+(28+(h-mn)*PX_MIN)+'px;">'+min2hhmm(h)+'</div>'; }
+    gutter+='</div>';
+
+    let cols='<div class="planif-cols">';
+    const today=isoToday();
+    jours.forEach(jr=>{
+      const js=weekday(jr); const est_today=jr===today;
+      cols+='<div class="planif-col" data-jour="'+jr+'">';
+      cols+='<div class="planif-colhead'+(est_today?' today':'')+'">'+JOURS_COURT[js]+'<span class="num">'+parse(jr).getDate()+'</span></div>';
+      cols+='<div class="planif-colbody" style="position:relative;height:'+hauteur+'px;">';
+      // bandes horaires de travail
+      const h=horaireJour(js);
+      if(h && h.actif){
+        [[h.matin_debut,h.matin_fin],[h.aprem_debut,h.aprem_fin]].forEach(iv=>{
+          const d=hhmm2min(iv[0]), f=hhmm2min(iv[1]);
+          if(d!=null && f!=null && f>d){ cols+='<div class="planif-workband" style="top:'+((d-mn)*PX_MIN)+'px;height:'+((f-d)*PX_MIN)+'px;"></div>'; }
+        });
+      }
+      for(let hh=Math.ceil(mn/60)*60; hh<=mx; hh+=60){ cols+='<div class="planif-hourline" style="top:'+((hh-mn)*PX_MIN)+'px;"></div>'; }
+      if(est_today){ const now=new Date().getHours()*60+new Date().getMinutes(); if(now>=mn&&now<=mx){ cols+='<div class="planif-now" style="top:'+((now-mn)*PX_MIN)+'px;"></div>'; } }
+      // blocs
+      blocsCache.filter(b=>b.date===jr).forEach(b=>{
+        const d=hhmm2min(b.heure_debut), f=hhmm2min(b.heure_fin);
+        const top=(d-mn)*PX_MIN, hgt=Math.max(16,(f-d)*PX_MIN);
+        const cls=classeBloc(b);
+        cols+='<div class="planif-bloc '+cls+'" data-id="'+b.id+'" style="top:'+top+'px;height:'+hgt+'px;">'
+          +'<div class="bt">'+iconeBloc(b)+esc(b.titre)+'</div>'
+          +(hgt>30?'<div class="bh">'+b.heure_debut+'–'+b.heure_fin+'</div>':'')+'</div>';
+      });
+      cols+='</div></div>';
+    });
+    cols+='</div>';
+    return '<div class="planif-grid">'+gutter+cols+'</div>';
+  }
+
+  function rendreMois(){
+    const [deb,fin]=rangeFetch();
+    const moisRef=parse(state.date).getMonth();
+    const today=isoToday();
+    let html='<div class="planif-month">';
+    JOURS_COURT.forEach(j=>html+='<div class="mh">'+j+'</div>');
+    const parJour={};
+    blocsCache.forEach(b=>{ (parJour[b.date]=parJour[b.date]||[]).push(b); });
+    let cur=deb;
+    while(cur<=fin){
+      const out=parse(cur).getMonth()!==moisRef;
+      html+='<div class="planif-day'+(out?' out':'')+(cur===today?' today':'')+'">';
+      html+='<span class="dn" data-goto="'+cur+'">'+parse(cur).getDate()+'</span>';
+      const items=(parJour[cur]||[]).sort((a,b)=>a.heure_debut.localeCompare(b.heure_debut));
+      items.slice(0,3).forEach(b=>{
+        html+='<div class="planif-chip '+classeBloc(b)+'" data-id="'+b.id+'">'+iconeBloc(b)+b.heure_debut+' '+esc(b.titre)+'</div>';
+      });
+      if(items.length>3) html+='<div class="planif-more" data-goto="'+cur+'">+'+(items.length-3)+' autres</div>';
+      html+='</div>';
+      cur=addDays(cur,1);
+    }
+    html+='</div>';
+    return html;
+  }
+
+  function classeBloc(b){
+    if(b.type==='evenement') return 'evenement'+(b.statut==='fait'?' fait':'');
+    return 'u-'+(b.urgence||'sans_echeance')+(b.statut==='fait'?' fait':'');
+  }
+  function iconeBloc(b){
+    if(b.statut==='fait') return '✓ ';
+    if(b.type==='evenement') return '📌 ';
+    if(b.recurrente) return '🔁 ';
+    return '';
+  }
+
+  function brancherBlocs(){
+    document.querySelectorAll('.planif-bloc, .planif-chip').forEach(el=>{
+      el.addEventListener('click', ()=>{ const b=blocsCache.find(x=>x.id==el.dataset.id); if(b) ouvrirDetail(b); });
+    });
+    document.querySelectorAll('[data-goto]').forEach(el=>{
+      el.addEventListener('click', (e)=>{ e.stopPropagation(); state.date=el.dataset.goto; state.vue='jour'; charger(); });
+    });
+  }
+
+  // ── Détail d'un bloc ──
+  function ouvrirDetail(b){
+    document.getElementById('detailTitre').textContent = b.titre;
+    const ech = b.deadline ? ('Échéance : '+fmtFR(b.deadline)) : 'Sans échéance';
+    const prio = {basse:'Basse',normale:'Normale',haute:'Haute'}[b.priorite]||b.priorite;
+    let corps='';
+    corps+='<div class="planif-detail-line">📅 '+JOURS[weekday(b.date)]+' '+fmtFR(b.date)+' · '+b.heure_debut+'–'+b.heure_fin+' ('+dureeTxt(b.duree_min)+')</div>';
+    if(b.type==='evenement'){
+      corps+='<div class="planif-detail-line">📌 Événement fixe</div>';
+    }else{
+      corps+='<div class="planif-detail-line">⏳ '+esc(ech)+' · 🚩 Priorité '+prio+(b.recurrente?' · 🔁 récurrente':'')+'</div>';
+    }
+    if(b.description) corps+='<div class="planif-detail-line">📝 '+esc(b.description)+'</div>';
+    if(b.statut==='fait') corps+='<div class="planif-detail-line">✅ Marqué comme effectué</div>';
+
+    let act='<div class="planif-detail-actions">';
+    if(b.statut!=='fait') act+='<button class="btn btn-primary" data-act="bloc_fait">✓ Marquer ce créneau fait</button>';
+    else act+='<button class="btn btn-secondary" data-act="bloc_repris">↩ Rétablir</button>';
+    if(b.type!=='evenement'){
+      act+='<button class="btn btn-secondary" data-act="tache_fait">✓✓ Tâche entière faite</button>';
+      act+='<button class="btn btn-secondary" data-act="reporter">📆 Reporter</button>';
+      act+='<button class="btn btn-secondary" data-act="fin">✂️ Planifier la fin</button>';
+    }
+    act+='<button class="btn btn-secondary" data-act="modifier">✏️ Modifier</button>';
+    act+='<button class="btn btn-secondary" data-act="bloc_suppr">🗑 Supprimer ce créneau</button>';
+    act+='<button class="btn btn-danger" data-act="tache_suppr">🗑 Supprimer la tâche</button>';
+    act+='</div>';
+    document.getElementById('detailCorps').innerHTML = corps+act;
+    document.querySelectorAll('#detailCorps [data-act]').forEach(btn=>{
+      btn.addEventListener('click', ()=>actionDetail(btn.dataset.act, b));
+    });
+    ouvrir('modalDetail');
+  }
+
+  async function actionDetail(act, b){
+    try{
+      let res=null;
+      if(act==='bloc_fait') res=await apiPost('/planificateur/api/bloc/'+b.id+'/statut',{statut:'fait'});
+      else if(act==='bloc_repris') res=await apiPost('/planificateur/api/bloc/'+b.id+'/statut',{statut:'planifie'});
+      else if(act==='bloc_suppr') res=await apiPost('/planificateur/api/bloc/'+b.id+'/supprimer',{});
+      else if(act==='tache_fait') res=await apiPost('/planificateur/api/tache/'+b.tache_id+'/statut',{statut:'fait'});
+      else if(act==='tache_suppr'){ if(!confirm('Supprimer définitivement cette tâche et tous ses créneaux ?')) return; res=await apiPost('/planificateur/api/tache/'+b.tache_id+'/supprimer',{}); }
+      else if(act==='reporter'){ const d=prompt('Reporter à partir de quelle date ? (AAAA-MM-JJ)', addDays(isoToday(),1)); if(!d) return; res=await apiPost('/planificateur/api/tache/'+b.tache_id+'/reporter',{date_min:d}); }
+      else if(act==='fin'){ const m=prompt('Combien de minutes déjà réalisées ? Le reste sera replanifié.', String(b.duree_min)); if(m===null) return; res=await apiPost('/planificateur/api/tache/'+b.tache_id+'/terminer_partiel',{minutes_faites:parseInt(m,10)||0}); }
+      else if(act==='modifier'){ planifFermerModales(); return ouvrirEdition(b); }
+      planifFermerModales();
+      if(res){ toast('✓ Mis à jour', 'ok'); montrerNonPlanifie(res.non_planifie); }
+      await charger();
+    }catch(e){ toast(e.message,'err'); }
+  }
+
+  // ── Modale ajouter / modifier ──
+  let typeCourant='tache';
+  function setType(t){
+    typeCourant=t;
+    document.querySelectorAll('#ajTabs button').forEach(b=>b.classList.toggle('active', b.dataset.type===t));
+    document.getElementById('champsTache').style.display = t==='tache'?'':'none';
+    document.getElementById('champsEvenement').style.display = t==='evenement'?'':'none';
+  }
+  function ouvrirAjout(){
+    document.getElementById('formTache').reset();
+    document.getElementById('t_id').value='';
+    document.getElementById('modalAjouterTitre').textContent='Ajouter';
+    document.getElementById('ajTabs').style.display='';
+    document.getElementById('t_secable').checked=true;
+    document.getElementById('grpMinBloc').style.display='';
+    setType('tache');
+    if(state.vue!=='mois'){ document.getElementById('e_date').value=state.date; }
+    ouvrir('modalAjouter');
+  }
+  function ouvrirEdition(b){
+    document.getElementById('formTache').reset();
+    document.getElementById('t_id').value=b.tache_id;
+    document.getElementById('modalAjouterTitre').textContent='Modifier';
+    document.getElementById('ajTabs').style.display='none';
+    document.getElementById('t_titre').value=b.titre;
+    document.getElementById('t_description').value=b.description||'';
+    if(b.type==='evenement'){
+      setType('evenement');
+      document.getElementById('e_date').value=b.date;
+      document.getElementById('e_debut').value=b.heure_debut;
+      document.getElementById('e_fin').value=b.heure_fin;
+    }else{
+      setType('tache');
+      const duree = b.tache_duree_min || b.duree_min;
+      document.getElementById('t_heures').value=Math.floor(duree/60);
+      document.getElementById('t_minutes').value=duree%60;
+      document.getElementById('t_deadline').value=b.deadline||'';
+      document.getElementById('t_priorite').value=b.priorite||'normale';
+      document.getElementById('t_preference').value=b.preference||'aucune';
+      document.getElementById('t_secable').checked=!!b.secable;
+      document.getElementById('t_min_bloc').value=b.duree_min_bloc||30;
+      document.getElementById('grpMinBloc').style.display=b.secable?'':'none';
+    }
+    ouvrir('modalAjouter');
+  }
+  async function soumettreTache(e){
+    e.preventDefault();
+    const id=document.getElementById('t_id').value;
+    const titre=document.getElementById('t_titre').value.trim();
+    if(!titre){ toast('Le titre est obligatoire','err'); return; }
+    let payload, url;
+    if(typeCourant==='evenement'){
+      payload={ type:'evenement', titre, description:document.getElementById('t_description').value,
+        date_fixe:document.getElementById('e_date').value,
+        heure_debut:document.getElementById('e_debut').value,
+        heure_fin:document.getElementById('e_fin').value };
+    }else{
+      const duree=(parseInt(document.getElementById('t_heures').value,10)||0)*60+(parseInt(document.getElementById('t_minutes').value,10)||0);
+      if(duree<5){ toast('La durée doit être d\'au moins 5 minutes','err'); return; }
+      payload={ type:'tache', titre, description:document.getElementById('t_description').value,
+        duree_min:duree, deadline:document.getElementById('t_deadline').value,
+        priorite:document.getElementById('t_priorite').value,
+        preference:document.getElementById('t_preference').value,
+        secable:document.getElementById('t_secable').checked?1:0,
+        duree_min_bloc:parseInt(document.getElementById('t_min_bloc').value,10)||30 };
+    }
+    url = id ? ('/planificateur/api/tache/'+id) : '{{ url_for("planificateur_bp.api_creer_tache") }}';
+    try{
+      const res=await apiPost(url,payload);
+      planifFermerModales();
+      toast('✓ Enregistré et planifié','ok');
+      montrerNonPlanifie(res.non_planifie);
+      await charger();
+    }catch(err){ toast(err.message,'err'); }
+  }
+
+  // ── Horaires ──
+  function construireHoraires(){
+    const grid=document.getElementById('horairesGrid');
+    let html='';
+    for(let j=0;j<7;j++){
+      const h=horaireJour(j)||{actif:j<5,matin_debut:'09:00',matin_fin:'12:30',aprem_debut:'13:30',aprem_fin:'17:30'};
+      html+='<div class="planif-hday'+(h.actif?'':' off')+'" data-j="'+j+'">'
+        +'<label class="jr"><input type="checkbox" class="h_actif" '+(h.actif?'checked':'')+'> '+JOURS[j]+'</label>'
+        +'<input type="time" class="h_md" value="'+(h.matin_debut||'')+'">'
+        +'<input type="time" class="h_mf" value="'+(h.matin_fin||'')+'">'
+        +'<input type="time" class="h_ad" value="'+(h.aprem_debut||'')+'">'
+        +'<input type="time" class="h_af" value="'+(h.aprem_fin||'')+'">'
+        +'</div>';
+    }
+    grid.innerHTML=html;
+    grid.querySelectorAll('.h_actif').forEach(cb=>cb.addEventListener('change',()=>cb.closest('.planif-hday').classList.toggle('off',!cb.checked)));
+  }
+  async function soumettreHoraires(e){
+    e.preventDefault();
+    const jours=[];
+    document.querySelectorAll('#horairesGrid .planif-hday').forEach(row=>{
+      jours.push({ actif:row.querySelector('.h_actif').checked?1:0,
+        matin_debut:row.querySelector('.h_md').value, matin_fin:row.querySelector('.h_mf').value,
+        aprem_debut:row.querySelector('.h_ad').value, aprem_fin:row.querySelector('.h_af').value });
+    });
+    try{
+      const res=await apiPost('{{ url_for("planificateur_bp.api_horaires") }}',{jours});
+      DATA.horaires = jours.map((c,j)=>({jour_semaine:j, actif:c.actif, matin_debut:c.matin_debut, matin_fin:c.matin_fin, aprem_debut:c.aprem_debut, aprem_fin:c.aprem_fin}));
+      planifFermerModales();
+      toast('✓ Horaires enregistrés','ok');
+      montrerNonPlanifie(res.non_planifie);
+      await charger();
+    }catch(err){ toast(err.message,'err'); }
+  }
+
+  // ── Récurrences ──
+  function construireRecur(){
+    const liste=document.getElementById('recurListe');
+    const recs=DATA.recurrences||[];
+    if(!recs.length){ liste.innerHTML='<p style="color:var(--gray-500);font-size:.85rem;">Aucune tâche récurrente.</p>'; }
+    else{
+      liste.innerHTML=recs.map(r=>{
+        const freq={quotidien:'Tous les jours',hebdomadaire:'Chaque semaine',mensuel:'Chaque mois'}[r.frequence]||r.frequence;
+        return '<div class="planif-recur-item"><span><strong>'+esc(r.titre)+'</strong> · '+freq+' · '+dureeTxt(r.duree_min)+'</span>'
+          +'<button class="btn btn-danger" style="padding:.25rem .5rem;font-size:.75rem;" data-rec="'+r.id+'">🗑</button></div>';
+      }).join('');
+      liste.querySelectorAll('[data-rec]').forEach(b=>b.addEventListener('click',()=>supprimerRecur(b.dataset.rec)));
+    }
+    if(!document.getElementById('r_debut').value) document.getElementById('r_debut').value=isoToday();
+    majChampsFreq();
+  }
+  function majChampsFreq(){
+    const f=document.getElementById('r_frequence').value;
+    document.getElementById('grpJourSem').style.display = f==='hebdomadaire'?'':'none';
+    document.getElementById('grpJourMois').style.display = f==='mensuel'?'':'none';
+  }
+  async function soumettreRecur(e){
+    e.preventDefault();
+    const duree=(parseInt(document.getElementById('r_heures').value,10)||0)*60+(parseInt(document.getElementById('r_minutes').value,10)||0);
+    if(duree<5){ toast('La durée doit être d\'au moins 5 minutes','err'); return; }
+    const payload={ titre:document.getElementById('r_titre').value.trim(),
+      frequence:document.getElementById('r_frequence').value, duree_min:duree,
+      priorite:document.getElementById('r_priorite').value, preference:document.getElementById('r_preference').value,
+      jour_semaine:document.getElementById('r_jour_sem').value, jour_mois:document.getElementById('r_jour_mois').value,
+      date_debut:document.getElementById('r_debut').value, date_fin:document.getElementById('r_fin').value };
+    if(!payload.titre){ toast('Le titre est obligatoire','err'); return; }
+    try{
+      const res=await apiPost('{{ url_for("planificateur_bp.api_creer_recurrence") }}',payload);
+      // Recharger la page pour rafraîchir la liste des récurrences côté serveur.
+      toast('✓ Récurrence ajoutée','ok');
+      montrerNonPlanifie(res.non_planifie);
+      setTimeout(()=>window.location.reload(), 600);
+    }catch(err){ toast(err.message,'err'); }
+  }
+  async function supprimerRecur(id){
+    if(!confirm('Supprimer cette récurrence et ses occurrences à venir ?')) return;
+    try{ await apiPost('/planificateur/api/recurrence/'+id+'/supprimer',{}); toast('✓ Supprimée','ok'); setTimeout(()=>window.location.reload(),500); }
+    catch(e){ toast(e.message,'err'); }
+  }
+
+  // ── Modales utils ──
+  function ouvrir(id){ planifFermerModales(); document.getElementById(id).style.display='flex'; }
+  window.planifFermerModales=function(){ document.querySelectorAll('.planif-modal').forEach(m=>m.style.display='none'); };
+
+  // ── Navigation ──
+  function naviguer(sens){
+    if(state.vue==='jour') state.date=addDays(state.date, sens);
+    else if(state.vue==='semaine') state.date=addDays(state.date, sens*7);
+    else { const d=parse(state.date); state.date=iso(new Date(d.getFullYear(), d.getMonth()+sens, 1)); }
+    charger();
+  }
+
+  // ── Init ──
+  document.getElementById('planifViews').addEventListener('click', e=>{
+    if(e.target.dataset.vue){ state.vue=e.target.dataset.vue; charger(); }
+  });
+  document.getElementById('navPrev').addEventListener('click', ()=>naviguer(-1));
+  document.getElementById('navNext').addEventListener('click', ()=>naviguer(1));
+  document.getElementById('navToday').addEventListener('click', ()=>{ state.date=isoToday(); charger(); });
+  document.getElementById('btnAjouter').addEventListener('click', ouvrirAjout);
+  document.getElementById('btnReplan').addEventListener('click', async ()=>{
+    try{ const res=await apiPost('{{ url_for("planificateur_bp.api_replanifier") }}',{}); toast('✓ Planning recalculé','ok'); montrerNonPlanifie(res.non_planifie); await charger(); }
+    catch(e){ toast(e.message,'err'); }
+  });
+  document.getElementById('btnHoraires').addEventListener('click', ()=>{ construireHoraires(); ouvrir('modalHoraires'); });
+  document.getElementById('btnRecur').addEventListener('click', ()=>{ construireRecur(); ouvrir('modalRecur'); });
+  document.getElementById('ajTabs').addEventListener('click', e=>{ if(e.target.dataset.type) setType(e.target.dataset.type); });
+  document.getElementById('formTache').addEventListener('submit', soumettreTache);
+  document.getElementById('formHoraires').addEventListener('submit', soumettreHoraires);
+  document.getElementById('formRecur').addEventListener('submit', soumettreRecur);
+  document.getElementById('r_frequence').addEventListener('change', majChampsFreq);
+  document.getElementById('t_secable').addEventListener('change', e=>{ document.getElementById('grpMinBloc').style.display=e.target.checked?'':'none'; });
+  document.addEventListener('keydown', e=>{ if(e.key==='Escape') planifFermerModales(); });
+
+  // Bandeau tâches non placées (chargé côté serveur)
+  (function(){
+    const np=DATA.taches_non_placees||[];
+    if(np.length){
+      const titres=np.map(t=>esc(t.titre)).slice(0,5).join(', ');
+      document.getElementById('planifAlertes').innerHTML='<div class="planif-alerte">⚠️ '+np.length+' tâche(s) sans créneau planifié : '+titres+'. Ajustez les horaires, échéances ou cliquez sur « Replanifier ».</div>';
+    }
+  })();
+
+  charger();
+})();
+</script>
+{% endblock %}

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -18,9 +18,21 @@ import planificateur_engine as moteur
 # Moteur d'optimisation (logique pure)
 # ──────────────────────────────────────────────────────────────────────────
 
-def _horaires_standard():
-    """Lun-ven : 09:00-12:30 / 13:30-17:30."""
-    return {j: [(540, 750), (810, 1050)] for j in range(5)}
+def _horaires_standard(intervalles=((540, 750), (810, 1050)), jours=(0, 1, 2, 3, 4)):
+    """Horaires lun-ven 09:00-12:30 / 13:30-17:30, indexes par date.
+
+    Le moteur attend desormais des horaires par date (le planning peut varier
+    selon la periode / l'alternance). On couvre un large horizon : le moteur ne
+    lit que les dates de [date_debut, date_fin], les dates en trop sont ignorees.
+    """
+    h = {}
+    d = date.today() - timedelta(days=1)
+    fin = date.today() + timedelta(days=120)
+    while d <= fin:
+        if d.weekday() in jours:
+            h[d.isoformat()] = [tuple(iv) for iv in intervalles]
+        d += timedelta(days=1)
+    return h
 
 
 def _lundi_prochain():
@@ -279,29 +291,69 @@ def test_supprimer_tache(comptable_client, db):
     assert db.execute("SELECT COUNT(*) AS n FROM planif_blocs WHERE tache_id = ?", (tache['id'],)).fetchone()['n'] == 0
 
 
-def test_horaires_sauvegarde_et_seed(comptable_client, db, sample_users):
-    # Le premier acces seed les horaires par defaut (lun-ven).
-    comptable_client.get('/planificateur')
-    rows = db.execute(
-        "SELECT COUNT(*) AS n FROM planif_horaires WHERE user_id = ?",
-        (sample_users['comptable_id'],)
-    ).fetchone()
-    assert rows['n'] == 7
+def _inserer_planning(db, user_id, matin=('08:00', '12:00'), aprem=(None, None)):
+    """Cree un planning theorique simple (lun-ven) pour un utilisateur."""
+    data = {'user_id': user_id, 'type_periode': 'periode_scolaire',
+            'date_debut_validite': '2000-01-01', 'type_alternance': 'fixe'}
+    for jour in ('lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi'):
+        data[f'{jour}_matin_debut'] = matin[0]
+        data[f'{jour}_matin_fin'] = matin[1]
+        data[f'{jour}_aprem_debut'] = aprem[0]
+        data[f'{jour}_aprem_fin'] = aprem[1]
+    cols = ', '.join(data.keys())
+    ph = ', '.join(['?'] * len(data))
+    db.execute(f"INSERT INTO planning_theorique ({cols}) VALUES ({ph})", list(data.values()))
+    db.commit()
 
-    # Modification : desactiver le lundi.
-    jours = []
-    for j in range(7):
-        jours.append({'actif': 0 if j == 0 else (1 if j < 5 else 0),
-                      'matin_debut': '08:00', 'matin_fin': '12:00',
-                      'aprem_debut': '14:00', 'aprem_fin': '18:00'})
-    resp = comptable_client.post('/planificateur/api/horaires', json={'jours': jours})
-    assert resp.status_code == 200
-    lundi_cfg = db.execute(
-        "SELECT actif, matin_debut FROM planif_horaires WHERE user_id = ? AND jour_semaine = 0",
-        (sample_users['comptable_id'],)
-    ).fetchone()
-    assert lundi_cfg['actif'] == 0
-    assert lundi_cfg['matin_debut'] == '08:00'
+
+def test_horaires_issus_du_planning(comptable_client, db, sample_users):
+    """Le planificateur respecte le planning theorique (Mon planning), sans ressaisie."""
+    # Planning : uniquement le matin 08:00-12:00 (pas d'apres-midi).
+    _inserer_planning(db, sample_users['comptable_id'], matin=('08:00', '12:00'))
+
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Tache matin', 'duree_min': 180,
+        'secable': 1, 'duree_min_bloc': 30,
+    })
+    fin = (date.today() + timedelta(days=20)).isoformat()
+    blocs = comptable_client.get(
+        f'/planificateur/api/blocs?debut={date.today().isoformat()}&fin={fin}'
+    ).get_json()['blocs']
+    assert blocs, "des blocs devraient etre planifies"
+    for b in blocs:
+        deb, f = moteur._to_min(b['heure_debut']), moteur._to_min(b['heure_fin'])
+        assert 480 <= deb and f <= 720, f"hors planning (matin 08:00-12:00) : {b}"
+
+
+def test_api_blocs_retourne_horaires_du_planning(comptable_client, db, sample_users):
+    """L'API expose les horaires de travail (pour les plages du calendrier)."""
+    _inserer_planning(db, sample_users['comptable_id'],
+                      matin=('09:00', '12:00'), aprem=('14:00', '17:00'))
+    # Trouver un lundi a venir (jour ouvre garanti).
+    d = date.today()
+    while d.weekday() != 0:
+        d += timedelta(days=1)
+    data = comptable_client.get(
+        f'/planificateur/api/blocs?debut={d.isoformat()}&fin={d.isoformat()}'
+    ).get_json()
+    assert 'horaires' in data
+    assert data['horaires'].get(d.isoformat()) == [[540, 720], [840, 1020]]
+
+
+def test_horaires_defaut_sans_planning(comptable_client, sample_users):
+    """Sans planning, des horaires par defaut (9h-12h30 / 13h30-17h30) s'appliquent."""
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Tache defaut', 'duree_min': 60,
+        'secable': 0, 'duree_min_bloc': 60,
+    })
+    fin = (date.today() + timedelta(days=20)).isoformat()
+    blocs = comptable_client.get(
+        f'/planificateur/api/blocs?debut={date.today().isoformat()}&fin={fin}'
+    ).get_json()['blocs']
+    assert blocs
+    for b in blocs:
+        deb, f = moteur._to_min(b['heure_debut']), moteur._to_min(b['heure_fin'])
+        assert 540 <= deb and f <= 1050, f"hors horaires par defaut : {b}"
 
 
 def test_recurrence_cree_occurrences(comptable_client, db, sample_users):

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -399,6 +399,80 @@ def test_confidentialite_blocs_par_utilisateur(comptable_client, db, sample_user
     assert all(b['titre'] != 'Secret direction' for b in blocs)
 
 
+def test_bloc_fait_tache_sous_planifiee_reste_ouverte(comptable_client, db, sample_users):
+    """Cocher tous les blocs visibles d'une tache sous-planifiee ne la cloture pas.
+
+    Une tache de 120 min dont un seul bloc de 30 min a pu etre place (capacite
+    insuffisante) doit rester 'a_faire' apres que ce bloc soit marque fait :
+    son reliquat (90 min) ne doit pas etre perdu.
+    """
+    uid = sample_users['comptable_id']
+    jour = (date.today() + timedelta(days=1)).isoformat()
+    cur = db.execute(
+        "INSERT INTO planif_taches (user_id, type, titre, duree_min, statut) "
+        "VALUES (?, 'tache', 'Sous-planifiee', 120, 'a_faire')", (uid,)
+    )
+    tache_id = cur.lastrowid
+    bloc = db.execute(
+        "INSERT INTO planif_blocs (tache_id, user_id, date, heure_debut, heure_fin, duree_min) "
+        "VALUES (?, ?, ?, '09:00', '09:30', 30)", (tache_id, uid, jour)
+    )
+    db.commit()
+
+    resp = comptable_client.post(f'/planificateur/api/bloc/{bloc.lastrowid}/statut', json={'statut': 'fait'})
+    assert resp.status_code == 200
+    statut = db.execute("SELECT statut FROM planif_taches WHERE id = ?", (tache_id,)).fetchone()['statut']
+    assert statut == 'a_faire', "la tache ne doit pas etre cloturee tant que sa duree n'est pas couverte"
+
+
+def test_terminer_partiel_libere_les_blocs_futurs(comptable_client, db, sample_users):
+    """« Planifier la fin » libere les creneaux futurs (pas de double comptage)."""
+    uid = sample_users['comptable_id']
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Mission', 'duree_min': 240,
+        'secable': 1, 'duree_min_bloc': 60,
+    })
+    tache = db.execute("SELECT id FROM planif_taches WHERE titre = 'Mission'").fetchone()
+
+    resp = comptable_client.post(
+        f'/planificateur/api/tache/{tache["id"]}/terminer_partiel', json={'minutes_faites': 60}
+    )
+    assert resp.status_code == 200
+
+    # La tache d'origine est cloturee et n'a plus de bloc non realise.
+    assert db.execute("SELECT statut FROM planif_taches WHERE id = ?", (tache['id'],)).fetchone()['statut'] == 'fait'
+    assert db.execute(
+        "SELECT COUNT(*) AS n FROM planif_blocs WHERE tache_id = ? AND statut != 'fait'", (tache['id'],)
+    ).fetchone()['n'] == 0
+
+    # Une tache « suite » de 180 min est creee et planifiee.
+    suite = db.execute("SELECT id, duree_min FROM planif_taches WHERE titre LIKE '%suite%'").fetchone()
+    assert suite is not None and suite['duree_min'] == 180
+
+    # Pas de double comptage : le total planifie correspond au reste (180 min).
+    total = db.execute(
+        "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs WHERE user_id = ?", (uid,)
+    ).fetchone()['s']
+    assert total == 180
+
+
+def test_supprimer_bloc_evenement_refuse(comptable_client, db):
+    """On ne peut pas supprimer le seul creneau d'un evenement fixe."""
+    jour = (date.today() + timedelta(days=2)).isoformat()
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'evenement', 'titre': 'RDV important', 'date_fixe': jour,
+        'heure_debut': '10:00', 'heure_fin': '11:00',
+    })
+    bloc = db.execute(
+        "SELECT b.id FROM planif_blocs b JOIN planif_taches t ON b.tache_id = t.id "
+        "WHERE t.titre = 'RDV important'"
+    ).fetchone()
+    resp = comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/supprimer', json={})
+    assert resp.status_code == 400
+    # Le creneau existe toujours (l'evenement continue de bloquer son horaire).
+    assert db.execute("SELECT COUNT(*) AS n FROM planif_blocs WHERE id = ?", (bloc['id'],)).fetchone()['n'] == 1
+
+
 def test_menu_lien_visible_comptable(comptable_client):
     resp = comptable_client.get('/dashboard_comptable')
     html = resp.get_data(as_text=True)

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -1,0 +1,353 @@
+"""
+Tests du module Planificateur de taches (Time Blocking).
+
+Couvre :
+- le moteur d'optimisation pur (planificateur_engine) : horaires, evenements
+  fixes, decoupage, equilibrage, echeances, recurrences, micro-pauses ;
+- les routes du blueprint : controle d'acces (comptable uniquement),
+  creation / replanification / suivi des taches, confidentialite.
+"""
+from datetime import date, timedelta
+
+import pytest
+
+import planificateur_engine as moteur
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Moteur d'optimisation (logique pure)
+# ──────────────────────────────────────────────────────────────────────────
+
+def _horaires_standard():
+    """Lun-ven : 09:00-12:30 / 13:30-17:30."""
+    return {j: [(540, 750), (810, 1050)] for j in range(5)}
+
+
+def _lundi_prochain():
+    """Retourne le prochain lundi (horizon deterministe, jours ouvres)."""
+    d = date.today()
+    while d.weekday() != 0:
+        d += timedelta(days=1)
+    return d
+
+
+def test_to_min_et_hhmm():
+    assert moteur._to_min('09:30') == 570
+    assert moteur._to_min('') is None
+    assert moteur._to_hhmm(570) == '09:30'
+
+
+def test_soustraire_creneau():
+    # Retirer 10h-11h de 9h-12h30 -> [9h-10h, 11h-12h30]
+    res = moteur._soustraire([(540, 750)], [(600, 660)])
+    assert res == [(540, 600), (660, 750)]
+
+
+def test_engine_respecte_horaires():
+    """Toutes les minutes placees tombent dans les horaires de travail."""
+    lundi = _lundi_prochain()
+    taches = [{'id': 1, 'titre': 'T', 'duree_min': 120, 'deadline': None,
+               'priorite': 'normale', 'preference': 'aucune', 'secable': True,
+               'duree_min_bloc': 30}]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=6))
+    assert res['blocs']
+    for b in res['blocs']:
+        deb, fin = moteur._to_min(b['heure_debut']), moteur._to_min(b['heure_fin'])
+        dans_matin = 540 <= deb and fin <= 750
+        dans_aprem = 810 <= deb and fin <= 1050
+        assert dans_matin or dans_aprem, f"bloc hors horaires : {b}"
+
+
+def test_engine_evenement_fixe_non_chevauche():
+    """Aucun bloc de tache ne chevauche un creneau occupe."""
+    lundi = _lundi_prochain()
+    occ = {lundi.isoformat(): [(600, 660)]}  # 10h-11h occupe
+    taches = [{'id': 1, 'titre': 'T', 'duree_min': 300, 'deadline': None,
+               'priorite': 'normale', 'preference': 'aucune', 'secable': True,
+               'duree_min_bloc': 30}]
+    res = moteur.planifier(taches, occ, _horaires_standard(), lundi, lundi + timedelta(days=6))
+    for b in res['blocs']:
+        if b['date'] != lundi.isoformat():
+            continue
+        deb, fin = moteur._to_min(b['heure_debut']), moteur._to_min(b['heure_fin'])
+        assert fin <= 600 or deb >= 660, f"chevauche l'evenement fixe : {b}"
+
+
+def test_engine_non_secable_bloc_unique():
+    """Une tache non secable est placee en un seul bloc contigu."""
+    lundi = _lundi_prochain()
+    taches = [{'id': 7, 'titre': 'Appel', 'duree_min': 90, 'deadline': None,
+               'priorite': 'normale', 'preference': 'aucune', 'secable': False,
+               'duree_min_bloc': 30}]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=6))
+    blocs = [b for b in res['blocs'] if b['tache_id'] == 7]
+    assert len(blocs) == 1
+    assert blocs[0]['duree_min'] == 90
+
+
+def test_engine_decoupe_longue_mission_sur_plusieurs_jours():
+    """Une longue mission secable est repartie sur plusieurs jours."""
+    lundi = _lundi_prochain()
+    taches = [{'id': 2, 'titre': 'Gros dossier', 'duree_min': 360, 'deadline': None,
+               'priorite': 'normale', 'preference': 'aucune', 'secable': True,
+               'duree_min_bloc': 60}]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=13))
+    jours = {b['date'] for b in res['blocs']}
+    assert len(jours) >= 2, "la mission de 6h devrait etre etalee sur plusieurs jours"
+    assert sum(b['duree_min'] for b in res['blocs']) == 360
+    # Pas de bloc minuscule (< duree_min_bloc) en dehors d'un eventuel reliquat.
+    assert all(b['duree_min'] >= 5 for b in res['blocs'])
+
+
+def test_engine_echeance_prioritaire():
+    """La tache avec l'echeance la plus proche est planifiee en premier."""
+    lundi = _lundi_prochain()
+    taches = [
+        {'id': 1, 'titre': 'Lointaine', 'duree_min': 120, 'deadline': (lundi + timedelta(days=12)).isoformat(),
+         'priorite': 'normale', 'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30},
+        {'id': 2, 'titre': 'Urgente', 'duree_min': 120, 'deadline': (lundi + timedelta(days=1)).isoformat(),
+         'priorite': 'normale', 'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30},
+    ]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=13))
+    premier = {b['tache_id']: b['date'] for b in res['blocs']}
+    assert premier[2] <= premier[1], "la tache urgente doit etre placee au plus tot"
+
+
+def test_engine_recurrente_placee_en_dernier():
+    """Les taches recurrentes remplissent l'espace restant (placees apres)."""
+    lundi = _lundi_prochain()
+    taches = [
+        {'id': 1, 'titre': 'Normale', 'duree_min': 120, 'deadline': None,
+         'priorite': 'haute', 'preference': 'aucune', 'secable': True, 'duree_min_bloc': 60},
+        {'id': 2, 'titre': 'Recurrente', 'duree_min': 30, 'deadline': None,
+         'priorite': 'haute', 'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30,
+         'est_recurrente': True},
+    ]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=6))
+    debut_normale = min(b['heure_debut'] for b in res['blocs'] if b['tache_id'] == 1
+                        and b['date'] == lundi.isoformat())
+    rec = [b for b in res['blocs'] if b['tache_id'] == 2 and b['date'] == lundi.isoformat()]
+    # La recurrente du lundi ne prend pas le tout premier creneau (reserve a la normale).
+    if rec:
+        assert rec[0]['heure_debut'] >= debut_normale
+
+
+def test_engine_micro_pauses_journee_chargee():
+    """Sur une journee pleine, des respirations separent les blocs successifs."""
+    lundi = _lundi_prochain()
+    # 300 min secables, blocs de 60 -> doivent etre separes par des pauses.
+    taches = [{'id': 1, 'titre': 'T', 'duree_min': 300, 'deadline': lundi.isoformat(),
+               'priorite': 'haute', 'preference': 'aucune', 'secable': True, 'duree_min_bloc': 60}]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi)
+    blocs = sorted((b for b in res['blocs']), key=lambda b: b['heure_debut'])
+    # Au moins deux blocs consecutifs dans le meme segment avec un trou entre eux.
+    trouve_pause = False
+    for i in range(1, len(blocs)):
+        fin_prec = moteur._to_min(blocs[i - 1]['heure_fin'])
+        deb = moteur._to_min(blocs[i]['heure_debut'])
+        if 0 < deb - fin_prec <= 20:  # un trou de respiration (pas la pause dejeuner)
+            trouve_pause = True
+    assert trouve_pause, "des micro-pauses devraient separer les blocs d'une journee chargee"
+
+
+def test_engine_capacite_insuffisante():
+    """Une tache trop grosse pour l'horizon est signalee non planifiee."""
+    lundi = _lundi_prochain()
+    taches = [{'id': 1, 'titre': 'Enorme', 'duree_min': 600, 'deadline': lundi.isoformat(),
+               'priorite': 'normale', 'preference': 'aucune', 'secable': True, 'duree_min_bloc': 30}]
+    # Horizon = un seul jour (capacite ~7h = 420 min < 600).
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi)
+    assert res['non_planifie'], "le reste non placé doit etre signale"
+
+
+def test_engine_preference_matin():
+    """Une tache avec preference matin est placee le matin si possible."""
+    lundi = _lundi_prochain()
+    taches = [{'id': 1, 'titre': 'Matinale', 'duree_min': 60, 'deadline': None,
+               'priorite': 'normale', 'preference': 'matin', 'secable': False, 'duree_min_bloc': 30}]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=6))
+    b = res['blocs'][0]
+    assert moteur._to_min(b['heure_debut']) < 720, "devrait etre place le matin"
+
+
+def test_niveau_urgence():
+    ref = date(2026, 6, 30)
+    assert moteur.niveau_urgence(None, ref) == 'sans_echeance'
+    assert moteur.niveau_urgence('2026-06-29', ref) == 'retard'
+    assert moteur.niveau_urgence('2026-06-30', ref) == 'urgent'
+    assert moteur.niveau_urgence('2026-07-02', ref) == 'proche'
+    assert moteur.niveau_urgence('2026-07-20', ref) == 'a_venir'
+    assert moteur.niveau_urgence('2026-07-20', ref, statut='fait') == 'fait'
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Routes du blueprint
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_acces_comptable_ok(comptable_client):
+    resp = comptable_client.get('/planificateur')
+    assert resp.status_code == 200
+    assert 'Planificateur' in resp.get_data(as_text=True)
+
+
+def test_acces_salarie_refuse(auth_client):
+    resp = auth_client.get('/planificateur', follow_redirects=False)
+    assert resp.status_code == 302  # redirige vers le dashboard
+
+
+def test_acces_directeur_refuse(admin_client):
+    resp = admin_client.get('/planificateur', follow_redirects=False)
+    assert resp.status_code == 302
+
+
+def test_api_refuse_non_comptable(auth_client):
+    resp = auth_client.post('/planificateur/api/tache', json={'titre': 'X', 'duree_min': 30})
+    assert resp.status_code == 403
+
+
+def test_creer_tache_genere_des_blocs(comptable_client):
+    demain = (date.today() + timedelta(days=3)).isoformat()
+    resp = comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Cloture comptable', 'duree_min': 120,
+        'deadline': demain, 'priorite': 'haute', 'preference': 'aucune',
+        'secable': 1, 'duree_min_bloc': 30,
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['ok'] is True
+
+    # Les blocs doivent etre crees sur l'horizon.
+    fin = (date.today() + timedelta(days=14)).isoformat()
+    blocs = comptable_client.get(f'/planificateur/api/blocs?debut={date.today().isoformat()}&fin={fin}')
+    data = blocs.get_json()
+    assert data['ok'] is True
+    total = sum(b['duree_min'] for b in data['blocs'])
+    assert total == 120
+    assert all(b['titre'] == 'Cloture comptable' for b in data['blocs'])
+
+
+def test_creer_evenement_fixe_bloc_verrouille(comptable_client, db):
+    jour = (date.today() + timedelta(days=2)).isoformat()
+    resp = comptable_client.post('/planificateur/api/tache', json={
+        'type': 'evenement', 'titre': 'Reunion equipe', 'date_fixe': jour,
+        'heure_debut': '10:00', 'heure_fin': '11:00',
+    })
+    assert resp.status_code == 200
+    row = db.execute(
+        "SELECT b.verrouille, b.duree_min FROM planif_blocs b "
+        "JOIN planif_taches t ON b.tache_id = t.id WHERE t.titre = 'Reunion equipe'"
+    ).fetchone()
+    assert row is not None
+    assert row['verrouille'] == 1
+    assert row['duree_min'] == 60
+
+
+def test_evenement_fixe_repousse_les_taches(comptable_client):
+    """Une tache ne doit pas etre planifiee sur un evenement fixe."""
+    jour = (date.today() + timedelta(days=1)).isoformat()
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'evenement', 'titre': 'RDV', 'date_fixe': jour,
+        'heure_debut': '09:00', 'heure_fin': '17:00',  # journee entiere occupee
+    })
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Tache jour', 'duree_min': 60,
+        'deadline': None, 'secable': 1, 'duree_min_bloc': 30,
+    })
+    blocs = comptable_client.get(f'/planificateur/api/blocs?debut={jour}&fin={jour}').get_json()['blocs']
+    taches_ce_jour = [b for b in blocs if b['type'] == 'tache']
+    assert taches_ce_jour == [], "aucune tache ne doit etre placee sur la journee bloquee"
+
+
+def test_marquer_bloc_fait(comptable_client, db):
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'A faire', 'duree_min': 60, 'secable': 0, 'duree_min_bloc': 60,
+    })
+    bloc = db.execute("SELECT id FROM planif_blocs LIMIT 1").fetchone()
+    resp = comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/statut', json={'statut': 'fait'})
+    assert resp.status_code == 200
+    maj = db.execute("SELECT statut FROM planif_blocs WHERE id = ?", (bloc['id'],)).fetchone()
+    assert maj['statut'] == 'fait'
+
+
+def test_supprimer_tache(comptable_client, db):
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'A supprimer', 'duree_min': 60, 'secable': 0, 'duree_min_bloc': 60,
+    })
+    tache = db.execute("SELECT id FROM planif_taches WHERE titre = 'A supprimer'").fetchone()
+    resp = comptable_client.post(f'/planificateur/api/tache/{tache["id"]}/supprimer', json={})
+    assert resp.status_code == 200
+    assert db.execute("SELECT COUNT(*) AS n FROM planif_taches WHERE id = ?", (tache['id'],)).fetchone()['n'] == 0
+    assert db.execute("SELECT COUNT(*) AS n FROM planif_blocs WHERE tache_id = ?", (tache['id'],)).fetchone()['n'] == 0
+
+
+def test_horaires_sauvegarde_et_seed(comptable_client, db, sample_users):
+    # Le premier acces seed les horaires par defaut (lun-ven).
+    comptable_client.get('/planificateur')
+    rows = db.execute(
+        "SELECT COUNT(*) AS n FROM planif_horaires WHERE user_id = ?",
+        (sample_users['comptable_id'],)
+    ).fetchone()
+    assert rows['n'] == 7
+
+    # Modification : desactiver le lundi.
+    jours = []
+    for j in range(7):
+        jours.append({'actif': 0 if j == 0 else (1 if j < 5 else 0),
+                      'matin_debut': '08:00', 'matin_fin': '12:00',
+                      'aprem_debut': '14:00', 'aprem_fin': '18:00'})
+    resp = comptable_client.post('/planificateur/api/horaires', json={'jours': jours})
+    assert resp.status_code == 200
+    lundi_cfg = db.execute(
+        "SELECT actif, matin_debut FROM planif_horaires WHERE user_id = ? AND jour_semaine = 0",
+        (sample_users['comptable_id'],)
+    ).fetchone()
+    assert lundi_cfg['actif'] == 0
+    assert lundi_cfg['matin_debut'] == '08:00'
+
+
+def test_recurrence_cree_occurrences(comptable_client, db, sample_users):
+    debut = date.today().isoformat()
+    resp = comptable_client.post('/planificateur/api/recurrence', json={
+        'titre': 'Point quotidien', 'frequence': 'quotidien', 'duree_min': 30,
+        'priorite': 'normale', 'preference': 'aucune', 'date_debut': debut,
+    })
+    assert resp.status_code == 200
+    occ = db.execute(
+        "SELECT COUNT(*) AS n FROM planif_taches WHERE user_id = ? AND recurrence_id IS NOT NULL",
+        (sample_users['comptable_id'],)
+    ).fetchone()
+    assert occ['n'] > 0, "des occurrences quotidiennes doivent etre generees"
+
+
+def test_replanifier_endpoint(comptable_client):
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'T', 'duree_min': 60, 'secable': 0, 'duree_min_bloc': 60,
+    })
+    resp = comptable_client.post('/planificateur/api/replanifier', json={})
+    assert resp.status_code == 200
+    assert resp.get_json()['ok'] is True
+
+
+def test_confidentialite_blocs_par_utilisateur(comptable_client, db, sample_users):
+    """Un utilisateur ne voit jamais les blocs d'un autre (planning prive)."""
+    # Inserer une tache + bloc pour le directeur directement en base.
+    jour = (date.today() + timedelta(days=1)).isoformat()
+    cur = db.execute(
+        "INSERT INTO planif_taches (user_id, type, titre, duree_min, statut) "
+        "VALUES (?, 'tache', 'Secret direction', 60, 'a_faire')",
+        (sample_users['directeur_id'],)
+    )
+    db.execute(
+        "INSERT INTO planif_blocs (tache_id, user_id, date, heure_debut, heure_fin, duree_min) "
+        "VALUES (?, ?, ?, '09:00', '10:00', 60)",
+        (cur.lastrowid, sample_users['directeur_id'], jour)
+    )
+    db.commit()
+
+    blocs = comptable_client.get(f'/planificateur/api/blocs?debut={jour}&fin={jour}').get_json()['blocs']
+    assert all(b['titre'] != 'Secret direction' for b in blocs)
+
+
+def test_menu_lien_visible_comptable(comptable_client):
+    resp = comptable_client.get('/dashboard_comptable')
+    html = resp.get_data(as_text=True)
+    assert '/planificateur' in html


### PR DESCRIPTION
## Résumé

Ajout d'un **gestionnaire de tâches** inspiré de FlowSavvy (épuré et simple) dans le menu **Mon espace**, avec calendrier et **Time Blocking**. L'organisation du planning est automatique, gérée par **optimisation sous contraintes** via un **moteur Python intégré** (placement glouton + équilibrage de charge).

> ℹ️ Choix technique : plutôt que Google OR-Tools (dépendance native lourde qui complique le packaging `.exe` Windows), le moteur est écrit en Python pur, sans nouvelle dépendance. L'architecture isole le moteur (`planificateur_engine.py`) pour pouvoir brancher OR-Tools plus tard sans réécrire le reste.

## Périmètre (phase 1)

- **Tâches** : durée estimée, échéance (optionnelle), priorité (normale par défaut), préférence matin / après-midi, possibilité de découpage, taille de bloc minimum.
- **Événements fixes** (rendez-vous, réunions) : bloqués en priorité par le moteur.
- **Bouton « Replanifier »** + replanification automatique à chaque ajout.
- **Optimisation** : équilibrage de la charge par jour ; micro-pauses (5 min/h les journées chargées, 15 min/2 h sinon) pour un planning humainement acceptable ; respect des horaires de travail ; répartition sensée des longues missions (≥ 3 h) sur plusieurs jours sans blocs minuscules.
- **Tâches récurrentes** (quotidien / hebdomadaire / mensuel) placées là où il reste de la place.
- **Suivi depuis le calendrier** : marquer effectuée, reporter, planifier la fin (créer une tâche pour le reste), modifier, supprimer.
- **Code couleur** selon la proximité de l'échéance.
- **Vues jour / semaine / mois** avec navigation simple.

## Horaires de travail (sans ressaisie)

Les horaires sont **repris automatiquement du planning théorique du salarié** (table `planning_theorique`, menu **Mon planning**) — aucune double saisie. Ils sont résolus **par date** pour tenir compte des périodes (scolaire / vacances) et de l'alternance. Un horaire par défaut (lun.–ven. 9h–12h30 / 13h30–17h30) s'applique uniquement si aucun planning n'est défini.

## Sécurité & confidentialité

- Planning **strictement privé** : toutes les requêtes sont filtrées par `user_id` ; aucune route n'expose le planning d'un autre utilisateur (même la direction n'y a pas accès).
- Accès réservé au **comptable** pour la phase de test (constante `PROFILS_AUTORISES`, facile à étendre).
- Protection CSRF conservée (jeton `X-CSRFToken` sur les appels AJAX), validation stricte des entrées côté serveur.

## Détails techniques

- **`planificateur_engine.py`** : moteur d'optimisation *pur* (aucun accès base, horaires indexés par date), donc testable et remplaçable.
- **`blueprints/planificateur.py`** : routes (page + API JSON), replanification, génération des occurrences récurrentes, résolution des horaires depuis le planning, contrôle d'accès.
- **`templates/planificateur.html`** : UI calendrier (vanilla JS) jour/semaine/mois, modales d'ajout/édition, récurrences, détail.
- **Schéma** : migration `0049_module_planificateur` + tables ajoutées à `init_db()` (`planif_taches`, `planif_blocs`, `planif_recurrences`). Pas de table d'horaires : ils proviennent du planning existant.
- **Menu** : lien ajouté dans « Mon espace » (profil comptable) ; blueprint enregistré dans `app.py`.

## Tests

- 28 tests ajoutés (`tests/test_planificateur.py`) : moteur (horaires, événements fixes, découpage, équilibrage, échéances, récurrences, micro-pauses, capacité, préférences, urgence) + routes (contrôle d'accès, création/replanification/suivi, **horaires issus du planning**, confidentialité).
- **623 tests au total au vert** (`python3 -m pytest`).
- Vérification visuelle des vues semaine / mois et de la modale d'ajout, avec et sans planning théorique.

## À noter

- Aucune nouvelle dépendance dans `requirements.txt`.
- Les suppressions gèrent manuellement les lignes enfants (le `PRAGMA foreign_keys` n'est pas actif sur cette base, comme pour le module Salles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5