### PR TITLE
Barre intelligente : intention « demande de congés »

### DIFF
--- a/search_engine.py
+++ b/search_engine.py
@@ -316,6 +316,15 @@ _KW_SALLES = {'salle', 'salles', 'reservation', 'reservations'}
 # consultation du clôturé vers bilan-secteurs, qui accepte n'importe quelle année.
 _BILAN_ACTION_ANNEES_PASSEES = 4
 
+# Déposer une demande de congés : « demande (de) congé(s) », « poser congé(s) »,
+# « prendre congé(s) » (+ variantes « demander », « faire une demande de… »).
+# Le verbe est requis : « congé Marie » reste l'intention « absences ».
+_RE_DEMANDE_CONGE = re.compile(
+    r'\b(?:demande|demandes|demander|demandez|pose|poser|posez|prendre|prends|prend|prenez)\b'
+    r'(?:\s+(?:de|d|un|une|des|mes|ma|mon|le|la|les|nouvelle))*'
+    r'\s+conges?\b'
+)
+
 # Mots outils ignorés en tête de requête (« voir budget », « liste subventions »…)
 _MOTS_OUTILS = {'liste', 'listes', 'voir', 'afficher', 'montre', 'montrer', 'montrez',
                 'ouvre', 'ouvrir', 'les', 'la', 'le', 'des', 'du', 'de', 'mes', 'mon', 'ma'}
@@ -352,6 +361,9 @@ def analyser_recherche(conn, query, profil, today):
     if any(p in norm for p in ('analyse poste', 'analyse pesee', 'calcul pesee',
                                'estimation pesee', 'cotation poste')):
         return _redirect(url_for('pesee_alisfa_bp.pesee_alisfa'), 'Analyse / pesée ALISFA')
+    # Déposer une demande de congés (direction et comptable y ont accès).
+    if _RE_DEMANDE_CONGE.search(norm):
+        return _redirect(url_for('recup_bp.demande_conge'), 'Demande de congés')
 
     # Retirer les mots outils en tête (« voir », « liste », « les »…) pour révéler le mot-clé.
     while reste and reste[0] in _MOTS_OUTILS:

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -398,3 +398,28 @@ class TestJournalRecherches:
     def test_journal_recherches_refuse_salarie(self, app, auth_client, sample_users):
         r = auth_client.get('/securite/journal-recherches', follow_redirects=False)
         assert r.status_code in (301, 302)
+
+
+class TestDemandeConge:
+    def test_variantes_renvoient_vers_la_demande(self, app, db, sample_users):
+        with app.app_context():
+            _seed(db)
+        for q in ('demande de congés', 'demande congé', 'demande congés',
+                  'poser congé', 'poser des congés', 'prendre congé',
+                  'prendre un congé', 'demander un congé', 'faire une demande de congé'):
+            v = _analyse(app, db, q)
+            assert v['type'] == 'redirect' and '/demande_conge' in v['url'], q
+
+    def test_accessible_au_comptable(self, app, db, sample_users):
+        # La barre est réservée direction + comptable : les deux y ont droit.
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'demande de congés', profil='comptable')
+        assert v['type'] == 'redirect' and '/demande_conge' in v['url']
+
+    def test_absence_non_confondue_avec_demande(self, app, db, sample_users):
+        # Sans verbe, « absence/congé <nom> » reste l'intention « absences ».
+        with app.app_context():
+            _seed(db)
+        v = _analyse(app, db, 'absence Fatou')
+        assert '/absences' in v['url'] and '/demande_conge' not in v['url']


### PR DESCRIPTION
## Contexte

La requête « demande de congés » (et ses variantes) ne donnait **aucun résultat** dans la barre de recherche intelligente. Cette PR ajoute l'intention correspondante.

## Ce qui change

- Nouvelle intention dans le moteur (`search_engine.py`) : une requête de type **demande de congés** renvoie vers la page de dépôt de demande (`/demande_conge`, `recup_bp.demande_conge`).
- La barre étant déjà réservée à la **direction** et à la **comptabilité**, l'intention les couvre tous les deux (aucun autre profil n'atteint la barre).

## Synonymes reconnus

Le **verbe est requis**, pour ne pas confondre avec « congé &lt;nom&gt; » qui reste l'intention **absences** :

- `demande (de) congé(s)`, `demander (un) congé`, `faire une demande de congé`
- `poser congé(s)`, `poser des congés`
- `prendre congé(s)`, `prendre un congé`

Exclusions vérifiées (pas de faux positif) : `congé Marie`, `absence Fatou`, `demande de subvention`, `prendre rendez-vous`, `poser une salle`, `budget congés`.

## Tests

`tests/test_search_engine.py` (classe `TestDemandeConge`) : les variantes renvoient vers `/demande_conge`, accès comptable, et non-confusion avec « absence &lt;nom&gt; ».

**Suite complète verte (773 tests).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_