### PR TITLE
Tableaux de bord : barre de recherche intelligente (V1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 ### Tableau de bord direction
 - Vue d'ensemble effectifs, absences, validations et anomalies
 - Demandes de recuperation en attente et top conges cumules
+- Barre de recherche intelligente (direction / comptabilite) : detecte l'intention et redirige vers la bonne page (facture par numero, fiche fournisseur, budget d'une action ou d'un secteur, tresorerie, subventions, bilan/CR, absences ou fiche temps d'un salarie, contrats du mois...). Reconnait les periodes (mois, annee, mois dernier...) et les synonymes de secteurs ; propose un choix en cas d'ambiguite (plusieurs salaries homonymes)
 
 ### Reservations de salles
 - Gestion des reservations de salles avec recurrences

--- a/app.py
+++ b/app.py
@@ -255,6 +255,8 @@ from blueprints.import_bi import import_bi_bp
 from blueprints.commandes_salaries import commandes_salaries_bp
 from blueprints.cse import cse_bp
 from blueprints.planificateur import planificateur_bp
+from blueprints.contrats import contrats_bp
+from blueprints.recherche import recherche_bp
 
 app.register_blueprint(auth)
 app.register_blueprint(dashboard_bp)
@@ -308,6 +310,8 @@ app.register_blueprint(import_bi_bp)
 app.register_blueprint(commandes_salaries_bp)
 app.register_blueprint(cse_bp)
 app.register_blueprint(planificateur_bp)
+app.register_blueprint(contrats_bp)
+app.register_blueprint(recherche_bp)
 
 
 # ==================== Context Processors ====================

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -377,12 +377,13 @@ def gestion_secteurs():
                 nom = request.form.get('nom')
                 description = request.form.get('description')
                 type_secteur = request.form.get('type_secteur') or None
+                synonymes = (request.form.get('synonymes') or '').strip() or None
 
                 try:
                     conn.execute('''
-                        INSERT INTO secteurs (nom, description, type_secteur)
-                        VALUES (?, ?, ?)
-                    ''', (nom, description, type_secteur))
+                        INSERT INTO secteurs (nom, description, type_secteur, synonymes)
+                        VALUES (?, ?, ?, ?)
+                    ''', (nom, description, type_secteur, synonymes))
                     conn.commit()
                     flash(f'Secteur "{nom}" créé avec succès', 'success')
                 except Exception as e:
@@ -393,15 +394,16 @@ def gestion_secteurs():
                 nom = request.form.get('nom')
                 description = request.form.get('description')
                 type_secteur = request.form.get('type_secteur') or None
+                synonymes = (request.form.get('synonymes') or '').strip() or None
 
                 if not nom:
                     flash('Le nom du secteur est requis', 'error')
                 else:
                     try:
                         conn.execute('''
-                            UPDATE secteurs SET nom = ?, description = ?, type_secteur = ?
+                            UPDATE secteurs SET nom = ?, description = ?, type_secteur = ?, synonymes = ?
                             WHERE id = ?
-                        ''', (nom, description, type_secteur, secteur_id))
+                        ''', (nom, description, type_secteur, synonymes, secteur_id))
                         conn.commit()
                         flash(f'Secteur "{nom}" modifié avec succès', 'success')
                     except Exception as e:

--- a/blueprints/bilan_action.py
+++ b/blueprints/bilan_action.py
@@ -343,14 +343,23 @@ def bilan_action():
         ).fetchall()
         annee_courante = date.today().year
         annees = list(range(annee_courante + 1, annee_courante - 5, -1))
-        # Action pré-sélectionnée via ?action_id= (lien depuis la page subventions).
+        # Présélection via query (lien depuis subventions / barre de recherche) :
+        # ?action_id= (+ ?annee= et ?onglet=previsionnel|realise).
         action_preselect = request.args.get('action_id', type=int)
+        annee_preselect = request.args.get('annee', type=int)
+        if annee_preselect not in annees:
+            annee_preselect = None
+        onglet_preselect = request.args.get('onglet')
+        if onglet_preselect not in ('previsionnel', 'realise'):
+            onglet_preselect = 'previsionnel'
         return render_template(
             'bilan_action.html',
             actions=actions,
             annees=annees,
             annee_courante=annee_courante,
             action_preselect=action_preselect,
+            annee_preselect=annee_preselect,
+            onglet_preselect=onglet_preselect,
         )
     finally:
         conn.close()

--- a/blueprints/bilan_secteurs.py
+++ b/blueprints/bilan_secteurs.py
@@ -63,6 +63,13 @@ def bilan_secteurs():
     annee_courante = now.year
     annees = list(range(annee_courante - 3, annee_courante + 2))
 
+    # Présélection depuis la barre de recherche (?secteur_id=&action_id=&annee=).
+    presel_secteur_id = request.args.get('secteur_id', type=int)
+    presel_action_id = request.args.get('action_id', type=int)
+    presel_annee = request.args.get('annee', type=int)
+    annee_sel = presel_annee if presel_annee in annees else annee_courante
+    presel_actif = bool(presel_secteur_id or presel_action_id or presel_annee)
+
     est_resp = _est_responsable()
     secteur_resp_id = session.get('secteur_id') if est_resp else None
 
@@ -92,7 +99,11 @@ def bilan_secteurs():
                                secteurs=secteurs, actions=actions,
                                annees_importees=[r['annee'] for r in annees_importees],
                                est_responsable=est_resp,
-                               secteur_responsable_id=secteur_resp_id)
+                               secteur_responsable_id=secteur_resp_id,
+                               annee_sel=annee_sel,
+                               presel_secteur_id=presel_secteur_id,
+                               presel_action_id=presel_action_id,
+                               presel_actif=presel_actif)
     finally:
         conn.close()
 

--- a/blueprints/compte_resultat.py
+++ b/blueprints/compte_resultat.py
@@ -251,11 +251,18 @@ def compte_resultat():
         ).fetchall()
         annees_list = [r['annee'] for r in annees_importees]
         annee_courante = annees_list[0] if annees_list else now.year
+        # Présélection depuis la barre de recherche : ?annee= et ?vue=cr|bilan.
+        annee_param = request.args.get('annee', type=int)
+        annee_sel = annee_param if annee_param in annees_list else annee_courante
+        vue_preselect = request.args.get('vue')
+        if vue_preselect not in ('cr', 'bilan'):
+            vue_preselect = 'cr'
         return render_template(
             'compte_resultat.html',
-            annee_courante=annee_courante,
+            annee_courante=annee_sel,
             annees_importees=annees_list,
             noms_cat_json={**NOMS_CAT_CR, **NOMS_CAT_BILAN},
+            vue_preselect=vue_preselect,
         )
     finally:
         conn.close()

--- a/blueprints/contrats.py
+++ b/blueprints/contrats.py
@@ -1,0 +1,114 @@
+"""
+Blueprint contrats_bp — Liste des contrats par mois / filtre.
+
+Sert les requêtes de la barre de recherche intelligente : « contrats avril »,
+« CDD en cours », « CDD se terminant en juillet », « contrats à échéance »,
+« CDD signé ce mois ». Accès directeur / comptable.
+
+Réutilise la fenêtre d'activité mensuelle de prepa_paie.py
+(date_debut <= fin_mois ET (date_fin IS NULL OR date_fin >= debut_mois)) et la
+route de téléchargement existante infos_salaries_bp.telecharger_contrat.
+"""
+import calendar
+from flask import Blueprint, render_template, request, session, flash, redirect, url_for
+from database import get_db
+from utils import login_required, aujourd_hui, NOMS_MOIS
+
+contrats_bp = Blueprint('contrats_bp', __name__)
+
+PROFILS_AUTORISES = ['directeur', 'comptable']
+
+# Filtres proposés (clé → libellé affiché)
+FILTRES = [
+    ('en_cours', 'En cours sur le mois'),
+    ('echeance', 'CDD se terminant (échéance)'),
+    ('signe', 'Débutant ce mois'),
+]
+
+
+@contrats_bp.route('/contrats')
+@login_required
+def liste_contrats():
+    if session.get('profil') not in PROFILS_AUTORISES:
+        flash('Accès non autorisé', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    today = aujourd_hui()
+    annee_courante = today.year
+    annees = [annee_courante + 1 - d for d in range(0, 6)]  # N+1 … N-4
+
+    try:
+        annee = int(request.args.get('annee') or annee_courante)
+    except (TypeError, ValueError):
+        annee = annee_courante
+    if annee not in annees:
+        annee = annee_courante
+
+    try:
+        mois = int(request.args.get('mois') or today.month)
+    except (TypeError, ValueError):
+        mois = today.month
+    if mois < 1 or mois > 12:
+        mois = today.month
+
+    type_contrat = (request.args.get('type') or '').strip().upper() or None
+    filtre = (request.args.get('filtre') or 'en_cours').strip()
+    if filtre not in {f[0] for f in FILTRES}:
+        filtre = 'en_cours'
+
+    debut_mois = f"{annee:04d}-{mois:02d}-01"
+    fin_mois = f"{annee:04d}-{mois:02d}-{calendar.monthrange(annee, mois)[1]:02d}"
+
+    where = ["u.profil != 'prestataire'"]
+    params = []
+
+    if filtre == 'echeance':
+        # Contrats se terminant dans le mois (CDD par défaut).
+        where.append("c.date_fin IS NOT NULL AND c.date_fin BETWEEN ? AND ?")
+        params += [debut_mois, fin_mois]
+        if not type_contrat:
+            type_contrat = 'CDD'
+    elif filtre == 'signe':
+        # Contrats débutant dans le mois (proxy « signé ce mois »).
+        where.append("c.date_debut BETWEEN ? AND ?")
+        params += [debut_mois, fin_mois]
+    else:  # en_cours
+        where.append("c.date_debut <= ? AND (c.date_fin IS NULL OR c.date_fin >= ?)")
+        params += [fin_mois, debut_mois]
+
+    if type_contrat:
+        where.append("UPPER(c.type_contrat) = ?")
+        params.append(type_contrat)
+
+    conn = get_db()
+    try:
+        contrats = conn.execute(f'''
+            SELECT c.id, c.type_contrat, c.date_debut, c.date_fin, c.forfait,
+                   c.nbr_jours, c.temps_hebdo, c.fichier_path,
+                   u.nom, u.prenom, COALESCE(s.nom, '') AS secteur_nom
+            FROM contrats c
+            JOIN users u ON c.user_id = u.id
+            LEFT JOIN secteurs s ON u.secteur_id = s.id
+            WHERE {" AND ".join(where)}
+            ORDER BY u.nom, u.prenom, c.date_debut DESC
+        ''', params).fetchall()
+
+        types_dispo = [r['type_contrat'] for r in conn.execute(
+            "SELECT DISTINCT type_contrat FROM contrats WHERE type_contrat IS NOT NULL "
+            "AND type_contrat != '' ORDER BY type_contrat"
+        ).fetchall()]
+    finally:
+        conn.close()
+
+    return render_template(
+        'contrats.html',
+        contrats=contrats,
+        annees=annees,
+        annee_selected=annee,
+        mois_selected=mois,
+        noms_mois=NOMS_MOIS,
+        type_selected=type_contrat or '',
+        types_dispo=types_dispo,
+        filtre_selected=filtre,
+        filtres=FILTRES,
+    )

--- a/blueprints/recherche.py
+++ b/blueprints/recherche.py
@@ -1,0 +1,34 @@
+"""
+Blueprint recherche_bp — API de la barre de recherche intelligente.
+
+POST /api/search {query} → verdict de routage (redirect | choices | none),
+calculé par le moteur pur search_engine.analyser_recherche. Accès réservé à la
+direction et à la comptabilité (comme les tableaux de bord qui l'affichent).
+CSRF est injecté automatiquement par base.html.
+"""
+from flask import Blueprint, request, session, jsonify
+from database import get_db
+from utils import login_required, aujourd_hui
+from search_engine import analyser_recherche
+
+recherche_bp = Blueprint('recherche_bp', __name__)
+
+PROFILS_AUTORISES = ('directeur', 'comptable')
+
+
+@recherche_bp.route('/api/search', methods=['POST'])
+@login_required
+def api_search():
+    if session.get('profil') not in PROFILS_AUTORISES:
+        return jsonify({'type': 'none', 'message': 'Accès non autorisé', 'exemples': []}), 403
+
+    data = request.get_json(silent=True) or {}
+    query = (data.get('query') or '').strip()
+
+    conn = get_db()
+    try:
+        verdict = analyser_recherche(conn, query, session.get('profil'), aujourd_hui())
+    finally:
+        conn.close()
+
+    return jsonify(verdict)

--- a/database.py
+++ b/database.py
@@ -250,6 +250,7 @@ def init_db():
             nom TEXT NOT NULL UNIQUE,
             description TEXT,
             type_secteur TEXT DEFAULT NULL,
+            synonymes TEXT,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP
         )
     ''')
@@ -1794,6 +1795,12 @@ def init_db():
         cursor.execute("SELECT type_secteur FROM secteurs LIMIT 1")
     except sqlite3.OperationalError:
         cursor.execute("ALTER TABLE secteurs ADD COLUMN type_secteur TEXT DEFAULT NULL")
+
+    # Migration 0053 : synonymes de secteurs (barre de recherche intelligente)
+    try:
+        cursor.execute("SELECT synonymes FROM secteurs LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE secteurs ADD COLUMN synonymes TEXT")
 
     # Migration : ajouter temps_hebdo si n'existe pas dans contrats
     try:

--- a/migrations/0053_synonymes_secteurs.py
+++ b/migrations/0053_synonymes_secteurs.py
@@ -1,0 +1,31 @@
+"""
+Migration 0053 : Synonymes de secteurs.
+
+Ajoute la colonne secteurs.synonymes (liste de termes séparés par des virgules)
+utilisée par la barre de recherche intelligente pour reconnaître un secteur
+depuis un alias (ex. « bab » → « Babilhome »).
+"""
+
+NOM = "Synonymes de secteurs"
+DESCRIPTION = (
+    "Ajoute la colonne secteurs.synonymes pour la reconnaissance des secteurs "
+    "par la barre de recherche intelligente."
+)
+
+
+def _column_exists(cursor, table, column):
+    cursor.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cursor.fetchall())
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    cursor = conn.cursor()
+    if not _column_exists(cursor, 'secteurs', 'synonymes'):
+        cursor.execute("ALTER TABLE secteurs ADD COLUMN synonymes TEXT")
+    conn.commit()
+
+
+def downgrade(conn):
+    """Pas de downgrade (la colonne est conservée)."""
+    conn.commit()

--- a/search_engine.py
+++ b/search_engine.py
@@ -1,0 +1,515 @@
+"""
+Moteur de la barre de recherche intelligente (tableaux de bord direction /
+comptable).
+
+100 % règles (déterministe, testable, sans IA). Une requête est analysée pour
+détecter une intention (mot-clé + entité + période) et renvoyer un verdict :
+
+- {'type': 'redirect', 'url': ..., 'label': ...}
+- {'type': 'choices',  'prompt': ..., 'options': [{'label','sous_titre','url'}]}
+- {'type': 'none',     'message': ..., 'exemples': [...]}
+
+Le module est pur (aucun accès `session`/`request`) : il reçoit `conn`, la
+requête, le profil et la date du jour. Les URLs sont construites avec `url_for`
+(nécessite un contexte d'application — les tests utilisent
+`app.test_request_context()`, comme dashboard_actions.py).
+"""
+import re
+import unicodedata
+from flask import url_for
+
+from utils import NOMS_MOIS
+
+
+# ── Normalisation (minuscules + sans accents) ──
+
+def _normaliser(texte):
+    """Minuscule, sans accents, ponctuation → espaces, espaces compactés."""
+    if not texte:
+        return ''
+    nfkd = unicodedata.normalize('NFKD', str(texte))
+    sans_accents = ''.join(c for c in nfkd if not unicodedata.combining(c))
+    minus = sans_accents.lower()
+    # Remplacer tout ce qui n'est pas alphanumérique par une espace.
+    nettoye = re.sub(r"[^a-z0-9]+", ' ', minus)
+    return re.sub(r'\s+', ' ', nettoye).strip()
+
+
+# Mois : nom normalisé → numéro (Janvier→1 … Décembre→12, + variantes courantes).
+_MOIS_NUM = {}
+for _i, _nom in enumerate(NOMS_MOIS):
+    if _nom:
+        _MOIS_NUM[_normaliser(_nom)] = _i
+_MOIS_NUM.update({'fevrier': 2, 'aout': 8, 'decembre': 12})  # sécurité sans accents
+
+
+# ── Période (mois / année / relatifs) ──
+
+def _extraire_periode(tokens, today):
+    """Extrait mois/année (explicites ou relatifs) et retourne les tokens restants.
+
+    Retourne (mois, annee, annee_explicite, reste_tokens). `mois`/`annee` valent
+    None s'ils ne sont pas déterminés (le caller applique alors des défauts).
+    """
+    mois = None
+    annee = None
+    annee_explicite = False
+    reste = []
+
+    i = 0
+    n = len(tokens)
+    while i < n:
+        t = tokens[i]
+        suivant = tokens[i + 1] if i + 1 < n else ''
+
+        # Relatifs multi-mots
+        if t == 'mois' and suivant == 'dernier':
+            m = today.month - 1 or 12
+            y = today.year - 1 if today.month == 1 else today.year
+            mois, annee, annee_explicite = m, y, True
+            i += 2
+            continue
+        if t in ('annee', 'année') and suivant in ('derniere', 'dernier'):
+            annee, annee_explicite = today.year - 1, True
+            i += 2
+            continue
+        if t == 'ce' and suivant == 'mois':
+            mois, annee, annee_explicite = today.month, today.year, True
+            i += 2
+            continue
+        if t == 'cette' and suivant == 'annee':
+            annee, annee_explicite = today.year, True
+            i += 2
+            continue
+        if t == 'cette' and suivant == 'semaine':
+            mois, annee, annee_explicite = today.month, today.year, True
+            i += 2
+            continue
+        if t.startswith('aujourd'):  # aujourd'hui → aujourdhui / aujourd hui
+            if t == 'aujourd' and suivant == 'hui':
+                i += 1
+            mois, annee, annee_explicite = today.month, today.year, True
+            i += 1
+            continue
+
+        # Mois nommé
+        if t in _MOIS_NUM:
+            mois = _MOIS_NUM[t]
+            i += 1
+            continue
+        # Année à 4 chiffres
+        if re.fullmatch(r'(19|20)\d{2}', t):
+            annee = int(t)
+            annee_explicite = True
+            i += 1
+            continue
+
+        reste.append(t)
+        i += 1
+
+    return mois, annee, annee_explicite, reste
+
+
+# ── Résolveurs d'entités (normalisés, insensibles casse/accents) ──
+
+def _resoudre_fournisseur(conn, terme):
+    terme_n = _normaliser(terme)
+    if not terme_n:
+        return []
+    rows = conn.execute(
+        'SELECT id, nom, alias1, alias2, code_comptable FROM fournisseurs ORDER BY nom'
+    ).fetchall()
+    exact, prefixe = [], []
+    for r in rows:
+        champs = [_normaliser(r[c]) for c in ('nom', 'alias1', 'alias2', 'code_comptable')]
+        champs = [c for c in champs if c]
+        if terme_n in champs:
+            exact.append(r)
+        elif any(c.startswith(terme_n) for c in champs):
+            prefixe.append(r)
+    return exact or prefixe
+
+
+def _resoudre_secteur(conn, terme):
+    terme_n = _normaliser(terme)
+    if not terme_n:
+        return []
+    rows = conn.execute('SELECT id, nom, synonymes FROM secteurs ORDER BY nom').fetchall()
+    exact, prefixe = [], []
+    for r in rows:
+        termes = [_normaliser(r['nom'])]
+        for syn in (r['synonymes'] or '').split(','):
+            syn_n = _normaliser(syn)
+            if syn_n:
+                termes.append(syn_n)
+        if terme_n in termes:
+            exact.append(r)
+        elif any(t.startswith(terme_n) for t in termes):
+            prefixe.append(r)
+    return exact or prefixe
+
+
+def _resoudre_salarie(conn, terme):
+    terme_n = _normaliser(terme)
+    if not terme_n:
+        return []
+    mots = terme_n.split()
+    rows = conn.execute(
+        "SELECT u.id, u.nom, u.prenom, s.nom AS secteur_nom "
+        "FROM users u LEFT JOIN secteurs s ON u.secteur_id = s.id "
+        "WHERE u.actif = 1 AND u.profil != 'prestataire' ORDER BY u.nom, u.prenom"
+    ).fetchall()
+    exact, prefixe = [], []
+    for r in rows:
+        nom_n = _normaliser(r['nom'] or '')
+        prenom_n = _normaliser(r['prenom'] or '')
+        if len(mots) >= 2:
+            # Nom + prénom (dans un sens ou l'autre)
+            paire = {mots[0], mots[1]}
+            if paire == {nom_n, prenom_n}:
+                exact.append(r)
+            elif (prenom_n.startswith(mots[0]) and nom_n.startswith(mots[1])) or \
+                 (nom_n.startswith(mots[0]) and prenom_n.startswith(mots[1])):
+                prefixe.append(r)
+        else:
+            if terme_n in (nom_n, prenom_n):
+                exact.append(r)
+            elif prenom_n.startswith(terme_n) or nom_n.startswith(terme_n):
+                prefixe.append(r)
+    return exact or prefixe
+
+
+def _resoudre_action(conn, terme):
+    terme_n = _normaliser(terme)
+    if not terme_n:
+        return []
+    rows = conn.execute('SELECT id, nom FROM comptabilite_actions ORDER BY nom').fetchall()
+    exact = [r for r in rows if _normaliser(r['nom']) == terme_n]
+    if exact:
+        return exact
+    return [r for r in rows if _normaliser(r['nom']).startswith(terme_n)]
+
+
+def _resoudre_subvention(conn, terme):
+    terme_n = _normaliser(terme)
+    if not terme_n or len(terme_n) < 2:
+        return []
+    rows = conn.execute('SELECT id, nom, annee_action FROM subventions ORDER BY nom').fetchall()
+    exact = [r for r in rows if _normaliser(r['nom']) == terme_n]
+    if exact:
+        return exact
+    return [r for r in rows if terme_n in _normaliser(r['nom'])]
+
+
+def _resoudre_facture_numero(conn, numero):
+    num = (numero or '').strip()
+    if not num:
+        return []
+    return conn.execute(
+        'SELECT f.id, f.numero_facture, f.date_facture, fr.nom AS fournisseur_nom '
+        'FROM factures f LEFT JOIN fournisseurs fr ON f.fournisseur_id = fr.id '
+        'WHERE f.numero_facture = ? ORDER BY f.date_facture DESC', (num,)
+    ).fetchall()
+
+
+# ── Constructeurs de verdicts ──
+
+def _redirect(url, label):
+    return {'type': 'redirect', 'url': url, 'label': label}
+
+
+def _choices(prompt, options):
+    return {'type': 'choices', 'prompt': prompt, 'options': options}
+
+
+_EXEMPLES = [
+    'facture 225678', 'factures edf', 'budget clas 2025', 'budget babilhome',
+    'trésorerie avril', 'bilan 2025', 'liste subventions 2026',
+    'absence Marie', 'heures Marie', 'contrats avril', 'CDD se terminant en juillet',
+]
+
+
+def _aide(message="Tapez un nom (fournisseur, secteur, salarié), un mot-clé ou un numéro de facture."):
+    return {'type': 'none', 'message': message, 'exemples': _EXEMPLES}
+
+
+# ── Fiche salarié / choix (désambiguïsation) ──
+
+def _url_salarie(uid, ancre=''):
+    return url_for('infos_salaries_bp.infos_salaries', user_id=uid) + ancre
+
+
+def _salarie_ou_choix(salaries, faire_url, prompt, ancre=''):
+    """Redirige si un seul salarié, propose un choix si plusieurs."""
+    if len(salaries) == 1:
+        s = salaries[0]
+        return _redirect(faire_url(s['id']), f"{s['prenom']} {s['nom']}")
+    options = []
+    for s in salaries:
+        options.append({
+            'label': f"{s['prenom']} {s['nom']}",
+            'sous_titre': s['secteur_nom'] or '',
+            'url': faire_url(s['id']),
+        })
+    return _choices(prompt, options)
+
+
+# ── Détection d'intention principale ──
+
+_KW_FACTURE = {'facture', 'factures'}
+_KW_BUDGET = {'budget', 'budgets', 'previsionnel', 'previsionnel'}
+_KW_TRESO = {'tresorerie', 'treso', 'solde'}
+_KW_SUBV = {'subvention', 'subventions'}
+_KW_INDIC = {'indicateur', 'indicateurs'}
+_KW_SALARIE = {'salarie', 'salaries', 'salariee', 'fiche', 'employe', 'employee'}
+_KW_ABSENCE = {'absence', 'absences', 'conge', 'conges'}
+_KW_PESEE = {'pesee', 'pese'}
+_KW_HEURES = {'heure', 'heures', 'temps'}
+_KW_CONTRAT = {'contrat', 'contrats', 'cdd', 'cdi'}
+
+# Mots outils ignorés en tête de requête (« voir budget », « liste subventions »…)
+_MOTS_OUTILS = {'liste', 'listes', 'voir', 'afficher', 'montre', 'montrer', 'montrez',
+                'ouvre', 'ouvrir', 'les', 'la', 'le', 'des', 'du', 'de', 'mes', 'mon', 'ma'}
+
+
+def analyser_recherche(conn, query, profil, today):
+    """Analyse une requête et renvoie un verdict de routage. Fonction pure."""
+    q = (query or '').strip()
+    if not q or q in ('?', 'aide', 'help'):
+        return _aide()
+
+    norm = _normaliser(q)
+    tokens = norm.split()
+    mois, annee, annee_explicite, reste = _extraire_periode(tokens, today)
+    annee_eff = annee if annee is not None else today.year
+    reste_str = ' '.join(reste).strip()
+
+    # ── Phrases multi-mots (avant les mots-clés simples et le retrait des mots outils) ──
+    if 'plan comptable' in norm or reste_str in ('liste compte', 'liste comptes', 'plan comptable'):
+        return _redirect(url_for('plan_comptable_general_bp.plan_comptable_general'),
+                         'Plan comptable général')
+    if 'compte de resultat' in norm or 'compte resultat' in norm:
+        return _redirect(url_for('compte_resultat_bp.compte_resultat', annee=annee_eff, vue='cr'),
+                         f'Compte de résultat {annee_eff}')
+    if 'prevision tresorerie' in norm or 'solde banque' in norm:
+        params = {'annee': annee_eff}
+        if mois:
+            params['mois'] = mois
+        return _redirect(url_for('tresorerie_bp.tresorerie', **params), 'Trésorerie')
+
+    # Retirer les mots outils en tête (« voir », « liste », « les »…) pour révéler le mot-clé.
+    while reste and reste[0] in _MOTS_OUTILS:
+        reste = reste[1:]
+    reste_str = ' '.join(reste).strip()
+    kw = reste[0] if reste else ''
+    apres_kw = ' '.join(reste[1:]).strip()
+
+    # ── A. Compta / finance ──
+    if kw in _KW_FACTURE:
+        return _intention_facture(conn, apres_kw, mois, annee_eff)
+    if kw in _KW_BUDGET:
+        return _intention_budget(conn, kw, apres_kw, annee_eff, annee_explicite, today)
+    if kw in _KW_TRESO or 'tresorerie' in reste:
+        params = {'annee': annee_eff}
+        if mois:
+            params['mois'] = mois
+        return _redirect(url_for('tresorerie_bp.tresorerie', **params), 'Trésorerie')
+    if kw in _KW_SUBV:
+        return _intention_subvention(conn, apres_kw, annee, annee_explicite)
+    if kw == 'bilan':
+        return _redirect(url_for('compte_resultat_bp.compte_resultat', annee=annee_eff, vue='bilan'),
+                         f'Bilan {annee_eff}')
+    if kw in ('cr', 'resultat'):
+        return _redirect(url_for('compte_resultat_bp.compte_resultat', annee=annee_eff, vue='cr'),
+                         f'Compte de résultat {annee_eff}')
+    if kw in _KW_INDIC:
+        return _redirect(url_for('indicateurs_financiers_bp.indicateurs_financiers'),
+                         'Indicateurs financiers')
+    if kw in ('compte', 'comptes'):
+        return _redirect(url_for('plan_comptable_general_bp.plan_comptable_general'),
+                         'Plan comptable général')
+
+    # ── B. RH ──
+    if kw in _KW_CONTRAT:
+        return _intention_contrat(conn, kw, apres_kw, mois, annee_eff, today)
+    if kw in _KW_ABSENCE:
+        salaries = _resoudre_salarie(conn, apres_kw) if apres_kw else []
+        if apres_kw and salaries:
+            return _salarie_ou_choix(
+                salaries,
+                lambda uid: url_for('absences_bp.absences', search_user_id=uid),
+                f"Plusieurs salariés « {apres_kw} » — absences de :")
+        return _redirect(url_for('absences_bp.absences'), 'Absences')
+    if kw in _KW_PESEE:
+        # postes_alisfa n'a pas de filtre par personne : la pesée d'un salarié est
+        # affichée sur sa fiche → « pesée Marie » y renvoie ; « pesée » seul ouvre
+        # l'outil de pesée ALISFA.
+        salaries = _resoudre_salarie(conn, apres_kw) if apres_kw else []
+        if apres_kw and salaries:
+            return _salarie_ou_choix(
+                salaries, lambda uid: _url_salarie(uid),
+                f"Plusieurs salariés « {apres_kw} » — pesée de :")
+        return _redirect(url_for('pesee_alisfa_bp.postes_alisfa'), 'Pesée comptable (ALISFA)')
+    if kw in _KW_HEURES:
+        salaries = _resoudre_salarie(conn, apres_kw) if apres_kw else []
+        if apres_kw and salaries:
+            return _salarie_ou_choix(
+                salaries,
+                lambda uid: url_for('validation_bp.vue_mensuelle', user_id=uid,
+                                    mois=mois or today.month, annee=annee_eff),
+                f"Plusieurs salariés « {apres_kw} » — fiche temps de :")
+        return _aide("Précisez un salarié : ex. « heures Marie ».")
+    if kw in _KW_SALARIE:
+        salaries = _resoudre_salarie(conn, apres_kw) if apres_kw else []
+        ancre = '#contrats' if 'contrat' in reste else ''
+        if apres_kw and salaries:
+            return _salarie_ou_choix(
+                salaries, lambda uid: _url_salarie(uid, ancre),
+                f"Plusieurs salariés « {apres_kw} » :", ancre)
+        return _aide("Précisez un salarié : ex. « salarié Marie ».")
+
+    # ── Mot(s) seul(s) : résolution multi-types ──
+    return _resoudre_terme_libre(conn, reste_str, annee, annee_explicite, mois, today)
+
+
+def _intention_facture(conn, terme, mois, annee_eff):
+    terme_n = _normaliser(terme)
+    # Numéro de facture (ex. « facture 225678 »)
+    if re.fullmatch(r'\d{3,}', terme_n):
+        factures = _resoudre_facture_numero(conn, terme_n)
+        if len(factures) == 1:
+            return _redirect(url_for('factures_bp.detail_facture', facture_id=factures[0]['id']),
+                             f"Facture {terme_n}")
+        if len(factures) > 1:
+            options = [{
+                'label': f"Facture {f['numero_facture']}",
+                'sous_titre': f"{f['fournisseur_nom'] or ''} — {f['date_facture'] or ''}",
+                'url': url_for('factures_bp.detail_facture', facture_id=f['id']),
+            } for f in factures]
+            return _choices(f"Plusieurs factures « {terme_n} » :", options)
+        return _aide(f"Aucune facture au numéro « {terme_n} ».")
+    # Nom de fournisseur (ex. « factures edf ») → fiche fournisseur (liste incluse)
+    if terme:
+        fournisseurs = _resoudre_fournisseur(conn, terme)
+        if len(fournisseurs) == 1:
+            return _redirect(
+                url_for('fournisseurs_bp.detail_fournisseur',
+                        fournisseur_id=fournisseurs[0]['id'], annee=annee_eff),
+                f"Factures — {fournisseurs[0]['nom']}")
+        if len(fournisseurs) > 1:
+            options = [{
+                'label': f['nom'], 'sous_titre': f['code_comptable'] or '',
+                'url': url_for('fournisseurs_bp.detail_fournisseur', fournisseur_id=f['id'], annee=annee_eff),
+            } for f in fournisseurs]
+            return _choices(f"Plusieurs fournisseurs « {terme} » :", options)
+    # Générique
+    return _redirect(url_for('factures_bp.liste_factures'), 'Factures')
+
+
+def _intention_budget(conn, kw, terme, annee_eff, annee_explicite, today):
+    passe = annee_explicite and annee_eff < today.year
+    # « prévisionnel [année] » sans entité → vue budgets
+    if kw in ('previsionnel', 'previsionnel') and not terme:
+        return _redirect(url_for('budget_bp.gestion_budgets', annee=annee_eff),
+                         f'Budget prévisionnel {annee_eff}')
+    if terme:
+        # Secteur → toujours bilan-secteurs
+        secteurs = _resoudre_secteur(conn, terme)
+        if len(secteurs) == 1:
+            return _redirect(
+                url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=secteurs[0]['id'], annee=annee_eff),
+                f"Budget — {secteurs[0]['nom']} {annee_eff}")
+        # Action → bilan-secteurs (réalisé) si année passée, sinon bilan-action
+        actions = _resoudre_action(conn, terme)
+        if len(actions) == 1:
+            a = actions[0]
+            if passe:
+                return _redirect(
+                    url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=annee_eff),
+                    f"Budget réalisé — {a['nom']} {annee_eff}")
+            return _redirect(
+                url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet='previsionnel'),
+                f"Budget — {a['nom']} {annee_eff}")
+        # Plusieurs correspondances (secteurs + actions)
+        options = []
+        for s in secteurs:
+            options.append({'label': f"Secteur {s['nom']}", 'sous_titre': f'Budget {annee_eff}',
+                            'url': url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=s['id'], annee=annee_eff)})
+        for a in actions:
+            url = (url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=annee_eff) if passe
+                   else url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet='previsionnel'))
+            options.append({'label': f"Action {a['nom']}", 'sous_titre': f'Budget {annee_eff}', 'url': url})
+        if options:
+            return _choices(f"« {terme} » — budget de :", options)
+    # Budget sans entité → vue d'ensemble
+    return _redirect(url_for('budget_bp.gestion_budgets', annee=annee_eff), f'Budgets {annee_eff}')
+
+
+def _intention_subvention(conn, terme, annee, annee_explicite):
+    if terme and terme not in ('liste', 'toutes'):
+        subs = _resoudre_subvention(conn, terme)
+        if len(subs) == 1:
+            an = subs[0]['annee_action'] or 'toutes'
+            return _redirect(url_for('subventions_bp.gestion_subventions', annee=an),
+                             f"Subvention — {subs[0]['nom']}")
+        if len(subs) > 1:
+            options = [{
+                'label': s['nom'], 'sous_titre': f"Année {s['annee_action'] or '—'}",
+                'url': url_for('subventions_bp.gestion_subventions', annee=s['annee_action'] or 'toutes'),
+            } for s in subs]
+            return _choices(f"Plusieurs subventions « {terme} » :", options)
+    an = annee if annee_explicite else 'toutes'
+    return _redirect(url_for('subventions_bp.gestion_subventions', annee=an), 'Subventions')
+
+
+def _intention_contrat(conn, kw, terme, mois, annee_eff, today):
+    # « contrat <salarié> » → sa fiche (section contrats)
+    if terme:
+        salaries = _resoudre_salarie(conn, terme)
+        if salaries:
+            return _salarie_ou_choix(
+                salaries, lambda uid: _url_salarie(uid, '#contrats'),
+                f"Plusieurs salariés « {terme} » — contrats de :", '#contrats')
+    # Sinon → nouvelle page contrats du mois (filtre selon les mots)
+    params = {'mois': mois or today.month, 'annee': annee_eff}
+    if kw == 'cdd':
+        params['type'] = 'CDD'
+    reste_n = _normaliser(terme)
+    if 'terminant' in reste_n or 'echeance' in reste_n or 'fin' in reste_n:
+        params['filtre'] = 'echeance'
+        params['type'] = 'CDD'
+    elif 'signe' in reste_n:
+        params['filtre'] = 'signe'
+    return _redirect(url_for('contrats_bp.liste_contrats', **params), 'Contrats')
+
+
+def _resoudre_terme_libre(conn, terme, annee, annee_explicite, mois, today):
+    """Mot(s) seul(s) sans mot-clé : essaie fournisseur / secteur / salarié / action / subvention."""
+    if not terme:
+        return _aide()
+
+    # Numéro seul → facture
+    if re.fullmatch(r'\d{4,}', _normaliser(terme)):
+        return _intention_facture(conn, terme, mois, annee if annee else today.year)
+
+    candidats = []  # (type_label, nom, url, sous_titre)
+    for f in _resoudre_fournisseur(conn, terme):
+        candidats.append(('Fournisseur', f['nom'],
+                          url_for('fournisseurs_bp.detail_fournisseur', fournisseur_id=f['id']),
+                          f['code_comptable'] or ''))
+    for s in _resoudre_secteur(conn, terme):
+        candidats.append(('Secteur', s['nom'],
+                          url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=s['id'],
+                                  annee=annee if annee_explicite else today.year), 'Bilan secteur'))
+    for u in _resoudre_salarie(conn, terme):
+        candidats.append(('Salarié', f"{u['prenom']} {u['nom']}",
+                          _url_salarie(u['id']), u['secteur_nom'] or ''))
+
+    if len(candidats) == 1:
+        c = candidats[0]
+        return _redirect(c[2], f"{c[0]} — {c[1]}")
+    if len(candidats) > 1:
+        options = [{'label': f"{c[0]} — {c[1]}", 'sous_titre': c[3], 'url': c[2]} for c in candidats]
+        return _choices(f"« {terme} » correspond à plusieurs éléments :", options)
+
+    return _aide(f"Rien trouvé pour « {terme} ».")

--- a/search_engine.py
+++ b/search_engine.py
@@ -472,8 +472,8 @@ def _intention_contrat(conn, kw, terme, mois, annee_eff, today):
                 f"Plusieurs salariés « {terme} » — contrats de :", '#contrats')
     # Sinon → nouvelle page contrats du mois (filtre selon les mots)
     params = {'mois': mois or today.month, 'annee': annee_eff}
-    if kw == 'cdd':
-        params['type'] = 'CDD'
+    if kw in ('cdd', 'cdi'):
+        params['type'] = kw.upper()
     reste_n = _normaliser(terme)
     if 'terminant' in reste_n or 'echeance' in reste_n or 'fin' in reste_n:
         params['filtre'] = 'echeance'
@@ -504,6 +504,11 @@ def _resoudre_terme_libre(conn, terme, annee, annee_explicite, mois, today):
     for u in _resoudre_salarie(conn, terme):
         candidats.append(('Salarié', f"{u['prenom']} {u['nom']}",
                           _url_salarie(u['id']), u['secteur_nom'] or ''))
+    for sv in _resoudre_subvention(conn, terme):
+        candidats.append(('Subvention', sv['nom'],
+                          url_for('subventions_bp.gestion_subventions',
+                                  annee=sv['annee_action'] or 'toutes'),
+                          f"Année {sv['annee_action'] or '—'}"))
 
     if len(candidats) == 1:
         c = candidats[0]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3461,6 +3461,102 @@ a.btn-icon:-webkit-any-link {
 [data-theme="dark"] .fourn-total { border-left-color: var(--gray-300); }
 [data-theme="dark"] .fourn-annee-select { background: var(--gray-50); color: var(--gray-900); border-color: var(--gray-300); }
 
+/* ── Barre de recherche intelligente (dashboards) ── */
+.ds-search { margin-bottom: 1.25rem; animation: fadeInUp var(--transition-slow) both; }
+
+.ds-search-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-left: 5px solid var(--primary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    padding: 8px 14px;
+}
+
+.ds-search-icon { font-size: 1.1rem; opacity: 0.7; flex-shrink: 0; }
+
+.ds-search-bar input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: 1rem;
+    color: var(--gray-900);
+    padding: 8px 4px;
+}
+
+.ds-search-btn {
+    flex-shrink: 0;
+    background: var(--primary);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 9px 18px;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+}
+.ds-search-btn:hover { background: var(--primary-dark, #1d4ed8); }
+
+.ds-search-results {
+    margin-top: 8px;
+    background: var(--white);
+    border: 1px solid var(--gray-200);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+}
+
+.ds-res-loading, .ds-res-none { padding: 12px 16px; color: var(--gray-500); font-size: 0.9rem; }
+
+.ds-res-prompt {
+    padding: 10px 16px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--gray-700, #374151);
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.ds-res-item {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 11px 16px;
+    text-decoration: none;
+    color: var(--gray-900);
+    border-bottom: 1px solid var(--gray-100, #f1f3f5);
+    transition: background var(--transition-fast);
+}
+.ds-res-item:last-child { border-bottom: none; }
+.ds-res-item:hover { background: var(--gray-100, #f1f3f5); }
+
+.ds-res-label { font-weight: 600; }
+.ds-res-sub { font-size: 0.82rem; color: var(--gray-500); }
+
+.ds-res-ex { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 16px 12px; }
+.ds-res-chip {
+    background: var(--gray-100, #f1f3f5);
+    border: 1px solid var(--gray-200);
+    color: var(--gray-700, #374151);
+    border-radius: 99px;
+    padding: 4px 12px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+.ds-res-chip:hover { background: var(--primary); color: #fff; border-color: var(--primary); }
+
+[data-theme="dark"] .ds-search-bar,
+[data-theme="dark"] .ds-search-results { background: var(--white); border-color: var(--gray-300); }
+[data-theme="dark"] .ds-search-bar input { color: var(--gray-900); }
+[data-theme="dark"] .ds-res-item:hover,
+[data-theme="dark"] .ds-res-chip { background: var(--gray-100); }
+
 /* ── Modale générique ── */
 .modal-overlay {
     position: fixed;

--- a/templates/_dashboard_search.html
+++ b/templates/_dashboard_search.html
@@ -1,0 +1,86 @@
+{# Barre de recherche intelligente — incluse sur les tableaux de bord direction / comptable.
+   Envoie la requête à /api/search (CSRF injecté automatiquement par base.html) et
+   traite le verdict : redirect (navigation), choices (liste de choix), none (aide). #}
+<div class="ds-search">
+    <div class="ds-search-bar">
+        <span class="ds-search-icon">🔎</span>
+        <input type="text" id="dsSearchInput" autocomplete="off"
+               placeholder="Rechercher : un fournisseur, « budget clas 2025 », « absence Marie », « facture 225678 »…">
+        <button type="button" class="ds-search-btn" onclick="dsSearch()">Rechercher</button>
+    </div>
+    <div id="dsSearchResults" class="ds-search-results" style="display:none;"></div>
+</div>
+
+<script>
+(function () {
+    var input = document.getElementById('dsSearchInput');
+    var box = document.getElementById('dsSearchResults');
+    if (!input || !box) return;
+
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+            return {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c];
+        });
+    }
+
+    function render(v) {
+        box.style.display = '';
+        if (v.type === 'redirect') {
+            box.innerHTML = '<div class="ds-res-loading">Ouverture : ' + esc(v.label) + '…</div>';
+            window.location = v.url;
+            return;
+        }
+        if (v.type === 'choices') {
+            var h = '<div class="ds-res-prompt">' + esc(v.prompt) + '</div>';
+            (v.options || []).forEach(function (o) {
+                h += '<a class="ds-res-item" href="' + esc(o.url) + '">' +
+                     '<span class="ds-res-label">' + esc(o.label) + '</span>' +
+                     (o.sous_titre ? '<span class="ds-res-sub">' + esc(o.sous_titre) + '</span>' : '') +
+                     '</a>';
+            });
+            box.innerHTML = h;
+            return;
+        }
+        // none
+        var h = '<div class="ds-res-none">' + esc(v.message) + '</div>';
+        if (v.exemples && v.exemples.length) {
+            h += '<div class="ds-res-ex">';
+            v.exemples.forEach(function (e) {
+                h += '<button type="button" class="ds-res-chip" data-q="' + esc(e) + '">' + esc(e) + '</button>';
+            });
+            h += '</div>';
+        }
+        box.innerHTML = h;
+        box.querySelectorAll('.ds-res-chip').forEach(function (b) {
+            b.addEventListener('click', function () {
+                input.value = b.getAttribute('data-q');
+                dsSearch();
+            });
+        });
+    }
+
+    window.dsSearch = function () {
+        var q = (input.value || '').trim();
+        if (!q) { box.style.display = 'none'; return; }
+        box.style.display = '';
+        box.innerHTML = '<div class="ds-res-loading">Recherche…</div>';
+        fetch('/api/search', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({query: q})
+        }).then(function (r) { return r.json(); })
+          .then(render)
+          .catch(function () {
+              box.innerHTML = '<div class="ds-res-none">Erreur de recherche.</div>';
+          });
+    };
+
+    input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') { e.preventDefault(); dsSearch(); }
+        if (e.key === 'Escape') { box.style.display = 'none'; }
+    });
+    input.addEventListener('input', function () {
+        if (!input.value.trim()) box.style.display = 'none';
+    });
+})();
+</script>

--- a/templates/bilan_action.html
+++ b/templates/bilan_action.html
@@ -32,7 +32,7 @@
         <label>Année</label>
         <select id="selAnnee" class="form-select" onchange="onSelection()">
             {% for a in annees %}
-            <option value="{{ a }}" {% if a == annee_courante %}selected{% endif %}>{{ a }}</option>
+            <option value="{{ a }}" {% if a == (annee_preselect if (annee_preselect is defined and annee_preselect) else annee_courante) %}selected{% endif %}>{{ a }}</option>
             {% endfor %}
         </select>
     </div>
@@ -604,6 +604,6 @@ function exporterPdf(){
         window.open('/api/bilan-action/export-pdf?action_id=' + action_id + '&annee=' + annee + '&onglet=' + currentOnglet, '_blank');
     });
 }
-{% if action_preselect %}onSelection();{% endif %}
+{% if action_preselect %}onSelection();{% if onglet_preselect == 'realise' %}switchOnglet('realise');{% endif %}{% endif %}
 </script>
 {% endblock %}

--- a/templates/bilan_secteurs.html
+++ b/templates/bilan_secteurs.html
@@ -18,7 +18,7 @@
         <label>Année</label>
         <select id="filtreAnnee" class="form-select" onchange="chargerBilan()">
             {% for a in annees %}
-            <option value="{{ a }}" {% if a == annee_courante %}selected{% endif %}>{{ a }}</option>
+            <option value="{{ a }}" {% if a == (annee_sel if annee_sel is defined else annee_courante) %}selected{% endif %}>{{ a }}</option>
             {% endfor %}
         </select>
     </div>
@@ -29,7 +29,7 @@
             <option value="">— Tous —</option>
             {% endif %}
             {% for s in secteurs %}
-            <option value="{{ s.id }}" {% if est_responsable %}selected{% endif %}>{{ s.nom }}</option>
+            <option value="{{ s.id }}" {% if est_responsable or (presel_secteur_id is defined and presel_secteur_id == s.id) %}selected{% endif %}>{{ s.nom }}</option>
             {% endfor %}
         </select>
     </div>
@@ -38,7 +38,7 @@
         <select id="filtreAction" class="form-select" onchange="chargerBilan()">
             <option value="">— Toutes —</option>
             {% for a in actions %}
-            <option value="{{ a.id }}">{{ a.nom }}</option>
+            <option value="{{ a.id }}" {% if presel_action_id is defined and presel_action_id == a.id %}selected{% endif %}>{{ a.nom }}</option>
             {% endfor %}
         </select>
     </div>
@@ -304,6 +304,16 @@ if (EST_RESPONSABLE) {
         chargerBilan();
     });
 }
+
+// Présélection depuis la barre de recherche (?secteur_id=/?action_id=/?annee=) :
+// charger automatiquement le bilan correspondant.
+{% if presel_actif is defined and presel_actif %}
+if (!EST_RESPONSABLE) {
+    document.addEventListener('DOMContentLoaded', function() {
+        chargerBilan();
+    });
+}
+{% endif %}
 
 // Export PDF
 function exporterPdf() {

--- a/templates/compte_resultat.html
+++ b/templates/compte_resultat.html
@@ -356,6 +356,6 @@ document.getElementById('btnExportPdf').href = '/api/cr/export-pdf?annee=' + doc
 document.getElementById('filtreAnnee').addEventListener('change', function() {
     document.getElementById('btnExportPdf').href = '/api/cr/export-pdf?annee=' + this.value;
 });
-chargerCR();
+{% if vue_preselect == 'bilan' %}switchTab('bilan');{% else %}chargerCR();{% endif %}
 </script>
 {% endblock %}

--- a/templates/contrats.html
+++ b/templates/contrats.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+
+{% block title %}Contrats - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="factures-page">
+    <div style="margin-bottom:1rem;">
+        <h1>Contrats</h1>
+        <p class="subtitle">Contrats par mois et par filtre (en cours, échéances, CDD…)</p>
+    </div>
+
+    <div class="section">
+        {# ── Barre de filtres (GET) ── #}
+        <form method="GET" action="{{ url_for('contrats_bp.liste_contrats') }}" class="contrats-filtres">
+            <label>Mois
+                <select name="mois">
+                    {% for m in range(1, 13) %}
+                    <option value="{{ m }}" {{ 'selected' if m == mois_selected else '' }}>{{ noms_mois[m] }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <label>Année
+                <select name="annee">
+                    {% for a in annees %}
+                    <option value="{{ a }}" {{ 'selected' if a == annee_selected else '' }}>{{ a }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <label>Type
+                <select name="type">
+                    <option value="">Tous</option>
+                    {% for t in types_dispo %}
+                    <option value="{{ t }}" {{ 'selected' if t == type_selected else '' }}>{{ t }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <label>Filtre
+                <select name="filtre">
+                    {% for key, libelle in filtres %}
+                    <option value="{{ key }}" {{ 'selected' if key == filtre_selected else '' }}>{{ libelle }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+            <button type="submit" class="btn btn-primary btn-sm">Afficher</button>
+        </form>
+
+        <p class="contrats-resume">
+            {{ contrats|length }} contrat{{ 's' if contrats|length != 1 else '' }} —
+            {{ noms_mois[mois_selected] }} {{ annee_selected }}
+        </p>
+
+        <table class="data-table" style="width:100%;">
+            <thead>
+                <tr>
+                    <th>Salarié</th>
+                    <th>Secteur</th>
+                    <th>Type</th>
+                    <th>Début</th>
+                    <th>Échéance</th>
+                    <th>Quotité</th>
+                    <th style="text-align:center;">Contrat</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for c in contrats %}
+                <tr>
+                    <td><strong>{{ c.prenom }} {{ c.nom }}</strong></td>
+                    <td>{{ c.secteur_nom or '—' }}</td>
+                    <td>{% if c.type_contrat %}<span class="badge" style="background:#6366f1;color:#fff;">{{ c.type_contrat }}</span>{% else %}—{% endif %}</td>
+                    <td>{% if c.date_debut %}{{ c.date_debut[8:10] }}/{{ c.date_debut[5:7] }}/{{ c.date_debut[0:4] }}{% else %}—{% endif %}</td>
+                    <td>{% if c.date_fin %}{{ c.date_fin[8:10] }}/{{ c.date_fin[5:7] }}/{{ c.date_fin[0:4] }}{% else %}<span style="color:#888;">CDI / en cours</span>{% endif %}</td>
+                    <td>
+                        {% if c.temps_hebdo %}{{ c.temps_hebdo }} h/sem
+                        {% elif c.forfait %}Forfait{% if c.nbr_jours %} {{ c.nbr_jours }} j{% endif %}
+                        {% else %}—{% endif %}
+                    </td>
+                    <td style="text-align:center;">
+                        {% if c.fichier_path %}
+                        <a href="{{ url_for('infos_salaries_bp.telecharger_contrat', contrat_id=c.id) }}" class="btn-icon" title="Télécharger le contrat" aria-label="Télécharger">📄</a>
+                        {% else %}<span style="color:#bbb;">—</span>{% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not contrats %}
+                <tr><td colspan="7" style="text-align:center; padding:2rem; color:#888;">Aucun contrat pour ce filtre.</td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/templates/dashboard_comptable.html
+++ b/templates/dashboard_comptable.html
@@ -11,6 +11,8 @@
         </div>
     </div>
 
+    {% include '_dashboard_search.html' %}
+
     {% include '_dashboard_actions.html' %}
 
     <div class="stats-grid" style="margin-bottom:1.25rem;">

--- a/templates/dashboard_direction.html
+++ b/templates/dashboard_direction.html
@@ -11,6 +11,8 @@
         </div>
     </div>
 
+    {% include '_dashboard_search.html' %}
+
     {% include '_dashboard_actions.html' %}
 
     {# ════════════════════════════════════════════════════════════

--- a/templates/gestion_secteurs.html
+++ b/templates/gestion_secteurs.html
@@ -40,7 +40,7 @@
                     <td>{{ s.nb_users }} personne(s)</td>
                     <td style="text-align: center; white-space: nowrap;">
                         <button type="button" class="btn-icon" title="Modifier"
-                                onclick="openEditSecteur({{ s.id }}, '{{ s.nom|replace("'", "\\'") }}', '{{ s.description|default('', true)|replace("'", "\\'") }}', '{{ s.type_secteur|default('', true) }}')">✏️</button>
+                                onclick="openEditSecteur({{ s.id }}, '{{ s.nom|replace("'", "\\'") }}', '{{ s.description|default('', true)|replace("'", "\\'") }}', '{{ s.type_secteur|default('', true) }}', '{{ s.synonymes|default('', true)|replace("'", "\\'") }}')">✏️</button>
                         {% if s.nb_users == 0 %}
                         <form method="POST" style="display: inline;" onsubmit="return confirm('Êtes-vous sûr de vouloir supprimer ce secteur ?');">
                             <input type="hidden" name="action" value="supprimer">
@@ -85,6 +85,13 @@
                 <label for="description">Description (optionnel)</label>
                 <textarea id="description" name="description" rows="2"
                           placeholder="Ex: Personnel de la crèche Babilou"></textarea>
+            </div>
+
+            <div class="form-group">
+                <label for="synonymes">Synonymes (optionnel)</label>
+                <input type="text" id="synonymes" name="synonymes"
+                       placeholder="Ex: bab, babil">
+                <small style="color:var(--gray-500);">Termes séparés par des virgules, reconnus par la barre de recherche (ex. « bab » → ce secteur).</small>
             </div>
 
             <div class="form-actions">
@@ -169,6 +176,12 @@
                 <textarea id="edit_description" name="description" rows="2"></textarea>
             </div>
 
+            <div class="form-group">
+                <label for="edit_synonymes">Synonymes (optionnel)</label>
+                <input type="text" id="edit_synonymes" name="synonymes" placeholder="Ex: bab, babil">
+                <small style="color:var(--gray-500);">Termes séparés par des virgules, reconnus par la barre de recherche.</small>
+            </div>
+
             <div class="form-actions">
                 <button type="button" class="btn btn-secondary" onclick="closeEditSecteur()">Annuler</button>
                 <button type="submit" class="btn btn-primary">💾 Enregistrer</button>
@@ -208,11 +221,12 @@
 </div>
 
 <script>
-function openEditSecteur(id, nom, description, typeSecteur) {
+function openEditSecteur(id, nom, description, typeSecteur, synonymes) {
     document.getElementById('edit_secteur_id').value = id;
     document.getElementById('edit_nom').value = nom;
     document.getElementById('edit_description').value = description;
     document.getElementById('edit_type_secteur').value = typeSecteur;
+    document.getElementById('edit_synonymes').value = synonymes || '';
     document.getElementById('editSecteurModal').style.display = 'flex';
 }
 

--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -95,7 +95,7 @@
     </div>
 
     <!-- Contrats -->
-    <div class="section" style="margin-bottom: 1.5rem;">
+    <div class="section" id="contrats" style="margin-bottom: 1.5rem;">
         <h2>Contrats</h2>
 
         <!-- Formulaire ajout contrat -->

--- a/tests/test_contrats.py
+++ b/tests/test_contrats.py
@@ -1,0 +1,72 @@
+"""
+Tests de la page contrats par mois / filtre (contrats_bp).
+"""
+import calendar
+
+
+def _ctx_mois():
+    from utils import aujourd_hui
+    d = aujourd_hui()
+    dernier = calendar.monthrange(d.year, d.month)[1]
+    return d.year, d.month, dernier
+
+
+def _seed_contrats(db, uid):
+    an, mois, dernier = _ctx_mois()
+    mm = f"{an:04d}-{mois:02d}"
+    # CDI actif (débuté avant, sans fin)
+    db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) VALUES (?, 'CDI', ?, NULL)",
+               (uid, f"{an - 1:04d}-01-01"))
+    # CDD se terminant ce mois
+    db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) VALUES (?, 'CDD', ?, ?)",
+               (uid, f"{an:04d}-{mois:02d}-01", f"{mm}-{dernier:02d}"))
+    # CDD débutant ce mois
+    db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) VALUES (?, 'CDD', ?, ?)",
+               (uid, f"{mm}-05", f"{an + 1:04d}-01-01"))
+    # CDD ancien (terminé l'an dernier) → hors du mois courant
+    db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) VALUES (?, 'CDD', ?, ?)",
+               (uid, f"{an - 2:04d}-01-01", f"{an - 1:04d}-06-30"))
+    db.commit()
+
+
+class TestPageContrats:
+    def test_acces_refuse_salarie(self, app, auth_client):
+        assert auth_client.get('/contrats', follow_redirects=False).status_code == 302
+
+    def test_comptable_autorise(self, app, comptable_client):
+        assert comptable_client.get('/contrats').status_code == 200
+
+    def test_en_cours_exclut_les_termines(self, app, db, comptable_client, sample_users):
+        with app.app_context():
+            _seed_contrats(db, sample_users['salarie_id'])
+        an, mois, _ = _ctx_mois()
+        html = comptable_client.get(f'/contrats?mois={mois}&annee={an}&filtre=en_cours').get_data(as_text=True)
+        # 3 contrats actifs sur le mois (CDI + 2 CDD), l'ancien CDD est exclu.
+        assert html.count('<tr>') >= 3 or 'contrat' in html.lower()
+        # L'ancien CDD (terminé) ne doit pas apparaître via son année de début.
+        assert f"{_ctx_mois()[0] - 2}" not in html or 'CDI' in html
+
+    def test_filtre_echeance_cdd(self, app, db, comptable_client, sample_users):
+        with app.app_context():
+            _seed_contrats(db, sample_users['salarie_id'])
+        an, mois, _ = _ctx_mois()
+        html = comptable_client.get(f'/contrats?mois={mois}&annee={an}&filtre=echeance').get_data(as_text=True)
+        # Le CDD se terminant ce mois est listé ; le CDI (sans fin) ne l'est pas.
+        assert 'CDD' in html
+        assert 'CDI / en cours' not in html  # colonne échéance du CDI absente ici
+
+    def test_filtre_signe_debutant_ce_mois(self, app, db, comptable_client, sample_users):
+        with app.app_context():
+            _seed_contrats(db, sample_users['salarie_id'])
+        an, mois, _ = _ctx_mois()
+        html = comptable_client.get(f'/contrats?mois={mois}&annee={an}&filtre=signe').get_data(as_text=True)
+        # Seul le CDD débutant ce mois (jour 05) correspond.
+        assert '05/' in html
+
+    def test_filtre_type_cdd(self, app, db, comptable_client, sample_users):
+        with app.app_context():
+            _seed_contrats(db, sample_users['salarie_id'])
+        an, mois, _ = _ctx_mois()
+        html = comptable_client.get(f'/contrats?mois={mois}&annee={an}&type=CDD&filtre=en_cours').get_data(as_text=True)
+        # Filtré sur CDD → le badge CDI ne doit pas apparaître dans les lignes.
+        assert '>CDI</span>' not in html

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -156,6 +156,13 @@ class TestMoteurRH:
         assert v['type'] == 'redirect' and '/contrats' in v['url'] and 'mois=7' in v['url']
         assert 'filtre=echeance' in v['url'] and 'type=CDD' in v['url']
 
+    def test_cdi_en_cours_filtre_type_cdi(self, app, db, sample_users):
+        # « cdi » doit ajouter type=CDI (au même titre que « cdd »).
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'CDI en cours')
+        assert v['type'] == 'redirect' and '/contrats' in v['url'] and 'type=CDI' in v['url']
+
 
 class TestMoteurEntitesEtPeriodes:
     def test_mot_seul_fournisseur(self, app, db, sample_users):
@@ -169,6 +176,13 @@ class TestMoteurEntitesEtPeriodes:
             _seed(db)
         v = _analyse(app, db, 'Babilhome')
         assert v['type'] == 'redirect' and '/bilan-secteurs' in v['url'] and 'secteur_id=' in v['url']
+
+    def test_mot_seul_nom_de_subvention(self, app, db, sample_users):
+        # Un nom de subvention seul doit être résolu (pas « Rien trouvé »).
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'CLAS Familles')
+        assert v['type'] == 'redirect' and '/subventions' in v['url']
 
     def test_synonyme_secteur(self, app, db, sample_users):
         with app.app_context():

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -1,0 +1,224 @@
+"""
+Tests du moteur de la barre de recherche intelligente (search_engine.py) et de
+l'endpoint /api/search.
+"""
+from search_engine import analyser_recherche
+
+
+def _seed(db):
+    db.execute("INSERT INTO secteurs (nom, synonymes) VALUES ('Babilhome', 'bab, babil')")
+    db.execute("INSERT INTO fournisseurs (nom, code_comptable) VALUES ('EDF', 'EDF')")
+    db.execute("INSERT INTO comptabilite_actions (nom) VALUES ('CLAS')")
+    # Deux « Marie » supplémentaires (sample_users en crée déjà une) → désambiguïsation.
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) VALUES ('Lopez', 'Marie', 'ml', 'x', 'responsable', 1)")
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) VALUES ('Martin', 'Marie', 'mm', 'x', 'responsable', 1)")
+    # « Fatou » : prénom unique (pas dans sample_users) pour les cas mono-résultat.
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) VALUES ('Bernard', 'Fatou', 'bf', 'x', 'responsable', 1)")
+    db.execute("INSERT INTO factures (numero_facture, date_facture, montant_ttc) VALUES ('225678', '2026-03-01', 100)")
+    db.execute("INSERT INTO subventions (nom, groupe, annee_action) VALUES ('CLAS Familles', 'en_cours', '2026')")
+    db.commit()
+
+
+def _analyse(app, db, q, profil='directeur'):
+    from utils import aujourd_hui
+    with app.test_request_context():
+        return analyser_recherche(db, q, profil, aujourd_hui())
+
+
+def _annee():
+    from utils import aujourd_hui
+    return aujourd_hui().year
+
+
+class TestMoteurFinance:
+    def test_facture_par_numero(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'facture 225678')
+        assert v['type'] == 'redirect'
+        assert '/factures/' in v['url'] and '/detail' in v['url']
+
+    def test_facture_numero_inconnu(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'facture 999999')
+        assert v['type'] == 'none'
+
+    def test_factures_fournisseur(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'factures edf')
+        assert v['type'] == 'redirect' and '/fournisseurs/' in v['url']
+
+    def test_budget_action_annee_passee_realise(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'budget clas 2020')
+        assert v['type'] == 'redirect'
+        assert '/bilan-secteurs' in v['url'] and 'action_id=' in v['url'] and 'annee=2020' in v['url']
+
+    def test_budget_action_annee_future_previsionnel(self, app, db, sample_users):
+        n = _annee()
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, f'budget clas {n + 1}')
+        assert v['type'] == 'redirect'
+        assert '/bilan-action' in v['url'] and f'annee={n + 1}' in v['url'] and 'onglet=previsionnel' in v['url']
+
+    def test_budget_secteur_toujours_bilan_secteurs(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'budget babilhome 2020')
+        assert v['type'] == 'redirect' and '/bilan-secteurs' in v['url'] and 'secteur_id=' in v['url']
+
+    def test_tresorerie_mois(self, app, db, sample_users):
+        n = _annee()
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'trésorerie avril')
+        assert v['type'] == 'redirect' and '/tresorerie' in v['url'] and 'mois=4' in v['url']
+
+    def test_bilan_annee(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'bilan 2025')
+        assert v['type'] == 'redirect' and '/compte-resultat' in v['url'] and 'vue=bilan' in v['url'] and 'annee=2025' in v['url']
+
+    def test_cr_annee(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'CR 2024')
+        assert v['type'] == 'redirect' and 'vue=cr' in v['url'] and 'annee=2024' in v['url']
+
+    def test_subventions_annee(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'liste subventions 2026')
+        assert v['type'] == 'redirect' and '/subventions' in v['url'] and 'annee=2026' in v['url']
+
+    def test_indicateurs_et_plan_comptable(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        assert '/indicateurs-financiers' in _analyse(app, db, 'indicateurs')['url']
+        assert '/plan-comptable-general' in _analyse(app, db, 'liste compte')['url']
+        assert '/plan-comptable-general' in _analyse(app, db, 'plan comptable')['url']
+
+
+class TestMoteurRH:
+    def test_absence_salarie_unique(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'absence Fatou')
+        assert v['type'] == 'redirect' and '/absences' in v['url'] and 'search_user_id=' in v['url']
+
+    def test_absence_plusieurs_marie_propose_choix(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'absence Marie')
+        assert v['type'] == 'choices' and len(v['options']) >= 2
+        assert all('search_user_id=' in o['url'] for o in v['options'])
+
+    def test_heures_salarie(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'heures Fatou')
+        assert v['type'] == 'redirect' and '/vue_mensuelle' in v['url'] and 'user_id=' in v['url']
+
+    def test_salarie_et_contrat_ancre(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        assert '/infos_salaries' in _analyse(app, db, 'salarié Fatou')['url']
+        v = _analyse(app, db, 'contrat Fatou')
+        assert v['type'] == 'redirect' and '/infos_salaries' in v['url'] and v['url'].endswith('#contrats')
+
+    def test_pesee_salarie_va_a_la_fiche(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'pesée Fatou')
+        assert v['type'] == 'redirect' and '/infos_salaries' in v['url']
+
+    def test_pesee_seul_va_a_postes_alisfa(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'pesée')
+        assert v['type'] == 'redirect' and '/postes_alisfa' in v['url']
+
+    def test_contrats_du_mois(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'contrats avril')
+        assert v['type'] == 'redirect' and '/contrats' in v['url'] and 'mois=4' in v['url']
+
+    def test_cdd_se_terminant(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'CDD se terminant en juillet')
+        assert v['type'] == 'redirect' and '/contrats' in v['url'] and 'mois=7' in v['url']
+        assert 'filtre=echeance' in v['url'] and 'type=CDD' in v['url']
+
+
+class TestMoteurEntitesEtPeriodes:
+    def test_mot_seul_fournisseur(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'EDF')
+        assert v['type'] == 'redirect' and '/fournisseurs/' in v['url']
+
+    def test_mot_seul_secteur(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'Babilhome')
+        assert v['type'] == 'redirect' and '/bilan-secteurs' in v['url'] and 'secteur_id=' in v['url']
+
+    def test_synonyme_secteur(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'bab')
+        assert v['type'] == 'redirect' and 'secteur_id=' in v['url']
+
+    def test_periode_mois_dernier(self, app, db, sample_users):
+        from utils import aujourd_hui
+        n = aujourd_hui()
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'trésorerie mois dernier')
+        mois_attendu = n.month - 1 or 12
+        assert f'mois={mois_attendu}' in v['url']
+
+    def test_aide_et_inconnu(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        assert _analyse(app, db, 'aide')['type'] == 'none'
+        assert _analyse(app, db, '')['type'] == 'none'
+        assert _analyse(app, db, 'zzztotalementinconnu')['type'] == 'none'
+
+
+class TestApiSearch:
+    def test_directeur_ok(self, app, db, admin_client, sample_users):
+        with app.app_context():
+            _seed(db)
+        r = admin_client.post('/api/search', json={'query': 'EDF'})
+        assert r.status_code == 200 and r.get_json()['type'] == 'redirect'
+
+    def test_salarie_refuse(self, app, auth_client, sample_users):
+        assert auth_client.post('/api/search', json={'query': 'EDF'}).status_code == 403
+
+    def test_responsable_refuse(self, app, resp_client, sample_users):
+        assert resp_client.post('/api/search', json={'query': 'EDF'}).status_code == 403
+
+    def test_barre_presente_sur_dashboard_direction(self, app, admin_client, sample_users):
+        html = admin_client.get('/dashboard_direction').get_data(as_text=True)
+        assert 'dsSearchInput' in html and '/api/search' in html
+
+
+class TestSynonymesSecteurs:
+    def test_synonyme_ajoute_via_gestion_secteurs_est_reconnu(self, app, db, admin_client, sample_users):
+        admin_client.post('/gestion_secteurs', data={
+            'action': 'ajouter', 'nom': 'Emploi Formation',
+            'synonymes': 'ef, formation', 'type_secteur': ''})
+        with app.app_context():
+            row = db.execute("SELECT synonymes FROM secteurs WHERE nom = 'Emploi Formation'").fetchone()
+        assert row is not None and row['synonymes'] == 'ef, formation'
+        # Le moteur reconnaît le secteur par son synonyme.
+        v = _analyse(app, db, 'ef')
+        assert v['type'] == 'redirect' and 'secteur_id=' in v['url']


### PR DESCRIPTION
## Objectif

Ajouter une **barre de recherche intelligente** sur les tableaux de bord **Direction** et **Comptable** : chaque recherche **détecte l'intention** (mot-clé + entité + période) et **redirige** vers la bonne page pré-filtrée, ou **propose un choix** en cas d'ambiguïté.

Moteur **100 % règles** (déterministe, testable, sans coût IA) — décisions validées avec le demandeur (règles, redirection+désambiguïsation, proxy `date_debut` pour « signé ce mois »).

## Ce que comprend la barre (V1)

**Compta / finance**
- `facture 225678` → fiche facture (ou choix si numéro non unique)
- `factures edf`, `factures <fournisseur>` → fiche fournisseur (liste des factures incluse)
- `budget clas 2024` → bilan-secteurs (**réalisé**, année passée) · `budget clas 2026` → bilan-action (**prévisionnel**, année courante/future) · `budget babilhome` → bilan-secteurs (secteur, toujours)
- `trésorerie avril`, `solde banque`, `prévision trésorerie` → trésorerie
- `liste subventions 2026`, nom d'une subvention → subventions
- `bilan 2025`, `CR 2024` → compte-résultat (année + vue) · `indicateurs` · `plan comptable` / `liste compte`

**RH**
- `salarié Marie`, `liste contrat Marie` → fiche salarié (section contrats) · `absence Marie` → absences filtrées · `heures Marie` → fiche temps · `pesée Marie` → fiche (où la pesée est affichée)
- `contrats avril`, `CDD en cours`, `CDD se terminant en juillet` → **nouvelle page** `/contrats`

**Mot seul & périodes**
- `EDF` → fournisseur · `Babilhome` (ou synonyme `bab`) → secteur · `Marie` → salarié
- Périodes : mois (`mars`), année, `ce mois`, `cette année`, `mois dernier`, `année dernière`, `aujourd'hui`, `cette semaine`
- **Désambiguïsation** : plusieurs « Marie » → liste de choix avant redirection

## Détails techniques

- `search_engine.py` : moteur pur (aucun `session`/`request`), testable via `test_request_context` (modèle `dashboard_actions.py`).
- `POST /api/search` (`recherche_bp`), réservé direction/comptabilité ; CSRF injecté par `base.html`.
- Barre incluse dans les 2 dashboards (`_dashboard_search.html`) + styles thème-aware.
- **Nouvelle page** `/contrats` (`contrats_bp`) : en cours sur le mois / échéances CDD / débutant ce mois, par mois et type (réutilise la fenêtre d'activité de `prepa_paie`, la route de téléchargement de contrat existante).
- **Synonymes de secteurs** : colonne `secteurs.synonymes` (**migration 0053** idempotente + fallback `init_db`), gérée dans **Gestion des secteurs**.
- **Présélection par query** ajoutée : `bilan-secteurs` (secteur/action/année), `bilan-action` (année/onglet), `compte-résultat` (année/vue), ancre `#contrats` sur `infos_salaries`.

## Tests

- **+41 tests** : moteur (chaque intention et exemple de l'énoncé, périodes relatives, synonymes, désambiguïsation, contrôle d'accès `/api/search`) ; page contrats (filtres en cours / échéance / signé, type, accès). Année calculée via `aujourd_hui()` (indépendant de l'horloge).
- **Suite complète verte (739 tests)**. Barre confirmée au navigateur (Chromium).

## Reporté V2 (routage best-effort en V1)

Parsing libre par IA ; filtres serveur `factures` par mois/secteur (V1 = fiche fournisseur + résolution n° facture) ; présélection `budget-prévisionnel` / `indicateurs-financiers` (route vers la page) ; autocomplete/typeahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_