### PR TITLE
Planificateur : ouverture à tous + glisser-déposer verrouillé + horaires direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,16 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Calendrier visuel des reservations
 
 ### Planificateur de taches (Time Blocking)
-- Gestionnaire de taches personnel inspire de FlowSavvy (epure), accessible depuis le menu **Mon espace** (reserve au comptable en phase de test)
-- Planning strictement prive : chaque utilisateur ne voit que ses propres taches (meme la direction n'y a pas acces)
+- Gestionnaire de taches personnel inspire de FlowSavvy (epure), accessible depuis le menu **Mon espace** par tous les salaries internes (salarie, responsable, comptable, direction)
+- Planning strictement prive : chaque utilisateur ne voit que ses propres taches (meme la direction n'a acces qu'a son propre planning, et personne ne voit celui d'un autre)
 - Ajout de taches (duree estimee, echeance optionnelle, priorite, preference matin / apres-midi, possibilite de decoupage) et d'evenements fixes (rendez-vous, reunions)
-- Organisation automatique du planning par optimisation sous contraintes (moteur integre) : equilibrage de la charge par jour, micro-pauses sur les journees chargees, respect des horaires de travail, blocage prioritaire des evenements fixes, repartition des longues missions sur plusieurs jours
+- Organisation automatique du planning par optimisation sous contraintes (moteur integre) : equilibrage de la charge par jour, micro-pauses sur les journees chargees, respect des horaires de travail, blocage prioritaire des evenements fixes, repartition des longues missions sur plusieurs jours, sans planifier dans le passe (les taches du jour deja ecoule partent au lendemain)
 - Bouton **Replanifier** et replanification automatique a chaque ajout
+- Glisser-deposer un bloc sur le calendrier pour le repositionner : il est alors verrouille (la replanification ne le deplace plus) ; deverrouillage possible pour le rendre a l'optimiseur
 - Taches recurrentes (quotidien / hebdomadaire / mensuel) placees la ou il reste de la place
 - Suivi depuis le calendrier : marquer effectuee, reporter, planifier la fin d'une tache, modifier, supprimer
 - Code couleur selon la proximite de l'echeance ; vues jour / semaine / mois avec navigation simple
-- Horaires de travail repris automatiquement du planning theorique du salarie (menu « Mon planning ») : aucune ressaisie (horaires par defaut si aucun planning n'est defini)
+- Horaires de travail repris automatiquement du planning theorique du salarie (menu « Mon planning ») : aucune ressaisie. A defaut de planning, horaires par defaut lundi-vendredi 09:00-12:30 / 13:30-17:30 (et 09:00-12:30 / 14:00-18:00 pour la direction au forfait jours)
 
 ### Notifications par email
 - Envoi de notifications via Gmail (SMTP)

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -330,10 +330,15 @@ def _replanifier(conn, user_id, maintenant=None):
         # verrouilles manuellement (glisser-deposer). Verrouiller n'est pas
         # « faire » : on ne replanifie que le reste, autour de ces creneaux, mais
         # la tache reste a faire.
+        # Un bloc verrouille n'est compte que s'il est encore a venir (date >=
+        # aujourd'hui) : un creneau verrouille dont le jour est passe sans avoir
+        # ete realise n'occupe plus la capacite future, donc son temps doit etre
+        # replanifie (sinon il serait silencieusement perdu). Les blocs « fait »,
+        # eux, comptent quelle que soit leur date (travail reellement accompli).
         engage_min = conn.execute(
             "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs "
-            "WHERE tache_id = ? AND (statut = 'fait' OR verrouille = 1)",
-            (t['id'],)
+            "WHERE tache_id = ? AND (statut = 'fait' OR (verrouille = 1 AND date >= ?))",
+            (t['id'], today.isoformat())
         ).fetchone()['s']
         restant = duree - int(engage_min or 0)
         if restant <= 0:
@@ -888,6 +893,8 @@ def api_deplacer_bloc(bloc_id):
             return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
 
         nouvelle_date = _valide_date(data.get('date')) or bloc['date']
+        if nouvelle_date < date.today().isoformat():
+            return jsonify({'ok': False, 'erreur': "Impossible de déplacer un créneau dans le passé."}), 400
         deb = _valide_heure(data.get('heure_debut'))
         if not deb:
             return jsonify({'ok': False, 'erreur': 'Heure de debut invalide.'}), 400

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -27,8 +27,10 @@ logger = logging.getLogger(__name__)
 
 planificateur_bp = Blueprint('planificateur_bp', __name__)
 
-# Profils autorises a acceder au planificateur (phase 1 : comptable uniquement).
-PROFILS_AUTORISES = ('comptable',)
+# Profils autorises a acceder au planificateur : tous les salaries internes.
+# Chacun ne voit que son propre planning (le prestataire de paie externe est
+# hors perimetre).
+PROFILS_AUTORISES = ('directeur', 'comptable', 'responsable', 'salarie')
 
 # Horizon de planification (jours a partir d'aujourd'hui).
 HORIZON_JOURS = 60
@@ -40,6 +42,9 @@ FREQUENCES_VALIDES = ('quotidien', 'hebdomadaire', 'mensuel')
 # Horaires de travail par defaut (lundi-vendredi), utilises uniquement si le
 # salarie n'a aucun planning theorique defini (menu « Mon planning »).
 HORAIRE_DEFAUT_INTERVALLES = [(540, 750), (810, 1050)]  # 09:00-12:30 / 13:30-17:30
+# La direction est au forfait jours (pas d'horaires precis) : on retient une
+# amplitude de bureau classique 09:00-12:30 / 14:00-18:00.
+HORAIRE_DEFAUT_DIRECTION = [(540, 750), (840, 1080)]  # 09:00-12:30 / 14:00-18:00
 JOURS_NOMS_PLANNING = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi']
 
 
@@ -72,6 +77,18 @@ def _uid():
 
 # ── Helpers horaires (repris du planning theorique) ────────────────────────
 
+def _horaire_defaut_profil(conn, user_id):
+    """Horaires par defaut (intervalles en minutes) selon le profil.
+
+    La direction est au forfait jours : amplitude 09:00-12:30 / 14:00-18:00.
+    Les autres profils : 09:00-12:30 / 13:30-17:30.
+    """
+    row = conn.execute('SELECT profil FROM users WHERE id = ?', (user_id,)).fetchone()
+    if row and row['profil'] == 'directeur':
+        return HORAIRE_DEFAUT_DIRECTION
+    return HORAIRE_DEFAUT_INTERVALLES
+
+
 def _horaires_par_date(conn, user_id, debut, fin):
     """Construit {date_str: [(deb_min, fin_min), ...]} pour l'horizon.
 
@@ -82,14 +99,16 @@ def _horaires_par_date(conn, user_id, debut, fin):
     helpers existants.
 
     Si le salarie n'a aucun planning, un horaire par defaut est applique
-    (lundi-vendredi 09:00-12:30 / 13:30-17:30) afin que le planificateur reste
-    utilisable immediatement.
+    (lundi-vendredi) afin que le planificateur reste utilisable immediatement :
+    09:00-12:30 / 13:30-17:30 en general, et 09:00-12:30 / 14:00-18:00 pour la
+    direction (au forfait jours, sans horaires precis).
     """
     from utils import get_planning_valide_a_date, get_type_periode
 
     a_un_planning = conn.execute(
         'SELECT 1 FROM planning_theorique WHERE user_id = ? LIMIT 1', (user_id,)
     ).fetchone()
+    defaut = _horaire_defaut_profil(conn, user_id)
 
     horaires = {}
     d = debut
@@ -98,7 +117,7 @@ def _horaires_par_date(conn, user_id, debut, fin):
         if d.weekday() < 5:
             date_str = d.isoformat()
             if not a_un_planning:
-                horaires[date_str] = list(HORAIRE_DEFAUT_INTERVALLES)
+                horaires[date_str] = list(defaut)
             else:
                 planning = get_planning_valide_a_date(
                     user_id, get_type_periode(date_str), date_str
@@ -296,15 +315,29 @@ def _replanifier(conn, user_id, maintenant=None):
     titres = {}
     recurrence_ids = set()
     for t in taches_rows:
-        done = conn.execute(
+        duree = int(t['duree_min'])
+        # Temps reellement REALISE (blocs « fait ») : sert a savoir si la tache
+        # est terminee.
+        fait_min = conn.execute(
             "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs "
             "WHERE tache_id = ? AND statut = 'fait'",
             (t['id'],)
         ).fetchone()['s']
-        restant = int(t['duree_min']) - int(done or 0)
-        if restant <= 0:
+        if int(fait_min) >= duree:
             conn.execute("UPDATE planif_taches SET statut = 'fait' WHERE id = ?", (t['id'],))
             continue
+        # Temps deja ENGAGE et non replanifiable : blocs realises (fait) ET blocs
+        # verrouilles manuellement (glisser-deposer). Verrouiller n'est pas
+        # « faire » : on ne replanifie que le reste, autour de ces creneaux, mais
+        # la tache reste a faire.
+        engage_min = conn.execute(
+            "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs "
+            "WHERE tache_id = ? AND (statut = 'fait' OR verrouille = 1)",
+            (t['id'],)
+        ).fetchone()['s']
+        restant = duree - int(engage_min or 0)
+        if restant <= 0:
+            continue  # entierement planifie (creneaux verrouilles) : rien a ajouter
         dmin = t['date_min'] or today.isoformat()
         if dmin < today.isoformat():
             dmin = today.isoformat()
@@ -444,6 +477,11 @@ def planificateur():
         a_un_planning = conn.execute(
             'SELECT 1 FROM planning_theorique WHERE user_id = ? LIMIT 1', (user_id,)
         ).fetchone() is not None
+        # Description des horaires par defaut (affichee si aucun planning).
+        defaut = _horaire_defaut_profil(conn, user_id)
+        horaire_defaut_txt = ' / '.join(
+            f'{moteur._to_hhmm(a)}–{moteur._to_hhmm(b)}' for a, b in defaut
+        )
         recurrences = conn.execute(
             'SELECT * FROM planif_recurrences WHERE user_id = ? AND active = 1 ORDER BY id DESC',
             (user_id,)
@@ -472,6 +510,7 @@ def planificateur():
             recurrences=[dict(r) for r in recurrences],
             taches_non_placees=[dict(r) for r in taches_non_placees],
             a_un_planning=a_un_planning,
+            horaire_defaut_txt=horaire_defaut_txt,
         )
     finally:
         conn.close()
@@ -801,15 +840,19 @@ def api_supprimer_bloc(bloc_id):
     conn = get_db()
     try:
         user_id = _uid()
-        bloc = conn.execute('SELECT * FROM planif_blocs WHERE id = ? AND user_id = ?',
-                            (bloc_id, user_id)).fetchone()
+        bloc = conn.execute(
+            'SELECT b.*, t.type AS tache_type FROM planif_blocs b '
+            'JOIN planif_taches t ON b.tache_id = t.id '
+            'WHERE b.id = ? AND b.user_id = ?',
+            (bloc_id, user_id)
+        ).fetchone()
         if not bloc:
             return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
-        # Un creneau verrouille correspond a un evenement fixe : le supprimer
-        # seul laisserait l'evenement en base sans occuper son horaire (des
-        # taches pourraient s'y planifier). On passe par la suppression / la
-        # modification de l'evenement lui-meme.
-        if bloc['verrouille']:
+        # Le creneau d'un evenement fixe ne se supprime pas seul (sinon
+        # l'evenement reste en base sans occuper son horaire) : passer par la
+        # suppression de l'evenement. En revanche un bloc de tache verrouille
+        # (place manuellement) reste supprimable et libere son creneau.
+        if bloc['tache_type'] == 'evenement':
             return jsonify({
                 'ok': False,
                 'erreur': "Ce créneau correspond à un événement fixe : supprimez ou modifiez l'événement."
@@ -817,6 +860,85 @@ def api_supprimer_bloc(bloc_id):
         conn.execute('DELETE FROM planif_blocs WHERE id = ?', (bloc_id,))
         conn.commit()
         return jsonify({'ok': True})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/bloc/<int:bloc_id>/deplacer', methods=['POST'])
+@planif_required
+def api_deplacer_bloc(bloc_id):
+    """Deplace un bloc (glisser-deposer) puis le verrouille.
+
+    Le bloc conserve sa duree ; on change sa date et son heure de debut. Le
+    creneau devient fixe (verrouille = 1) : la replanification ne le deplace
+    plus et organise le reste autour. Pour un evenement, on met aussi a jour la
+    date/heure de l'evenement lui-meme.
+    """
+    data = _lire_payload()
+    conn = get_db()
+    try:
+        user_id = _uid()
+        bloc = conn.execute(
+            'SELECT b.*, t.type AS tache_type FROM planif_blocs b '
+            'JOIN planif_taches t ON b.tache_id = t.id '
+            'WHERE b.id = ? AND b.user_id = ?',
+            (bloc_id, user_id)
+        ).fetchone()
+        if not bloc:
+            return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
+
+        nouvelle_date = _valide_date(data.get('date')) or bloc['date']
+        deb = _valide_heure(data.get('heure_debut'))
+        if not deb:
+            return jsonify({'ok': False, 'erreur': 'Heure de debut invalide.'}), 400
+        duree = int(bloc['duree_min'])
+        deb_min = moteur._to_min(deb)
+        fin_min = deb_min + duree
+        if fin_min > 24 * 60:  # ne pas deborder sur le lendemain
+            fin_min = 24 * 60
+            deb_min = max(0, fin_min - duree)
+
+        conn.execute(
+            'UPDATE planif_blocs SET date = ?, heure_debut = ?, heure_fin = ?, verrouille = 1 WHERE id = ?',
+            (nouvelle_date, moteur._to_hhmm(deb_min), moteur._to_hhmm(fin_min), bloc_id)
+        )
+        if bloc['tache_type'] == 'evenement':
+            conn.execute(
+                'UPDATE planif_taches SET date_fixe = ?, heure_debut = ?, heure_fin = ?, '
+                'updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+                (nouvelle_date, moteur._to_hhmm(deb_min), moteur._to_hhmm(fin_min), bloc['tache_id'])
+            )
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
+    finally:
+        conn.close()
+
+
+@planificateur_bp.route('/planificateur/api/bloc/<int:bloc_id>/verrou', methods=['POST'])
+@planif_required
+def api_verrou_bloc(bloc_id):
+    """Verrouille / deverrouille un bloc de tache (le rend fixe ou re-planifiable)."""
+    data = _lire_payload()
+    verrou = 1 if str(data.get('verrouille')) in ('1', 'true', 'on', 'True') else 0
+    conn = get_db()
+    try:
+        user_id = _uid()
+        bloc = conn.execute(
+            'SELECT b.*, t.type AS tache_type FROM planif_blocs b '
+            'JOIN planif_taches t ON b.tache_id = t.id '
+            'WHERE b.id = ? AND b.user_id = ?',
+            (bloc_id, user_id)
+        ).fetchone()
+        if not bloc:
+            return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
+        # Un evenement fixe reste verrouille par nature.
+        if bloc['tache_type'] == 'evenement':
+            return jsonify({'ok': False, 'erreur': "Un événement fixe est toujours verrouillé."}), 400
+        conn.execute('UPDATE planif_blocs SET verrouille = ? WHERE id = ?', (verrou, bloc_id))
+        conn.commit()
+        non_planifie = _replanifier(conn, user_id)
+        return jsonify({'ok': True, 'non_planifie': non_planifie})
     finally:
         conn.close()
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,7 @@
                 </button>
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('dashboard_direction_bp.dashboard_direction') }}">🏢 Vue Direction</a>
+                    <a href="{{ url_for('planificateur_bp.planificateur') }}">🗓️ Planificateur</a>
                     <a href="{{ url_for('forfait_bp.dashboard_forfait_jour') }}">📅 Forfait jour</a>
                     <a href="{{ url_for('forfait_bp.calendrier_forfait_jour') }}">📆 Calendrier</a>
                 </div>
@@ -263,6 +264,7 @@
                 </button>
                 <div class="sidebar-section-menu">
                     <a href="{{ url_for('dashboard_responsable_bp.dashboard_responsable') }}">📊 Tableau de bord</a>
+                    <a href="{{ url_for('planificateur_bp.planificateur') }}">🗓️ Planificateur</a>
                     <a href="{{ url_for('validation_bp.vue_mensuelle') }}">📅 Vue mensuelle</a>
                     <a href="{{ url_for('validation_bp.vue_calendrier') }}">📆 Vue calendrier</a>
                     <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>
@@ -335,6 +337,7 @@
                 </button>
 		                <div class="sidebar-section-menu">
 		                    <a href="{{ url_for('dashboard_bp.dashboard') }}">📊 Tableau de bord</a>
+		                    <a href="{{ url_for('planificateur_bp.planificateur') }}">🗓️ Planificateur</a>
 		                    <a href="{{ url_for('validation_bp.vue_mensuelle') }}">📅 Vue mensuelle</a>
 		                    <a href="{{ url_for('validation_bp.vue_calendrier') }}">📆 Vue calendrier</a>
 		                    <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -55,7 +55,7 @@
   <p class="planif-hint">
     ⏰ Les tâches sont planifiées dans vos horaires de travail issus de
     <a href="{{ url_for('planning_bp.planning_theorique') }}">Mon planning</a>.
-    {% if not a_un_planning %}<strong>Aucun planning défini : des horaires par défaut (lun.–ven. 9h–12h30 / 13h30–17h30) sont utilisés.</strong>{% endif %}
+    {% if not a_un_planning %}<strong>Aucun planning défini : des horaires par défaut (lun.–ven. {{ horaire_defaut_txt }}) sont utilisés.</strong>{% endif %}
   </p>
 
   <div id="planifCal" class="planif-cal"></div>
@@ -296,8 +296,10 @@
 .planif-workband{position:absolute;left:0;right:0;background:rgba(47,93,80,0.06);}
 .planif-now{position:absolute;left:0;right:0;border-top:2px solid #e11d48;z-index:2;}
 
-.planif-bloc{position:absolute;left:3px;right:3px;border-left:4px solid;border-radius:5px;padding:2px 5px;font-size:.74rem;overflow:hidden;cursor:pointer;box-shadow:var(--shadow-sm);z-index:1;color:#1f2937;}
+.planif-bloc{position:absolute;left:3px;right:3px;border-left:4px solid;border-radius:5px;padding:2px 5px;font-size:.74rem;overflow:hidden;cursor:grab;box-shadow:var(--shadow-sm);z-index:1;color:#1f2937;touch-action:none;user-select:none;}
 .planif-bloc:hover{box-shadow:var(--shadow-md);filter:brightness(0.97);}
+.planif-bloc.locked{border-left-style:double;border-left-width:5px;}
+.planif-bloc.dragging{opacity:.85;cursor:grabbing;z-index:10;box-shadow:var(--shadow-lg);}
 .planif-bloc .bt{font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .planif-bloc .bh{opacity:.8;font-size:.68rem;}
 .planif-bloc.fait{opacity:.5;}
@@ -494,8 +496,9 @@
       blocsCache.filter(b=>b.date===jr).forEach(b=>{
         const d=hhmm2min(b.heure_debut), f=hhmm2min(b.heure_fin);
         const hgt=Math.max(16,(f-d)*PX_MIN);
-        cols+='<div class="planif-bloc '+classeBloc(b)+'" data-id="'+b.id+'" style="top:'+top(d)+'px;height:'+hgt+'px;">'
-          +'<div class="bt">'+iconeBloc(b)+esc(b.titre)+'</div>'
+        const verrou = b.verrouille && b.type!=='evenement';
+        cols+='<div class="planif-bloc '+classeBloc(b)+(verrou?' locked':'')+'" data-id="'+b.id+'" style="top:'+top(d)+'px;height:'+hgt+'px;">'
+          +'<div class="bt">'+iconeBloc(b)+esc(b.titre)+(verrou?' 🔒':'')+'</div>'
           +(hgt>30?'<div class="bh">'+b.heure_debut+'–'+b.heure_fin+'</div>':'')+'</div>';
       });
       cols+='</div>';
@@ -541,12 +544,68 @@
   }
 
   function brancherBlocs(){
-    document.querySelectorAll('.planif-bloc, .planif-chip').forEach(el=>{
+    // Vue mois : clic sur une pastille -> detail. (Les blocs de la grille
+    // jour/semaine sont geres par le glisser-deposer, voir plus bas.)
+    document.querySelectorAll('.planif-chip').forEach(el=>{
       el.addEventListener('click', ()=>{ const b=blocsCache.find(x=>x.id==el.dataset.id); if(b) ouvrirDetail(b); });
     });
     document.querySelectorAll('[data-goto]').forEach(el=>{
       el.addEventListener('click', (e)=>{ e.stopPropagation(); state.date=el.dataset.goto; state.vue='jour'; charger(); });
     });
+  }
+
+  // ── Glisser-deposer (vues jour / semaine) ──
+  let drag = null;
+  const SNAP = 5;          // minutes
+  const PAD_GRID = 10;     // doit correspondre au PAD de rendreGrille
+  function bcolUnderX(x){
+    for(const c of document.querySelectorAll('#planifCal .planif-bcol')){
+      const r=c.getBoundingClientRect();
+      if(x>=r.left && x<=r.right) return c;
+    }
+    return null;
+  }
+  function onDragStart(e){
+    if(state.vue==='mois') return;
+    const el = e.target.closest('.planif-bloc');
+    if(!el) return;
+    const b = blocsCache.find(x=>x.id==el.dataset.id);
+    if(!b) return;
+    const r = el.getBoundingClientRect();
+    drag = { el, b, startX:e.clientX, startY:e.clientY, grabY:e.clientY-r.top,
+             moved:false, range:plageMinutes(), date:b.date, min:hhmm2min(b.heure_debut) };
+    try{ el.setPointerCapture(e.pointerId); }catch(_){}
+  }
+  function onDragMove(e){
+    if(!drag) return;
+    if(!drag.moved){
+      if(Math.abs(e.clientX-drag.startX)<6 && Math.abs(e.clientY-drag.startY)<6) return;
+      drag.moved=true; drag.el.classList.add('dragging');
+    }
+    e.preventDefault();
+    const col = bcolUnderX(e.clientX) || drag.el.parentNode;
+    if(col && drag.el.parentNode!==col) col.appendChild(drag.el);
+    const r = col.getBoundingClientRect();
+    const [mn]=drag.range;
+    let minute = mn + (e.clientY - r.top - drag.grabY - PAD_GRID)/PX_MIN;
+    minute = Math.round(minute/SNAP)*SNAP;
+    minute = Math.max(0, Math.min(1440-drag.b.duree_min, minute));
+    drag.date = col.dataset.jour; drag.min = minute;
+    drag.el.style.top = (PAD_GRID + (minute-mn)*PX_MIN) + 'px';
+  }
+  async function onDragEnd(e){
+    if(!drag) return;
+    const d = drag; drag = null;
+    if(!d.moved){ ouvrirDetail(d.b); return; }   // simple clic -> detail
+    d.el.classList.remove('dragging');
+    if(d.date===d.b.date && d.min===hhmm2min(d.b.heure_debut)){ await charger(); return; }
+    try{
+      const res = await apiPost('/planificateur/api/bloc/'+d.b.id+'/deplacer',
+                                {date:d.date, heure_debut:min2hhmm(d.min)});
+      toast('✓ Créneau déplacé et verrouillé 🔒','ok');
+      montrerNonPlanifie(res.non_planifie);
+    }catch(err){ toast(err.message,'err'); }
+    await charger();
   }
 
   // ── Détail d'un bloc ──
@@ -563,12 +622,16 @@
     }
     if(b.description) corps+='<div class="planif-detail-line">📝 '+esc(b.description)+'</div>';
     if(b.statut==='fait') corps+='<div class="planif-detail-line">✅ Marqué comme effectué</div>';
+    if(b.verrouille && b.type!=='evenement') corps+='<div class="planif-detail-line">🔒 Créneau verrouillé (non déplacé par la replanification)</div>';
+    corps+='<div class="planif-detail-line" style="color:var(--gray-500);font-size:.8rem;">💡 Astuce : glissez un bloc sur le calendrier pour le déplacer ; il sera automatiquement verrouillé.</div>';
 
     let act='<div class="planif-detail-actions">';
     if(b.statut!=='fait') act+='<button class="btn btn-primary" data-act="bloc_fait">✓ Marquer ce créneau fait</button>';
     else act+='<button class="btn btn-secondary" data-act="bloc_repris">↩ Rétablir</button>';
     if(b.type!=='evenement'){
       act+='<button class="btn btn-secondary" data-act="tache_fait">✓✓ Tâche entière faite</button>';
+      if(b.verrouille) act+='<button class="btn btn-secondary" data-act="deverrouiller">🔓 Déverrouiller</button>';
+      else act+='<button class="btn btn-secondary" data-act="verrouiller">🔒 Verrouiller ici</button>';
       act+='<button class="btn btn-secondary" data-act="reporter">📆 Reporter</button>';
       act+='<button class="btn btn-secondary" data-act="fin">✂️ Planifier la fin</button>';
     }
@@ -599,6 +662,8 @@
       else if(act==='tache_suppr'){ if(!confirm('Supprimer définitivement cette tâche et tous ses créneaux ?')) return; res=await apiPost('/planificateur/api/tache/'+b.tache_id+'/supprimer',{}); }
       else if(act==='reporter'){ const d=prompt('Reporter à partir de quelle date ? (AAAA-MM-JJ)', addDays(isoToday(),1)); if(!d) return; res=await apiPost('/planificateur/api/tache/'+b.tache_id+'/reporter',{date_min:d}); }
       else if(act==='fin'){ const m=prompt('Combien de minutes déjà réalisées ? Le reste sera replanifié.', String(b.duree_min)); if(m===null) return; res=await apiPost('/planificateur/api/tache/'+b.tache_id+'/terminer_partiel',{minutes_faites:parseInt(m,10)||0}); }
+      else if(act==='verrouiller') res=await apiPost('/planificateur/api/bloc/'+b.id+'/verrou',{verrouille:1});
+      else if(act==='deverrouiller') res=await apiPost('/planificateur/api/bloc/'+b.id+'/verrou',{verrouille:0});
       else if(act==='modifier'){ planifFermerModales(); return ouvrirEdition(b); }
       planifFermerModales();
       if(res){ toast('✓ Mis à jour', 'ok'); montrerNonPlanifie(res.non_planifie); }
@@ -740,6 +805,11 @@
   }
 
   // ── Init ──
+  const planifCal = document.getElementById('planifCal');
+  planifCal.addEventListener('pointerdown', onDragStart);
+  planifCal.addEventListener('pointermove', onDragMove);
+  planifCal.addEventListener('pointerup', onDragEnd);
+  planifCal.addEventListener('pointercancel', ()=>{ if(drag){ drag.el.classList.remove('dragging'); drag=null; charger(); } });
   document.getElementById('planifViews').addEventListener('click', e=>{
     if(e.target.dataset.vue){ state.vue=e.target.dataset.vue; charger(); }
   });

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -659,6 +659,59 @@ def test_supprimer_bloc_tache_verrouille_autorise(comptable_client, db):
                       (bloc['id'],)).fetchone()['n'] == 0
 
 
+def test_bloc_verrouille_passe_non_compte(app, db, sample_users):
+    """Un creneau verrouille dont le jour est passe (non realise) ne reduit pas
+    le travail restant : il doit etre entierement replanifie, pas perdu."""
+    from datetime import datetime
+    from blueprints.planificateur import _replanifier
+
+    uid = sample_users['comptable_id']
+    # Aujourd'hui = un mardi a venir, 09:00 (journee en cours).
+    d = date.today() + timedelta(days=1)
+    while d.weekday() != 1:
+        d += timedelta(days=1)
+    maintenant = datetime(d.year, d.month, d.day, 9, 0)
+    hier = (d - timedelta(days=1)).isoformat()
+
+    cur = db.execute(
+        "INSERT INTO planif_taches (user_id, type, titre, duree_min, secable, duree_min_bloc, statut) "
+        "VALUES (?, 'tache', 'Mission', 120, 1, 60, 'a_faire')", (uid,)
+    )
+    tid = cur.lastrowid
+    # Bloc verrouille de 60 min place HIER (rate, jamais marque fait).
+    db.execute(
+        "INSERT INTO planif_blocs (tache_id, user_id, date, heure_debut, heure_fin, duree_min, statut, verrouille) "
+        "VALUES (?, ?, ?, '15:00', '16:00', 60, 'planifie', 1)", (tid, uid, hier)
+    )
+    db.commit()
+
+    with app.app_context():
+        _replanifier(db, uid, maintenant=maintenant)
+
+    # Les 120 minutes doivent etre entierement planifiees dans le futur (le bloc
+    # verrouille passe ne compte pas comme travail engage).
+    futur = db.execute(
+        "SELECT COALESCE(SUM(duree_min), 0) AS s FROM planif_blocs WHERE tache_id = ? AND date >= ?",
+        (tid, d.isoformat())
+    ).fetchone()['s']
+    assert futur == 120, f"attendu 120 min planifiees dans le futur, obtenu {futur}"
+    # La tache n'est pas marquee faite (rien n'a ete realise).
+    assert db.execute("SELECT statut FROM planif_taches WHERE id = ?",
+                      (tid,)).fetchone()['statut'] == 'a_faire'
+
+
+def test_deplacer_bloc_dans_le_passe_refuse(comptable_client, db):
+    """Le glisser-deposer refuse de deposer un creneau dans le passe."""
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'T', 'duree_min': 60, 'secable': 0, 'duree_min_bloc': 60,
+    })
+    bloc = db.execute("SELECT id FROM planif_blocs LIMIT 1").fetchone()
+    hier = (date.today() - timedelta(days=1)).isoformat()
+    resp = comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/deplacer',
+                                 json={'date': hier, 'heure_debut': '10:00'})
+    assert resp.status_code == 400
+
+
 def test_menu_lien_visible_comptable(comptable_client):
     resp = comptable_client.get('/dashboard_comptable')
     html = resp.get_data(as_text=True)

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -214,19 +214,53 @@ def test_acces_comptable_ok(comptable_client):
     assert 'Planificateur' in resp.get_data(as_text=True)
 
 
-def test_acces_salarie_refuse(auth_client):
-    resp = auth_client.get('/planificateur', follow_redirects=False)
-    assert resp.status_code == 302  # redirige vers le dashboard
+def test_acces_salarie_ok(auth_client):
+    resp = auth_client.get('/planificateur')
+    assert resp.status_code == 200
 
 
-def test_acces_directeur_refuse(admin_client):
-    resp = admin_client.get('/planificateur', follow_redirects=False)
-    assert resp.status_code == 302
+def test_acces_directeur_ok(admin_client):
+    resp = admin_client.get('/planificateur')
+    assert resp.status_code == 200
 
 
-def test_api_refuse_non_comptable(auth_client):
-    resp = auth_client.post('/planificateur/api/tache', json={'titre': 'X', 'duree_min': 30})
-    assert resp.status_code == 403
+def test_acces_responsable_ok(resp_client):
+    resp = resp_client.get('/planificateur')
+    assert resp.status_code == 200
+
+
+def test_acces_prestataire_refuse(client, db):
+    """Le prestataire de paie (externe) n'a pas acces au planificateur."""
+    from werkzeug.security import generate_password_hash
+    db.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil) "
+        "VALUES ('Presta', 'Paie', 'presta_test', ?, 'prestataire')",
+        (generate_password_hash('presta123'),)
+    )
+    db.commit()
+    client.post('/login', data={'login': 'presta_test', 'password': 'presta123'},
+                follow_redirects=True)
+    assert client.get('/planificateur', follow_redirects=False).status_code == 302
+    assert client.post('/planificateur/api/tache',
+                       json={'titre': 'X', 'duree_min': 30}).status_code == 403
+
+
+def test_confidentialite_directeur_ne_voit_pas_les_autres(admin_client, db, sample_users):
+    """Meme la direction ne voit que son propre planning."""
+    jour = (date.today() + timedelta(days=1)).isoformat()
+    cur = db.execute(
+        "INSERT INTO planif_taches (user_id, type, titre, duree_min, statut) "
+        "VALUES (?, 'tache', 'Prive comptable', 60, 'a_faire')",
+        (sample_users['comptable_id'],)
+    )
+    db.execute(
+        "INSERT INTO planif_blocs (tache_id, user_id, date, heure_debut, heure_fin, duree_min) "
+        "VALUES (?, ?, ?, '09:00', '10:00', 60)",
+        (cur.lastrowid, sample_users['comptable_id'], jour)
+    )
+    db.commit()
+    blocs = admin_client.get(f'/planificateur/api/blocs?debut={jour}&fin={jour}').get_json()['blocs']
+    assert all(b['titre'] != 'Prive comptable' for b in blocs)
 
 
 def test_creer_tache_genere_des_blocs(comptable_client):
@@ -534,7 +568,103 @@ def test_journee_terminee_reporte_au_lendemain(app, db, sample_users):
     assert all(x.get('titre') != 'lecture mails' for x in non_planifie)
 
 
+def test_horaires_defaut_direction(admin_client):
+    """Sans planning, la direction (forfait jours) a 09:00-12:30 / 14:00-18:00."""
+    admin_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Tache dir', 'duree_min': 120,
+        'preference': 'apres_midi', 'secable': 1, 'duree_min_bloc': 60,
+    })
+    fin = (date.today() + timedelta(days=20)).isoformat()
+    horaires = admin_client.get(
+        f'/planificateur/api/blocs?debut={date.today().isoformat()}&fin={fin}'
+    ).get_json()['horaires']
+    aprem = [iv for jour in horaires.values() for iv in jour if iv[0] >= 720]
+    assert aprem, "il doit y avoir un creneau d'apres-midi"
+    assert all(iv[0] == 840 and iv[1] == 1080 for iv in aprem), \
+        "l'apres-midi de la direction doit etre 14:00-18:00"
+
+
+def test_deplacer_bloc_le_verrouille(comptable_client, db):
+    """Glisser un bloc le deplace et le verrouille ; la replanif ne le bouge plus."""
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'A deplacer', 'duree_min': 60, 'secable': 0, 'duree_min_bloc': 60,
+    })
+    bloc = db.execute("SELECT id FROM planif_blocs LIMIT 1").fetchone()
+    cible = (date.today() + timedelta(days=3)).isoformat()
+    resp = comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/deplacer',
+                                 json={'date': cible, 'heure_debut': '15:00'})
+    assert resp.status_code == 200
+    maj = db.execute("SELECT date, heure_debut, heure_fin, verrouille FROM planif_blocs WHERE id = ?",
+                     (bloc['id'],)).fetchone()
+    assert maj['date'] == cible and maj['heure_debut'] == '15:00' and maj['heure_fin'] == '16:00'
+    assert maj['verrouille'] == 1
+
+    comptable_client.post('/planificateur/api/replanifier', json={})
+    apres = db.execute("SELECT date, heure_debut, verrouille FROM planif_blocs WHERE id = ?",
+                       (bloc['id'],)).fetchone()
+    assert apres is not None
+    assert apres['date'] == cible and apres['heure_debut'] == '15:00' and apres['verrouille'] == 1
+
+
+def test_verrou_bloc_pas_de_double_comptage(comptable_client, db, sample_users):
+    """Verrouiller un morceau d'une tache n'augmente pas le total planifie."""
+    uid = sample_users['comptable_id']
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Mission', 'duree_min': 240, 'secable': 1, 'duree_min_bloc': 60,
+    })
+    bloc = db.execute("SELECT id FROM planif_blocs WHERE user_id = ? LIMIT 1", (uid,)).fetchone()
+    comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/verrou', json={'verrouille': 1})
+    comptable_client.post('/planificateur/api/replanifier', json={})
+    total = db.execute("SELECT COALESCE(SUM(duree_min),0) AS s FROM planif_blocs WHERE user_id = ?",
+                       (uid,)).fetchone()['s']
+    assert total == 240, "le total planifie doit rester egal a la duree de la tache"
+
+
+def test_deverrouiller_bloc(comptable_client, db):
+    """Déverrouiller rend le bloc à l'optimiseur (la tâche reste planifiée, non verrouillée)."""
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'T', 'duree_min': 60, 'secable': 0, 'duree_min_bloc': 60,
+    })
+    bloc = db.execute("SELECT id, tache_id FROM planif_blocs LIMIT 1").fetchone()
+    tache_id = bloc['tache_id']
+    comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/verrou', json={'verrouille': 1})
+    assert db.execute("SELECT verrouille FROM planif_blocs WHERE id = ?",
+                      (bloc['id'],)).fetchone()['verrouille'] == 1
+    # Verrouiller n'est pas « faire » : la tache reste a faire.
+    assert db.execute("SELECT statut FROM planif_taches WHERE id = ?",
+                      (tache_id,)).fetchone()['statut'] == 'a_faire'
+
+    # Deverrouiller : le bloc est rendu a l'optimiseur (re-planifie librement).
+    comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/verrou', json={'verrouille': 0})
+    restants = db.execute(
+        "SELECT COUNT(*) AS n FROM planif_blocs WHERE tache_id = ? AND verrouille = 1",
+        (tache_id,)
+    ).fetchone()['n']
+    total = db.execute("SELECT COUNT(*) AS n FROM planif_blocs WHERE tache_id = ?",
+                       (tache_id,)).fetchone()['n']
+    assert restants == 0, "plus aucun bloc verrouille apres deverrouillage"
+    assert total >= 1, "la tache reste planifiee"
+
+
+def test_supprimer_bloc_tache_verrouille_autorise(comptable_client, db):
+    """Un bloc de tache verrouille reste supprimable (contrairement a un evenement)."""
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'T', 'duree_min': 60, 'secable': 0, 'duree_min_bloc': 60,
+    })
+    bloc = db.execute("SELECT id FROM planif_blocs LIMIT 1").fetchone()
+    comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/verrou', json={'verrouille': 1})
+    resp = comptable_client.post(f'/planificateur/api/bloc/{bloc["id"]}/supprimer', json={})
+    assert resp.status_code == 200
+    assert db.execute("SELECT COUNT(*) AS n FROM planif_blocs WHERE id = ?",
+                      (bloc['id'],)).fetchone()['n'] == 0
+
+
 def test_menu_lien_visible_comptable(comptable_client):
     resp = comptable_client.get('/dashboard_comptable')
     html = resp.get_data(as_text=True)
+    assert '/planificateur' in html
+
+
+def test_menu_lien_visible_salarie(auth_client):
+    html = auth_client.get('/dashboard').get_data(as_text=True)
     assert '/planificateur' in html


### PR DESCRIPTION
## Résumé

Suite des évolutions du planificateur après la phase 1 (toutes fusionnées) :

### 1. Ouverture à l'ensemble des salariés
- Accès étendu à **salarié, responsable, comptable et direction** (le prestataire de paie externe reste hors périmètre).
- Le planning reste **strictement individuel** : chacun ne voit que le sien — **même la direction n'a accès qu'à son propre planning**, et personne ne voit celui d'un autre. (Toutes les requêtes restent filtrées par `user_id` ; test de confidentialité directeur ↔ comptable ajouté.)
- Liens ajoutés dans les menus directeur / responsable / salarié.

### 2. Horaires par défaut selon le profil
- La **direction** (forfait jours, sans horaires précis et donc sans planning théorique) part sur **09:00–12:30 / 14:00–18:00**.
- Les autres profils sans planning : 09:00–12:30 / 13:30–17:30.
- Les salariés ayant un planning théorique (**Mon planning**) continuent de l'utiliser tel quel.

### 3. Glisser-déposer → verrouillage
- **Glisser un bloc** sur le calendrier (jour/semaine, souris **et** tactile) le **repositionne et le verrouille** 🔒 : la replanification ne le déplace plus, et le reste des tâches s'organise autour.
- **Déverrouillage** possible depuis le détail du bloc : il est rendu à l'optimiseur (re-planifié librement).
- Nouveaux endpoints `POST /bloc/<id>/deplacer` et `POST /bloc/<id>/verrou`.

### 4. Pauses
- **Inchangées** : elles correspondent à des recommandations de santé (travail de bureau).

## Correctif important

Verrouiller un créneau couvrant toute la durée d'une tâche **ne la marque plus « faite »** : verrouiller, c'est *engager* du temps (non replanifié), pas *réaliser*. Seul le temps réellement « fait » clôture la tâche. (Sans ce correctif, déverrouiller une telle tâche supprimait son bloc.)

## Tests

- Accès multi-profils (directeur/responsable/salarié autorisés, prestataire refusé) + confidentialité inter-profils.
- Horaires par défaut de la direction (14:00–18:00).
- Déplacer + verrouiller (persistance après replanification, pas de double comptage de la capacité), déverrouiller, suppression d'un bloc de tâche verrouillé.
- **636 tests au vert** (`python3 -m pytest`).
- Glisser-déposer vérifié visuellement (desktop) : bloc déplacé, verrouillé 🔒, et tâches reflowées autour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5

---
_Generated by [Claude Code](https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5)_