### PR TITLE
Barre de recherche : affiner budget/bilan + nouvelles intentions

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -945,6 +945,14 @@ def budget_previsionnel():
         else:
             secteurs = conn.execute('SELECT id, nom FROM secteurs ORDER BY nom').fetchall()
             secteur_id_defaut = secteurs[0]['id'] if secteurs else None
+            # Présélection depuis la barre de recherche : ?secteur_id=
+            secteur_param = request.args.get('secteur_id', type=int)
+            if secteur_param and any(s['id'] == secteur_param for s in secteurs):
+                secteur_id_defaut = secteur_param
+
+        # Présélection de l'année depuis la barre de recherche : ?annee=
+        annee_param = request.args.get('annee', type=int)
+        annee_selection = annee_param if annee_param in annees_traitement else now.year
 
         annees_importees = conn.execute(
             'SELECT DISTINCT annee FROM bilan_fec_imports ORDER BY annee DESC'
@@ -957,7 +965,7 @@ def budget_previsionnel():
         return render_template(
             'budget_previsionnel.html',
             annees_traitement=annees_traitement,
-            annee_courante=now.year,
+            annee_courante=annee_selection,
             secteurs=secteurs,
             secteur_id_defaut=secteur_id_defaut,
             annees_importees=[r['annee'] for r in annees_importees],

--- a/blueprints/recherche.py
+++ b/blueprints/recherche.py
@@ -11,7 +11,7 @@ import logging
 from flask import Blueprint, request, session, jsonify
 from database import get_db
 from utils import login_required, aujourd_hui, maintenant
-from search_engine import analyser_recherche
+from search_engine import analyser_recherche, anonymiser_terme_salaries
 
 recherche_bp = Blueprint('recherche_bp', __name__)
 
@@ -24,14 +24,17 @@ def _journaliser_recherche(conn, terme, verdict):
     """Trace la recherche (terme + a-t-elle abouti) — best-effort, jamais bloquant.
 
     Une redirection ou une liste de choix comptent comme un résultat ; un verdict
-    « none » (aucune correspondance) est enregistré comme sans résultat. Toute
-    erreur de journalisation reste silencieuse : elle ne doit pas casser la
-    recherche elle-même.
+    « none » (aucune correspondance) est enregistré comme sans résultat. Le terme
+    et le libellé de destination sont anonymisés (noms de salariés → « salarié »)
+    pour ne pas révéler quels salariés font l'objet de recherches. Toute erreur de
+    journalisation reste silencieuse : elle ne doit pas casser la recherche.
     """
     try:
         type_resultat = verdict.get('type', '')
         a_resultat = 1 if type_resultat in ('redirect', 'choices') else 0
         libelle = verdict.get('label') or verdict.get('prompt') or verdict.get('message') or ''
+        terme = anonymiser_terme_salaries(conn, terme)
+        libelle = anonymiser_terme_salaries(conn, libelle)
         conn.execute(
             'INSERT INTO recherche_log (date_heure, user_id, terme, type_resultat, a_resultat, libelle) '
             'VALUES (?, ?, ?, ?, ?, ?)',
@@ -40,7 +43,7 @@ def _journaliser_recherche(conn, terme, verdict):
         )
         conn.commit()
     except Exception:
-        logger.exception("Impossible de journaliser la recherche « %s »", terme)
+        logger.exception("Impossible de journaliser la recherche")
 
 
 @recherche_bp.route('/api/search', methods=['POST'])

--- a/blueprints/recherche.py
+++ b/blueprints/recherche.py
@@ -6,14 +6,41 @@ calculé par le moteur pur search_engine.analyser_recherche. Accès réservé à
 direction et à la comptabilité (comme les tableaux de bord qui l'affichent).
 CSRF est injecté automatiquement par base.html.
 """
+import logging
+
 from flask import Blueprint, request, session, jsonify
 from database import get_db
-from utils import login_required, aujourd_hui
+from utils import login_required, aujourd_hui, maintenant
 from search_engine import analyser_recherche
 
 recherche_bp = Blueprint('recherche_bp', __name__)
 
+logger = logging.getLogger(__name__)
+
 PROFILS_AUTORISES = ('directeur', 'comptable')
+
+
+def _journaliser_recherche(conn, terme, verdict):
+    """Trace la recherche (terme + a-t-elle abouti) — best-effort, jamais bloquant.
+
+    Une redirection ou une liste de choix comptent comme un résultat ; un verdict
+    « none » (aucune correspondance) est enregistré comme sans résultat. Toute
+    erreur de journalisation reste silencieuse : elle ne doit pas casser la
+    recherche elle-même.
+    """
+    try:
+        type_resultat = verdict.get('type', '')
+        a_resultat = 1 if type_resultat in ('redirect', 'choices') else 0
+        libelle = verdict.get('label') or verdict.get('prompt') or verdict.get('message') or ''
+        conn.execute(
+            'INSERT INTO recherche_log (date_heure, user_id, terme, type_resultat, a_resultat, libelle) '
+            'VALUES (?, ?, ?, ?, ?, ?)',
+            (maintenant().strftime('%Y-%m-%d %H:%M:%S'), session.get('user_id'),
+             terme[:200], type_resultat, a_resultat, libelle[:200]),
+        )
+        conn.commit()
+    except Exception:
+        logger.exception("Impossible de journaliser la recherche « %s »", terme)
 
 
 @recherche_bp.route('/api/search', methods=['POST'])
@@ -28,6 +55,8 @@ def api_search():
     conn = get_db()
     try:
         verdict = analyser_recherche(conn, query, session.get('profil'), aujourd_hui())
+        if query:
+            _journaliser_recherche(conn, query, verdict)
     finally:
         conn.close()
 

--- a/blueprints/securite.py
+++ b/blueprints/securite.py
@@ -269,3 +269,46 @@ def export_journal_actions():
         mimetype='text/csv; charset=utf-8',
         headers={'Content-Disposition': f'attachment; filename={nom_fichier}'},
     )
+
+
+# ================= Journal des recherches (barre intelligente) =================
+
+# Nombre de recherches recentes affichees dans l'onglet « Barre intelligente ».
+LIMITE_RECHERCHES = 50
+
+# Requete CONSTANTE (aucune saisie utilisateur n'y est concatenee). Liste les
+# dernieres recherches de la barre intelligente avec leur auteur et le fait
+# qu'elles aient abouti (a_resultat) ou non.
+_RECHERCHES_QUERY = '''
+    SELECT r.id, r.date_heure, r.terme, r.type_resultat, r.a_resultat, r.libelle,
+           u.nom AS nom, u.prenom AS prenom
+    FROM recherche_log r
+    LEFT JOIN users u ON r.user_id = u.id
+    ORDER BY r.date_heure DESC, r.id DESC
+    LIMIT :limite
+'''
+
+
+@securite_bp.route('/securite/journal-recherches')
+@login_required
+def journal_recherches():
+    """Affiche les dernieres recherches de la barre intelligente (direction/compta).
+
+    Permet a la direction de voir les termes reellement saisis et s'ils ont
+    abouti, afin d'enrichir les synonymes reconnus par le moteur de recherche.
+    """
+    if not _check_acces():
+        flash('Accès non autorisé', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    conn = get_db()
+    try:
+        entrees = conn.execute(_RECHERCHES_QUERY, {'limite': LIMITE_RECHERCHES}).fetchall()
+    finally:
+        conn.close()
+
+    return render_template(
+        'journal_recherches.html',
+        entrees=entrees,
+        limite=LIMITE_RECHERCHES,
+    )

--- a/database.py
+++ b/database.py
@@ -432,6 +432,27 @@ def init_db():
         "CREATE INDEX IF NOT EXISTS idx_journal_actions_date ON journal_actions(date_heure)"
     )
 
+    # ===== Journal des recherches (barre intelligente, migration 0054) =====
+    # Trace les termes saisis dans la barre de recherche intelligente et le fait
+    # que la recherche ait abouti (redirection / choix) ou non. Permet a la
+    # direction de voir les termes reellement utilises (et d'ajouter des
+    # synonymes). Aucune donnee sensible : uniquement le terme saisi.
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS recherche_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date_heure TEXT DEFAULT CURRENT_TIMESTAMP,
+            user_id INTEGER,
+            terme TEXT NOT NULL,
+            type_resultat TEXT,
+            a_resultat INTEGER DEFAULT 0,
+            libelle TEXT,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    ''')
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_recherche_log_date ON recherche_log(date_heure)"
+    )
+
     # ===== Table des demandes de recuperation =====
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS demandes_recup (

--- a/migrations/0054_recherche_log.py
+++ b/migrations/0054_recherche_log.py
@@ -1,0 +1,45 @@
+"""
+Migration 0054 : Journal des recherches (barre intelligente).
+
+Crée la table recherche_log qui trace les termes saisis dans la barre de
+recherche intelligente des tableaux de bord (Direction / Comptable) et le fait
+que la recherche ait abouti ou non. Permet à la direction de consulter les
+termes réellement utilisés (onglet « Barre intelligente » du journal de
+sécurité) afin d'enrichir les synonymes reconnus par le moteur.
+
+Aucune donnée sensible n'est stockée : uniquement le terme saisi, le type de
+résultat (redirect / choices / none) et un libellé de destination.
+"""
+
+NOM = "Journal des recherches (barre intelligente)"
+DESCRIPTION = (
+    "Crée la table recherche_log pour tracer les termes de la barre de "
+    "recherche intelligente et savoir s'ils ont abouti."
+)
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    cursor = conn.cursor()
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS recherche_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date_heure TEXT DEFAULT CURRENT_TIMESTAMP,
+            user_id INTEGER,
+            terme TEXT NOT NULL,
+            type_resultat TEXT,
+            a_resultat INTEGER DEFAULT 0,
+            libelle TEXT,
+            FOREIGN KEY (user_id) REFERENCES users(id)
+        )
+    ''')
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_recherche_log_date ON recherche_log(date_heure)"
+    )
+    conn.commit()
+
+
+def downgrade(conn):
+    """Supprime la table du journal des recherches."""
+    conn.cursor().execute("DROP TABLE IF EXISTS recherche_log")
+    conn.commit()

--- a/search_engine.py
+++ b/search_engine.py
@@ -179,6 +179,42 @@ def _resoudre_salarie(conn, terme):
     return exact or prefixe
 
 
+def anonymiser_terme_salaries(conn, texte):
+    """Masque les noms/prénoms de salariés dans un texte de recherche.
+
+    Remplace par « salarié » tout mot correspondant (normalisé) à un nom ou un
+    prénom d'utilisateur, afin que le journal des recherches ne révèle pas quels
+    salariés font l'objet de recherches (confidentialité RH). Les « salarié »
+    consécutifs sont fusionnés (« absence Marie Dupont » → « absence salarié »).
+    Fonction pure et défensive : renvoie le texte inchangé en cas d'erreur.
+    """
+    if not texte:
+        return texte
+    try:
+        noms = set()
+        for r in conn.execute("SELECT nom, prenom FROM users").fetchall():
+            for champ in (r['nom'], r['prenom']):
+                for mot in _normaliser(champ or '').split():
+                    if len(mot) >= 2:
+                        noms.add(mot)
+        if not noms:
+            return texte
+        resultat, masque_precedent = [], False
+        for tok in texte.split():
+            sous_mots = _normaliser(tok).split()
+            est_nom = bool(sous_mots) and any(m in noms for m in sous_mots)
+            if est_nom:
+                if not masque_precedent:
+                    resultat.append('salarié')
+                    masque_precedent = True
+            else:
+                resultat.append(tok)
+                masque_precedent = False
+        return ' '.join(resultat).strip()
+    except Exception:
+        return texte
+
+
 def _resoudre_action(conn, terme):
     terme_n = _normaliser(terme)
     if not terme_n:
@@ -258,7 +294,9 @@ def _salarie_ou_choix(salaries, faire_url, prompt, ancre=''):
 
 _KW_FACTURE = {'facture', 'factures'}
 _KW_BUDGET = {'budget', 'budgets'}
-_KW_PREV = {'prev', 'previsionnel', 'previsionnels', 'actualise'}  # prévisionnel / actualisé (normalisés)
+_KW_PREV = {'prev', 'previsionnel', 'previsionnels', 'actualise',
+            'bp',    # budget prévisionnel
+            'bpa'}   # budget prévisionnel actualisé
 _KW_TRESO = {'tresorerie', 'treso', 'solde'}
 _KW_SUBV = {'subvention', 'subventions'}
 _KW_INDIC = {'indicateur', 'indicateurs'}

--- a/search_engine.py
+++ b/search_engine.py
@@ -257,7 +257,8 @@ def _salarie_ou_choix(salaries, faire_url, prompt, ancre=''):
 # ── Détection d'intention principale ──
 
 _KW_FACTURE = {'facture', 'factures'}
-_KW_BUDGET = {'budget', 'budgets', 'previsionnel', 'previsionnel'}
+_KW_BUDGET = {'budget', 'budgets'}
+_KW_PREV = {'prev', 'previsionnel', 'previsionnels', 'actualise'}  # prévisionnel / actualisé (normalisés)
 _KW_TRESO = {'tresorerie', 'treso', 'solde'}
 _KW_SUBV = {'subvention', 'subventions'}
 _KW_INDIC = {'indicateur', 'indicateurs'}
@@ -266,6 +267,8 @@ _KW_ABSENCE = {'absence', 'absences', 'conge', 'conges'}
 _KW_PESEE = {'pesee', 'pese'}
 _KW_HEURES = {'heure', 'heures', 'temps'}
 _KW_CONTRAT = {'contrat', 'contrats', 'cdd', 'cdi'}
+_KW_PLANNING = {'planning', 'plannings', 'horaire', 'horaires'}
+_KW_SALLES = {'salle', 'salles', 'reservation', 'reservations'}
 
 # Mots outils ignorés en tête de requête (« voir budget », « liste subventions »…)
 _MOTS_OUTILS = {'liste', 'listes', 'voir', 'afficher', 'montre', 'montrer', 'montrez',
@@ -296,6 +299,13 @@ def analyser_recherche(conn, query, profil, today):
         if mois:
             params['mois'] = mois
         return _redirect(url_for('tresorerie_bp.tresorerie', **params), 'Trésorerie')
+    # RH : « infos RH », « information RH », « RH »
+    if reste_str in ('rh', 'info rh', 'infos rh', 'information rh', 'informations rh'):
+        return _redirect(url_for('rh_statistiques_bp.rh_statistiques'), 'Statistiques RH')
+    # Pesée / analyse de poste ALISFA (outil de cotation)
+    if any(p in norm for p in ('analyse poste', 'analyse pesee', 'calcul pesee',
+                               'estimation pesee', 'cotation poste')):
+        return _redirect(url_for('pesee_alisfa_bp.pesee_alisfa'), 'Analyse / pesée ALISFA')
 
     # Retirer les mots outils en tête (« voir », « liste », « les »…) pour révéler le mot-clé.
     while reste and reste[0] in _MOTS_OUTILS:
@@ -307,7 +317,7 @@ def analyser_recherche(conn, query, profil, today):
     # ── A. Compta / finance ──
     if kw in _KW_FACTURE:
         return _intention_facture(conn, apres_kw, mois, annee_eff)
-    if kw in _KW_BUDGET:
+    if kw in _KW_BUDGET or kw in _KW_PREV:
         return _intention_budget(conn, kw, apres_kw, annee_eff, annee_explicite, today)
     if kw in _KW_TRESO or 'tresorerie' in reste:
         params = {'annee': annee_eff}
@@ -317,8 +327,9 @@ def analyser_recherche(conn, query, profil, today):
     if kw in _KW_SUBV:
         return _intention_subvention(conn, apres_kw, annee, annee_explicite)
     if kw == 'bilan':
-        return _redirect(url_for('compte_resultat_bp.compte_resultat', annee=annee_eff, vue='bilan'),
-                         f'Bilan {annee_eff}')
+        # « bilan » seul → compte-résultat (bilan de la structure) ; « bilan <secteur|action> »
+        # → bilan-secteurs (consultation).
+        return _intention_bilan(conn, apres_kw, annee_eff)
     if kw in ('cr', 'resultat'):
         return _redirect(url_for('compte_resultat_bp.compte_resultat', annee=annee_eff, vue='cr'),
                          f'Compte de résultat {annee_eff}')
@@ -328,6 +339,8 @@ def analyser_recherche(conn, query, profil, today):
     if kw in ('compte', 'comptes'):
         return _redirect(url_for('plan_comptable_general_bp.plan_comptable_general'),
                          'Plan comptable général')
+    if kw in _KW_SALLES:
+        return _redirect(url_for('salles_bp.salles'), 'Réservation de salles')
 
     # ── B. RH ──
     if kw in _KW_CONTRAT:
@@ -367,6 +380,15 @@ def analyser_recherche(conn, query, profil, today):
                 salaries, lambda uid: _url_salarie(uid, ancre),
                 f"Plusieurs salariés « {apres_kw} » :", ancre)
         return _aide("Précisez un salarié : ex. « salarié Marie ».")
+    if kw in _KW_PLANNING:
+        salaries = _resoudre_salarie(conn, apres_kw) if apres_kw else []
+        if apres_kw and salaries:
+            return _salarie_ou_choix(
+                salaries, lambda uid: url_for('planning_bp.planning_theorique', user_id=uid),
+                f"Plusieurs salariés « {apres_kw} » — planning de :")
+        return _redirect(url_for('planning_bp.planning_theorique'), 'Planning théorique')
+    if kw == 'rh':
+        return _redirect(url_for('rh_statistiques_bp.rh_statistiques'), 'Statistiques RH')
 
     # ── Mot(s) seul(s) : résolution multi-types ──
     return _resoudre_terme_libre(conn, reste_str, annee, annee_explicite, mois, today)
@@ -406,43 +428,83 @@ def _intention_facture(conn, terme, mois, annee_eff):
     return _redirect(url_for('factures_bp.liste_factures'), 'Factures')
 
 
+def _intention_bilan(conn, terme, annee_eff):
+    """« bilan » : sans entité → compte-résultat (bilan de la structure) ; avec un
+    secteur ou une action → bilan-secteurs (consultation du clôturé / réalisé)."""
+    if not terme:
+        return _redirect(url_for('compte_resultat_bp.compte_resultat', annee=annee_eff, vue='bilan'),
+                         f'Bilan {annee_eff}')
+    secteurs = _resoudre_secteur(conn, terme)
+    actions = _resoudre_action(conn, terme)
+    if len(secteurs) == 1 and not actions:
+        s = secteurs[0]
+        return _redirect(url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=s['id'], annee=annee_eff),
+                         f"Bilan — {s['nom']} {annee_eff}")
+    if len(actions) == 1 and not secteurs:
+        a = actions[0]
+        return _redirect(url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=annee_eff),
+                         f"Bilan — {a['nom']} {annee_eff}")
+    options = []
+    for s in secteurs:
+        options.append({'label': f"Secteur {s['nom']}", 'sous_titre': f'Bilan {annee_eff}',
+                        'url': url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=s['id'], annee=annee_eff)})
+    for a in actions:
+        options.append({'label': f"Action {a['nom']}", 'sous_titre': f'Bilan {annee_eff}',
+                        'url': url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=annee_eff)})
+    if options:
+        return _choices(f"« {terme} » — bilan de :", options)
+    return _redirect(url_for('compte_resultat_bp.compte_resultat', annee=annee_eff, vue='bilan'),
+                     f'Bilan {annee_eff}')
+
+
 def _intention_budget(conn, kw, terme, annee_eff, annee_explicite, today):
+    """Budget / prévisionnel / actualisé :
+    - sans entité, ou « prev/budget <année> » → budget-prévisionnel (général) ;
+    - secteur année courante/future → budget-prévisionnel (secteur) ; secteur année
+      passée (clôturé) → bilan-secteurs ;
+    - action → bilan-action (« Budget action », construction ; onglet réalisé si
+      année passée)."""
+    is_prev = kw in _KW_PREV
     passe = annee_explicite and annee_eff < today.year
-    # « prévisionnel [année] » sans entité → vue budgets
-    if kw in ('previsionnel', 'previsionnel') and not terme:
-        return _redirect(url_for('budget_bp.gestion_budgets', annee=annee_eff),
+
+    if not terme:
+        return _redirect(url_for('budget_bp.budget_previsionnel', annee=annee_eff),
                          f'Budget prévisionnel {annee_eff}')
-    if terme:
-        # Secteur → toujours bilan-secteurs
-        secteurs = _resoudre_secteur(conn, terme)
-        if len(secteurs) == 1:
+
+    secteurs = _resoudre_secteur(conn, terme)
+    actions = _resoudre_action(conn, terme)
+
+    if len(secteurs) == 1 and not actions:
+        s = secteurs[0]
+        if passe:
             return _redirect(
-                url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=secteurs[0]['id'], annee=annee_eff),
-                f"Budget — {secteurs[0]['nom']} {annee_eff}")
-        # Action → bilan-secteurs (réalisé) si année passée, sinon bilan-action
-        actions = _resoudre_action(conn, terme)
-        if len(actions) == 1:
-            a = actions[0]
-            if passe:
-                return _redirect(
-                    url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=annee_eff),
-                    f"Budget réalisé — {a['nom']} {annee_eff}")
-            return _redirect(
-                url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet='previsionnel'),
-                f"Budget — {a['nom']} {annee_eff}")
-        # Plusieurs correspondances (secteurs + actions)
-        options = []
-        for s in secteurs:
-            options.append({'label': f"Secteur {s['nom']}", 'sous_titre': f'Budget {annee_eff}',
-                            'url': url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=s['id'], annee=annee_eff)})
-        for a in actions:
-            url = (url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=annee_eff) if passe
-                   else url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet='previsionnel'))
-            options.append({'label': f"Action {a['nom']}", 'sous_titre': f'Budget {annee_eff}', 'url': url})
-        if options:
-            return _choices(f"« {terme} » — budget de :", options)
-    # Budget sans entité → vue d'ensemble
-    return _redirect(url_for('budget_bp.gestion_budgets', annee=annee_eff), f'Budgets {annee_eff}')
+                url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=s['id'], annee=annee_eff),
+                f"Bilan — {s['nom']} {annee_eff}")
+        return _redirect(
+            url_for('budget_bp.budget_previsionnel', annee=annee_eff, secteur_id=s['id']),
+            f"Budget prévisionnel — {s['nom']} {annee_eff}")
+
+    if len(actions) == 1 and not secteurs:
+        a = actions[0]
+        onglet = 'realise' if (passe and not is_prev) else 'previsionnel'
+        return _redirect(
+            url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet=onglet),
+            f"Budget action — {a['nom']} {annee_eff}")
+
+    options = []
+    for s in secteurs:
+        url = (url_for('bilan_secteurs_bp.bilan_secteurs', secteur_id=s['id'], annee=annee_eff) if passe
+               else url_for('budget_bp.budget_previsionnel', annee=annee_eff, secteur_id=s['id']))
+        options.append({'label': f"Secteur {s['nom']}", 'sous_titre': f'Budget {annee_eff}', 'url': url})
+    for a in actions:
+        onglet = 'realise' if (passe and not is_prev) else 'previsionnel'
+        options.append({'label': f"Action {a['nom']}", 'sous_titre': f'Budget action {annee_eff}',
+                        'url': url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet=onglet)})
+    if options:
+        return _choices(f"« {terme} » — budget de :", options)
+
+    return _redirect(url_for('budget_bp.budget_previsionnel', annee=annee_eff),
+                     f'Budget prévisionnel {annee_eff}')
 
 
 def _intention_subvention(conn, terme, annee, annee_explicite):
@@ -509,6 +571,24 @@ def _resoudre_terme_libre(conn, terme, annee, annee_explicite, mois, today):
                           url_for('subventions_bp.gestion_subventions',
                                   annee=sv['annee_action'] or 'toutes'),
                           f"Année {sv['annee_action'] or '—'}"))
+
+    an = annee if annee_explicite else today.year
+    actions = _resoudre_action(conn, terme)
+
+    # Action seule → doute consultation / construction : proposer les deux.
+    if not candidats and len(actions) == 1:
+        a = actions[0]
+        return _choices(f"« {a['nom'] } » — que voir ?", [
+            {'label': f"Budget action — {a['nom']}", 'sous_titre': 'Construction du budget',
+             'url': url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=an, onglet='previsionnel')},
+            {'label': f"Bilan — {a['nom']}", 'sous_titre': 'Consultation (réalisé / clôturé)',
+             'url': url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=an)},
+        ])
+    # Sinon, une action rejoint les autres candidats (construction du budget par défaut).
+    for a in actions:
+        candidats.append(('Budget action', a['nom'],
+                          url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=an,
+                                  onglet='previsionnel'), 'Construction du budget'))
 
     if len(candidats) == 1:
         c = candidats[0]

--- a/search_engine.py
+++ b/search_engine.py
@@ -263,12 +263,20 @@ _KW_TRESO = {'tresorerie', 'treso', 'solde'}
 _KW_SUBV = {'subvention', 'subventions'}
 _KW_INDIC = {'indicateur', 'indicateurs'}
 _KW_SALARIE = {'salarie', 'salaries', 'salariee', 'fiche', 'employe', 'employee'}
-_KW_ABSENCE = {'absence', 'absences', 'conge', 'conges'}
+_KW_ABSENCE = {'absence', 'absences', 'conge', 'conges',
+               # Synonymes courants : arrêt / congé maladie.
+               'maladie', 'maladies', 'malade', 'arret', 'arrets'}
 _KW_PESEE = {'pesee', 'pese'}
 _KW_HEURES = {'heure', 'heures', 'temps'}
 _KW_CONTRAT = {'contrat', 'contrats', 'cdd', 'cdi'}
 _KW_PLANNING = {'planning', 'plannings', 'horaire', 'horaires'}
 _KW_SALLES = {'salle', 'salles', 'reservation', 'reservations'}
+
+# Nombre d'années passées présélectionnables par la page « Budget action »
+# (bilan_action.py : annees = current+1 … current-4). Au-delà (année réalisée
+# plus ancienne), la construction budgétaire n'est plus proposée : on renvoie la
+# consultation du clôturé vers bilan-secteurs, qui accepte n'importe quelle année.
+_BILAN_ACTION_ANNEES_PASSEES = 4
 
 # Mots outils ignorés en tête de requête (« voir budget », « liste subventions »…)
 _MOTS_OUTILS = {'liste', 'listes', 'voir', 'afficher', 'montre', 'montrer', 'montrez',
@@ -457,6 +465,22 @@ def _intention_bilan(conn, terme, annee_eff):
                      f'Bilan {annee_eff}')
 
 
+def _url_budget_action(a, annee_eff, passe, is_prev, today):
+    """(url, libellé) de budget pour une action selon l'année demandée.
+
+    La page « Budget action » (bilan-action) ne présélectionne que les années de
+    sa fenêtre (année courante et les quatre précédentes). Pour une année réalisée
+    plus ancienne, la présélection serait ignorée et la page retomberait sur
+    l'année courante : on renvoie alors la consultation du clôturé vers
+    bilan-secteurs, qui accepte n'importe quelle année."""
+    if passe and annee_eff < today.year - _BILAN_ACTION_ANNEES_PASSEES:
+        return (url_for('bilan_secteurs_bp.bilan_secteurs', action_id=a['id'], annee=annee_eff),
+                f"Bilan — {a['nom']} {annee_eff}")
+    onglet = 'realise' if (passe and not is_prev) else 'previsionnel'
+    return (url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet=onglet),
+            f"Budget action — {a['nom']} {annee_eff}")
+
+
 def _intention_budget(conn, kw, terme, annee_eff, annee_explicite, today):
     """Budget / prévisionnel / actualisé :
     - sans entité, ou « prev/budget <année> » → budget-prévisionnel (général) ;
@@ -485,11 +509,8 @@ def _intention_budget(conn, kw, terme, annee_eff, annee_explicite, today):
             f"Budget prévisionnel — {s['nom']} {annee_eff}")
 
     if len(actions) == 1 and not secteurs:
-        a = actions[0]
-        onglet = 'realise' if (passe and not is_prev) else 'previsionnel'
-        return _redirect(
-            url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet=onglet),
-            f"Budget action — {a['nom']} {annee_eff}")
+        url, label = _url_budget_action(actions[0], annee_eff, passe, is_prev, today)
+        return _redirect(url, label)
 
     options = []
     for s in secteurs:
@@ -497,9 +518,8 @@ def _intention_budget(conn, kw, terme, annee_eff, annee_explicite, today):
                else url_for('budget_bp.budget_previsionnel', annee=annee_eff, secteur_id=s['id']))
         options.append({'label': f"Secteur {s['nom']}", 'sous_titre': f'Budget {annee_eff}', 'url': url})
     for a in actions:
-        onglet = 'realise' if (passe and not is_prev) else 'previsionnel'
-        options.append({'label': f"Action {a['nom']}", 'sous_titre': f'Budget action {annee_eff}',
-                        'url': url_for('bilan_action_bp.bilan_action', action_id=a['id'], annee=annee_eff, onglet=onglet)})
+        url, label = _url_budget_action(a, annee_eff, passe, is_prev, today)
+        options.append({'label': f"Action {a['nom']}", 'sous_titre': label, 'url': url})
     if options:
         return _choices(f"« {terme} » — budget de :", options)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -89,7 +89,7 @@
                     <a href="{{ url_for('subventions_bp.gestion_subventions') }}">📋 Subventions</a>
                     <a href="{{ url_for('tresorerie_bp.tresorerie') }}">📈 Trésorerie</a>
                     <a href="{{ url_for('bilan_secteurs_bp.bilan_secteurs') }}">📊 Bilan secteurs/actions</a>
-                    <a href="{{ url_for('bilan_action_bp.bilan_action') }}">🎯 Bilan action</a>
+                    <a href="{{ url_for('bilan_action_bp.bilan_action') }}">🎯 Budget action</a>
                     <a href="{{ url_for('alsh_bp.analyse_alsh') }}">🏕️ Analyse ALSH</a>
                 </div>
             </div>
@@ -208,7 +208,7 @@
                     <a href="{{ url_for('subventions_bp.gestion_subventions') }}">📋 Subventions</a>
                     <a href="{{ url_for('tresorerie_bp.tresorerie') }}">📈 Trésorerie</a>
                     <a href="{{ url_for('bilan_secteurs_bp.bilan_secteurs') }}">📊 Bilan secteurs/actions</a>
-                    <a href="{{ url_for('bilan_action_bp.bilan_action') }}">🎯 Bilan action</a>
+                    <a href="{{ url_for('bilan_action_bp.bilan_action') }}">🎯 Budget action</a>
                     <a href="{{ url_for('alsh_bp.analyse_alsh') }}">🏕️ Analyse ALSH</a>
                 </div>
             </div>

--- a/templates/bilan_action.html
+++ b/templates/bilan_action.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% block title %}Bilan action - CS-PILOT{% endblock %}
+{% block title %}Budget action - CS-PILOT{% endblock %}
 
 {% block content %}
 <div class="page-header" style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:10px;">
-    <h2>🎯 Bilan action</h2>
+    <h2>🎯 Budget action</h2>
     <div id="actionButtons" style="display:none;gap:8px;flex-wrap:wrap;">
         <span id="saveStatus" class="muted" style="align-self:center;"></span>
         <button class="btn btn-primary" onclick="sauvegarder(true)">💾 Enregistrer</button>

--- a/templates/journal_acces.html
+++ b/templates/journal_acces.html
@@ -54,6 +54,7 @@
     <div class="journal-tabs">
         <a href="{{ url_for('securite_bp.journal_acces') }}" class="journal-tab active">🔑 Connexions</a>
         <a href="{{ url_for('securite_bp.journal_actions') }}" class="journal-tab">📋 Actions</a>
+        <a href="{{ url_for('securite_bp.journal_recherches') }}" class="journal-tab">🔎 Barre intelligente</a>
     </div>
     <p class="subtitle">
         Traçabilité des connexions à l'application — affichage des {{ limite }} entrées les plus récentes.

--- a/templates/journal_actions.html
+++ b/templates/journal_actions.html
@@ -62,6 +62,7 @@
     <div class="journal-tabs">
         <a href="{{ url_for('securite_bp.journal_acces') }}" class="journal-tab">🔑 Connexions</a>
         <a href="{{ url_for('securite_bp.journal_actions') }}" class="journal-tab active">📋 Actions</a>
+        <a href="{{ url_for('securite_bp.journal_recherches') }}" class="journal-tab">🔎 Barre intelligente</a>
     </div>
     <p class="subtitle">
         Traçabilité des actions sensibles (qui a fait quoi, sur quelle cible) — affichage des {{ limite }} entrées les plus récentes.

--- a/templates/journal_recherches.html
+++ b/templates/journal_recherches.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+
+{% block title %}Sécurité — Barre intelligente{% endblock %}
+
+{% block content %}
+<style>
+    .journal-page { max-width: 1100px; margin: 0 auto; }
+    .journal-table-wrap {
+        background: var(--white);
+        border: 1px solid var(--gray-200);
+        border-radius: 12px;
+        padding: 8px;
+        box-shadow: var(--shadow-sm);
+        overflow-x: auto;
+    }
+    .journal-terme { font-weight: 600; color: var(--gray-900); }
+    .journal-user-nom { font-size: 0.82rem; color: var(--gray-500); }
+    .journal-dest { color: var(--gray-600); font-size: 0.85rem; }
+    .journal-date small { color: var(--gray-500); }
+    .journal-tabs { display: flex; gap: 8px; margin: 18px 0 4px; border-bottom: 2px solid var(--gray-200); flex-wrap: wrap; }
+    .journal-tab {
+        padding: 10px 18px; text-decoration: none; color: var(--gray-600);
+        font-weight: 600; border-bottom: 3px solid transparent; margin-bottom: -2px;
+    }
+    .journal-tab:hover { color: var(--gray-900); }
+    .journal-tab.active { color: var(--primary); border-bottom-color: var(--primary); }
+</style>
+
+<div class="journal-page">
+    <h1>🔒 Journal de sécurité</h1>
+    <div class="journal-tabs">
+        <a href="{{ url_for('securite_bp.journal_acces') }}" class="journal-tab">🔑 Connexions</a>
+        <a href="{{ url_for('securite_bp.journal_actions') }}" class="journal-tab">📋 Actions</a>
+        <a href="{{ url_for('securite_bp.journal_recherches') }}" class="journal-tab active">🔎 Barre intelligente</a>
+    </div>
+    <p class="subtitle">
+        Termes saisis dans la barre de recherche intelligente des tableaux de bord —
+        affichage des {{ limite }} recherches les plus récentes.
+    </p>
+
+    <!-- Statistiques rapides (sur les entrées affichées) -->
+    <div class="stats-grid" style="grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));">
+        <div class="stat-card">
+            <div class="stat-icon">🔎</div>
+            <div class="stat-content">
+                <h3>Recherches affichées</h3>
+                <p class="stat-value">{{ entrees|length }}</p>
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon">✅</div>
+            <div class="stat-content">
+                <h3>Avec résultat</h3>
+                <p class="stat-value">{{ entrees|selectattr('a_resultat', 'equalto', 1)|list|length }}</p>
+            </div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-icon">🚫</div>
+            <div class="stat-content">
+                <h3>Sans résultat</h3>
+                <p class="stat-value">{{ entrees|rejectattr('a_resultat', 'equalto', 1)|list|length }}</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tableau des recherches -->
+    <div class="journal-table-wrap">
+        {% if entrees %}
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Date et heure</th>
+                    <th>Utilisateur</th>
+                    <th>Terme recherché</th>
+                    <th>Résultat</th>
+                    <th>Destination</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for e in entrees %}
+                <tr>
+                    <td class="journal-date" style="white-space: nowrap;">
+                        {% set parts = (e.date_heure or '').split(' ') %}
+                        <strong>{{ parts[0] }}</strong>
+                        {% if parts|length > 1 %}<br><small>{{ parts[1] }}</small>{% endif %}
+                    </td>
+                    <td>
+                        {% if e.prenom or e.nom %}
+                        <span class="journal-user-nom">{{ e.prenom }} {{ e.nom }}</span>
+                        {% else %}—{% endif %}
+                    </td>
+                    <td><span class="journal-terme">{{ e.terme }}</span></td>
+                    <td>
+                        {% if e.a_resultat %}
+                        <span class="badge badge-success">✅ Résultat</span>
+                        {% else %}
+                        <span class="badge badge-danger">🚫 Aucun</span>
+                        {% endif %}
+                    </td>
+                    <td><span class="journal-dest">{{ e.libelle or '—' }}</span></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="no-data">Aucune recherche enregistrée pour le moment.</p>
+        {% endif %}
+    </div>
+
+    <div class="help-box" style="margin-top: 1.5rem;">
+        <h4>ℹ️ À propos de la barre intelligente</h4>
+        <ul>
+            <li><strong>✅ Résultat</strong> : la recherche a mené à une page (redirection) ou proposé un choix.</li>
+            <li><strong>🚫 Aucun</strong> : aucune correspondance trouvée pour le terme saisi.</li>
+        </ul>
+        <p>
+            Cette liste sert à repérer les termes fréquemment utilisés (et ceux qui
+            n'aboutissent pas) afin d'enrichir les synonymes reconnus par le moteur.
+            <strong>Confidentialité :</strong> réservée à la direction et à la comptabilité.
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/templates/journal_recherches.html
+++ b/templates/journal_recherches.html
@@ -116,7 +116,12 @@
         <p>
             Cette liste sert à repérer les termes fréquemment utilisés (et ceux qui
             n'aboutissent pas) afin d'enrichir les synonymes reconnus par le moteur.
+        </p>
+        <p>
             <strong>Confidentialité :</strong> réservée à la direction et à la comptabilité.
+            Les noms de salariés recherchés sont <strong>anonymisés</strong> (remplacés par
+            « salarié ») : on voit qu'une recherche RH a eu lieu, sans savoir quel salarié
+            était concerné.
         </p>
     </div>
 </div>

--- a/tests/test_bilan_action.py
+++ b/tests/test_bilan_action.py
@@ -26,7 +26,8 @@ def _make_action(app, nom='Action Test'):
 def test_page_accessible_directeur(admin_client):
     r = admin_client.get('/bilan-action')
     assert r.status_code == 200
-    assert 'Bilan action' in r.get_data(as_text=True)
+    # La page a été renommée « Budget action » (mais l'URL /bilan-action reste).
+    assert 'Budget action' in r.get_data(as_text=True)
 
 
 def test_page_refuse_salarie(auth_client):

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -53,14 +53,28 @@ class TestMoteurFinance:
         assert v['type'] == 'redirect' and '/fournisseurs/' in v['url']
 
     def test_budget_action_construction_bilan_action(self, app, db, sample_users):
-        # « budget <action> » → bilan-action (Budget action) ; onglet réalisé si passé.
+        # « budget <action> » → bilan-action (Budget action) ; onglet réalisé pour
+        # une année passée récente (dans la fenêtre présélectionnable).
         n = _annee()
         with app.app_context():
             _seed(db)
         v = _analyse(app, db, f'budget clas {n + 1}')
         assert '/bilan-action' in v['url'] and 'onglet=previsionnel' in v['url']
-        v2 = _analyse(app, db, 'budget clas 2020')
+        v2 = _analyse(app, db, f'budget clas {n - 1}')
         assert '/bilan-action' in v2['url'] and 'onglet=realise' in v2['url']
+
+    def test_budget_action_annee_ancienne_va_a_bilan_secteurs(self, app, db, sample_users):
+        # Année réalisée hors fenêtre de « Budget action » (> 4 ans) : on renvoie la
+        # consultation du clôturé vers bilan-secteurs (qui accepte toute année),
+        # plutôt que vers bilan-action qui ignorerait l'année et retomberait sur
+        # l'année courante.
+        n = _annee()
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, f'budget clas {n - 6}')
+        assert '/bilan-secteurs' in v['url'] and 'action_id=' in v['url']
+        assert f'annee={n - 6}' in v['url']
+        assert '/bilan-action' not in v['url']
 
     def test_bilan_secteur_va_a_bilan_secteurs(self, app, db, sample_users):
         with app.app_context():
@@ -157,6 +171,18 @@ class TestMoteurRH:
         v = _analyse(app, db, 'absence Marie')
         assert v['type'] == 'choices' and len(v['options']) >= 2
         assert all('search_user_id=' in o['url'] for o in v['options'])
+
+    def test_absence_synonymes_maladie_arret(self, app, db, sample_users):
+        # « maladie » / « arrêt(s) » sont des synonymes d'« absence » : ils doivent
+        # déclencher la même intention (ex. « maladie Marie », « arrêts Marie »).
+        with app.app_context():
+            _seed(db)
+        for q in ('maladie Fatou', 'arrêts Fatou', 'arret Fatou', 'malade Fatou'):
+            v = _analyse(app, db, q)
+            assert v['type'] == 'redirect' and '/absences' in v['url'] and 'search_user_id=' in v['url'], q
+        # Comme « absence Marie », un synonyme + prénom ambigu propose un choix.
+        v = _analyse(app, db, 'maladie Marie')
+        assert v['type'] == 'choices' and all('search_user_id=' in o['url'] for o in v['options'])
 
     def test_heures_salarie(self, app, db, sample_users):
         with app.app_context():
@@ -303,3 +329,38 @@ class TestSynonymesSecteurs:
         # Le moteur reconnaît le secteur par son synonyme.
         v = _analyse(app, db, 'ef')
         assert v['type'] == 'redirect' and 'secteur_id=' in v['url']
+
+
+class TestJournalRecherches:
+    def test_recherche_est_journalisee_avec_resultat(self, app, db, admin_client, sample_users):
+        # Chaque recherche est tracée avec le fait qu'elle ait abouti ou non.
+        with app.app_context():
+            _seed(db)
+        admin_client.post('/api/search', json={'query': 'EDF'})
+        admin_client.post('/api/search', json={'query': 'zzztotalementinconnu'})
+        with app.app_context():
+            rows = db.execute(
+                "SELECT terme, a_resultat FROM recherche_log ORDER BY id").fetchall()
+        termes = {r['terme']: r['a_resultat'] for r in rows}
+        assert termes.get('EDF') == 1
+        assert termes.get('zzztotalementinconnu') == 0
+
+    def test_recherche_vide_non_journalisee(self, app, db, admin_client, sample_users):
+        with app.app_context():
+            _seed(db)
+        admin_client.post('/api/search', json={'query': '   '})
+        with app.app_context():
+            nb = db.execute("SELECT COUNT(*) FROM recherche_log").fetchone()[0]
+        assert nb == 0
+
+    def test_onglet_barre_intelligente_liste_les_recherches(self, app, db, admin_client, sample_users):
+        with app.app_context():
+            _seed(db)
+        admin_client.post('/api/search', json={'query': 'EDF'})
+        html = admin_client.get('/securite/journal-recherches').get_data(as_text=True)
+        assert 'Barre intelligente' in html
+        assert 'EDF' in html
+
+    def test_journal_recherches_refuse_salarie(self, app, auth_client, sample_users):
+        r = auth_client.get('/securite/journal-recherches', follow_redirects=False)
+        assert r.status_code in (301, 302)

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -116,6 +116,17 @@ class TestMoteurFinance:
         v = _analyse(app, db, 'actualisé babilhome 2026')
         assert '/budget-previsionnel' in v['url'] and 'secteur_id=' in v['url']
 
+    def test_bp_et_bpa_synonymes_previsionnel(self, app, db, sample_users):
+        # « BP » (budget prévisionnel) et « BPA » (budget prévisionnel actualisé)
+        # sont des synonymes de prévisionnel.
+        n = _annee()
+        with app.app_context():
+            _seed(db)
+        assert '/budget-previsionnel' in _analyse(app, db, f'BP {n}')['url']
+        assert '/budget-previsionnel' in _analyse(app, db, f'BPA {n}')['url']
+        v = _analyse(app, db, f'BP babilhome {n}')
+        assert '/budget-previsionnel' in v['url'] and 'secteur_id=' in v['url']
+
     def test_action_seule_propose_consultation_et_construction(self, app, db, sample_users):
         # Un nom d'action seul (sans mot-clé) → deux alternatives (doute).
         with app.app_context():
@@ -360,6 +371,29 @@ class TestJournalRecherches:
         html = admin_client.get('/securite/journal-recherches').get_data(as_text=True)
         assert 'Barre intelligente' in html
         assert 'EDF' in html
+
+    def test_noms_salaries_anonymises_dans_le_terme(self, app, db, admin_client, sample_users):
+        # Le terme journalisé ne doit pas révéler le nom du salarié recherché.
+        with app.app_context():
+            _seed(db)
+        admin_client.post('/api/search', json={'query': 'absence Fatou'})
+        with app.app_context():
+            row = db.execute(
+                "SELECT terme FROM recherche_log ORDER BY id DESC LIMIT 1").fetchone()
+        assert 'Fatou' not in row['terme']
+        assert 'salarié' in row['terme']
+        assert 'absence' in row['terme']  # l'intention reste visible
+
+    def test_nom_dans_libelle_destination_anonymise(self, app, db, admin_client, sample_users):
+        # Même la destination (« Prénom Nom » d'une fiche salarié) est anonymisée.
+        with app.app_context():
+            _seed(db)
+        admin_client.post('/api/search', json={'query': 'salarié Fatou'})
+        with app.app_context():
+            row = db.execute(
+                "SELECT terme, libelle FROM recherche_log ORDER BY id DESC LIMIT 1").fetchone()
+        assert 'Fatou' not in row['terme']
+        assert 'Fatou' not in (row['libelle'] or '') and 'Bernard' not in (row['libelle'] or '')
 
     def test_journal_recherches_refuse_salarie(self, app, auth_client, sample_users):
         r = auth_client.get('/securite/journal-recherches', follow_redirects=False)

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -9,6 +9,8 @@ def _seed(db):
     db.execute("INSERT INTO secteurs (nom, synonymes) VALUES ('Babilhome', 'bab, babil')")
     db.execute("INSERT INTO fournisseurs (nom, code_comptable) VALUES ('EDF', 'EDF')")
     db.execute("INSERT INTO comptabilite_actions (nom) VALUES ('CLAS')")
+    db.execute("INSERT INTO comptabilite_actions (nom) VALUES ('Fracture numerique')")
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) VALUES ('Borand', 'Cyril', 'cb', 'x', 'directeur', 1)")
     # Deux « Marie » supplémentaires (sample_users en crée déjà une) → désambiguïsation.
     db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) VALUES ('Lopez', 'Marie', 'ml', 'x', 'responsable', 1)")
     db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) VALUES ('Martin', 'Marie', 'mm', 'x', 'responsable', 1)")
@@ -50,26 +52,64 @@ class TestMoteurFinance:
         v = _analyse(app, db, 'factures edf')
         assert v['type'] == 'redirect' and '/fournisseurs/' in v['url']
 
-    def test_budget_action_annee_passee_realise(self, app, db, sample_users):
-        with app.app_context():
-            _seed(db)
-        v = _analyse(app, db, 'budget clas 2020')
-        assert v['type'] == 'redirect'
-        assert '/bilan-secteurs' in v['url'] and 'action_id=' in v['url'] and 'annee=2020' in v['url']
-
-    def test_budget_action_annee_future_previsionnel(self, app, db, sample_users):
+    def test_budget_action_construction_bilan_action(self, app, db, sample_users):
+        # « budget <action> » → bilan-action (Budget action) ; onglet réalisé si passé.
         n = _annee()
         with app.app_context():
             _seed(db)
         v = _analyse(app, db, f'budget clas {n + 1}')
-        assert v['type'] == 'redirect'
-        assert '/bilan-action' in v['url'] and f'annee={n + 1}' in v['url'] and 'onglet=previsionnel' in v['url']
+        assert '/bilan-action' in v['url'] and 'onglet=previsionnel' in v['url']
+        v2 = _analyse(app, db, 'budget clas 2020')
+        assert '/bilan-action' in v2['url'] and 'onglet=realise' in v2['url']
 
-    def test_budget_secteur_toujours_bilan_secteurs(self, app, db, sample_users):
+    def test_bilan_secteur_va_a_bilan_secteurs(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'bilan babilhome 2025')
+        assert '/bilan-secteurs' in v['url'] and 'secteur_id=' in v['url'] and 'annee=2025' in v['url']
+
+    def test_bilan_action_va_a_bilan_secteurs(self, app, db, sample_users):
+        # « bilan <action> » = consultation → bilan-secteurs (avec action_id).
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'bilan CLAS 2025')
+        assert '/bilan-secteurs' in v['url'] and 'action_id=' in v['url']
+
+    def test_bilan_seul_va_a_compte_resultat(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'bilan 2025')
+        assert '/compte-resultat' in v['url'] and 'vue=bilan' in v['url']
+
+    def test_budget_secteur_courant_va_a_previsionnel(self, app, db, sample_users):
+        n = _annee()
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, f'budget babilhome {n}')
+        assert '/budget-previsionnel' in v['url'] and 'secteur_id=' in v['url']
+
+    def test_budget_secteur_passe_va_a_bilan_secteurs(self, app, db, sample_users):
         with app.app_context():
             _seed(db)
         v = _analyse(app, db, 'budget babilhome 2020')
-        assert v['type'] == 'redirect' and '/bilan-secteurs' in v['url'] and 'secteur_id=' in v['url']
+        assert '/bilan-secteurs' in v['url'] and 'secteur_id=' in v['url']
+
+    def test_prev_et_budget_general_va_a_previsionnel(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        assert '/budget-previsionnel' in _analyse(app, db, 'prev 2026')['url']
+        assert '/budget-previsionnel' in _analyse(app, db, 'budget 2026')['url']
+        v = _analyse(app, db, 'actualisé babilhome 2026')
+        assert '/budget-previsionnel' in v['url'] and 'secteur_id=' in v['url']
+
+    def test_action_seule_propose_consultation_et_construction(self, app, db, sample_users):
+        # Un nom d'action seul (sans mot-clé) → deux alternatives (doute).
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'fracture numerique')
+        assert v['type'] == 'choices' and len(v['options']) == 2
+        urls = ' '.join(o['url'] for o in v['options'])
+        assert '/bilan-action' in urls and '/bilan-secteurs' in urls
 
     def test_tresorerie_mois(self, app, db, sample_users):
         n = _annee()
@@ -205,6 +245,33 @@ class TestMoteurEntitesEtPeriodes:
         assert _analyse(app, db, 'aide')['type'] == 'none'
         assert _analyse(app, db, '')['type'] == 'none'
         assert _analyse(app, db, 'zzztotalementinconnu')['type'] == 'none'
+
+
+class TestNouvellesIntentions:
+    def test_planning_salarie(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        for q in ('planning Cyril', 'horaire Cyril'):
+            v = _analyse(app, db, q)
+            assert v['type'] == 'redirect' and '/planning_theorique' in v['url'] and 'user_id=' in v['url']
+
+    def test_rh(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        for q in ('RH', 'infos RH', 'information RH'):
+            assert '/rh/statistiques' in _analyse(app, db, q)['url']
+
+    def test_analyse_pesee(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        for q in ('analyse poste', 'analyse pesée', 'calcul pesée', 'estimation pesée'):
+            assert '/pesee_alisfa' in _analyse(app, db, q)['url']
+
+    def test_salles(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        for q in ('salles', 'salle', 'réservation'):
+            assert '/salles' in _analyse(app, db, q)['url']
 
 
 class TestApiSearch:


### PR DESCRIPTION
## Objectif

Affiner la barre de recherche intelligente suite aux retours d&#39;usage : routage budget/bilan plus fin (sans passer par `gestion_budgets`), nouvelles intentions, renommage « Bilan action » → « Budget action », **synonymes** (absence, BP/BPA), et **journal des termes recherchés (anonymisé)**.

## Budget / bilan (routage)

| Requête | Redirection |
|---|---|
| `bilan` (seul) | compte-résultat (bilan de la **structure**) |
| `bilan babilhome`, `bilan clas 2025` | **bilan-secteurs** (consultation) — secteur et/ou action + année |
| `budget clas 2026` | **bilan-action** (Budget action, prévisionnel) |
| `budget clas 2025` (année passée récente, dans la fenêtre) | bilan-action (onglet **réalisé**) |
| `budget clas 2020` (année réalisée **ancienne**, hors fenêtre N-4) | **bilan-secteurs** (consultation du clôturé) |
| `budget babilhome 2026` | **budget-prévisionnel** (secteur, année courante) |
| `budget babilhome 2020` | bilan-secteurs (secteur **clôturé**) |
| `prev 2026`, `BP 2026`, `BPA 2026`, `budget 2026`, `actualisé babilhome 2026` | **budget-prévisionnel** (général / secteur) |
| `fracture numérique` (nom d&#39;action seul) | **doute → 2 alternatives** : Construction (Budget action) vs Consultation (Bilan secteurs) — *comportement confirmé, évite le mauvais choix* |

- Abréviations : **`prev`** / **`BP`** = budget prévisionnel ; **`actualisé`** / **`BPA`** = budget prévisionnel actualisé.
- **Présélection** `?annee=` / `?secteur_id=` sur la page **budget-prévisionnel**.
- **Correctif de revue (Codex P2)** : la page « Budget action » ne présélectionne que les années de sa fenêtre (courante à N-4). Une année réalisée plus ancienne était ignorée (retour à l&#39;année courante) ; elle est désormais routée vers **bilan-secteurs**, qui accepte n&#39;importe quelle année. Fenêtre factorisée dans `_BILAN_ACTION_ANNEES_PASSEES` + helper `_url_budget_action`.

## Synonymes d&#39;absence

`maladie`, `maladies`, `malade`, `arrêt(s)` déclenchent l&#39;intention **absence** — ex. « maladie Marie », « arrêts Marie » fonctionnent comme « absence Marie ».

## Journal des recherches (onglet « Barre intelligente », anonymisé)

- Nouvelle table **`recherche_log`** (init_db + **migration 0054**) : chaque terme saisi est tracé avec le fait qu&#39;il ait **abouti ou non** (redirection / choix vs aucun résultat). Journalisation *best-effort* dans `/api/search` (jamais bloquante).
- **Anonymisation RH** : les noms/prénoms de salariés présents dans le terme ou la destination sont remplacés par « salarié » (`anonymiser_terme_salaries`). L&#39;intention reste lisible (« absence salarié ») mais le journal ne révèle **pas** quel salarié est recherché.
- Nouvel **onglet « 🔎 Barre intelligente »** (`/securite/journal-recherches`) listant les **50 dernières recherches** (terme, résultat, destination, auteur). Réservé direction / comptabilité.

## Autres intentions

- `planning cyril`, `horaire cyril` → **planning théorique** du salarié
- `RH`, `infos RH`, `information RH` → **rh/statistiques**
- `analyse poste`, `analyse/calcul/estimation pesée` → **pesée ALISFA** (`/pesee_alisfa`)
- `salle(s)`, `réservation` → **salles**

## Renommage

« Bilan action » → « **Budget action** » (menu + titre de page). L&#39;URL `/bilan-action` et l&#39;endpoint `bilan_action_bp.bilan_action` restent inchangés.

## Tests

- Moteur : routage budget/bilan, doute action, synonymes maladie/arrêt, **BP/BPA**, routage année ancienne → bilan-secteurs, **anonymisation** (terme + destination), journalisation + onglet dédié.
- **Suite complète verte (759 tests).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp