### PR TITLE
Planificateur : rendre gérables les tâches non planifiables (fin des « tâches fantômes »)

### DIFF
--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -437,6 +437,31 @@ def _serialiser_blocs(conn, user_id, debut, fin):
     return blocs
 
 
+def _taches_non_placees(conn, user_id):
+    """Taches (non recurrentes, a faire) sans aucun bloc futur planifie.
+
+    Ce sont les taches que le moteur n'a pas pu caser : echeance depassee sans
+    capacite, horizon sature, ou tache non secable plus longue que le plus grand
+    creneau. N'ayant aucun bloc sur le calendrier, elles seraient invisibles et
+    non gerables ; on les expose a part pour qu'elles restent modifiables,
+    reportables et supprimables (sinon elles deviennent des « taches fantomes »
+    qui declenchent l'alerte sans pouvoir etre corrigees).
+    """
+    today = aujourd_hui().isoformat()
+    rows = conn.execute(
+        '''SELECT t.* FROM planif_taches t
+           WHERE t.user_id = ? AND t.type = 'tache' AND t.statut = 'a_faire'
+             AND t.recurrence_id IS NULL
+             AND NOT EXISTS (
+                 SELECT 1 FROM planif_blocs b
+                 WHERE b.tache_id = t.id AND b.date >= ?
+             )
+           ORDER BY t.deadline IS NULL, t.deadline''',
+        (user_id, today)
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
 # ── Validation des entrees ─────────────────────────────────────────────────
 
 def _parse_int(valeur, defaut=0, mini=None, maxi=None):
@@ -494,27 +519,16 @@ def planificateur():
         ).fetchall()
 
         # Taches sans bloc futur planifie = non placees (indicateur persistant).
-        today = aujourd_hui().isoformat()
         # Les occurrences recurrentes sont exclues : elles sont placees « au
         # mieux, la ou il reste de la place » et leur absence n'est pas une
         # anomalie a signaler.
-        taches_non_placees = conn.execute(
-            '''SELECT t.* FROM planif_taches t
-               WHERE t.user_id = ? AND t.type = 'tache' AND t.statut = 'a_faire'
-                 AND t.recurrence_id IS NULL
-                 AND NOT EXISTS (
-                     SELECT 1 FROM planif_blocs b
-                     WHERE b.tache_id = t.id AND b.date >= ?
-                 )
-               ORDER BY t.deadline IS NULL, t.deadline''',
-            (user_id, today)
-        ).fetchall()
+        taches_non_placees = _taches_non_placees(conn, user_id)
 
         return render_template(
             'planificateur.html',
             vue=vue, date_ref=date_ref,
             recurrences=[dict(r) for r in recurrences],
-            taches_non_placees=[dict(r) for r in taches_non_placees],
+            taches_non_placees=taches_non_placees,
             a_un_planning=a_un_planning,
             horaire_defaut_txt=horaire_defaut_txt,
         )
@@ -537,7 +551,12 @@ def api_blocs():
             conn, user_id, date.fromisoformat(debut), date.fromisoformat(fin)
         )
         horaires = {k: [[d, f] for (d, f) in v] for k, v in horaires_min.items()}
-        return jsonify({'ok': True, 'blocs': blocs, 'horaires': horaires})
+        # Taches non placees : renvoyees a chaque rafraichissement pour que le
+        # bandeau reste a jour apres une action (creation, suppression...) sans
+        # rechargement complet de la page.
+        non_placees = _taches_non_placees(conn, user_id)
+        return jsonify({'ok': True, 'blocs': blocs, 'horaires': horaires,
+                        'non_placees': non_placees})
     finally:
         conn.close()
 

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -333,6 +333,13 @@
 .planif-detail-actions{display:flex;flex-wrap:wrap;gap:.5rem;margin-top:1rem;}
 .planif-detail-actions .btn{font-size:.82rem;padding:.4rem .7rem;}
 .planif-alerte{background:#fdf2cf;border:1px solid #ba7a2a;color:#7a5314;border-radius:var(--radius-sm);padding:.6rem .8rem;margin-bottom:1rem;font-size:.88rem;}
+.planif-alerte-intro{margin-bottom:.5rem;font-weight:600;}
+.planif-np-item{display:flex;align-items:center;flex-wrap:wrap;gap:.5rem;padding:.4rem 0;border-top:1px solid rgba(186,122,42,.35);}
+.planif-np-item:first-of-type{border-top:none;}
+.planif-np-nom{font-weight:600;}
+.planif-np-meta{color:#8a6a2e;font-size:.8rem;}
+.planif-np-actions{display:flex;gap:.35rem;margin-left:auto;flex-wrap:wrap;}
+.planif-np-actions .btn{font-size:.78rem;padding:.3rem .55rem;}
 .planif-toasts{position:fixed;bottom:20px;right:20px;display:flex;flex-direction:column;gap:.5rem;z-index:10000;}
 .planif-toast{background:var(--gray-900);color:#fff;padding:.7rem 1rem;border-radius:var(--radius-sm);box-shadow:var(--shadow-lg);font-size:.85rem;max-width:340px;animation:planifIn .2s ease;}
 .planif-toast.err{background:#7f1d1d;}
@@ -369,6 +376,7 @@
   const state = { vue: DATA.vue || 'semaine', date: DATA.date || isoToday() };
   let blocsCache = [];
   let horairesCache = {};
+  let nonPlaceesCache = DATA.taches_non_placees || [];
 
   // ── Helpers dates ──
   function isoToday(){ const d=new Date(); return iso(d); }
@@ -442,8 +450,10 @@
       const j = await apiGet('{{ url_for("planificateur_bp.api_blocs") }}?debut='+deb+'&fin='+fin);
       blocsCache = (j && j.blocs) ? j.blocs : [];
       horairesCache = (j && j.horaires) ? j.horaires : {};
+      nonPlaceesCache = (j && j.non_placees) ? j.non_placees : [];
     }catch(e){ blocsCache=[]; horairesCache={}; }
     rendre();
+    rendreNonPlacees();
   }
   function rendre(){
     document.querySelectorAll('#planifViews button').forEach(b=>b.classList.toggle('active', b.dataset.vue===state.vue));
@@ -844,14 +854,46 @@
   document.getElementById('t_secable').addEventListener('change', e=>{ document.getElementById('grpMinBloc').style.display=e.target.checked?'':'none'; });
   document.addEventListener('keydown', e=>{ if(e.key==='Escape') planifFermerModales(); });
 
-  // Bandeau tâches non placées (chargé côté serveur)
-  (function(){
-    const np=DATA.taches_non_placees||[];
-    if(np.length){
-      const titres=np.map(t=>esc(t.titre)).slice(0,5).join(', ');
-      document.getElementById('planifAlertes').innerHTML='<div class="planif-alerte">⚠️ '+np.length+' tâche(s) sans créneau planifié : '+titres+'. Ajustez les horaires, échéances ou cliquez sur « Replanifier ».</div>';
-    }
-  })();
+  // ── Bandeau tâches non placées (actionnable) ──
+  // Une tâche que le moteur n'a pas pu caser n'a aucun bloc sur le calendrier :
+  // sans ce panneau, elle serait invisible et impossible à corriger/supprimer.
+  function npToBloc(t){
+    return { tache_id:t.id, titre:t.titre, description:t.description||'', type:'tache',
+      deadline:t.deadline||'', priorite:t.priorite||'normale', preference:t.preference||'aucune',
+      secable:!!t.secable, duree_min_bloc:t.duree_min_bloc||30, tache_duree_min:t.duree_min };
+  }
+  async function actionNonPlacee(act, t){
+    try{
+      let res=null;
+      if(act==='reporter'){ const d=prompt('Reporter à partir de quelle date ? (AAAA-MM-JJ)', addDays(isoToday(),1)); if(!d) return; res=await apiPost('/planificateur/api/tache/'+t.id+'/reporter',{date_min:d}); }
+      else if(act==='suppr'){ if(!confirm('Supprimer définitivement la tâche « '+t.titre+' » ?')) return; res=await apiPost('/planificateur/api/tache/'+t.id+'/supprimer',{}); }
+      else if(act==='modifier'){ return ouvrirEdition(npToBloc(t)); }
+      if(res){ toast('✓ Mis à jour','ok'); montrerNonPlanifie(res.non_planifie); }
+      await charger();
+    }catch(e){ toast(e.message,'err'); }
+  }
+  function rendreNonPlacees(){
+    const box=document.getElementById('planifAlertes');
+    const np=nonPlaceesCache||[];
+    if(!np.length){ box.innerHTML=''; return; }
+    let h='<div class="planif-alerte"><div class="planif-alerte-intro">⚠️ '+np.length+' tâche(s) sans créneau planifié (échéance dépassée, capacité insuffisante ou tâche non sécable trop longue). Modifiez-les, reportez-les ou supprimez-les :</div>';
+    np.forEach((t,i)=>{
+      const ech = t.deadline ? ('échéance '+fmtFR(t.deadline)) : 'sans échéance';
+      h+='<div class="planif-np-item"><span class="planif-np-nom">'+esc(t.titre)+'</span>'
+        +'<span class="planif-np-meta">'+dureeTxt(t.duree_min)+' · '+ech+(t.secable?'':' · non sécable')+'</span>'
+        +'<span class="planif-np-actions">'
+        +'<button class="btn btn-secondary" data-np="modifier" data-i="'+i+'">✏️ Modifier</button>'
+        +'<button class="btn btn-secondary" data-np="reporter" data-i="'+i+'">📆 Reporter</button>'
+        +'<button class="btn btn-danger" data-np="suppr" data-i="'+i+'">🗑 Supprimer</button>'
+        +'</span></div>';
+    });
+    h+='</div>';
+    box.innerHTML=h;
+    box.querySelectorAll('[data-np]').forEach(btn=>{
+      btn.addEventListener('click', ()=>actionNonPlacee(btn.dataset.np, np[+btn.dataset.i]));
+    });
+  }
+  rendreNonPlacees();
 
   charger();
 })();

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -432,6 +432,39 @@ def test_creer_tache_genere_des_blocs(comptable_client):
     assert all(b['titre'] == 'Cloture comptable' for b in data['blocs'])
 
 
+def test_tache_non_placee_exposee_et_supprimable(comptable_client):
+    """Une tache que le moteur ne peut pas caser (non secable, plus longue que
+    le plus grand creneau) n'a aucun bloc mais reste exposee dans `non_placees`,
+    donc modifiable / reportable / supprimable — plus de « tache fantome »."""
+    demain = (date.today() + timedelta(days=5)).isoformat()
+    r = comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Gros dossier', 'duree_min': 300,
+        'deadline': demain, 'priorite': 'normale', 'preference': 'aucune',
+        'secable': 0, 'duree_min_bloc': 30,
+    })
+    assert r.status_code == 200
+    # Signalee comme non planifiee des la creation.
+    assert any('Gros dossier' in (x.get('titre') or '')
+               for x in r.get_json().get('non_planifie', []))
+
+    debut = date.today().isoformat()
+    fin = (date.today() + timedelta(days=14)).isoformat()
+    data = comptable_client.get(
+        f'/planificateur/api/blocs?debut={debut}&fin={fin}').get_json()
+    # Aucun bloc sur le calendrier, mais exposee dans non_placees (avec son id).
+    assert all(b['titre'] != 'Gros dossier' for b in data['blocs'])
+    cibles = [t for t in data['non_placees'] if t['titre'] == 'Gros dossier']
+    assert len(cibles) == 1
+    tid = cibles[0]['id']
+
+    # Supprimable directement depuis le bandeau (l'action pointe sur cet id).
+    d = comptable_client.post(f'/planificateur/api/tache/{tid}/supprimer', json={})
+    assert d.status_code == 200
+    data2 = comptable_client.get(
+        f'/planificateur/api/blocs?debut={debut}&fin={fin}').get_json()
+    assert all(t['titre'] != 'Gros dossier' for t in data2['non_placees'])
+
+
 def test_creer_evenement_fixe_bloc_verrouille(comptable_client, db):
     jour = (date.today() + timedelta(days=2)).isoformat()
     resp = comptable_client.post('/planificateur/api/tache', json={


### PR DESCRIPTION
## Le bug

Sur le planificateur, une tâche non réalisée qui ne peut pas être recasée déclenchait l'alerte « éléments non planifiés » mais **n'apparaissait nulle part** et **restait impossible à supprimer** — une « tâche fantôme ». La recréer sous le même nom ne faisait que dupliquer le problème (le nom n'y est pour rien : il n'y a aucune contrainte d'unicité, c'était une coïncidence).

### Cause

Une tâche que le moteur ne parvient pas à placer (échéance dépassée sans capacité, horizon saturé, ou **tâche non sécable plus longue que le plus grand créneau**) n'obtient **aucun bloc** sur le calendrier. Or toutes les actions — modifier, reporter, terminer, **supprimer** — étaient portées par les blocs du calendrier. Sans bloc, aucune prise : la tâche générait l'alerte mais échappait à toute correction.

De plus, le bandeau des tâches non placées n'était rendu **qu'au chargement de la page** (côté serveur) : après une création/suppression en AJAX il restait figé, renforçant l'impression de tâche « collée ».

## Le correctif

Le bandeau des tâches non placées devient **actionnable** : chaque tâche y est listée avec sa durée / son échéance et trois boutons **✏️ Modifier · 📆 Reporter · 🗑 Supprimer**, qui réutilisent les endpoints existants. Il est en outre **réhydraté via l'API à chaque action**, donc toujours à jour.

- `_taches_non_placees(conn, user_id)` : requête extraite, réutilisée par la page **et** par `/api/blocs` (qui renvoie désormais `non_placees`).
- Front : le bandeau statique devient une liste d'items avec actions, reconstruite à chaque `charger()`.

## Tests

- Nouveau test : une tâche non sécable trop longue pour tout créneau n'a aucun bloc mais est **exposée dans `non_placees` avec son id, puis supprimée directement** — plus de tâche fantôme.
- Suite complète : **672 tests** au vert.

## Vérification visuelle

- Deux tâches non sécables trop longues apparaissent dans le bandeau avec les actions Modifier / Reporter / Supprimer ; une tâche sécable de même échéance est, elle, correctement planifiée sur le calendrier. Suppression testée : l'item disparaît sans rechargement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5

---
_Generated by [Claude Code](https://claude.ai/code/session_014HMmo12Zzmj91wAzVeKMf5)_