### PR TITLE
Planificateur : ne pas planifier dans le passé (heure courante)

### DIFF
--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -233,10 +233,18 @@ def _generer_occurrences(conn, user_id, today, fin, horaires):
 
 # ── Replanification ────────────────────────────────────────────────────────
 
-def _replanifier(conn, user_id):
+def _replanifier(conn, user_id, maintenant=None):
     """Recalcule le planning des taches sur l'horizon. Retourne la liste des
-    taches non planifiees (chacune enrichie de son titre)."""
-    today = date.today()
+    taches non planifiees (chacune enrichie de son titre).
+
+    `maintenant` (datetime) permet de figer l'instant courant pour les tests ;
+    par defaut, datetime.now(). On ne planifie jamais dans le passe : si la
+    journee en cours est terminee, les taches partent au lendemain.
+    """
+    if maintenant is None:
+        maintenant = datetime.now()
+    today = maintenant.date()
+    minute_courante = maintenant.hour * 60 + maintenant.minute
     fin = today + timedelta(days=HORIZON_JOURS)
 
     # Horaires de travail repris du planning theorique du salarie.
@@ -286,6 +294,7 @@ def _replanifier(conn, user_id):
 
     taches = []
     titres = {}
+    recurrence_ids = set()
     for t in taches_rows:
         done = conn.execute(
             "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs "
@@ -300,6 +309,8 @@ def _replanifier(conn, user_id):
         if dmin < today.isoformat():
             dmin = today.isoformat()
         titres[t['id']] = t['titre']
+        if t['recurrence_id'] is not None:
+            recurrence_ids.add(t['id'])
         taches.append({
             'id': t['id'], 'titre': t['titre'], 'duree_min': restant,
             'deadline': t['deadline'], 'priorite': t['priorite'],
@@ -309,7 +320,8 @@ def _replanifier(conn, user_id):
             'date_min': dmin,
         })
 
-    resultat = moteur.planifier(taches, occupes, horaires, today, fin, feries)
+    resultat = moteur.planifier(taches, occupes, horaires, today, fin, feries,
+                                minute_courante=minute_courante)
 
     for b in resultat['blocs']:
         conn.execute(
@@ -320,8 +332,13 @@ def _replanifier(conn, user_id):
         )
     conn.commit()
 
+    # Les occurrences recurrentes sont placees « au mieux, la ou il reste de la
+    # place » : leur absence (ex. journee deja terminee) n'est pas une anomalie
+    # a signaler a l'utilisateur.
     non_planifie = []
     for np in resultat['non_planifie']:
+        if np['tache_id'] in recurrence_ids:
+            continue
         non_planifie.append({**np, 'titre': titres.get(np['tache_id'], '')})
     return non_planifie
 

--- a/planificateur_engine.py
+++ b/planificateur_engine.py
@@ -236,7 +236,7 @@ def _taille_chunk(duree, min_bloc, nb_jours_dispo, secable):
 
 
 def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
-              jours_feries=None):
+              jours_feries=None, minute_courante=0):
     """Calcule le placement des taches sur l'horizon donne.
 
     Args:
@@ -255,6 +255,10 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
             c'est pourquoi ils sont indexes par date et non par jour de semaine.
         date_debut, date_fin: objets date delimitant l'horizon (inclus).
         jours_feries: ensemble de chaines 'YYYY-MM-DD' a ne pas planifier.
+        minute_courante: minute (depuis minuit) deja ecoulee le premier jour
+            (date_debut). On ne planifie pas dans le passe : la partie de la
+            journee anterieure a cette minute est consideree occupee. A 0
+            (defaut), toute la journee est disponible.
 
     Returns:
         dict {
@@ -273,7 +277,11 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
         if date_str not in jours_feries:
             work = horaires.get(date_str, [])
             if work:
-                libres = _soustraire(work, occupes_par_date.get(date_str, []))
+                occ = list(occupes_par_date.get(date_str, []))
+                # Le premier jour, on ne planifie pas avant l'heure courante.
+                if d == date_debut and minute_courante > 0:
+                    occ.append((0, minute_courante))
+                libres = _soustraire(work, occ)
                 if libres:
                     jours[date_str] = _PlanJour(d, libres)
         d += timedelta(days=1)

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -182,6 +182,18 @@ def test_engine_preference_matin():
     assert moteur._to_min(b['heure_debut']) < 720, "devrait etre place le matin"
 
 
+def test_engine_ne_planifie_pas_dans_le_passe():
+    """A 23h, plus rien ne se planifie le jour courant : tout part au lendemain."""
+    lundi = _lundi_prochain()
+    taches = [{'id': 1, 'titre': 'T', 'duree_min': 60, 'deadline': None,
+               'priorite': 'normale', 'preference': 'aucune', 'secable': 1, 'duree_min_bloc': 30}]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi,
+                           lundi + timedelta(days=6), minute_courante=23 * 60)
+    assert res['blocs'], "la tache doit etre planifiee (les jours suivants)"
+    assert all(b['date'] != lundi.isoformat() for b in res['blocs']), \
+        "rien ne doit etre place le jour deja ecoule"
+
+
 def test_niveau_urgence():
     ref = date(2026, 6, 30)
     assert moteur.niveau_urgence(None, ref) == 'sans_echeance'
@@ -258,7 +270,7 @@ def test_evenement_fixe_repousse_les_taches(comptable_client):
     jour = (date.today() + timedelta(days=1)).isoformat()
     comptable_client.post('/planificateur/api/tache', json={
         'type': 'evenement', 'titre': 'RDV', 'date_fixe': jour,
-        'heure_debut': '09:00', 'heure_fin': '17:00',  # journee entiere occupee
+        'heure_debut': '08:00', 'heure_fin': '19:00',  # couvre toute la journee de travail
     })
     comptable_client.post('/planificateur/api/tache', json={
         'type': 'tache', 'titre': 'Tache jour', 'duree_min': 60,
@@ -471,6 +483,55 @@ def test_supprimer_bloc_evenement_refuse(comptable_client, db):
     assert resp.status_code == 400
     # Le creneau existe toujours (l'evenement continue de bloquer son horaire).
     assert db.execute("SELECT COUNT(*) AS n FROM planif_blocs WHERE id = ?", (bloc['id'],)).fetchone()['n'] == 1
+
+
+def test_journee_terminee_reporte_au_lendemain(app, db, sample_users):
+    """Quand la journee est finie (23h), une nouvelle tache part au lendemain
+    et l'occurrence recurrente manquee n'est pas signalee comme anomalie."""
+    from datetime import datetime
+    from blueprints.planificateur import _replanifier
+
+    uid = sample_users['comptable_id']
+    # Choisir un lundi a venir, a 23h00.
+    d = date.today() + timedelta(days=1)
+    while d.weekday() != 0:
+        d += timedelta(days=1)
+    maintenant = datetime(d.year, d.month, d.day, 23, 0)
+    lendemain = (d + timedelta(days=1)).isoformat()
+
+    db.execute(
+        "INSERT INTO planif_taches (user_id, type, titre, duree_min, priorite, "
+        "preference, secable, duree_min_bloc, statut) "
+        "VALUES (?, 'tache', 'Tache jour', 60, 'normale', 'aucune', 1, 30, 'a_faire')",
+        (uid,)
+    )
+    db.execute(
+        "INSERT INTO planif_recurrences (user_id, titre, duree_min, priorite, "
+        "preference, secable, duree_min_bloc, frequence, date_debut, active) "
+        "VALUES (?, 'lecture mails', 10, 'haute', 'aucune', 0, 10, 'quotidien', ?, 1)",
+        (uid, d.isoformat())
+    )
+    db.commit()
+
+    with app.app_context():
+        non_planifie = _replanifier(db, uid, maintenant=maintenant)
+
+    # Rien n'est planifie le jour deja termine.
+    nb_jour = db.execute(
+        "SELECT COUNT(*) AS n FROM planif_blocs WHERE user_id = ? AND date = ?",
+        (uid, d.isoformat())
+    ).fetchone()['n']
+    assert nb_jour == 0, "aucun bloc ne doit etre place sur la journee terminee"
+
+    # La tache normale est bien planifiee (au lendemain ou apres).
+    bloc_tache = db.execute(
+        "SELECT b.date FROM planif_blocs b JOIN planif_taches t ON b.tache_id = t.id "
+        "WHERE t.titre = 'Tache jour'"
+    ).fetchone()
+    assert bloc_tache is not None and bloc_tache['date'] >= lendemain
+
+    # L'occurrence recurrente manquee n'est pas remontee comme non planifiee.
+    assert all(x.get('titre') != 'lecture mails' for x in non_planifie)
 
 
 def test_menu_lien_visible_comptable(comptable_client):


### PR DESCRIPTION
## Contexte

Bug remonté après la mise en production de la phase 1 (PR #174, fusionnée) : le moteur ignorait l'**heure courante** et plaçait des tâches dans des créneaux **déjà écoulés**.

**Scénario** : à 23h, une nouvelle tâche se fixait à 9h le jour même (dans le passé). Une occurrence récurrente quotidienne bloquée sur ce jour ne trouvait alors plus de place et apparaissait à tort comme « non planifiée » (`⚠️ 1 élément non planifié : Lecture mails`), alors qu'il restait de la place les jours suivants.

## Correctif

- **Moteur** (`planificateur_engine.py`) : nouveau paramètre `minute_courante`. La partie de la **première journée** déjà écoulée est considérée occupée → on ne planifie jamais dans le passé. Si la journée est terminée, les tâches partent au lendemain.
- **`_replanifier`** : injecte l'heure courante (`datetime.now()`, **paramétrable** via `maintenant=` pour des tests déterministes) et **exclut les occurrences récurrentes** du signalement « non planifié » — leur placement est « au mieux, là où il reste de la place » par conception, donc une occurrence manquée (journée finie) n'est pas une anomalie à remonter.

## Comportement après correctif

- Une nouvelle tâche créée à 23h se planifie **le lendemain** (et non dans le passé du jour même).
- Les occurrences récurrentes continuent de se placer normalement les jours à venir ; celle du jour terminé est simplement ignorée, sans alerte.

## Tests

- 2 tests ajoutés (heure figée pour un comportement déterministe) :
  - `test_engine_ne_planifie_pas_dans_le_passe` (moteur)
  - `test_journee_terminee_reporte_au_lendemain` (bout-en-bout, via `_replanifier(maintenant=…)`)
- Ajustement de `test_evenement_fixe_repousse_les_taches` (l'événement couvre désormais toute la journée de travail, pour rester déterministe indépendamment de l'heure d'exécution).
- **628 tests au vert** (`python3 -m pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5

---
_Generated by [Claude Code](https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5)_