### PR TITLE
Subventions : catégories par type de subvention

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Approbation des factures par les responsables
 
 ### Subventions et benevoles
-- Gestion des dossiers de subventions en kanban (Nouveau → Envoye → Accepte / Refuse)
+- Gestion des dossiers de subventions organises par type de financeur (SUBV. GLOBAL, CAF PS, CAF, VILLE, METROPOLE, ETAT, AUTRES — types personnalisables : creation / suppression)
+- Statut d'avancement editable par dossier (nouveau projet / en cours / accepte / refuse), conserve pour les tableaux de bord
 - Gestion des benevoles avec suivi des heures assignees
 
 ### CSE (Comite Social et Economique)

--- a/blueprints/chatbot.py
+++ b/blueprints/chatbot.py
@@ -117,9 +117,10 @@ PAGE_PROMPTS = {
         "L'utilisateur est sur la page Subventions. Ce module permet de gérer les subventions reçues "
         "ou demandées par la structure. "
         "Points importants : "
+        "- Les subventions sont classées par type de financeur (SUBV. GLOBAL, CAF PS, CAF, VILLE, METROPOLE, ETAT, AUTRES), types personnalisables "
         "- Indiquer les deadlines (dates limites) est crucial pour ne pas rater les échéances "
         "- Les personnes assignées à une subvention y ont accès et voient les tâches qu'elles doivent réaliser "
-        "- Le suivi permet de connaître l'état d'avancement de chaque subvention "
+        "- Le suivi permet de connaître l'état d'avancement de chaque subvention (statut : nouveau projet, en cours, accepté, refusé) "
         "Tu peux répondre aux questions générales des responsables sur le fonctionnement des subventions "
         "dans le contexte associatif (demande, conventionnement, justification, bilan)."
     ),

--- a/blueprints/subventions.py
+++ b/blueprints/subventions.py
@@ -7,6 +7,7 @@ Les responsables ne voient que les subventions auxquelles ils sont assignes.
 import os
 import re
 import json
+import sqlite3
 import unicodedata
 from datetime import datetime
 from flask import (Blueprint, render_template, request, redirect,
@@ -77,6 +78,14 @@ def _peut_voir():
 
 def _peut_modifier():
     return session.get('profil') in ('directeur', 'comptable', 'responsable')
+
+
+def _peut_gerer_types():
+    """La gestion des types (creation / renommage / suppression) est une action
+    globale : elle modifie le classement de toutes les subventions. Elle est donc
+    reservee a la direction et a la comptabilite — en coherence avec l'interface
+    qui masque « Gerer les types » aux responsables."""
+    return session.get('profil') in ('directeur', 'comptable')
 
 
 def _get_initiales(prenom, nom):
@@ -366,6 +375,14 @@ def api_modifier_subvention(sub_id):
 
     conn = get_db()
     try:
+        # Coherence avec la creation : refuser un type inexistant plutot que de
+        # laisser une reference orpheline (les FK ne sont pas activees).
+        if field == 'type_id' and value is not None:
+            if not conn.execute(
+                'SELECT 1 FROM subventions_types WHERE id = ?', (value,)
+            ).fetchone():
+                return jsonify({'ok': False, 'error': 'Type introuvable'}), 404
+
         # Detecter un changement d'assignation pour notifier le nouvel assigne.
         infos_notif = None
         if field in ('assignee_1_id', 'assignee_2_id') and value:
@@ -415,7 +432,7 @@ def api_supprimer_subvention(sub_id):
 @subventions_bp.route('/api/subventions/types/ajouter', methods=['POST'])
 @login_required
 def api_ajouter_type():
-    if not _peut_modifier():
+    if not _peut_gerer_types():
         return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
 
     data = request.get_json(silent=True) or {}
@@ -437,10 +454,21 @@ def api_ajouter_type():
             'SELECT COUNT(*) AS n, COALESCE(MAX(ordre), -1) AS m FROM subventions_types'
         ).fetchone()
         couleur = TYPE_COULEURS[row['n'] % len(TYPE_COULEURS)]
-        cursor = conn.execute(
-            'INSERT INTO subventions_types (nom, couleur, ordre) VALUES (?, ?, ?)',
-            (nom, couleur, row['m'] + 1)
-        )
+        try:
+            cursor = conn.execute(
+                'INSERT INTO subventions_types (nom, couleur, ordre) VALUES (?, ?, ?)',
+                (nom, couleur, row['m'] + 1)
+            )
+        except sqlite3.IntegrityError:
+            # Course entre deux creations simultanees du meme nom : renvoyer l'existant.
+            existing = conn.execute(
+                'SELECT id, nom, couleur FROM subventions_types WHERE nom = ? COLLATE NOCASE',
+                (nom,)
+            ).fetchone()
+            if existing:
+                return jsonify({'ok': True, 'id': existing['id'], 'nom': existing['nom'],
+                                'couleur': existing['couleur'], 'existe': True})
+            return jsonify({'ok': False, 'error': 'Ce type existe déjà'}), 400
         conn.commit()
         return jsonify({'ok': True, 'id': cursor.lastrowid, 'nom': nom, 'couleur': couleur})
     finally:
@@ -450,7 +478,7 @@ def api_ajouter_type():
 @subventions_bp.route('/api/subventions/types/<int:type_id>/modifier', methods=['POST'])
 @login_required
 def api_modifier_type(type_id):
-    if not _peut_modifier():
+    if not _peut_gerer_types():
         return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
 
     data = request.get_json(silent=True) or {}
@@ -461,6 +489,10 @@ def api_modifier_type(type_id):
         return jsonify({'ok': False, 'error': f'Champ non autorisé: {field}'}), 400
     if field == 'nom' and not value:
         return jsonify({'ok': False, 'error': 'Nom requis'}), 400
+    # La couleur alimente des attributs de style et le JS inline de la page :
+    # on impose un code hexadecimal strict (#rrggbb) pour eviter toute injection.
+    if field == 'couleur' and not re.fullmatch(r'#[0-9A-Fa-f]{6}', value):
+        return jsonify({'ok': False, 'error': 'Couleur invalide'}), 400
 
     conn = get_db()
     try:
@@ -485,7 +517,7 @@ def api_modifier_type(type_id):
 @subventions_bp.route('/api/subventions/types/<int:type_id>/supprimer', methods=['POST'])
 @login_required
 def api_supprimer_type(type_id):
-    if not _peut_modifier():
+    if not _peut_gerer_types():
         return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
 
     conn = get_db()

--- a/blueprints/subventions.py
+++ b/blueprints/subventions.py
@@ -18,14 +18,32 @@ subventions_bp = Blueprint('subventions_bp', __name__)
 
 DOCUMENTS_DIR = os.path.join(DATA_DIR, 'documents', 'subventions')
 
-GROUPES = [
+# Statuts d'avancement d'une subvention (conserves pour les tableaux de bord :
+# pipeline, echeances a venir, exclusion des refusees). Sur la page subventions,
+# ce statut est affiche comme une petite etiquette editable par ligne — le
+# regroupement principal se fait desormais par type de subvention.
+STATUTS = [
     {'key': 'nouveau_projet', 'label': 'Nouveau projet', 'color': '#579bfc'},
-    {'key': 'en_cours', 'label': 'Subvention en cours', 'color': '#fdab3d'},
-    {'key': 'acceptee', 'label': 'Subventions acceptées', 'color': '#00c875'},
-    {'key': 'refusee', 'label': 'Subventions refusées', 'color': '#e2445c'},
+    {'key': 'en_cours', 'label': 'En cours', 'color': '#fdab3d'},
+    {'key': 'acceptee', 'label': 'Acceptée', 'color': '#00c875'},
+    {'key': 'refusee', 'label': 'Refusée', 'color': '#e2445c'},
 ]
 
-GROUPES_MAP = {g['key']: g for g in GROUPES}
+STATUTS_MAP = {s['key']: s for s in STATUTS}
+
+# Groupe (statut) par defaut a la creation d'une subvention.
+STATUT_DEFAUT = 'nouveau_projet'
+
+# Palette de couleurs attribuee aux nouveaux types de subvention crees par
+# l'utilisateur (cyclee selon le nombre de types existants).
+TYPE_COULEURS = [
+    '#579bfc', '#00c875', '#a25ddc', '#fdab3d', '#e2445c',
+    '#037f4c', '#ff7575', '#9d99b9', '#66ccff', '#bb3354',
+    '#ffcb00', '#7f5347',
+]
+
+# Couleur affichee pour le groupe « Sans type » (subventions non classees).
+TYPE_COULEUR_SANS = '#c4c4c4'
 
 SOUS_ELEMENT_STATUTS = [
     {'key': 'non_commence', 'label': 'Non commencé', 'color': '#c4c4c4'},
@@ -180,14 +198,41 @@ def gestion_subventions():
                 r_dict['statut'] = _normalize_sous_element_statut(r_dict.get('statut'))
                 sous_elements.setdefault(r['subvention_id'], []).append(r_dict)
 
+        # Types de subvention = groupes (swimlanes) de la page. Charges depuis la
+        # base pour permettre la creation / suppression par l'utilisateur.
+        types_rows = conn.execute(
+            'SELECT id, nom, couleur, ordre FROM subventions_types ORDER BY ordre, nom'
+        ).fetchall()
+        types_list = [dict(t) for t in types_rows]
+        types_map = {t['id']: t for t in types_list}
+
+        # Un groupe par type, dans l'ordre defini.
         groupes_data = []
-        for g in GROUPES:
-            lignes = [s for s in subventions_data if s['groupe'] == g['key']]
+        for t in types_list:
+            lignes = [s for s in subventions_data if s.get('type_id') == t['id']]
             groupes_data.append({
-                'key': g['key'],
-                'label': g['label'],
-                'color': g['color'],
+                'key': 'type_%d' % t['id'],
+                'type_id': t['id'],
+                'label': t['nom'],
+                'color': t['couleur'] or '#579bfc',
                 'lignes': lignes,
+                'is_type': True,
+            })
+
+        # Groupe « Sans type » : subventions non classees (type_id NULL ou type
+        # supprime). Affiche uniquement s'il contient des elements.
+        sans_type = [
+            s for s in subventions_data
+            if not s.get('type_id') or s.get('type_id') not in types_map
+        ]
+        if sans_type:
+            groupes_data.append({
+                'key': 'sans_type',
+                'type_id': None,
+                'label': 'Sans type',
+                'color': TYPE_COULEUR_SANS,
+                'lignes': sans_type,
+                'is_type': False,
             })
 
     finally:
@@ -201,8 +246,10 @@ def gestion_subventions():
         users_map=users_map,
         actions_budget=actions_budget,
         benevoles_list=benevoles_list,
-        groupes_config=GROUPES,
-        statuts_config=SOUS_ELEMENT_STATUTS,
+        types_config=types_list,
+        types_map=types_map,
+        statuts_config=STATUTS,
+        statuts_se_config=SOUS_ELEMENT_STATUTS,
         is_responsable=is_responsable,
     )
 
@@ -217,19 +264,33 @@ def api_ajouter_subvention():
 
     data = request.get_json(silent=True) or {}
     nom = (data.get('nom') or '').strip()
-    groupe = data.get('groupe', 'nouveau_projet')
+    groupe = data.get('groupe') or STATUT_DEFAUT
     annee_action = (data.get('annee_action') or '').strip()
 
     if not nom:
         return jsonify({'ok': False, 'error': 'Nom requis'}), 400
-    if groupe not in GROUPES_MAP:
-        groupe = 'nouveau_projet'
+    if groupe not in STATUTS_MAP:
+        groupe = STATUT_DEFAUT
+
+    # Type de subvention (defini a la creation, modifiable ensuite).
+    type_id = data.get('type_id')
+    try:
+        type_id = int(type_id) if type_id not in (None, '', 'null') else None
+    except (ValueError, TypeError):
+        type_id = None
 
     conn = get_db()
     try:
+        if type_id is not None:
+            exists = conn.execute(
+                'SELECT 1 FROM subventions_types WHERE id = ?', (type_id,)
+            ).fetchone()
+            if not exists:
+                type_id = None
+
         cursor = conn.execute(
-            'INSERT INTO subventions (nom, groupe, annee_action) VALUES (?, ?, ?)',
-            (nom, groupe, annee_action or None)
+            'INSERT INTO subventions (nom, groupe, annee_action, type_id) VALUES (?, ?, ?, ?)',
+            (nom, groupe, annee_action or None, type_id)
         )
         sub_id = cursor.lastrowid
 
@@ -279,7 +340,7 @@ def api_modifier_subvention(sub_id):
     value = data.get('value')
 
     allowed_fields = {
-        'nom', 'groupe', 'assignee_1_id', 'assignee_2_id',
+        'nom', 'groupe', 'type_id', 'assignee_1_id', 'assignee_2_id',
         'date_echeance', 'montant_demande', 'montant_accorde',
         'date_notification', 'analytique_id', 'contact_email',
         'compte_comptable', 'annee_action',
@@ -290,9 +351,12 @@ def api_modifier_subvention(sub_id):
     if field not in allowed_fields:
         return jsonify({'ok': False, 'error': f'Champ non autorisé: {field}'}), 400
 
+    if field == 'groupe' and value not in STATUTS_MAP:
+        return jsonify({'ok': False, 'error': 'Statut invalide'}), 400
+
     if field in ('assignee_1_id', 'assignee_2_id', 'analytique_id',
                  'compte_comptable_1_id', 'compte_comptable_2_id',
-                 'action_budget_id'):
+                 'action_budget_id', 'type_id'):
         value = int(value) if value else None
     elif field in ('montant_demande', 'montant_accorde'):
         try:
@@ -340,6 +404,95 @@ def api_supprimer_subvention(sub_id):
             if chemin_reel.startswith(dossier_reel + os.sep) and os.path.exists(chemin):
                 os.remove(chemin)
         conn.execute('DELETE FROM subventions WHERE id = ?', (sub_id,))
+        conn.commit()
+        return jsonify({'ok': True})
+    finally:
+        conn.close()
+
+
+# ── API : Types de subvention ──
+
+@subventions_bp.route('/api/subventions/types/ajouter', methods=['POST'])
+@login_required
+def api_ajouter_type():
+    if not _peut_modifier():
+        return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
+
+    data = request.get_json(silent=True) or {}
+    nom = (data.get('nom') or '').strip()
+    if not nom:
+        return jsonify({'ok': False, 'error': 'Nom requis'}), 400
+
+    conn = get_db()
+    try:
+        existing = conn.execute(
+            'SELECT id, nom, couleur FROM subventions_types WHERE nom = ? COLLATE NOCASE',
+            (nom,)
+        ).fetchone()
+        if existing:
+            return jsonify({'ok': True, 'id': existing['id'], 'nom': existing['nom'],
+                            'couleur': existing['couleur'], 'existe': True})
+
+        row = conn.execute(
+            'SELECT COUNT(*) AS n, COALESCE(MAX(ordre), -1) AS m FROM subventions_types'
+        ).fetchone()
+        couleur = TYPE_COULEURS[row['n'] % len(TYPE_COULEURS)]
+        cursor = conn.execute(
+            'INSERT INTO subventions_types (nom, couleur, ordre) VALUES (?, ?, ?)',
+            (nom, couleur, row['m'] + 1)
+        )
+        conn.commit()
+        return jsonify({'ok': True, 'id': cursor.lastrowid, 'nom': nom, 'couleur': couleur})
+    finally:
+        conn.close()
+
+
+@subventions_bp.route('/api/subventions/types/<int:type_id>/modifier', methods=['POST'])
+@login_required
+def api_modifier_type(type_id):
+    if not _peut_modifier():
+        return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
+
+    data = request.get_json(silent=True) or {}
+    field = data.get('field', 'nom')
+    value = (data.get('value') or '').strip()
+
+    if field not in ('nom', 'couleur'):
+        return jsonify({'ok': False, 'error': f'Champ non autorisé: {field}'}), 400
+    if field == 'nom' and not value:
+        return jsonify({'ok': False, 'error': 'Nom requis'}), 400
+
+    conn = get_db()
+    try:
+        exists = conn.execute('SELECT 1 FROM subventions_types WHERE id = ?', (type_id,)).fetchone()
+        if not exists:
+            return jsonify({'ok': False, 'error': 'Type introuvable'}), 404
+        if field == 'nom':
+            doublon = conn.execute(
+                'SELECT 1 FROM subventions_types WHERE nom = ? COLLATE NOCASE AND id != ?',
+                (value, type_id)
+            ).fetchone()
+            if doublon:
+                return jsonify({'ok': False, 'error': 'Ce type existe déjà'}), 400
+        # field est valide ('nom' ou 'couleur') : pas d'injection possible.
+        conn.execute(f'UPDATE subventions_types SET {field} = ? WHERE id = ?', (value, type_id))
+        conn.commit()
+        return jsonify({'ok': True})
+    finally:
+        conn.close()
+
+
+@subventions_bp.route('/api/subventions/types/<int:type_id>/supprimer', methods=['POST'])
+@login_required
+def api_supprimer_type(type_id):
+    if not _peut_modifier():
+        return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
+
+    conn = get_db()
+    try:
+        # Les subventions rattachees a ce type basculent en « Sans type ».
+        conn.execute('UPDATE subventions SET type_id = NULL WHERE type_id = ?', (type_id,))
+        conn.execute('DELETE FROM subventions_types WHERE id = ?', (type_id,))
         conn.commit()
         return jsonify({'ok': True})
     finally:

--- a/database.py
+++ b/database.py
@@ -1825,6 +1825,17 @@ def init_db():
         except sqlite3.OperationalError:
             cursor.execute(f"ALTER TABLE presence_forfait_jour ADD COLUMN {col} TEXT")
 
+    # Migration 0052 : colonne type_id sur subventions si elle n'existe pas.
+    # Fallback indispensable : la table subventions_types (et ses types par
+    # defaut) est creee au demarrage par init_db, mais la colonne type_id d'une
+    # base preexistante n'est ajoutee que par la migration 0052. Sans ce
+    # fallback, la page afficherait les types tout en faisant echouer la
+    # creation d'une subvention tant que la migration n'est pas appliquee.
+    try:
+        cursor.execute("SELECT type_id FROM subventions LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE subventions ADD COLUMN type_id INTEGER REFERENCES subventions_types(id)")
+
     # Migration 0038 : corriger les colonnes numeriques creees en TEXT dans
     # variables_paie / variables_paie_defauts (cases mutuelle toutes cochees).
     # Fallback indispensable : les bases creees par d'anciennes versions

--- a/database.py
+++ b/database.py
@@ -80,6 +80,19 @@ ALL_MIGRATION_VERSIONS = [
     ('0040', 'Module CSE'),
 ]
 
+# Types de subvention par defaut (migration 0052)
+# (nom, couleur, ordre) — types manageables (creation / suppression) servant a
+# regrouper les subventions par organisme financeur sur la page subventions.
+_TYPES_SUBVENTION_DEFAUT = [
+    ('SUBV. GLOBAL', '#579bfc', 0),
+    ('CAF PS', '#00c875', 1),
+    ('CAF', '#a25ddc', 2),
+    ('VILLE', '#fdab3d', 3),
+    ('METROPOLE', '#e2445c', 4),
+    ('ETAT', '#037f4c', 5),
+    ('AUTRES', '#808080', 6),
+]
+
 # Postes de depense par defaut (migration 0012)
 _POSTES_DEPENSE_DEFAUT = [
     ('Alimentation', ['creche', 'accueil_loisirs', 'famille', 'emploi_formation', 'administratif', 'entretien']),
@@ -788,11 +801,30 @@ def init_db():
         )
     ''')
 
+    # Types de subvention (categories manageables : SUBV. GLOBAL, CAF, VILLE...).
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS subventions_types (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            nom TEXT NOT NULL UNIQUE,
+            couleur TEXT DEFAULT '#579bfc',
+            ordre INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+    cursor.execute("SELECT COUNT(*) FROM subventions_types")
+    if cursor.fetchone()[0] == 0:
+        for nom_type, couleur_type, ordre_type in _TYPES_SUBVENTION_DEFAUT:
+            cursor.execute(
+                'INSERT INTO subventions_types (nom, couleur, ordre) VALUES (?, ?, ?)',
+                (nom_type, couleur_type, ordre_type)
+            )
+
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS subventions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             nom TEXT NOT NULL,
             groupe TEXT NOT NULL DEFAULT 'nouveau_projet',
+            type_id INTEGER,
             assignee_1_id INTEGER,
             assignee_2_id INTEGER,
             date_echeance TEXT,
@@ -817,7 +849,8 @@ def init_db():
             FOREIGN KEY (analytique_id) REFERENCES subventions_analytiques(id),
             FOREIGN KEY (compte_comptable_1_id) REFERENCES comptabilite_comptes(id),
             FOREIGN KEY (compte_comptable_2_id) REFERENCES comptabilite_comptes(id),
-            FOREIGN KEY (action_budget_id) REFERENCES comptabilite_actions(id)
+            FOREIGN KEY (action_budget_id) REFERENCES comptabilite_actions(id),
+            FOREIGN KEY (type_id) REFERENCES subventions_types(id)
         )
     ''')
 

--- a/migrations/0052_subventions_types.py
+++ b/migrations/0052_subventions_types.py
@@ -1,0 +1,71 @@
+"""
+Migration 0052 : Types de subvention (categories par type).
+
+- Cree la table subventions_types (types manageables : creation / suppression)
+- Insere les types par defaut (SUBV. GLOBAL, CAF PS, CAF, VILLE, METROPOLE,
+  ETAT, AUTRES)
+- Ajoute la colonne subventions.type_id (FK subventions_types)
+
+La page subventions regroupe desormais les dossiers par type de subvention
+(organisme financeur) au lieu du statut. Le statut (groupe) est conserve pour
+les tableaux de bord.
+"""
+
+NOM = "Types de subvention"
+DESCRIPTION = (
+    "Ajoute la table subventions_types (types manageables) et la colonne "
+    "subventions.type_id pour regrouper les subventions par type."
+)
+
+# (nom, couleur, ordre)
+TYPES_DEFAUT = [
+    ('SUBV. GLOBAL', '#579bfc', 0),
+    ('CAF PS', '#00c875', 1),
+    ('CAF', '#a25ddc', 2),
+    ('VILLE', '#fdab3d', 3),
+    ('METROPOLE', '#e2445c', 4),
+    ('ETAT', '#037f4c', 5),
+    ('AUTRES', '#808080', 6),
+]
+
+
+def _column_exists(cursor, table, column):
+    """Verifie si une colonne existe dans une table."""
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    cursor = conn.cursor()
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS subventions_types (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            nom TEXT NOT NULL UNIQUE,
+            couleur TEXT DEFAULT '#579bfc',
+            ordre INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    # Seed des types par defaut uniquement si la table est vide.
+    cursor.execute("SELECT COUNT(*) FROM subventions_types")
+    if cursor.fetchone()[0] == 0:
+        for nom, couleur, ordre in TYPES_DEFAUT:
+            cursor.execute(
+                'INSERT INTO subventions_types (nom, couleur, ordre) VALUES (?, ?, ?)',
+                (nom, couleur, ordre)
+            )
+
+    if not _column_exists(cursor, 'subventions', 'type_id'):
+        cursor.execute(
+            "ALTER TABLE subventions ADD COLUMN type_id INTEGER REFERENCES subventions_types(id)"
+        )
+
+    conn.commit()
+
+
+def downgrade(conn):
+    """Pas de downgrade (les donnees sont conservees)."""
+    conn.commit()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2816,6 +2816,119 @@ a.btn-icon:-webkit-any-link {
 .sv-cell-amount { cursor: text; }
 .sv-cell-person { cursor: pointer; }
 
+/* ── Colonne Statut (petite étiquette d'avancement) ── */
+.sv-col-statut-mini { width: 128px; min-width: 128px; }
+
+.sv-statut-mini {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: 99px;
+    color: #fff;
+    font-weight: 600;
+    font-size: 0.72rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all var(--transition-fast);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+.sv-statut-mini:hover { opacity: 0.9; transform: scale(1.05); }
+
+/* ── Type non défini (placeholder cliquable) ── */
+.sv-type-empty {
+    display: inline-block;
+    padding: 4px 12px;
+    border-radius: 99px;
+    border: 1px dashed var(--gray-300);
+    color: var(--gray-500);
+    font-weight: 600;
+    font-size: 0.8rem;
+    font-style: italic;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all var(--transition-fast);
+}
+
+.sv-type-empty:hover { border-color: var(--primary); color: var(--primary); }
+
+/* ── Bouton « Gérer les types » ── */
+.sv-manage-types-btn { white-space: nowrap; flex-shrink: 0; }
+
+/* ── Modale : gestion des types de subvention ── */
+.sv-types-hint {
+    padding: 0 1.5rem;
+    margin: 0 0 1rem;
+    font-size: 0.82rem;
+    color: var(--gray-500);
+    line-height: 1.4;
+}
+
+.sv-types-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 1.5rem;
+    max-height: 340px;
+    overflow-y: auto;
+}
+
+.sv-types-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    margin-bottom: 6px;
+}
+
+.sv-type-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+}
+
+.sv-type-name { flex: 1; font-weight: 600; font-size: 0.9rem; color: var(--gray-900); word-break: break-word; }
+
+.sv-types-item-actions { display: flex; gap: 4px; flex-shrink: 0; }
+
+.sv-type-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.95rem;
+    padding: 4px 6px;
+    border-radius: 6px;
+    color: var(--gray-500);
+    transition: all var(--transition-fast);
+}
+
+.sv-type-btn:hover { background: var(--gray-100); color: var(--gray-900); }
+.sv-type-btn-del:hover { background: rgba(226,68,92,0.12); color: #e2445c; }
+
+.sv-types-empty { list-style: none; color: var(--gray-500); font-style: italic; padding: 8px 10px; }
+
+.sv-types-add {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 1rem 1.5rem 1.5rem;
+    border-top: 1px solid var(--gray-200);
+    margin-top: 0.75rem;
+}
+
+.sv-types-add input {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 12px;
+    border: 1px solid var(--gray-300);
+    border-radius: 8px;
+    font-size: 0.9rem;
+}
+
+.sv-types-add input:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 2px rgba(37,99,235,0.15); }
+
 /* ── Dark theme subventions ── */
 [data-theme="dark"] .sv-header { background: var(--white); border-color: var(--gray-300); border-left-color: var(--primary-light); }
 [data-theme="dark"] .sv-group { border-color: var(--gray-300); }
@@ -2832,6 +2945,9 @@ a.btn-icon:-webkit-any-link {
 [data-theme="dark"] .sv-avatar-empty { border-color: var(--gray-300); color: var(--gray-500); }
 [data-theme="dark"] .sv-inline-input { background: var(--gray-50); color: var(--gray-900); }
 [data-theme="dark"] .sv-inline-select { background: var(--gray-50); color: var(--gray-900); }
+[data-theme="dark"] .sv-types-item { border-color: var(--gray-300); }
+[data-theme="dark"] .sv-type-btn:hover { background: var(--gray-100); }
+[data-theme="dark"] .sv-types-add input { background: var(--gray-50); color: var(--gray-900); border-color: var(--gray-300); }
 
 /* ── Benevoles : colonne commentaire + textarea inline ── */
 .sv-col-comment { min-width: 200px; max-width: 300px; white-space: pre-wrap; word-break: break-word; }

--- a/templates/subventions.html
+++ b/templates/subventions.html
@@ -288,7 +288,7 @@ BENEVOLES[{{ b.id }}] = "{{ b.nom }}";
 /* Types de subvention (catégories de la page) */
 var TYPES = [
 {% for t in types_config %}
-    {id: {{ t.id }}, nom: {{ t.nom|tojson }}, couleur: "{{ t.couleur }}"}{{ ',' if not loop.last else '' }}
+    {id: {{ t.id }}, nom: {{ t.nom|tojson }}, couleur: {{ t.couleur|tojson }}}{{ ',' if not loop.last else '' }}
 {% endfor %}
 ];
 var TYPES_DIRTY = false;
@@ -524,6 +524,25 @@ function editPerson(el, id, field) {
     sel.addEventListener('change', save);
 }
 
+/* ── Rendu d'une cellule Type (pastille ou placeholder) ── */
+function renderTypeCell(td, typeId, subId) {
+    td.innerHTML = '';
+    var t = TYPES.find(function(x){ return String(x.id) === String(typeId); });
+    var sp = document.createElement('span');
+    if (t) {
+        sp.className = 'sv-status-pill';
+        sp.style.background = t.couleur;
+        sp.setAttribute('data-type-id', t.id);
+        sp.textContent = t.nom;
+    } else {
+        sp.className = 'sv-type-empty';
+        sp.setAttribute('data-type-id', '');
+        sp.textContent = 'Choisir…';
+    }
+    sp.onclick = function() { editType(sp, subId); };
+    td.appendChild(sp);
+}
+
 /* ── Edition inline : type de subvention (change de swimlane → reload) ── */
 function editType(el, id) {
     var td = el.closest('td');
@@ -543,16 +562,40 @@ function editType(el, id) {
     td.appendChild(sel);
     sel.focus();
 
-    var done = false;
-    function save() {
-        if (done) return;
-        done = true;
-        apiCall('/api/subventions/' + id + '/modifier', {field: 'type_id', value: sel.value}).then(function(r) {
-            location.reload();
+    var handled = false;
+    function commit() {
+        if (handled) return;
+        handled = true;
+        var val = sel.value;
+        // Sans changement : restaurer la pastille sur place (pas de reload).
+        if (String(val) === String(currentId)) { renderTypeCell(td, currentId, id); return; }
+        apiCall('/api/subventions/' + id + '/modifier', {field: 'type_id', value: val}).then(function(r) {
+            if (r.ok) {
+                location.reload();  // la ligne change de swimlane
+            } else {
+                alert(r.error || 'Erreur');
+                renderTypeCell(td, currentId, id);
+            }
         });
     }
-    sel.addEventListener('change', save);
-    sel.addEventListener('blur', function() { if (!done) location.reload(); });
+    sel.addEventListener('change', commit);
+    sel.addEventListener('blur', commit);
+    sel.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') { handled = true; renderTypeCell(td, currentId, id); }
+    });
+}
+
+/* ── Rendu d'une cellule Statut (petite étiquette) ── */
+function renderStatutCell(td, key, subId) {
+    var st = STATUTS.find(function(s){ return s.key === key; }) || STATUTS[0];
+    td.innerHTML = '';
+    var sp = document.createElement('span');
+    sp.className = 'sv-statut-mini';
+    sp.style.background = st.color;
+    sp.setAttribute('data-statut', st.key);
+    sp.textContent = st.label;
+    sp.onclick = function() { editStatus(sp, subId); };
+    td.appendChild(sp);
 }
 
 /* ── Edition inline : statut d'avancement (mise à jour sur place) ── */
@@ -573,25 +616,27 @@ function editStatus(el, id) {
     td.appendChild(sel);
     sel.focus();
 
-    var done = false;
-    function save() {
-        if (done) return;
-        done = true;
+    var handled = false;
+    function commit() {
+        if (handled) return;
+        handled = true;
         var val = sel.value;
+        // Sans changement : restaurer sans écrire ni recharger.
+        if (val === currentKey) { renderStatutCell(td, currentKey, id); return; }
         apiCall('/api/subventions/' + id + '/modifier', {field: 'groupe', value: val}).then(function(r) {
-            var st = STATUTS.find(function(s){return s.key===val;}) || STATUTS[0];
-            td.innerHTML = '';
-            var sp = document.createElement('span');
-            sp.className = 'sv-statut-mini';
-            sp.style.background = st.color;
-            sp.setAttribute('data-statut', val);
-            sp.textContent = st.label;
-            sp.onclick = function() { editStatus(sp, id); };
-            td.appendChild(sp);
+            if (r.ok) {
+                renderStatutCell(td, val, id);
+            } else {
+                alert(r.error || 'Erreur');
+                renderStatutCell(td, currentKey, id);
+            }
         });
     }
-    sel.addEventListener('change', save);
-    sel.addEventListener('blur', save);
+    sel.addEventListener('change', commit);
+    sel.addEventListener('blur', commit);
+    sel.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') { handled = true; renderStatutCell(td, currentKey, id); }
+    });
 }
 
 /* ── Edition inline : analytique ── */
@@ -796,8 +841,8 @@ function addType() {
         if (!r.ok) { alert(r.error || 'Erreur'); return; }
         if (!r.existe) {
             TYPES.push({id: r.id, nom: r.nom, couleur: r.couleur});
+            TYPES_DIRTY = true;  // ne recharger au close que si un type a réellement changé
         }
-        TYPES_DIRTY = true;
         input.value = '';
         input.focus();
         renderTypesList();

--- a/templates/subventions.html
+++ b/templates/subventions.html
@@ -7,19 +7,22 @@
     <div class="sv-header">
         <div>
             <h1>Gestion des subventions</h1>
-            <p class="subtitle">Suivi des dossiers de subventions par statut</p>
+            <p class="subtitle">Suivi des dossiers de subventions par type</p>
         </div>
+        {% if not is_responsable %}
+        <button class="btn btn-secondary sv-manage-types-btn" onclick="openTypesManager()">⚙️ Gérer les types</button>
+        {% endif %}
     </div>
 
     {% for groupe in groupes %}
     <div class="sv-group" data-groupe="{{ groupe.key }}">
-        {# ── En-tête de groupe ── #}
+        {# ── En-tête de groupe (= type de subvention) ── #}
         <div class="sv-group-head" style="background:{{ groupe.color }};" onclick="toggleGroup(this)">
             <span class="sv-group-arrow">▾</span>
             <span class="sv-group-label">{{ groupe.label }}</span>
             <span class="sv-group-count">{{ groupe.lignes|length }} élément{{ 's' if groupe.lignes|length != 1 else '' }}</span>
             {% if not is_responsable %}
-            <button class="sv-group-add" onclick="event.stopPropagation(); promptAdd('{{ groupe.key }}')">+ Ajouter</button>
+            <button class="sv-group-add" onclick="event.stopPropagation(); promptAdd({{ groupe.type_id if groupe.type_id else 'null' }})">+ Ajouter</button>
             {% endif %}
         </div>
 
@@ -32,7 +35,8 @@
                             <th class="sv-col-name">Subvention</th>
                             <th class="sv-col-person">Assigné 1</th>
                             <th class="sv-col-person">Assigné 2</th>
-                            <th class="sv-col-status">Statut</th>
+                            <th class="sv-col-status">Type</th>
+                            <th class="sv-col-statut-mini">Statut</th>
                             <th class="sv-col-date">Échéance</th>
                             <th class="sv-col-amount">Montant demandé</th>
                             <th class="sv-col-amount">Montant accordé</th>
@@ -72,9 +76,25 @@
                                 <span class="sv-avatar-empty">+</span>
                                 {% endif %}
                             </td>
-                            {# ── Statut (= groupe) ── #}
+                            {# ── Type (défini à la création, modifiable) ── #}
                             <td class="sv-col-status">
-                                <span class="sv-status-pill" style="background:{{ groupe.color }};" onclick="editStatus(this, {{ sub.id }})">{{ groupe.label }}</span>
+                                {% set t = types_map.get(sub.type_id) %}
+                                {% if t %}
+                                <span class="sv-status-pill" style="background:{{ t.couleur }};" data-type-id="{{ sub.type_id }}" onclick="editType(this, {{ sub.id }})">{{ t.nom }}</span>
+                                {% else %}
+                                <span class="sv-type-empty" data-type-id="" onclick="editType(this, {{ sub.id }})">Choisir…</span>
+                                {% endif %}
+                            </td>
+                            {# ── Statut (avancement — conservé pour les tableaux de bord) ── #}
+                            <td class="sv-col-statut-mini">
+                                {% set ns_st = namespace(color='#579bfc', label='Nouveau projet') %}
+                                {% for st in statuts_config %}
+                                    {% if st.key == sub.groupe %}
+                                        {% set ns_st.color = st.color %}
+                                        {% set ns_st.label = st.label %}
+                                    {% endif %}
+                                {% endfor %}
+                                <span class="sv-statut-mini" style="background:{{ ns_st.color }};" data-statut="{{ sub.groupe }}" onclick="editStatus(this, {{ sub.id }})">{{ ns_st.label }}</span>
                             </td>
                             {# ── Date échéance ── #}
                             <td class="sv-col-date sv-cell-date" onclick="editDate(this, {{ sub.id }}, 'date_echeance')">
@@ -142,7 +162,7 @@
                         {# ── Sous-éléments (masqués par défaut) ── #}
                         <tr class="sv-sub-row" id="se-row-{{ sub.id }}" style="display:none;">
                             <td class="sv-sub-spacer"><span class="sv-left-color" style="background:{{ groupe.color }};"></span></td>
-                            <td colspan="{% if not is_responsable %}15{% else %}14{% endif %}" class="sv-sub-td">
+                            <td colspan="{% if not is_responsable %}14{% else %}13{% endif %}" class="sv-sub-td">
                                 <table class="sv-sub-table">
                                     <thead>
                                         <tr>
@@ -169,7 +189,7 @@
                                             </td>
                                             <td>
                                                 {% set ns = namespace(color='#c4c4c4', label='Non commencé') %}
-                                                {% for st in statuts_config %}
+                                                {% for st in statuts_se_config %}
                                                     {% if st.key == se.statut %}
                                                         {% set ns.color = st.color %}
                                                         {% set ns.label = st.label %}
@@ -203,8 +223,8 @@
 
                     {% if not groupe.lignes %}
                         <tr>
-                            <td colspan="{% if not is_responsable %}16{% else %}15{% endif %}" class="sv-empty">
-                                Aucune subvention dans ce groupe
+                            <td colspan="{% if not is_responsable %}15{% else %}14{% endif %}" class="sv-empty">
+                                Aucune subvention dans ce type
                             </td>
                         </tr>
                     {% endif %}
@@ -214,7 +234,38 @@
         </div>
     </div>
     {% endfor %}
+
+    {% if not groupes %}
+    <div class="sv-group">
+        <div class="sv-group-body">
+            <div class="sv-empty" style="padding:2rem;">
+                Aucun type de subvention.
+                {% if not is_responsable %}Cliquez sur « ⚙️ Gérer les types » pour en créer un.{% endif %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
 </div>
+
+{# ── Modale : gestion des types de subvention ── #}
+{% if not is_responsable %}
+<div id="sv-types-modal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeTypesManager()">
+    <div class="modal-content" style="max-width:480px;">
+        <div class="modal-header">
+            <h3>Types de subvention</h3>
+            <button class="modal-close" onclick="closeTypesManager()" title="Fermer">&times;</button>
+        </div>
+        <p class="sv-types-hint">Les types classent les subventions par organisme financeur.
+            Supprimer un type ne supprime pas ses subventions : elles passent en « Sans type ».</p>
+        <ul id="sv-types-list" class="sv-types-list"></ul>
+        <div class="sv-types-add">
+            <input type="text" id="sv-new-type" placeholder="Nouveau type…" maxlength="60"
+                   onkeydown="if(event.key==='Enter'){event.preventDefault();addType();}">
+            <button class="btn btn-primary btn-sm" onclick="addType()">+ Ajouter</button>
+        </div>
+    </div>
+</div>
+{% endif %}
 
 <script>
 /* ── Config (depuis Jinja) ── */
@@ -234,14 +285,24 @@ var BENEVOLES = {};
 BENEVOLES[{{ b.id }}] = "{{ b.nom }}";
 {% endfor %}
 
-var GROUPES = [
-{% for g in groupes_config %}
-    {key: "{{ g.key }}", label: "{{ g.label }}", color: "{{ g.color }}"}{{ ',' if not loop.last else '' }}
+/* Types de subvention (catégories de la page) */
+var TYPES = [
+{% for t in types_config %}
+    {id: {{ t.id }}, nom: {{ t.nom|tojson }}, couleur: "{{ t.couleur }}"}{{ ',' if not loop.last else '' }}
+{% endfor %}
+];
+var TYPES_DIRTY = false;
+
+/* Statut d'avancement (petite étiquette) */
+var STATUTS = [
+{% for s in statuts_config %}
+    {key: "{{ s.key }}", label: "{{ s.label }}", color: "{{ s.color }}"}{{ ',' if not loop.last else '' }}
 {% endfor %}
 ];
 
+/* Statuts des sous-éléments */
 var STATUTS_SE = [
-{% for s in statuts_config %}
+{% for s in statuts_se_config %}
     {key: "{{ s.key }}", label: "{{ s.label }}", color: "{{ s.color }}"}{{ ',' if not loop.last else '' }}
 {% endfor %}
 ];
@@ -260,6 +321,12 @@ function apiUpload(url, formData) {
     var headers = {};
     if (meta) headers['X-CSRFToken'] = meta.getAttribute('content');
     return fetch(url, {method: 'POST', headers: headers, body: formData}).then(function(r){return r.json();});
+}
+
+function escapeHtml(s) {
+    return (s == null ? '' : String(s)).replace(/[&<>"']/g, function(c) {
+        return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];
+    });
 }
 
 function getInitiales(prenom, nom) {
@@ -309,13 +376,13 @@ function toggleSubElements(subId, btn) {
     }
 }
 
-/* ── Ajouter subvention ── */
-function promptAdd(groupe) {
+/* ── Ajouter subvention (dans un type donné) ── */
+function promptAdd(typeId) {
     var nom = prompt('Nom de la subvention :');
     if (!nom || !nom.trim()) return;
     var annee = prompt('Année de l\'action :', new Date().getFullYear());
     if (annee === null) return;
-    apiCall('/api/subventions/ajouter', {nom: nom.trim(), groupe: groupe, annee_action: annee.trim()}).then(function(r) {
+    apiCall('/api/subventions/ajouter', {nom: nom.trim(), type_id: typeId, annee_action: annee.trim()}).then(function(r) {
         if (r.ok) location.reload();
         else alert(r.error || 'Erreur');
     });
@@ -457,28 +524,74 @@ function editPerson(el, id, field) {
     sel.addEventListener('change', save);
 }
 
-/* ── Edition inline : statut (groupe de la subvention) ── */
-function editStatus(el, id) {
-    if (el.querySelector('select') || el.tagName === 'SELECT') return;
-    var parent = el.parentElement;
+/* ── Edition inline : type de subvention (change de swimlane → reload) ── */
+function editType(el, id) {
+    var td = el.closest('td');
+    if (!td || td.querySelector('select')) return;
+    var currentId = el.getAttribute('data-type-id') || '';
     var sel = document.createElement('select');
     sel.className = 'sv-inline-select';
-    GROUPES.forEach(function(g) {
-        sel.innerHTML += '<option value="'+g.key+'">'+g.label+'</option>';
+    sel.innerHTML = '<option value="">— Sans type —</option>';
+    TYPES.forEach(function(t) {
+        var opt = document.createElement('option');
+        opt.value = t.id;
+        opt.textContent = t.nom;
+        if (String(t.id) === String(currentId)) opt.selected = true;
+        sel.appendChild(opt);
     });
-    parent.textContent = '';
-    parent.appendChild(sel);
+    td.innerHTML = '';
+    td.appendChild(sel);
     sel.focus();
 
-    sel.addEventListener('change', function() {
+    var done = false;
+    function save() {
+        if (done) return;
+        done = true;
+        apiCall('/api/subventions/' + id + '/modifier', {field: 'type_id', value: sel.value}).then(function(r) {
+            location.reload();
+        });
+    }
+    sel.addEventListener('change', save);
+    sel.addEventListener('blur', function() { if (!done) location.reload(); });
+}
+
+/* ── Edition inline : statut d'avancement (mise à jour sur place) ── */
+function editStatus(el, id) {
+    var td = el.closest('td');
+    if (!td || td.querySelector('select')) return;
+    var currentKey = el.getAttribute('data-statut') || 'nouveau_projet';
+    var sel = document.createElement('select');
+    sel.className = 'sv-inline-select';
+    STATUTS.forEach(function(s) {
+        var opt = document.createElement('option');
+        opt.value = s.key;
+        opt.textContent = s.label;
+        if (s.key === currentKey) opt.selected = true;
+        sel.appendChild(opt);
+    });
+    td.innerHTML = '';
+    td.appendChild(sel);
+    sel.focus();
+
+    var done = false;
+    function save() {
+        if (done) return;
+        done = true;
         var val = sel.value;
         apiCall('/api/subventions/' + id + '/modifier', {field: 'groupe', value: val}).then(function(r) {
-            if (r.ok) location.reload();
+            var st = STATUTS.find(function(s){return s.key===val;}) || STATUTS[0];
+            td.innerHTML = '';
+            var sp = document.createElement('span');
+            sp.className = 'sv-statut-mini';
+            sp.style.background = st.color;
+            sp.setAttribute('data-statut', val);
+            sp.textContent = st.label;
+            sp.onclick = function() { editStatus(sp, id); };
+            td.appendChild(sp);
         });
-    });
-    sel.addEventListener('blur', function() {
-        if (!sel._changed) location.reload();
-    });
+    }
+    sel.addEventListener('change', save);
+    sel.addEventListener('blur', save);
 }
 
 /* ── Edition inline : analytique ── */
@@ -614,6 +727,105 @@ function uploadSEDoc(input, seId) {
     apiUpload('/api/subventions/sous-elements/' + seId + '/document', fd).then(function(r) {
         if (r.ok) location.reload();
         else alert(r.error || 'Erreur');
+    });
+}
+
+/* ══════════════════════════════════════════
+   Types de subvention (gestion)
+   ══════════════════════════════════════════ */
+
+function openTypesManager() {
+    renderTypesList();
+    var modal = document.getElementById('sv-types-modal');
+    if (modal) modal.style.display = 'flex';
+}
+
+function closeTypesManager() {
+    var modal = document.getElementById('sv-types-modal');
+    if (modal) modal.style.display = 'none';
+    // Recharger pour refléter les swimlanes si des types ont changé.
+    if (TYPES_DIRTY) location.reload();
+}
+
+function renderTypesList() {
+    var ul = document.getElementById('sv-types-list');
+    if (!ul) return;
+    ul.innerHTML = '';
+    if (!TYPES.length) {
+        var empty = document.createElement('li');
+        empty.className = 'sv-types-empty';
+        empty.textContent = 'Aucun type. Ajoutez-en un ci-dessous.';
+        ul.appendChild(empty);
+        return;
+    }
+    TYPES.forEach(function(t) {
+        var li = document.createElement('li');
+        li.className = 'sv-types-item';
+        li.innerHTML =
+            '<span class="sv-type-dot" style="background:' + escapeHtml(t.couleur) + '"></span>' +
+            '<span class="sv-type-name">' + escapeHtml(t.nom) + '</span>';
+
+        var actions = document.createElement('span');
+        actions.className = 'sv-types-item-actions';
+
+        var renameBtn = document.createElement('button');
+        renameBtn.className = 'sv-type-btn';
+        renameBtn.title = 'Renommer';
+        renameBtn.textContent = '✎';
+        renameBtn.onclick = function() { renameType(t.id); };
+
+        var delBtn = document.createElement('button');
+        delBtn.className = 'sv-type-btn sv-type-btn-del';
+        delBtn.title = 'Supprimer';
+        delBtn.textContent = '🗑';
+        delBtn.onclick = function() { deleteType(t.id, t.nom); };
+
+        actions.appendChild(renameBtn);
+        actions.appendChild(delBtn);
+        li.appendChild(actions);
+        ul.appendChild(li);
+    });
+}
+
+function addType() {
+    var input = document.getElementById('sv-new-type');
+    if (!input) return;
+    var nom = (input.value || '').trim();
+    if (!nom) return;
+    apiCall('/api/subventions/types/ajouter', {nom: nom}).then(function(r) {
+        if (!r.ok) { alert(r.error || 'Erreur'); return; }
+        if (!r.existe) {
+            TYPES.push({id: r.id, nom: r.nom, couleur: r.couleur});
+        }
+        TYPES_DIRTY = true;
+        input.value = '';
+        input.focus();
+        renderTypesList();
+    });
+}
+
+function renameType(id) {
+    var t = TYPES.find(function(x){ return x.id === id; });
+    if (!t) return;
+    var nom = prompt('Renommer le type :', t.nom);
+    if (nom === null) return;
+    nom = nom.trim();
+    if (!nom || nom === t.nom) return;
+    apiCall('/api/subventions/types/' + id + '/modifier', {field: 'nom', value: nom}).then(function(r) {
+        if (!r.ok) { alert(r.error || 'Erreur'); return; }
+        t.nom = nom;
+        TYPES_DIRTY = true;
+        renderTypesList();
+    });
+}
+
+function deleteType(id, nom) {
+    if (!confirm('Supprimer le type « ' + nom + ' » ?\nLes subventions de ce type passeront en « Sans type ».')) return;
+    apiCall('/api/subventions/types/' + id + '/supprimer', {}).then(function(r) {
+        if (!r.ok) { alert(r.error || 'Erreur'); return; }
+        TYPES = TYPES.filter(function(x){ return x.id !== id; });
+        TYPES_DIRTY = true;
+        renderTypesList();
     });
 }
 

--- a/tests/test_subventions.py
+++ b/tests/test_subventions.py
@@ -1,6 +1,129 @@
 import io
 
 
+class TestTypesSubvention:
+    """Catégories de la page subventions par type (créer / supprimer / assigner)."""
+
+    def test_types_par_defaut_sont_seedes(self, app, db):
+        with app.app_context():
+            noms = [r['nom'] for r in db.execute(
+                'SELECT nom FROM subventions_types ORDER BY ordre'
+            ).fetchall()]
+        assert noms == ['SUBV. GLOBAL', 'CAF PS', 'CAF', 'VILLE',
+                        'METROPOLE', 'ETAT', 'AUTRES']
+
+    def test_page_regroupe_par_type(self, app, admin_client, db, sample_users):
+        # Chaque type est un groupe (swimlane) ; la colonne « Type » remplace
+        # « Statut » qui devient une petite étiquette.
+        resp = admin_client.get('/subventions')
+        assert resp.status_code == 200
+        html = resp.get_data(as_text=True)
+        assert 'SUBV. GLOBAL' in html
+        assert 'AUTRES' in html
+        assert '>Type<' in html
+        assert '>Statut<' in html
+
+    def test_creer_type(self, app, admin_client, db, sample_users):
+        resp = admin_client.post('/api/subventions/types/ajouter',
+                                 json={'nom': 'RÉGION'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['ok'] is True
+        with app.app_context():
+            row = db.execute('SELECT nom FROM subventions_types WHERE id = ?',
+                             (data['id'],)).fetchone()
+        assert row['nom'] == 'RÉGION'
+
+    def test_creer_type_doublon_renvoie_existant(self, app, admin_client, db, sample_users):
+        r1 = admin_client.post('/api/subventions/types/ajouter', json={'nom': 'CAF'})
+        assert r1.get_json()['existe'] is True
+        with app.app_context():
+            nb = db.execute(
+                "SELECT COUNT(*) AS n FROM subventions_types WHERE nom = 'CAF'"
+            ).fetchone()['n']
+        assert nb == 1
+
+    def test_subvention_creee_avec_type(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            type_id = db.execute(
+                "SELECT id FROM subventions_types WHERE nom = 'VILLE'"
+            ).fetchone()['id']
+        resp = admin_client.post('/api/subventions/ajouter',
+                                 json={'nom': 'Aide locale', 'type_id': type_id,
+                                       'annee_action': '2026'})
+        assert resp.status_code == 200
+        sub_id = resp.get_json()['id']
+        with app.app_context():
+            row = db.execute('SELECT groupe, type_id FROM subventions WHERE id = ?',
+                             (sub_id,)).fetchone()
+        # Le type est enregistré ; le statut par défaut reste « nouveau_projet ».
+        assert row['type_id'] == type_id
+        assert row['groupe'] == 'nouveau_projet'
+
+    def test_modifier_type_subvention(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            cur = db.execute("INSERT INTO subventions (nom, groupe) VALUES ('X', 'nouveau_projet')")
+            sub_id = cur.lastrowid
+            type_id = db.execute("SELECT id FROM subventions_types WHERE nom = 'ETAT'").fetchone()['id']
+            db.commit()
+        resp = admin_client.post(f'/api/subventions/{sub_id}/modifier',
+                                 json={'field': 'type_id', 'value': type_id})
+        assert resp.status_code == 200
+        with app.app_context():
+            assert db.execute('SELECT type_id FROM subventions WHERE id = ?',
+                              (sub_id,)).fetchone()['type_id'] == type_id
+
+    def test_supprimer_type_bascule_subventions_en_sans_type(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            type_id = db.execute("SELECT id FROM subventions_types WHERE nom = 'METROPOLE'").fetchone()['id']
+            cur = db.execute(
+                "INSERT INTO subventions (nom, groupe, type_id) VALUES ('Dossier M', 'en_cours', ?)",
+                (type_id,)
+            )
+            sub_id = cur.lastrowid
+            db.commit()
+
+        resp = admin_client.post(f'/api/subventions/types/{type_id}/supprimer', json={})
+        assert resp.status_code == 200
+        with app.app_context():
+            assert db.execute('SELECT COUNT(*) AS n FROM subventions_types WHERE id = ?',
+                              (type_id,)).fetchone()['n'] == 0
+            # La subvention n'est pas supprimée : elle devient « Sans type ».
+            row = db.execute('SELECT type_id FROM subventions WHERE id = ?', (sub_id,)).fetchone()
+        assert row is not None
+        assert row['type_id'] is None
+
+    def test_subvention_sans_type_apparait_dans_groupe_dedie(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            db.execute("INSERT INTO subventions (nom, groupe) VALUES ('Non classee', 'nouveau_projet')")
+            db.commit()
+        html = admin_client.get('/subventions').get_data(as_text=True)
+        assert 'Non classee' in html
+        assert 'Sans type' in html
+
+    def test_statut_reste_editable_et_valide(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            cur = db.execute("INSERT INTO subventions (nom, groupe) VALUES ('Y', 'nouveau_projet')")
+            sub_id = cur.lastrowid
+            db.commit()
+        # Statut valide accepté.
+        ok = admin_client.post(f'/api/subventions/{sub_id}/modifier',
+                               json={'field': 'groupe', 'value': 'acceptee'})
+        assert ok.status_code == 200
+        with app.app_context():
+            assert db.execute('SELECT groupe FROM subventions WHERE id = ?',
+                              (sub_id,)).fetchone()['groupe'] == 'acceptee'
+        # Statut invalide rejeté.
+        ko = admin_client.post(f'/api/subventions/{sub_id}/modifier',
+                               json={'field': 'groupe', 'value': 'nimportequoi'})
+        assert ko.status_code == 400
+
+    def test_responsable_ne_peut_pas_gerer_les_types(self, app, resp_client, db, sample_users):
+        # Le bouton de gestion des types n'est pas rendu pour un responsable.
+        html = resp_client.get('/subventions').get_data(as_text=True)
+        assert 'Gérer les types' not in html
+
+
 class TestSousElementDocumentNaming:
     def _login_admin(self, client):
         client.post('/login', data={'login': 'admin', 'password': 'Admin1234'}, follow_redirects=False)

--- a/tests/test_subventions.py
+++ b/tests/test_subventions.py
@@ -119,9 +119,70 @@ class TestTypesSubvention:
         assert ko.status_code == 400
 
     def test_responsable_ne_peut_pas_gerer_les_types(self, app, resp_client, db, sample_users):
-        # Le bouton de gestion des types n'est pas rendu pour un responsable.
+        # Le bouton de gestion des types n'est pas rendu pour un responsable...
         html = resp_client.get('/subventions').get_data(as_text=True)
         assert 'Gérer les types' not in html
+        # ...et les endpoints de gestion des types lui sont interdits (403),
+        # même en appel direct : gérer les types est une action globale réservée
+        # à la direction / comptabilité.
+        with app.app_context():
+            type_id = db.execute("SELECT id FROM subventions_types WHERE nom = 'CAF'").fetchone()['id']
+        assert resp_client.post('/api/subventions/types/ajouter', json={'nom': 'X'}).status_code == 403
+        assert resp_client.post(f'/api/subventions/types/{type_id}/modifier',
+                                json={'field': 'nom', 'value': 'Y'}).status_code == 403
+        assert resp_client.post(f'/api/subventions/types/{type_id}/supprimer', json={}).status_code == 403
+        # La suppression n'a pas eu lieu.
+        with app.app_context():
+            assert db.execute('SELECT COUNT(*) AS n FROM subventions_types WHERE id = ?',
+                              (type_id,)).fetchone()['n'] == 1
+
+    def test_salarie_ne_peut_pas_gerer_les_types(self, app, auth_client, db, sample_users):
+        assert auth_client.post('/api/subventions/types/ajouter', json={'nom': 'Z'}).status_code == 403
+
+    def test_creer_type_nom_vide_refuse(self, app, admin_client, db, sample_users):
+        assert admin_client.post('/api/subventions/types/ajouter',
+                                 json={'nom': '   '}).status_code == 400
+
+    def test_creer_type_insensible_a_la_casse(self, app, admin_client, db, sample_users):
+        # « caf » ne crée pas de doublon de « CAF » (déjà seedé).
+        r = admin_client.post('/api/subventions/types/ajouter', json={'nom': 'caf'})
+        assert r.status_code == 200 and r.get_json()['existe'] is True
+        with app.app_context():
+            assert db.execute(
+                "SELECT COUNT(*) AS n FROM subventions_types WHERE nom = 'CAF' COLLATE NOCASE"
+            ).fetchone()['n'] == 1
+
+    def test_renommer_type_en_doublon_refuse(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            ville = db.execute("SELECT id FROM subventions_types WHERE nom = 'VILLE'").fetchone()['id']
+        # Renommer VILLE en « CAF » (déjà pris) doit échouer.
+        r = admin_client.post(f'/api/subventions/types/{ville}/modifier',
+                              json={'field': 'nom', 'value': 'CAF'})
+        assert r.status_code == 400
+
+    def test_modifier_type_couleur_valide_et_invalide(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            tid = db.execute("SELECT id FROM subventions_types WHERE nom = 'ETAT'").fetchone()['id']
+        assert admin_client.post(f'/api/subventions/types/{tid}/modifier',
+                                 json={'field': 'couleur', 'value': '#123abc'}).status_code == 200
+        # Une couleur non hexadécimale est refusée (protège le JS/CSS de la page).
+        assert admin_client.post(f'/api/subventions/types/{tid}/modifier',
+                                 json={'field': 'couleur', 'value': 'red; evil'}).status_code == 400
+        with app.app_context():
+            assert db.execute('SELECT couleur FROM subventions_types WHERE id = ?',
+                              (tid,)).fetchone()['couleur'] == '#123abc'
+
+    def test_modifier_subvention_type_inexistant_refuse(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            cur = db.execute("INSERT INTO subventions (nom, groupe) VALUES ('Z', 'nouveau_projet')")
+            sub_id = cur.lastrowid
+            db.commit()
+        r = admin_client.post(f'/api/subventions/{sub_id}/modifier',
+                              json={'field': 'type_id', 'value': 999999})
+        assert r.status_code == 404
+        with app.app_context():
+            assert db.execute('SELECT type_id FROM subventions WHERE id = ?',
+                              (sub_id,)).fetchone()['type_id'] is None
 
 
 class TestSousElementDocumentNaming:


### PR DESCRIPTION
## Objectif

Réorganiser la page **Subventions** autour du **type de financeur** au lieu des 4 catégories de statut (nouveau projet / en cours / acceptées / refusées), et remplacer la colonne « Statut » par une colonne « Type » modifiable, définie à la création.

## Changements

### Catégories par type (swimlanes)
- Les subventions sont regroupées par **type** au lieu du statut.
- Types par défaut : **SUBV. GLOBAL, CAF PS, CAF, VILLE, METROPOLE, ETAT, AUTRES**.
- Types **personnalisables** : bouton « ⚙️ Gérer les types » (créer / renommer / supprimer).
- Supprimer un type ne supprime **pas** ses subventions : elles basculent dans un groupe « Sans type ».

### Colonne « Statut » → « Type »
- La colonne à l'emplacement de l'ancien « Statut » affiche désormais le **type**, éditable (menu déroulant).
- Le **type est défini à la création** : le bouton « + Ajouter » de chaque catégorie crée la subvention directement dans ce type.

### Statut conservé (aucune régression sur les tableaux de bord)
- Le statut d'avancement (`groupe` : nouveau projet / en cours / accepté / refusé) est **conservé** sous forme d'une petite étiquette éditable par ligne.
- Les tableaux de bord Direction / Responsable (pipeline des subventions, échéances à venir) et les Actions à faire (exclusion des refusées) continuent de fonctionner **sans modification**.

## Base de données
- Nouvelle table `subventions_types` (`nom`, `couleur`, `ordre`) + seed des types par défaut.
- Nouvelle colonne `subventions.type_id` (FK).
- Migration **0052** idempotente (testée sur base existante et en double passage) + schéma `init_db` mis à jour.

## API ajoutées
- `POST /api/subventions/types/ajouter`
- `POST /api/subventions/types/<id>/modifier` (renommer / couleur)
- `POST /api/subventions/types/<id>/supprimer`
- `type_id` accepté à la création (`/api/subventions/ajouter`) et en modification.

## Tests
- +10 tests (`TestTypesSubvention`) : seed, groupement par type, création/renommage/suppression, bascule « Sans type », statut conservé et validé, accès responsable.
- Suite complète : **681 passed**.

## Notes
- Sur une base existante, les subventions déjà présentes apparaissent dans « Sans type » jusqu'à ce qu'un type leur soit attribué (rien n'est perdu).
- Docs mises à jour : `README.md` et contexte assistant (`chatbot.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_