### PR TITLE
Corriger le décalage horaire (UTC) du planning et des journaux

### DIFF
--- a/access_log.py
+++ b/access_log.py
@@ -18,6 +18,7 @@ Les deux journaux sont consultables par la direction via Administration > Securi
 import logging
 
 from database import get_db
+from utils import maintenant
 
 logger = logging.getLogger(__name__)
 
@@ -114,9 +115,9 @@ def enregistrer_acces(evenement, login_saisi=None, user_id=None, adresse_ip=None
     try:
         conn = get_db()
         conn.execute(
-            'INSERT INTO journal_acces (login_saisi, user_id, evenement, adresse_ip) '
-            'VALUES (?, ?, ?, ?)',
-            (login_saisi, user_id, evenement, adresse_ip)
+            'INSERT INTO journal_acces (date_heure, login_saisi, user_id, evenement, adresse_ip) '
+            'VALUES (?, ?, ?, ?, ?)',
+            (maintenant().strftime('%Y-%m-%d %H:%M:%S'), login_saisi, user_id, evenement, adresse_ip)
         )
         conn.commit()
     except Exception:
@@ -155,7 +156,8 @@ def journaliser_action(conn, action, user_id=None, cible_type=None,
             user_id = None
     conn.execute(
         'INSERT INTO journal_actions '
-        '(user_id, action, cible_type, cible_id, details, adresse_ip) '
-        'VALUES (?, ?, ?, ?, ?, ?)',
-        (user_id, action, cible_type, cible_id, details, _adresse_ip())
+        '(date_heure, user_id, action, cible_type, cible_id, details, adresse_ip) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?)',
+        (maintenant().strftime('%Y-%m-%d %H:%M:%S'), user_id, action,
+         cible_type, cible_id, details, _adresse_ip())
     )

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -13,14 +13,14 @@ Acces (phase 1) : reserve au profil comptable, pour la phase de test.
 """
 import calendar
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from functools import wraps
 
 from flask import (Blueprint, render_template, request, redirect, url_for,
                    session, flash, jsonify)
 
 from database import get_db
-from utils import login_required
+from utils import login_required, aujourd_hui, maintenant as _maintenant
 import planificateur_engine as moteur
 
 logger = logging.getLogger(__name__)
@@ -257,11 +257,12 @@ def _replanifier(conn, user_id, maintenant=None):
     taches non planifiees (chacune enrichie de son titre).
 
     `maintenant` (datetime) permet de figer l'instant courant pour les tests ;
-    par defaut, datetime.now(). On ne planifie jamais dans le passe : si la
-    journee en cours est terminee, les taches partent au lendemain.
+    par defaut, l'heure locale applicative (utils.maintenant, Europe/Paris). On
+    ne planifie jamais dans le passe : si la journee en cours est terminee, les
+    taches partent au lendemain.
     """
     if maintenant is None:
-        maintenant = datetime.now()
+        maintenant = _maintenant()
     today = maintenant.date()
     minute_courante = maintenant.hour * 60 + maintenant.minute
     fin = today + timedelta(days=HORIZON_JOURS)
@@ -417,7 +418,7 @@ def _serialiser_blocs(conn, user_id, debut, fin):
            ORDER BY b.date, b.heure_debut''',
         (user_id, debut, fin)
     ).fetchall()
-    today = date.today()
+    today = aujourd_hui()
     blocs = []
     for r in rows:
         urgence = moteur.niveau_urgence(r['deadline'], today, r['bloc_statut'])
@@ -477,7 +478,7 @@ def planificateur():
         vue = request.args.get('vue', 'semaine')
         if vue not in ('jour', 'semaine', 'mois'):
             vue = 'semaine'
-        date_ref = _valide_date(request.args.get('date')) or date.today().isoformat()
+        date_ref = _valide_date(request.args.get('date')) or aujourd_hui().isoformat()
 
         a_un_planning = conn.execute(
             'SELECT 1 FROM planning_theorique WHERE user_id = ? LIMIT 1', (user_id,)
@@ -493,7 +494,7 @@ def planificateur():
         ).fetchall()
 
         # Taches sans bloc futur planifie = non placees (indicateur persistant).
-        today = date.today().isoformat()
+        today = aujourd_hui().isoformat()
         # Les occurrences recurrentes sont exclues : elles sont placees « au
         # mieux, la ou il reste de la place » et leur absence n'est pas une
         # anomalie a signaler.
@@ -528,7 +529,7 @@ def api_blocs():
     conn = get_db()
     try:
         user_id = _uid()
-        debut = _valide_date(request.args.get('debut')) or date.today().isoformat()
+        debut = _valide_date(request.args.get('debut')) or aujourd_hui().isoformat()
         fin = _valide_date(request.args.get('fin')) or debut
         blocs = _serialiser_blocs(conn, user_id, debut, fin)
         # Horaires de travail (par date) pour afficher les plages travaillees.
@@ -709,7 +710,7 @@ def api_statut_tache(tache_id):
             # Marquer ses blocs futurs comme realises (ils restent en place).
             conn.execute(
                 "UPDATE planif_blocs SET statut = 'fait' WHERE tache_id = ? AND date >= ?",
-                (tache_id, date.today().isoformat())
+                (tache_id, aujourd_hui().isoformat())
             )
         elif statut in ('a_faire', 'annule'):
             if tache['type'] == 'evenement':
@@ -736,7 +737,7 @@ def api_reporter_tache(tache_id):
 
         nouveau_min = _valide_date(data.get('date_min'))
         if not nouveau_min:
-            nouveau_min = (date.today() + timedelta(days=1)).isoformat()
+            nouveau_min = (aujourd_hui() + timedelta(days=1)).isoformat()
         conn.execute(
             'UPDATE planif_taches SET date_min = ?, statut = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
             (nouveau_min, 'a_faire', tache_id)
@@ -893,7 +894,7 @@ def api_deplacer_bloc(bloc_id):
             return jsonify({'ok': False, 'erreur': 'Bloc introuvable.'}), 404
 
         nouvelle_date = _valide_date(data.get('date')) or bloc['date']
-        if nouvelle_date < date.today().isoformat():
+        if nouvelle_date < aujourd_hui().isoformat():
             return jsonify({'ok': False, 'erreur': "Impossible de déplacer un créneau dans le passé."}), 400
         deb = _valide_heure(data.get('heure_debut'))
         if not deb:
@@ -985,7 +986,7 @@ def api_creer_recurrence():
         jour_semaine = _parse_int(jour_semaine, None, mini=0, maxi=6) if jour_semaine not in (None, '', 'null') else None
         jour_mois = data.get('jour_mois')
         jour_mois = _parse_int(jour_mois, None, mini=1, maxi=28) if jour_mois not in (None, '', 'null') else None
-        date_debut = _valide_date(data.get('date_debut')) or date.today().isoformat()
+        date_debut = _valide_date(data.get('date_debut')) or aujourd_hui().isoformat()
         date_fin = _valide_date(data.get('date_fin'))
 
         conn.execute(

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ requests==2.33.0
 openpyxl==3.1.5
 python-docx==1.2.0
 waitress==3.0.1
+tzdata==2025.2
 
 # Tests
 pytest==9.0.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 # Définir une SECRET_KEY pour les tests AVANT l'import de l'app
 os.environ.setdefault('SECRET_KEY', 'test-secret-key-for-pytest')
 
+# Les tests comparent avec datetime.now()/date.today() (fuseau du système, UTC
+# dans l'environnement CI). On aligne la timezone applicative sur UTC pour que
+# l'heure de l'app et celle des tests coïncident (la valeur métier par défaut
+# reste Europe/Paris en production).
+os.environ.setdefault('APP_TIMEZONE', 'UTC')
+
 
 @pytest.fixture(scope='function')
 def app(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -312,3 +312,39 @@ class TestNomsMois:
             assert NOMS_MOIS[0] == ''
             assert NOMS_MOIS[1] == 'Janvier'
             assert NOMS_MOIS[12] == 'Décembre'
+
+
+class TestTimezoneApplicative:
+    """Tests des helpers d'heure locale (maintenant / aujourd_hui)."""
+
+    def test_maintenant_respecte_la_timezone(self, monkeypatch):
+        """maintenant() renvoie l'heure de la timezone applicative (Europe/Paris)."""
+        from datetime import datetime, timezone
+        from zoneinfo import ZoneInfo
+        import utils
+
+        monkeypatch.setenv('APP_TIMEZONE', 'Europe/Paris')
+        m = utils.maintenant()  # naif, heure de Paris
+        attendu = datetime.now(ZoneInfo('Europe/Paris')).replace(tzinfo=None)
+        assert abs((m - attendu).total_seconds()) < 5
+
+        # Paris = UTC+1 (hiver) ou +2 (ete) : le decalage doit etre l'un des deux.
+        utc = datetime.now(timezone.utc).replace(tzinfo=None)
+        delta_h = round((m - utc).total_seconds() / 3600)
+        assert delta_h in (1, 2)
+
+    def test_journal_acces_horodate_en_heure_locale(self, app, db, monkeypatch):
+        """Le journal de connexion enregistre l'heure locale, pas l'UTC."""
+        from datetime import datetime, timezone
+        import access_log
+
+        monkeypatch.setenv('APP_TIMEZONE', 'Europe/Paris')
+        with app.app_context():
+            access_log.enregistrer_acces(access_log.EVT_CONNEXION_REUSSIE, login_saisi='x')
+        row = db.execute(
+            "SELECT date_heure FROM journal_acces ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        logged = datetime.strptime(row['date_heure'], '%Y-%m-%d %H:%M:%S')
+        utc = datetime.now(timezone.utc).replace(tzinfo=None)
+        delta_h = round((logged - utc).total_seconds() / 3600)
+        assert delta_h in (1, 2), f"journal doit etre en heure locale FR (delta={delta_h}h)"

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@
 Fonctions utilitaires partagées entre tous les blueprints.
 """
 import logging
+import os
 import re
 from flask import session, flash, redirect, url_for
 from functools import wraps
@@ -9,6 +10,48 @@ from datetime import datetime, timedelta
 from database import get_db
 
 logger = logging.getLogger(__name__)
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # Python < 3.9
+    ZoneInfo = None
+
+
+# ── Heure locale (timezone applicative) ──
+# Le processus peut tourner en UTC (conteneur, executable Windows...), ce qui
+# decalerait l'heure affichee et les calculs (planning, journaux). On force la
+# timezone metier — Europe/Paris par defaut, surchargeable via APP_TIMEZONE.
+
+def _timezone_app():
+    """ZoneInfo de la timezone applicative, ou None si indisponible."""
+    if ZoneInfo is None:
+        return None
+    nom = os.environ.get('APP_TIMEZONE', 'Europe/Paris')
+    try:
+        return ZoneInfo(nom)
+    except Exception:
+        logger.warning(
+            "Timezone '%s' introuvable (paquet tzdata manquant ?) : "
+            "repli sur l'heure locale du systeme.", nom
+        )
+        return None
+
+
+def maintenant():
+    """Datetime courant (naif) exprime dans la timezone applicative.
+
+    Retourne un datetime sans tzinfo (heure « murale » locale), conforme au
+    reste de l'application qui manipule des dates/heures naives.
+    """
+    tz = _timezone_app()
+    if tz is None:
+        return datetime.now()
+    return datetime.now(tz).replace(tzinfo=None)
+
+
+def aujourd_hui():
+    """Date courante dans la timezone applicative."""
+    return maintenant().date()
 
 
 # ── Chiffrement / déchiffrement (clés API, etc.) ──


### PR DESCRIPTION
## Problème

Le serveur est à l'heure, mais le processus applicatif tourne en **UTC** (conteneur). En France (UTC+2 l'été, UTC+1 l'hiver), cela décalait l'heure « murale » de 1 à 2 heures :

- **Planificateur** : à 12 h réel, l'app croyait qu'il était 10 h → des tâches étaient posées jusqu'à 2 h dans le passé.
- **Traceur de connexion / journaux** : les horodatages étaient enregistrés en UTC (via `CURRENT_TIMESTAMP` SQLite), donc décalés à l'affichage.

## Correctif

Introduction d'une **heure locale applicative** centralisée, appliquée partout où l'app lit « maintenant » ou « aujourd'hui ».

- **`utils.maintenant()` / `utils.aujourd_hui()`** : renvoient l'instant/la date dans la timezone métier via `zoneinfo`.
  - Timezone `Europe/Paris` par défaut, surchargeable par la variable d'environnement `APP_TIMEZONE`.
  - Repli silencieux sur l'heure système (avec avertissement dans les logs) si la base de fuseaux est absente.
- **`blueprints/planificateur.py`** : `_replanifier()` et toutes les références à la date du jour (fin de journée, créneaux passés, deadlines, bornes de vue) passent par l'heure locale. Le nettoyage retire l'import `datetime` devenu inutile.
- **`access_log.py`** : les deux journaux (accès et actions) écrivent une colonne `date_heure` explicite en heure locale au lieu de laisser SQLite poser l'UTC.
- **`requirements.txt`** : ajout de `tzdata` pour garantir la base de fuseaux sur les environnements qui n'en fournissent pas (Windows, images minimales).

## Tests

- Nouvelle classe `TestTimezoneApplicative` dans `tests/test_utils.py` : vérifie que `maintenant()` respecte `APP_TIMEZONE` et que le journal d'accès est horodaté en heure locale (et non UTC).
- `tests/conftest.py` fixe `APP_TIMEZONE=UTC` pour que l'heure de l'app coïncide avec les comparaisons `datetime.now()` des tests existants (la valeur métier par défaut reste `Europe/Paris` en production).
- Suite complète : **643 tests passent** (dont les 46 tests du planificateur).

## Sécurité / vie privée

Aucun changement de périmètre d'accès : le planning reste strictement individuel (`user_id = session['user_id']`), y compris vis-à-vis de la direction. Le correctif ne touche que le calcul du temps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5

---
_Generated by [Claude Code](https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5)_