### PR TITLE
Subventions : filtre par année (N-3 à N+2)

### DIFF
--- a/blueprints/subventions.py
+++ b/blueprints/subventions.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from flask import (Blueprint, render_template, request, redirect,
                    url_for, session, flash, jsonify, send_file)
 from database import get_db, DATA_DIR
-from utils import login_required
+from utils import login_required, aujourd_hui
 
 subventions_bp = Blueprint('subventions_bp', __name__)
 
@@ -168,23 +168,49 @@ def gestion_subventions():
         is_responsable = session.get('profil') == 'responsable'
         user_id = session.get('user_id')
 
+        # Filtre par année de l'action : plage N-3 à N+2, année courante par
+        # défaut. La valeur spéciale « toutes » désactive le filtre (utile pour
+        # retrouver les subventions hors plage ou sans année renseignée).
+        annee_courante = aujourd_hui().year
+        annees = [str(annee_courante + delta) for delta in range(-3, 3)]  # N-3 … N+2
+        annee_param = (request.args.get('annee') or '').strip()
+        if annee_param == 'toutes':
+            annee_selected = 'toutes'
+            annee_filter = None
+        elif re.fullmatch(r'\d{4}', annee_param):
+            annee_selected = annee_param
+            annee_filter = annee_param
+        else:
+            annee_selected = str(annee_courante)
+            annee_filter = str(annee_courante)
+
         if is_responsable:
             # Le responsable voit les subventions dont il est assigné (parent) et
             # celles dont un sous-élément lui est directement attribué.
-            subventions = conn.execute(
+            base_sql = (
                 '''SELECT * FROM subventions
-                   WHERE assignee_1_id = ? OR assignee_2_id = ?
-                      OR id IN (
-                          SELECT subvention_id FROM subventions_sous_elements
-                          WHERE assignee_id = ?
-                      )
-                   ORDER BY ordre, id''',
-                (user_id, user_id, user_id)
-            ).fetchall()
+                   WHERE (assignee_1_id = ? OR assignee_2_id = ?
+                          OR id IN (
+                              SELECT subvention_id FROM subventions_sous_elements
+                              WHERE assignee_id = ?
+                          ))'''
+            )
+            params = [user_id, user_id, user_id]
+            if annee_filter is not None:
+                base_sql += ' AND annee_action = ?'
+                params.append(annee_filter)
+            base_sql += ' ORDER BY ordre, id'
+            subventions = conn.execute(base_sql, params).fetchall()
         else:
-            subventions = conn.execute(
-                'SELECT * FROM subventions ORDER BY ordre, id'
-            ).fetchall()
+            if annee_filter is not None:
+                subventions = conn.execute(
+                    'SELECT * FROM subventions WHERE annee_action = ? ORDER BY ordre, id',
+                    (annee_filter,)
+                ).fetchall()
+            else:
+                subventions = conn.execute(
+                    'SELECT * FROM subventions ORDER BY ordre, id'
+                ).fetchall()
 
         subventions_data = []
         for s in subventions:
@@ -260,6 +286,9 @@ def gestion_subventions():
         statuts_config=STATUTS,
         statuts_se_config=SOUS_ELEMENT_STATUTS,
         is_responsable=is_responsable,
+        annees=annees,
+        annee_selected=annee_selected,
+        annee_courante=str(annee_courante),
     )
 
 

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -122,15 +122,24 @@ def construire_actions(conn, profil, user_id, secteur_id=None):
             LIMIT 25""",
         sub_params
     ).fetchall()
+    # La page subventions filtre par année (année courante par défaut). Pour que
+    # la subvention pointée reste visible, on cible son année si elle est dans la
+    # plage du filtre (N-3..N+2), sinon « toutes » (année absente ou hors plage).
+    annee_min, annee_max = today.year - 3, today.year + 2
     for r in rows:
         ech = _to_date(r['date_echeance'])
         annee = f" ({r['annee_action']})" if r['annee_action'] else ''
+        annee_sub = (r['annee_action'] or '').strip()
+        if annee_sub.isdigit() and len(annee_sub) == 4 and annee_min <= int(annee_sub) <= annee_max:
+            lien_sub = url_for('subventions_bp.gestion_subventions', annee=annee_sub)
+        else:
+            lien_sub = url_for('subventions_bp.gestion_subventions', annee='toutes')
         actions.append({
             'categorie': 'subvention',
             'icone': '💶',
             'titre': f"{r['sub_nom']}{annee} — {r['etape']}",
             'detail': f"échéance le {_fr(ech)}" if ech else '',
-            'lien': url_for('subventions_bp.gestion_subventions'),
+            'lien': lien_sub,
             'lien_texte': 'Voir',
             'urgence': _urgence_echeance(ech, today),
         })

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2299,6 +2299,8 @@ a.btn-icon:-webkit-any-link {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 1rem;
     margin-bottom: 2rem;
     background: var(--white);
     padding: 1.75rem 2rem;
@@ -2851,6 +2853,42 @@ a.btn-icon:-webkit-any-link {
 
 .sv-type-empty:hover { border-color: var(--primary); color: var(--primary); }
 
+/* ── Actions de l'en-tête (filtre année + gérer les types) ── */
+.sv-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.sv-annee-filtre {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--gray-700);
+    white-space: nowrap;
+}
+
+.sv-annee-label { color: var(--gray-500); }
+
+.sv-annee-select {
+    padding: 7px 12px;
+    border: 1px solid var(--gray-300);
+    border-radius: 8px;
+    background: var(--white);
+    color: var(--gray-900);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.sv-annee-select:hover { border-color: var(--primary); }
+.sv-annee-select:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 2px rgba(37,99,235,0.15); }
+
 /* ── Bouton « Gérer les types » ── */
 .sv-manage-types-btn { white-space: nowrap; flex-shrink: 0; }
 
@@ -2948,6 +2986,7 @@ a.btn-icon:-webkit-any-link {
 [data-theme="dark"] .sv-types-item { border-color: var(--gray-300); }
 [data-theme="dark"] .sv-type-btn:hover { background: var(--gray-100); }
 [data-theme="dark"] .sv-types-add input { background: var(--gray-50); color: var(--gray-900); border-color: var(--gray-300); }
+[data-theme="dark"] .sv-annee-select { background: var(--gray-50); color: var(--gray-900); border-color: var(--gray-300); }
 
 /* ── Benevoles : colonne commentaire + textarea inline ── */
 .sv-col-comment { min-width: 200px; max-width: 300px; white-space: pre-wrap; word-break: break-word; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2461,7 +2461,9 @@ a.btn-icon:-webkit-any-link {
     max-width: 320px;
     font-weight: 600;
     color: var(--gray-900);
-    position: relative;
+    /* La position (sticky) et donc le contexte de positionnement du liseré
+       .sv-left-color viennent de .sv-sticky : ne pas redéclarer position ici,
+       cela écraserait le sticky. */
     padding-left: 42px !important;
 }
 
@@ -2482,7 +2484,6 @@ a.btn-icon:-webkit-any-link {
 .sv-col-select { width: 160px; min-width: 160px; }
 .sv-col-text { width: 160px; min-width: 160px; }
 .sv-col-actions { width: 44px; min-width: 44px; text-align: center; }
-.sv-col-name-end { min-width: 200px; font-weight: 600; color: var(--gray-900); white-space: nowrap; }
 
 .sv-tag {
     display: inline-block;
@@ -2624,7 +2625,8 @@ a.btn-icon:-webkit-any-link {
 .sv-sub-spacer {
     min-width: 260px;
     max-width: 320px;
-    position: relative;
+    /* Figée comme la colonne nom (via .sv-sticky) ; le fond gris de .sv-sub-row
+       td (plus spécifique) reste opaque au défilement horizontal. */
 }
 
 .sv-sub-td {

--- a/templates/subventions.html
+++ b/templates/subventions.html
@@ -43,7 +43,7 @@
                 <table class="sv-board">
                     <thead>
                         <tr>
-                            <th class="sv-col-name">Subvention</th>
+                            <th class="sv-col-name sv-sticky">Subvention</th>
                             <th class="sv-col-person">Assigné 1</th>
                             <th class="sv-col-person">Assigné 2</th>
                             <th class="sv-col-status">Type</th>
@@ -59,14 +59,13 @@
                             {% if not is_responsable %}
                             <th class="sv-col-actions"></th>
                             {% endif %}
-                            <th class="sv-col-name-end">Subvention</th>
                         </tr>
                     </thead>
                     <tbody>
                     {% for sub in groupe.lignes %}
                         <tr class="sv-row" data-id="{{ sub.id }}">
-                            {# ── Nom (sticky) ── #}
-                            <td class="sv-col-name sv-cell-name">
+                            {# ── Nom (colonne figée au défilement) ── #}
+                            <td class="sv-col-name sv-cell-name sv-sticky">
                                 <span class="sv-expand-btn" onclick="toggleSubElements({{ sub.id }}, this)" title="Sous-éléments">▸</span>
                                 <span class="sv-cell-text" onclick="editText(this, {{ sub.id }}, 'nom')">{{ sub.nom }}</span>
                                 <span class="sv-left-color" style="background:{{ groupe.color }};"></span>
@@ -168,12 +167,11 @@
                                 <button class="sv-del-btn" onclick="deleteSub({{ sub.id }})" title="Supprimer">🗑️</button>
                             </td>
                             {% endif %}
-                            <td class="sv-col-name-end">{{ sub.nom }}</td>
                         </tr>
                         {# ── Sous-éléments (masqués par défaut) ── #}
                         <tr class="sv-sub-row" id="se-row-{{ sub.id }}" style="display:none;">
-                            <td class="sv-sub-spacer"><span class="sv-left-color" style="background:{{ groupe.color }};"></span></td>
-                            <td colspan="{% if not is_responsable %}14{% else %}13{% endif %}" class="sv-sub-td">
+                            <td class="sv-sub-spacer sv-sticky"><span class="sv-left-color" style="background:{{ groupe.color }};"></span></td>
+                            <td colspan="{% if not is_responsable %}13{% else %}12{% endif %}" class="sv-sub-td">
                                 <table class="sv-sub-table">
                                     <thead>
                                         <tr>
@@ -234,7 +232,7 @@
 
                     {% if not groupe.lignes %}
                         <tr>
-                            <td colspan="{% if not is_responsable %}15{% else %}14{% endif %}" class="sv-empty">
+                            <td colspan="{% if not is_responsable %}14{% else %}13{% endif %}" class="sv-empty">
                                 Aucune subvention dans ce type
                             </td>
                         </tr>

--- a/templates/subventions.html
+++ b/templates/subventions.html
@@ -9,9 +9,20 @@
             <h1>Gestion des subventions</h1>
             <p class="subtitle">Suivi des dossiers de subventions par type</p>
         </div>
-        {% if not is_responsable %}
-        <button class="btn btn-secondary sv-manage-types-btn" onclick="openTypesManager()">⚙️ Gérer les types</button>
-        {% endif %}
+        <div class="sv-header-actions">
+            <label class="sv-annee-filtre">
+                <span class="sv-annee-label">Année</span>
+                <select id="sv-annee-select" class="sv-annee-select" onchange="changerAnnee(this.value)">
+                    {% for a in annees %}
+                    <option value="{{ a }}" {{ 'selected' if a == annee_selected else '' }}>{{ a }}</option>
+                    {% endfor %}
+                    <option value="toutes" {{ 'selected' if annee_selected == 'toutes' else '' }}>Toutes les années</option>
+                </select>
+            </label>
+            {% if not is_responsable %}
+            <button class="btn btn-secondary sv-manage-types-btn" onclick="openTypesManager()">⚙️ Gérer les types</button>
+            {% endif %}
+        </div>
     </div>
 
     {% for groupe in groupes %}
@@ -307,6 +318,10 @@ var STATUTS_SE = [
 {% endfor %}
 ];
 
+/* Filtre année (année de l'action) */
+var ANNEE_SELECTED = "{{ annee_selected }}";
+var ANNEE_COURANTE = "{{ annee_courante }}";
+
 /* ── Helpers ── */
 function apiCall(url, body) {
     return fetch(url, {
@@ -376,11 +391,19 @@ function toggleSubElements(subId, btn) {
     }
 }
 
+/* ── Filtre par année ── */
+function changerAnnee(val) {
+    window.location = "{{ url_for('subventions_bp.gestion_subventions') }}?annee=" + encodeURIComponent(val);
+}
+
 /* ── Ajouter subvention (dans un type donné) ── */
 function promptAdd(typeId) {
     var nom = prompt('Nom de la subvention :');
     if (!nom || !nom.trim()) return;
-    var annee = prompt('Année de l\'action :', new Date().getFullYear());
+    // Par défaut, l'année du filtre courant (pour que la subvention reste
+    // visible après création) ; sinon l'année en cours.
+    var defautAnnee = (ANNEE_SELECTED && ANNEE_SELECTED !== 'toutes') ? ANNEE_SELECTED : ANNEE_COURANTE;
+    var annee = prompt('Année de l\'action :', defautAnnee);
     if (annee === null) return;
     apiCall('/api/subventions/ajouter', {nom: nom.trim(), type_id: typeId, annee_action: annee.trim()}).then(function(r) {
         if (r.ok) location.reload();

--- a/tests/test_dashboard_actions.py
+++ b/tests/test_dashboard_actions.py
@@ -125,3 +125,41 @@ def test_subvention_refusee_exclue_du_panneau(app, db, sample_users):
     with app.test_request_context():
         actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
     assert not any('Refusee' in a['titre'] for a in actions if a['categorie'] == 'subvention')
+
+
+def test_lien_action_cible_l_annee_de_la_subvention(app, db, sample_users):
+    """Le lien d'une action pointe vers l'année de la subvention (si dans la plage
+    du filtre N-3..N+2) pour que la ligne reste visible sur la page filtrée ;
+    sinon vers « toutes » (année absente ou hors plage)."""
+    from utils import aujourd_hui
+    n = aujourd_hui().year
+    ech = (date.today() + timedelta(days=3)).isoformat()
+
+    def _sub(nom, annee_action):
+        cur = db.execute(
+            "INSERT INTO subventions (nom, groupe, annee_action) VALUES (?, 'en_cours', ?)",
+            (nom, annee_action)
+        )
+        db.execute(
+            "INSERT INTO subventions_sous_elements (subvention_id, nom, statut, date_echeance, ordre) "
+            "VALUES (?, 'Bilan', 'en_cours', ?, 0)",
+            (cur.lastrowid, ech)
+        )
+
+    _sub('AnCourante', str(n))       # dans la plage → année ciblée
+    _sub('SansAnnee', None)          # sans année → toutes
+    _sub('Vieille', str(n - 10))     # hors plage → toutes
+    db.commit()
+
+    with app.test_request_context():
+        actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+    def lien_de(nom):
+        for a in actions:
+            if a['categorie'] == 'subvention' and a['titre'].startswith(nom):
+                return a['lien']
+        return None
+
+    assert f'annee={n}' in lien_de('AnCourante')
+    assert 'annee=toutes' in lien_de('SansAnnee')
+    assert 'annee=toutes' in lien_de('Vieille')

--- a/tests/test_subventions.py
+++ b/tests/test_subventions.py
@@ -97,7 +97,8 @@ class TestTypesSubvention:
         with app.app_context():
             db.execute("INSERT INTO subventions (nom, groupe) VALUES ('Non classee', 'nouveau_projet')")
             db.commit()
-        html = admin_client.get('/subventions').get_data(as_text=True)
+        # ?annee=toutes : la subvention n'a pas d'année, on veut la voir ici.
+        html = admin_client.get('/subventions?annee=toutes').get_data(as_text=True)
         assert 'Non classee' in html
         assert 'Sans type' in html
 
@@ -299,7 +300,7 @@ class TestSubventionsBenevolesRendering:
             )
             db.commit()
 
-        response = admin_client.get('/subventions')
+        response = admin_client.get('/subventions?annee=toutes')
         assert response.status_code == 200
 
         html = response.get_data(as_text=True)
@@ -390,7 +391,68 @@ class TestVisibiliteResponsable:
         db.execute("INSERT INTO subventions (nom, groupe, annee_action) VALUES ('Cachee','en_cours','2026')")
         db.commit()
 
-        resp = resp_client.get('/subventions')
+        resp = resp_client.get('/subventions?annee=toutes')
         assert resp.status_code == 200
         assert b'DossierSE' in resp.data
         assert b'Cachee' not in resp.data
+
+
+class TestFiltreAnnee:
+    """Filtre par année de l'action : plage N-3..N+2, année courante par défaut."""
+
+    def _annee_courante(self):
+        from utils import aujourd_hui
+        return aujourd_hui().year
+
+    def _seed_deux_annees(self, db):
+        n = self._annee_courante()
+        db.execute("INSERT INTO subventions (nom, groupe, annee_action) VALUES ('SubvActuelle','en_cours',?)", (str(n),))
+        db.execute("INSERT INTO subventions (nom, groupe, annee_action) VALUES ('SubvAncienne','en_cours',?)", (str(n - 5),))
+        db.commit()
+        return n
+
+    def test_defaut_affiche_annee_courante_seulement(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            self._seed_deux_annees(db)
+        html = admin_client.get('/subventions').get_data(as_text=True)
+        assert 'SubvActuelle' in html
+        assert 'SubvAncienne' not in html
+
+    def test_annee_specifique_filtre(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            n = self._seed_deux_annees(db)
+        html = admin_client.get(f'/subventions?annee={n - 5}').get_data(as_text=True)
+        assert 'SubvAncienne' in html
+        assert 'SubvActuelle' not in html
+
+    def test_toutes_annees_affiche_tout(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            self._seed_deux_annees(db)
+        html = admin_client.get('/subventions?annee=toutes').get_data(as_text=True)
+        assert 'SubvActuelle' in html
+        assert 'SubvAncienne' in html
+
+    def test_selecteur_annee_rendu(self, app, admin_client, db, sample_users):
+        n = self._annee_courante()
+        html = admin_client.get('/subventions').get_data(as_text=True)
+        # Plage N-3 .. N+2 présente, année courante sélectionnée, option « Toutes ».
+        assert f'<option value="{n - 3}"' in html
+        assert f'<option value="{n + 2}"' in html
+        assert f'<option value="{n}" selected>' in html
+        assert 'Toutes les années' in html
+        # Hors plage : N-4 et N+3 absents du sélecteur.
+        assert f'<option value="{n - 4}"' not in html
+        assert f'<option value="{n + 3}"' not in html
+
+    def test_annee_invalide_retombe_sur_annee_courante(self, app, admin_client, db, sample_users):
+        with app.app_context():
+            self._seed_deux_annees(db)
+        # Un paramètre non valide ne doit pas planter et retombe sur l'année courante.
+        html = admin_client.get('/subventions?annee=abcd').get_data(as_text=True)
+        assert 'SubvActuelle' in html
+        assert 'SubvAncienne' not in html
+
+    def test_le_filtre_est_visible_pour_le_responsable(self, app, resp_client, db, sample_users):
+        # Le filtre par année est utile à tous (contrairement à « Gérer les types »).
+        html = resp_client.get('/subventions').get_data(as_text=True)
+        assert 'sv-annee-select' in html


### PR DESCRIPTION
## Objectif

Ajouter, en haut de la page **Subventions** (avant « Gérer les types »), un **filtre par année** allant de **N-3 à N+2**, avec l'**année en cours sélectionnée par défaut**, pour n'afficher que les subventions de l'année choisie.

## Changements

### Filtre par année
- Sélecteur d'année dans l'en-tête, **avant** le bouton « Gérer les types », **visible par tous les profils** (responsables inclus).
- Plage **N-3 … N+2** (6 années), **année courante par défaut** (calcul timezone-aware via `aujourd_hui()`).
- Filtrage **côté serveur** (`/subventions?annee=AAAA`) sur le champ `annee_action` : seules les subventions de l'année choisie sont affichées (dans tous les groupes de types).
- Option **« Toutes les années »** : désactive le filtre. Elle évite qu'une subvention **hors plage** ou **sans année renseignée** ne devienne invisible/ingérable.

### Confort
- À la création d'une subvention, l'année proposée reprend **l'année du filtre courant** (la subvention reste donc visible après création).
- Le filtre est conservé lors des rechargements (édition de type, ajout/suppression…).

## Tests
- **+6 tests** (`TestFiltreAnnee`) : défaut = année courante, année spécifique, « toutes », paramètre invalide → repli sur l'année courante, rendu du sélecteur (plage + option « Toutes »), visibilité pour le responsable.
- Tests de rendu existants (bénévoles, visibilité responsable, groupe « Sans type ») basculés sur `?annee=toutes` pour rester indépendants de l'année réelle.
- Tests indépendants de l'horloge de la machine (année calculée via `aujourd_hui()`).

## Notes
- Le filtre par défaut masque les subventions des autres années et **celles sans année** : « Toutes les années » est l'échappatoire.
- Aucune migration : s'appuie sur le champ `annee_action` existant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_