### PR TITLE
Direction & secteurs : forfait jours (absences), libellés e-mails congé, rattachement secteur

### DIFF
--- a/blueprints/absences.py
+++ b/blueprints/absences.py
@@ -156,10 +156,11 @@ def _reporter_absence_sur_forfait_jour(conn, absence_id, user_id, date_debut_str
     # Lazy import : evite tout cycle d'import au chargement de l'application.
     from blueprints.forfait import initialiser_annee_forfait_jour
 
-    # S'assurer que chaque annee couverte est pre-remplie en « travaille », sinon
-    # le decompte serait fausse (une annee vierge ne compte aucun jour travaille).
-    # Sans commit : l'ecriture reste dans la transaction de l'appelant.
-    for annee in {int(date_debut_str[:4]), int(date_fin_str[:4])}:
+    # S'assurer que CHAQUE annee couverte par l'absence est pre-remplie en
+    # « travaille » (annees intermediaires comprises pour une longue absence, ex.
+    # conge parental sur 2-3 ans), sinon une annee laissee vierge ne compterait
+    # aucun jour travaille. Sans commit : on reste dans la transaction appelante.
+    for annee in range(int(date_debut_str[:4]), int(date_fin_str[:4]) + 1):
         initialiser_annee_forfait_jour(conn, user_id, annee, commit=False)
 
     type_journee = MOTIF_VERS_TYPE_FORFAIT.get(motif, 'autre')

--- a/blueprints/absences.py
+++ b/blueprints/absences.py
@@ -26,7 +26,28 @@ MOTIFS_ABSENCE = [
     'Autre',
 ]
 
+# Correspondance motif d'absence -> type de journee du calendrier forfait jour
+# (direction). Les motifs non listes retombent sur 'autre' : toute absence
+# retire de toute facon le jour du decompte des jours travailles.
+MOTIF_VERS_TYPE_FORFAIT = {
+    'Congé payé': 'conge_paye',
+    'Congé conventionnel': 'conge_conv',
+    'Arrêt maladie': 'maladie',
+    'Sans solde': 'sans_solde',
+}
+
 DOCUMENTS_DIR = os.path.join(DATA_DIR, 'documents')
+
+
+def _est_forfait_jour(conn, user_id):
+    """Vrai si l'utilisateur releve du forfait jours (direction).
+
+    La direction n'a pas d'horaires precis : son « calendrier » et son decompte
+    vivent dans presence_forfait_jour, et non dans heures_reelles / les compteurs
+    de conges salaries. C'est ce qui aiguille le report des absences.
+    """
+    row = conn.execute('SELECT profil FROM users WHERE id = ?', (user_id,)).fetchone()
+    return bool(row) and row['profil'] == 'directeur'
 
 
 def _get_documents_dir():
@@ -81,6 +102,12 @@ def _actualiser_compteurs_conges(conn, user_id, motif, jours_ouvres, ajout=True)
         jours_ouvres: nombre de jours ouvres
         ajout: True pour une nouvelle absence, False pour une suppression
     """
+    # La direction (forfait jours) suit ses conges via presence_forfait_jour
+    # (decompte recalcule automatiquement) : ne pas toucher aux compteurs de
+    # conges salaries, qui ne la concernent pas.
+    if _est_forfait_jour(conn, user_id):
+        return
+
     if motif == 'Congé payé':
         user = conn.execute('SELECT cp_a_prendre, cp_pris FROM users WHERE id = ?', (user_id,)).fetchone()
         if not user:
@@ -117,8 +144,60 @@ def _actualiser_compteurs_conges(conn, user_id, motif, jours_ouvres, ajout=True)
         conn.execute('UPDATE users SET cc_solde = ? WHERE id = ?', (cc_solde, user_id))
 
 
+def _reporter_absence_sur_forfait_jour(conn, absence_id, user_id, date_debut_str, date_fin_str, motif):
+    """Reporte une absence sur le calendrier forfait jours (direction).
+
+    Chaque jour ouvre non ferie de la periode prend le type de journee
+    correspondant a l'absence (maladie, conge_paye…). L'absence PRIME : elle
+    remplace le type du jour meme s'il avait ete saisi a la main, et efface les
+    horaires eventuels. Le decompte (jours travailles, soldes CP / maladie) se
+    recalcule tout seul a partir de presence_forfait_jour.
+    """
+    # Lazy import : evite tout cycle d'import au chargement de l'application.
+    from blueprints.forfait import initialiser_annee_forfait_jour
+
+    # S'assurer que chaque annee couverte est pre-remplie en « travaille », sinon
+    # le decompte serait fausse (une annee vierge ne compte aucun jour travaille).
+    # Sans commit : l'ecriture reste dans la transaction de l'appelant.
+    for annee in {int(date_debut_str[:4]), int(date_fin_str[:4])}:
+        initialiser_annee_forfait_jour(conn, user_id, annee, commit=False)
+
+    type_journee = MOTIF_VERS_TYPE_FORFAIT.get(motif, 'autre')
+    date_debut = datetime.strptime(date_debut_str, '%Y-%m-%d')
+    date_fin = datetime.strptime(date_fin_str, '%Y-%m-%d')
+
+    feries_rows = conn.execute('''
+        SELECT date FROM jours_feries
+        WHERE date >= ? AND date <= ?
+    ''', (date_debut_str, date_fin_str)).fetchall()
+    jours_feries = {row['date'] for row in feries_rows}
+
+    commentaire = f"Absence #{absence_id} - {motif}"
+    jour_actuel = date_debut
+    while jour_actuel <= date_fin:
+        date_str = jour_actuel.strftime('%Y-%m-%d')
+        # Uniquement jours ouvres et non feries (comme pour les salaries).
+        if jour_actuel.weekday() < 5 and date_str not in jours_feries:
+            # INSERT OR REPLACE : l'absence prime et efface horaires/commentaire.
+            conn.execute('''
+                INSERT OR REPLACE INTO presence_forfait_jour
+                (user_id, date, type_journee, commentaire)
+                VALUES (?, ?, ?, ?)
+            ''', (user_id, date_str, type_journee, commentaire))
+        jour_actuel += timedelta(days=1)
+
+
 def _reporter_absence_sur_calendrier(conn, absence_id, user_id, date_debut_str, date_fin_str, motif):
-    """Reporte les jours d'absence sur heures_reelles avec declaration conforme (heures theoriques)."""
+    """Reporte les jours d'absence sur le calendrier de l'interesse.
+
+    - Salarie : sur heures_reelles (declaration conforme aux heures theoriques).
+    - Direction (forfait jours) : sur presence_forfait_jour (voir le helper dedie).
+    """
+    if _est_forfait_jour(conn, user_id):
+        _reporter_absence_sur_forfait_jour(conn, absence_id, user_id,
+                                           date_debut_str, date_fin_str, motif)
+        return
+
     date_debut = datetime.strptime(date_debut_str, '%Y-%m-%d')
     date_fin = datetime.strptime(date_fin_str, '%Y-%m-%d')
 
@@ -150,7 +229,24 @@ def _reporter_absence_sur_calendrier(conn, absence_id, user_id, date_debut_str, 
 
 
 def _supprimer_absence_du_calendrier(conn, absence_id, user_id, date_debut_str, date_fin_str):
-    """Supprime les entrees heures_reelles liees a une absence."""
+    """Retire du calendrier les jours poses par une absence.
+
+    - Salarie : supprime les entrees heures_reelles de l'absence.
+    - Direction (forfait jours) : repasse en « travaille » les jours ENCORE
+      marques par cette absence (on ne touche pas a une saisie manuelle faite
+      depuis), et efface horaires/commentaire residuels.
+    """
+    if _est_forfait_jour(conn, user_id):
+        conn.execute('''
+            UPDATE presence_forfait_jour
+            SET type_journee = 'travaille', commentaire = NULL,
+                matin_debut = NULL, matin_fin = NULL,
+                aprem_debut = NULL, aprem_fin = NULL
+            WHERE user_id = ? AND date >= ? AND date <= ?
+              AND commentaire LIKE ?
+        ''', (user_id, date_debut_str, date_fin_str, f"Absence #{absence_id}%"))
+        return
+
     conn.execute('''
         DELETE FROM heures_reelles
         WHERE user_id = ? AND date >= ? AND date <= ?

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1842,11 +1842,11 @@ def _paie_mois_actifs(date_debut, date_fin, annee):
 def _paie_employes_secteur(conn, secteur_id, annee):
     """Salariés actifs du secteur avec un contrat CDI/CDD chevauchant l'année.
 
-    La direction (profil 'directeur'), généralement sans secteur opérationnel,
-    est rattachée au secteur administratif (et n'apparaît que là). Pour éviter
-    tout double comptage si plusieurs secteurs sont de type 'administratif',
-    la direction n'est incluse que dans le secteur administratif principal
-    (le plus petit id).
+    La direction (profil 'directeur') est comptée dans SON secteur lorsqu'elle en
+    a un (utile pour les budgets, ex. « Pilotage » = administratif + direction).
+    Une direction SANS secteur est rattachée par défaut au secteur administratif
+    principal (le plus petit id parmi les secteurs de type 'administratif') et n'y
+    apparaît qu'une fois — jamais en double avec un secteur explicitement assigné.
     """
     sect = conn.execute('SELECT type_secteur FROM secteurs WHERE id = ?', (secteur_id,)).fetchone()
     is_admin = bool(sect) and (sect['type_secteur'] == 'administratif')
@@ -1862,15 +1862,17 @@ def _paie_employes_secteur(conn, secteur_id, annee):
             SELECT id, nom, prenom, pesee, competence, maintien
             FROM users
             WHERE actif = 1 AND profil != 'prestataire'
-              AND (secteur_id = ? OR profil = 'directeur')
+              AND (secteur_id = ? OR (profil = 'directeur' AND secteur_id IS NULL))
             ORDER BY nom, prenom
         ''', (secteur_id,)).fetchall()
     else:
-        # Hors secteur administratif principal : la direction n'apparaît pas.
+        # Hors secteur administratif principal : on inclut la direction
+        # explicitement rattachée à CE secteur (les directions sans secteur, elles,
+        # restent sur l'administratif principal via la branche ci-dessus).
         rows = conn.execute('''
             SELECT id, nom, prenom, pesee, competence, maintien
             FROM users
-            WHERE actif = 1 AND profil != 'prestataire' AND profil != 'directeur'
+            WHERE actif = 1 AND profil != 'prestataire'
               AND secteur_id = ?
             ORDER BY nom, prenom
         ''', (secteur_id,)).fetchall()

--- a/blueprints/forfait.py
+++ b/blueprints/forfait.py
@@ -10,7 +10,7 @@ from utils import login_required, get_user_info, calculer_stats_forfait_jour, ca
 forfait_bp = Blueprint('forfait_bp', __name__)
 
 
-def initialiser_annee_forfait_jour(conn, user_id, annee):
+def initialiser_annee_forfait_jour(conn, user_id, annee, commit=True):
     """Pré-remplit le calendrier forfait jour d'une année.
 
     Par défaut, chaque jour ouvré (lundi → vendredi) qui n'est pas férié est
@@ -54,7 +54,8 @@ def initialiser_annee_forfait_jour(conn, user_id, annee):
             "(user_id, date, type_journee) VALUES (?, ?, ?)",
             jours_a_inserer
         )
-        conn.commit()
+        if commit:
+            conn.commit()
     return True
 
 

--- a/blueprints/recup.py
+++ b/blueprints/recup.py
@@ -488,7 +488,8 @@ def validation_demandes_recup():
         action = request.form.get('action')  # 'valider' ou 'refuser'
         motif_refus = request.form.get('motif_refus', '').strip()
         demande_type = request.form.get('demande_type', 'recup')  # 'recup' ou 'conge'
-        
+        libelle_demande = 'congé' if demande_type == 'conge' else 'récupération'
+
         if not demande_id or not action:
             flash('Paramètres invalides', 'error')
             return redirect(url_for('recup_bp.validation_demandes_recup'))
@@ -536,7 +537,8 @@ def validation_demandes_recup():
                             notifier_demande_recup_decision(
                                 email_sal, salarie['prenom'], 'refusee',
                                 demande['date_debut'], demande['date_fin'],
-                                demande['nb_jours'], motif_refus
+                                demande['nb_jours'], motif_refus,
+                                type_libelle=libelle_demande
                             )
 
             elif action == 'valider':
@@ -570,7 +572,8 @@ def validation_demandes_recup():
                             for d in directeurs:
                                 notifier_demande_recup_validee_responsable(
                                     d['email'], d['prenom'], demandeur_nom, responsable_nom,
-                                    demande['date_debut'], demande['date_fin'], demande['nb_jours']
+                                    demande['date_debut'], demande['date_fin'], demande['nb_jours'],
+                                    type_libelle=libelle_demande
                                 )
 
                 elif session.get('profil') in ['directeur', 'comptable']:
@@ -662,7 +665,8 @@ def validation_demandes_recup():
                                 notifier_demande_recup_decision(
                                     email_sal, salarie['prenom'], 'validee',
                                     demande['date_debut'], demande['date_fin'],
-                                    demande['nb_jours']
+                                    demande['nb_jours'],
+                                    type_libelle=libelle_demande
                                 )
         finally:
             conn.close()
@@ -859,7 +863,8 @@ def demande_conge():
                         demandeur_nom = f"{demandeur['prenom']} {demandeur['nom']}"
                         notifier_nouvelle_demande_recup(
                             demandeur_nom, resp['email'], resp['prenom'],
-                            date_debut, date_fin, nb_jours, 0
+                            date_debut, date_fin, nb_jours, 0,
+                            type_libelle='congé'
                         )
 
             # Si responsable -> notifier directement la direction
@@ -874,7 +879,8 @@ def demande_conge():
                     for d in directeurs:
                         notifier_demande_recup_validee_responsable(
                             d['email'], d['prenom'], demandeur_nom, demandeur_nom,
-                            date_debut, date_fin, nb_jours
+                            date_debut, date_fin, nb_jours,
+                            type_libelle='congé'
                         )
 
         except Exception as e:

--- a/email_service.py
+++ b/email_service.py
@@ -241,30 +241,40 @@ def peut_envoyer_email(user_id):
 # ── Notifications pre-construites ──
 
 def notifier_nouvelle_demande_recup(demande_user, responsable_email, responsable_prenom,
-                                     date_debut, date_fin, nb_jours, nb_heures):
-    """Notifie le responsable d'une nouvelle demande de recuperation."""
+                                     date_debut, date_fin, nb_jours, nb_heures,
+                                     type_libelle='récupération'):
+    """Notifie le responsable d'une nouvelle demande (recuperation ou congé).
+
+    `type_libelle` adapte le libelle du courriel selon le type de demande
+    ('récupération' par defaut, 'congé' pour une demande de congé).
+    """
     _e = html_module.escape
+    # Les heures ne concernent que la recuperation partielle ; on les masque
+    # pour un conge (nb_heures == 0), ou l'unite pertinente est le jour.
+    duree = f"{nb_jours} jour(s)" + (f" - {nb_heures:.2f}h" if nb_heures else "")
     contenu = f"""
-    <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">Nouvelle demande de recuperation</h3>
-    <p><strong>{_e(demande_user)}</strong> a depose une demande de recuperation.</p>
+    <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">Nouvelle demande de {type_libelle}</h3>
+    <p><strong>{_e(demande_user)}</strong> a depose une demande de {type_libelle}.</p>
     <table style="width:100%;border-collapse:collapse;margin:12px 0;">
         <tr><td style="padding:8px 12px;background:#f3f4f6;border-radius:4px;font-weight:600;width:40%;">Periode</td>
             <td style="padding:8px 12px;">{_e(date_debut)} au {_e(date_fin)}</td></tr>
         <tr><td style="padding:8px 12px;background:#f3f4f6;border-radius:4px;font-weight:600;">Duree</td>
-            <td style="padding:8px 12px;">{nb_jours} jour(s) - {nb_heures:.2f}h</td></tr>
+            <td style="padding:8px 12px;">{duree}</td></tr>
     </table>
     <p style="margin-top:16px;">Connectez-vous a CS-PILOT pour valider ou refuser cette demande.</p>
     """
-    return envoyer_email(responsable_email, "Nouvelle demande de recuperation", contenu, responsable_prenom)
+    return envoyer_email(responsable_email, f"Nouvelle demande de {type_libelle}", contenu, responsable_prenom)
 
 
 def notifier_demande_recup_validee_responsable(direction_email, direction_prenom,
                                                 demande_user, responsable_nom,
-                                                date_debut, date_fin, nb_jours):
-    """Notifie la direction qu'une demande a ete validee par le responsable."""
+                                                date_debut, date_fin, nb_jours,
+                                                type_libelle='récupération'):
+    """Notifie la direction qu'une demande (recuperation ou congé) a ete validee
+    par le responsable. `type_libelle` adapte le libelle du courriel."""
     _e = html_module.escape
     contenu = f"""
-    <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">Demande de recuperation a valider</h3>
+    <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">Demande de {type_libelle} a valider</h3>
     <p>La demande de <strong>{_e(demande_user)}</strong> a ete validee par <strong>{_e(responsable_nom)}</strong>
        et est maintenant en attente de votre validation.</p>
     <table style="width:100%;border-collapse:collapse;margin:12px 0;">
@@ -277,27 +287,29 @@ def notifier_demande_recup_validee_responsable(direction_email, direction_prenom
     </table>
     <p style="margin-top:16px;">Connectez-vous a CS-PILOT pour valider ou refuser cette demande.</p>
     """
-    return envoyer_email(direction_email, "Demande de recuperation a valider", contenu, direction_prenom)
+    return envoyer_email(direction_email, f"Demande de {type_libelle} a valider", contenu, direction_prenom)
 
 
 def notifier_demande_recup_decision(salarie_email, salarie_prenom, decision,
-                                     date_debut, date_fin, nb_jours, motif_refus=''):
-    """Notifie le salarie de la decision sur sa demande de recuperation."""
+                                     date_debut, date_fin, nb_jours, motif_refus='',
+                                     type_libelle='récupération'):
+    """Notifie le salarie de la decision sur sa demande (recuperation ou congé).
+    `type_libelle` adapte le libelle du courriel."""
     _e = html_module.escape
     if decision == 'validee':
         statut_html = '<span style="color:#059669;font-weight:700;font-size:16px;">VALIDEE</span>'
-        detail = "<p>Vos jours de recuperation ont ete ajoutes automatiquement a votre calendrier.</p>"
+        detail = f"<p>Vos jours de {type_libelle} ont ete ajoutes automatiquement a votre calendrier.</p>"
     else:
         statut_html = '<span style="color:#dc2626;font-weight:700;font-size:16px;">REFUSEE</span>'
         detail = f"<p><strong>Motif du refus :</strong> {_e(motif_refus)}</p>" if motif_refus else ""
 
     contenu = f"""
-    <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">Decision sur votre demande de recuperation</h3>
-    <p>Votre demande de recuperation du <strong>{_e(date_debut)}</strong> au <strong>{_e(date_fin)}</strong>
+    <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">Decision sur votre demande de {type_libelle}</h3>
+    <p>Votre demande de {type_libelle} du <strong>{_e(date_debut)}</strong> au <strong>{_e(date_fin)}</strong>
        ({nb_jours} jour(s)) a ete : {statut_html}</p>
     {detail}
     """
-    sujet = f"Demande de recuperation {decision}"
+    sujet = f"Demande de {type_libelle} {decision}"
     return envoyer_email(salarie_email, sujet, contenu, salarie_prenom)
 
 

--- a/templates/absences.html
+++ b/templates/absences.html
@@ -17,7 +17,7 @@
                     <select id="user_id" name="user_id" required>
                         <option value="">-- Sélectionner un salarié --</option>
                         {% for s in salaries %}
-                        <option value="{{ s.id }}">{{ s.nom }} {{ s.prenom }} ({{ s.profil }})</option>
+                        <option value="{{ s.id }}" data-profil="{{ s.profil }}">{{ s.nom }} {{ s.prenom }} ({{ s.profil }})</option>
                         {% endfor %}
                     </select>
                 </div>
@@ -202,11 +202,16 @@ document.getElementById('date_fin').addEventListener('change', calculerJoursOuvr
 
 // Affichage des compteurs conges
 function chargerCompteursConges() {
-    var userId = document.getElementById('user_id').value;
+    var select = document.getElementById('user_id');
+    var userId = select.value;
     var motif = document.getElementById('motif').value;
     var compteursDiv = document.getElementById('compteurs-conges');
+    var opt = select.options[select.selectedIndex];
+    var profil = opt ? opt.getAttribute('data-profil') : '';
 
-    if (!userId || (motif !== 'Congé payé' && motif !== 'Congé conventionnel')) {
+    // La direction (forfait jours) ne suit pas les compteurs de congés salariés :
+    // ses congés sont décomptés sur son calendrier forfait, pas ici.
+    if (!userId || profil === 'directeur' || (motif !== 'Congé payé' && motif !== 'Congé conventionnel')) {
         compteursDiv.style.display = 'none';
         return;
     }

--- a/templates/creer_user.html
+++ b/templates/creer_user.html
@@ -172,8 +172,9 @@
             profilInfo.style.display = 'block';
             profilInfo.innerHTML = '<h4>💰 Profil Comptable</h4><p>Accès lecture seule à toutes les fiches + sa fiche personnelle (modification/validation).</p><p>Peut être rattaché à un secteur (optionnel) et doit pouvoir avoir un responsable hiérarchique.</p>';
         } else if (profil === 'directeur') {
+            secteurGroup.style.display = 'block';
             profilInfo.style.display = 'block';
-            profilInfo.innerHTML = '<h4>🎯 Profil Directeur</h4><p>Accès lecture seule à toutes les fiches + validation finale. <strong>Pas de fiche personnelle</strong> (forfait jour).</p>';
+            profilInfo.innerHTML = '<h4>🎯 Profil Directeur</h4><p>Accès lecture seule à toutes les fiches + validation finale. <strong>Pas de fiche personnelle</strong> (forfait jour).</p><p>Peut être rattaché à un secteur (optionnel) — utile pour les budgets, ex. Pilotage.</p>';
         } else if (profil === 'prestataire') {
             profilInfo.style.display = 'block';
             profilInfo.innerHTML = '<h4>📋 Profil Prestataire paie</h4><p>Accès uniquement à la page Préparation Paie. Ce profil n\'apparait pas dans les listes de salariés.</p>';

--- a/templates/modifier_user.html
+++ b/templates/modifier_user.html
@@ -160,7 +160,13 @@
             responsableGroup.style.display = 'block';
             soldeGroup.style.display = 'none';
             congesGroup.style.display = 'block';
-        } else if (profil === 'directeur' || profil === 'prestataire') {
+        } else if (profil === 'directeur') {
+            // La direction peut être rattachée à un secteur (utile pour les budgets).
+            secteurGroup.style.display = 'block';
+            responsableGroup.style.display = 'none';
+            soldeGroup.style.display = 'none';
+            congesGroup.style.display = 'none';
+        } else if (profil === 'prestataire') {
             secteurGroup.style.display = 'none';
             responsableGroup.style.display = 'none';
             soldeGroup.style.display = 'none';

--- a/tests/test_absences_forfait_jour.py
+++ b/tests/test_absences_forfait_jour.py
@@ -143,6 +143,30 @@ def test_suppression_absence_directeur_repasse_en_travaille(app, admin_client, d
     assert stats['travaille'] == _jours_ouvres_attendus(annee)
 
 
+def test_longue_absence_directeur_couvre_toutes_les_annees(app, admin_client, sample_users):
+    """Une longue absence d'un directeur couvrant plusieurs années (ex. congé
+    parental) est reportée sur CHAQUE année, y compris une année intermédiaire
+    entièrement couverte (initialisation de toute la plage d'années)."""
+    uid = sample_users['directeur_id']
+    # Du 02/11/2026 au 28/02/2028 : couvre 2026 (partiel), 2027 (entier), 2028 (partiel).
+    admin_client.post('/absences', data={
+        'user_id': uid, 'motif': 'Congé parental',
+        'date_debut': '2026-11-02', 'date_fin': '2028-02-28',
+    }, follow_redirects=True)
+
+    with app.app_context():
+        s2026 = utils.calculer_stats_forfait_jour(uid, 2026)
+        s2027 = utils.calculer_stats_forfait_jour(uid, 2027)
+        s2028 = utils.calculer_stats_forfait_jour(uid, 2028)
+
+    # 2027 entièrement couvert : aucun jour travaillé, tous les jours ouvrés en absence.
+    assert s2027['travaille'] == 0
+    assert s2027['autre'] == _jours_ouvres_attendus(2027)
+    # 2026 et 2028 partiellement couverts : il reste des jours travaillés hors absence.
+    assert s2026['travaille'] > 0 and s2026['autre'] > 0
+    assert s2028['travaille'] > 0 and s2028['autre'] > 0
+
+
 def test_arret_maladie_salarie_reste_sur_heures_reelles(app, admin_client, sample_users):
     """Le comportement salarié est inchangé : l'absence va sur heures_reelles et
     RIEN n'est écrit sur le calendrier forfait jours."""

--- a/tests/test_absences_forfait_jour.py
+++ b/tests/test_absences_forfait_jour.py
@@ -1,0 +1,166 @@
+"""
+Report des absences (arrêt maladie / congés) sur le calendrier forfait jours
+de la direction.
+
+La direction (forfait jours) tient son calendrier et son décompte dans
+`presence_forfait_jour`, et non dans `heures_reelles` / les compteurs de congés
+salariés. Une absence saisie pour un directeur doit donc :
+- marquer les jours ouvrés concernés du bon type (maladie, conge_paye…) ;
+- ajuster automatiquement le décompte (jours travaillés −, soldes CP/maladie +) ;
+- ne PAS toucher aux tables/compteurs salariés.
+
+Le comportement salarié doit rester strictement inchangé.
+"""
+from datetime import datetime, timedelta
+
+import utils
+import database
+
+
+def _un_jour_ouvre(annee, mois, decalage=0):
+    """(1 + decalage)-ième jour ouvré (lun-ven) du mois, format YYYY-MM-DD."""
+    jour = datetime(annee, mois, 1)
+    trouves = 0
+    while True:
+        if jour.weekday() < 5:
+            if trouves == decalage:
+                return jour.strftime('%Y-%m-%d')
+            trouves += 1
+        jour += timedelta(days=1)
+
+
+def _jours_ouvres_attendus(annee):
+    """Nombre de jours lun-ven de l'année (aucun férié dans la base de test)."""
+    n = 0
+    jour = datetime(annee, 1, 1)
+    fin = datetime(annee, 12, 31)
+    while jour <= fin:
+        if jour.weekday() < 5:
+            n += 1
+        jour += timedelta(days=1)
+    return n
+
+
+def _type_du_jour(app, user_id, date):
+    with app.app_context():
+        conn = database.get_db()
+        row = conn.execute(
+            "SELECT type_journee FROM presence_forfait_jour WHERE user_id = ? AND date = ?",
+            (user_id, date)
+        ).fetchone()
+        conn.close()
+    return row['type_journee'] if row else None
+
+
+def _compte(app, table, user_id, date=None):
+    with app.app_context():
+        conn = database.get_db()
+        if date is None:
+            row = conn.execute(f"SELECT COUNT(*) AS n FROM {table} WHERE user_id = ?", (user_id,)).fetchone()
+        else:
+            row = conn.execute(
+                f"SELECT COUNT(*) AS n FROM {table} WHERE user_id = ? AND date = ?", (user_id, date)
+            ).fetchone()
+        conn.close()
+    return row['n']
+
+
+def test_arret_maladie_directeur_reporte_sur_forfait(app, admin_client, sample_users):
+    """Un arrêt maladie saisi pour un directeur apparaît sur son forfait jours et
+    ajuste le décompte, sans écrire dans heures_reelles."""
+    annee = 2026
+    jour = _un_jour_ouvre(annee, 3)
+    uid = sample_users['directeur_id']
+
+    resp = admin_client.post('/absences', data={
+        'user_id': uid, 'motif': 'Arrêt maladie',
+        'date_debut': jour, 'date_fin': jour,
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+
+    # Marqué 'maladie' sur le calendrier forfait
+    assert _type_du_jour(app, uid, jour) == 'maladie'
+
+    # Décompte ajusté : 1 jour maladie, 1 jour travaillé de moins
+    with app.app_context():
+        stats = utils.calculer_stats_forfait_jour(uid, annee)
+    assert stats['maladie'] == 1
+    assert stats['travaille'] == _jours_ouvres_attendus(annee) - 1
+
+    # Rien dans heures_reelles (table des salariés)
+    assert _compte(app, 'heures_reelles', uid, jour) == 0
+
+
+def test_conge_paye_directeur_reporte_sans_toucher_compteurs_salaries(app, admin_client, db, sample_users):
+    """Un congé payé pour un directeur marque le forfait (conge_paye) et décrémente
+    le solde CP du décompte, sans toucher aux compteurs de congés salariés."""
+    annee = 2026
+    jour = _un_jour_ouvre(annee, 4)
+    uid = sample_users['directeur_id']
+
+    cp_avant = db.execute("SELECT cp_pris FROM users WHERE id = ?", (uid,)).fetchone()['cp_pris']
+
+    admin_client.post('/absences', data={
+        'user_id': uid, 'motif': 'Congé payé',
+        'date_debut': jour, 'date_fin': jour,
+    }, follow_redirects=True)
+
+    assert _type_du_jour(app, uid, jour) == 'conge_paye'
+
+    with app.app_context():
+        stats = utils.calculer_stats_forfait_jour(uid, annee)
+    assert stats['conge_paye'] == 1
+    assert stats['soldes']['conges_payes_restants'] == 25 - 1
+
+    # Les compteurs de congés salariés du directeur n'ont pas bougé
+    cp_apres = db.execute("SELECT cp_pris FROM users WHERE id = ?", (uid,)).fetchone()['cp_pris']
+    assert (cp_apres or 0) == (cp_avant or 0)
+
+
+def test_suppression_absence_directeur_repasse_en_travaille(app, admin_client, db, sample_users):
+    """Supprimer l'absence d'un directeur repasse les jours concernés en travaillé."""
+    annee = 2026
+    jour = _un_jour_ouvre(annee, 5)
+    uid = sample_users['directeur_id']
+
+    admin_client.post('/absences', data={
+        'user_id': uid, 'motif': 'Arrêt maladie',
+        'date_debut': jour, 'date_fin': jour,
+    }, follow_redirects=True)
+    assert _type_du_jour(app, uid, jour) == 'maladie'
+
+    absence_id = db.execute(
+        "SELECT id FROM absences WHERE user_id = ? ORDER BY id DESC LIMIT 1", (uid,)
+    ).fetchone()['id']
+    resp = admin_client.post(f'/absences/supprimer/{absence_id}', follow_redirects=True)
+    assert resp.status_code == 200
+
+    # Le jour est de nouveau 'travaille', et le décompte maladie est revenu à 0
+    assert _type_du_jour(app, uid, jour) == 'travaille'
+    with app.app_context():
+        stats = utils.calculer_stats_forfait_jour(uid, annee)
+    assert stats['maladie'] == 0
+    assert stats['travaille'] == _jours_ouvres_attendus(annee)
+
+
+def test_arret_maladie_salarie_reste_sur_heures_reelles(app, admin_client, sample_users):
+    """Le comportement salarié est inchangé : l'absence va sur heures_reelles et
+    RIEN n'est écrit sur le calendrier forfait jours."""
+    jour = _un_jour_ouvre(2026, 6)
+    uid = sample_users['salarie_id']
+
+    admin_client.post('/absences', data={
+        'user_id': uid, 'motif': 'Arrêt maladie',
+        'date_debut': jour, 'date_fin': jour,
+    }, follow_redirects=True)
+
+    with app.app_context():
+        conn = database.get_db()
+        row = conn.execute(
+            "SELECT type_saisie FROM heures_reelles WHERE user_id = ? AND date = ?", (uid, jour)
+        ).fetchone()
+        conn.close()
+    assert row is not None and row['type_saisie'] == 'absence'
+
+    # Aucun report sur le forfait jours pour un salarié
+    assert _compte(app, 'presence_forfait_jour', uid) == 0

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -959,6 +959,33 @@ def test_paie_direction_rattachee_au_secteur_administratif(app, db):
     assert not any(e['id'] == did for e in op_emps)
 
 
+def test_paie_direction_assignee_a_son_secteur(app, db):
+    """Un directeur RATTACHÉ à un secteur (ex. « Pilotage ») est compté dans CE
+    secteur pour le budget, et n'est plus rattaché d'office à l'administratif
+    principal (pas de double comptage)."""
+    from blueprints.budget import _paie_employes_secteur
+    annee = 2026
+    with app.app_context():
+        # Deux secteurs administratifs : 'Admin' (id le plus petit = principal)
+        # et 'Pilotage'. La direction est explicitement rattachée à Pilotage.
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Admin','administratif')")
+        admin_sid = db.execute("SELECT id FROM secteurs WHERE nom='Admin'").fetchone()['id']
+        db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Pilotage','administratif')")
+        pil_sid = db.execute("SELECT id FROM secteurs WHERE nom='Pilotage'").fetchone()['id']
+        db.execute("INSERT INTO users (nom,prenom,login,password,profil,actif,secteur_id,date_entree) "
+                   "VALUES ('Dir','Pil','dir_pil','x','directeur',1,?,?)", (pil_sid, f'{annee-5}-01-01'))
+        did = db.execute("SELECT id FROM users WHERE login='dir_pil'").fetchone()['id']
+        db.execute("INSERT INTO contrats (user_id,type_contrat,date_debut,date_fin) VALUES (?, 'CDI', ?, NULL)",
+                   (did, f'{annee-5}-01-01'))
+        db.commit()
+        admin_emps = _paie_employes_secteur(db, admin_sid, annee)
+        pil_emps = _paie_employes_secteur(db, pil_sid, annee)
+    # Compté dans son secteur (Pilotage)...
+    assert any(e['id'] == did for e in pil_emps)
+    # ... et plus dans l'administratif principal (pas de double comptage).
+    assert not any(e['id'] == did for e in admin_emps)
+
+
 def test_paie_maintien_ajoute_au_brut(app, db, admin_client):
     """Le maintien de salaire s'ajoute au brut mensuel et est persisté sur la fiche."""
     annee = 2026

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -1,0 +1,58 @@
+"""
+Libellé des notifications e-mail selon le type de demande (récupération / congé).
+
+Les demandes de congé réutilisent les mêmes constructeurs que les
+récupérations : le paramètre `type_libelle` doit adapter l'objet et le corps
+pour ne pas parler de « récupération » à propos d'un congé.
+"""
+import email_service
+
+
+def _capturer(monkeypatch):
+    """Intercepte les envois : renvoie la liste des (sujet, contenu)."""
+    calls = []
+    monkeypatch.setattr(
+        email_service, 'envoyer_email',
+        lambda dest, sujet, contenu, prenom='': (calls.append((sujet, contenu)), (True, 'ok'))[1]
+    )
+    return calls
+
+
+def test_emails_conge_disent_conge(monkeypatch):
+    calls = _capturer(monkeypatch)
+    email_service.notifier_nouvelle_demande_recup(
+        'Jean', 'a@b.c', 'Marie', '2026-03-09', '2026-03-11', 3, 0, type_libelle='congé')
+    email_service.notifier_demande_recup_validee_responsable(
+        'a@b.c', 'Dir', 'Jean', 'Marie', '2026-03-09', '2026-03-11', 3, type_libelle='congé')
+    email_service.notifier_demande_recup_decision(
+        'a@b.c', 'Jean', 'validee', '2026-03-09', '2026-03-11', 3, type_libelle='congé')
+
+    sujets = [s for s, _ in calls]
+    assert sujets == [
+        'Nouvelle demande de congé',
+        'Demande de congé a valider',
+        'Demande de congé validee',
+    ]
+    # Aucun e-mail de congé ne doit parler de « récupération ».
+    for sujet, contenu in calls:
+        assert 'récupération' not in sujet
+        assert 'récupération' not in contenu
+
+
+def test_emails_recup_restent_recuperation_par_defaut(monkeypatch):
+    calls = _capturer(monkeypatch)
+    email_service.notifier_nouvelle_demande_recup(
+        'Jean', 'a@b.c', 'Marie', '2026-03-09', '2026-03-09', 1, 3.5)  # défaut
+
+    sujet, contenu = calls[0]
+    assert sujet == 'Nouvelle demande de récupération'
+    assert '3.50h' in contenu  # les heures restent affichées pour une récup
+
+
+def test_email_conge_masque_les_heures_nulles(monkeypatch):
+    calls = _capturer(monkeypatch)
+    email_service.notifier_nouvelle_demande_recup(
+        'Jean', 'a@b.c', 'Marie', '2026-03-09', '2026-03-11', 3, 0, type_libelle='congé')
+    _, contenu = calls[0]
+    assert '0.00h' not in contenu       # pas de « - 0.00h » pour un congé
+    assert '3 jour(s)' in contenu


### PR DESCRIPTION
Plusieurs améliorations autour de la direction, des absences et des budgets.

---

## 1. Arrêts maladie & congés reportés sur le forfait jours de la direction

Un arrêt maladie / congé saisi pour un directeur n'apparaissait ni sur son **calendrier forfait jours** ni dans son **décompte** (l'automatisation écrivait dans `heures_reelles`, table des salariés ; le forfait lit `presence_forfait_jour`).

- `_reporter_absence_sur_calendrier` aiguille selon le profil → pour un directeur, écriture dans `presence_forfait_jour` (type `maladie`, `conge_paye`, …). L'absence prime.
- Le décompte se recalcule tout seul (jours travaillés −, soldes +).
- Suppression → jours repassés en « travaillé ». Compteurs de congés **salariés** non touchés pour un directeur.
- Comportement salarié strictement inchangé.

## 2. Formulaire d'absence : bloc « compteurs congés » masqué pour la direction

Ces compteurs (colonnes salariées CP/CC) n'ont pas de sens pour un forfait jours ; le bloc est masqué quand l'utilisateur sélectionné est un directeur.

## 3. E-mails de congé : bon libellé

Les demandes de **congé** réutilisaient les modèles d'e-mail des **récupérations** (objet/corps « demande de récupération »). Les constructeurs prennent un paramètre `type_libelle` (« récupération » par défaut, « congé » aux points d'appel des congés : soumission + décisions). Les heures `- 0.00h` sont masquées pour un congé. Récupérations inchangées.

## 4. Rattachement d'un directeur à un secteur (budgets)

La direction peut désormais appartenir à un secteur (ex. « Pilotage » = administratif **+** direction), utile pour les budgets. C'était bloqué uniquement côté formulaire.

- `creer_user.html` / `modifier_user.html` : le sélecteur de secteur s'affiche pour le profil directeur (serveur inchangé — `secteur_id` était déjà persisté).
- `budget.py` `_paie_employes_secteur` : un directeur **rattaché** à un secteur est compté dans **ce** secteur ; une direction **sans** secteur reste rattachée d'office à l'administratif principal, **sans double comptage**.

---

## Vérifications (démonstration)

- **Forfait** : arrêt maladie 9–11 mars + congé 23–24 mars visibles sur le calendrier, décompte à jour.
- **Secteur** : le sélecteur apparaît pour une directrice ; sélection de « Pilotage » → `secteur_id` persisté ; comptée dans le budget Pilotage.

## Tests

- Forfait : maladie / congé d'un directeur reportés + décompte + suppression + non-régression salarié (4).
- E-mails : libellés congé vs récupération, masquage des heures nulles (3).
- Budget : directeur rattaché compté dans son secteur, pas de double comptage (1).
- Suite complète : **656 tests** (+ 3 tests e-mail unitaires) au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5