### PR TITLE
IA OpenAI : GPT-5.5 / GPT-5.4 + choix de l'effort de raisonnement

### DIFF
--- a/blueprints/api_keys.py
+++ b/blueprints/api_keys.py
@@ -19,7 +19,9 @@ AI_PROVIDERS = {
         'key_setting': 'openai_api_key',
         'key_prefix': 'sk-',
         'models': [
-            {'id': 'gpt-5.2', 'label': 'gpt-5.2 (recommande)'},
+            {'id': 'gpt-5.5', 'label': 'gpt-5.5 (recommande)'},
+            {'id': 'gpt-5.4', 'label': 'gpt-5.4'},
+            {'id': 'gpt-5.2', 'label': 'gpt-5.2'},
             {'id': 'gpt-4.1-mini', 'label': 'gpt-4.1-mini (~gratuit)'},
         ],
     },
@@ -89,9 +91,29 @@ def is_openai_reasoning_model(model_id):
 
     Les modèles o1/o3/o4 et la famille GPT-5 ne supportent pas les paramètres
     `temperature` / `seed` personnalisés (température figée à 1) : les omettre
-    évite une erreur 400.
+    évite une erreur 400. Ils acceptent en revanche `reasoning_effort`.
     """
     return str(model_id).startswith(('o1', 'o3', 'o4', 'gpt-5'))
+
+
+# Niveaux d'effort de raisonnement acceptés par les modèles OpenAI (o-series /
+# GPT-5). Plus l'effort est élevé, plus le modèle « réfléchit » (meilleure
+# qualité, mais plus lent et plus coûteux en tokens).
+EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh']
+DEFAULT_EFFORT = 'medium'
+
+
+def get_openai_reasoning_effort():
+    """Niveau d'effort de raisonnement OpenAI configuré (défaut : medium).
+
+    Défensif : toute erreur d'accès au réglage retombe sur le défaut, pour ne
+    jamais faire échouer un appel IA à cause de ce paramètre optionnel.
+    """
+    try:
+        val = get_setting('openai_reasoning_effort')
+    except Exception:
+        val = None
+    return val if val in EFFORT_LEVELS else DEFAULT_EFFORT
 
 
 def get_configured_providers():
@@ -204,7 +226,9 @@ def gestion_cles_api():
     return render_template('gestion_cles_api.html', providers=AI_PROVIDERS,
                            providers_status=providers_status,
                            chatbot_model=chatbot_model,
-                           available_models=available_models)
+                           available_models=available_models,
+                           reasoning_effort=get_openai_reasoning_effort(),
+                           effort_levels=EFFORT_LEVELS)
 
 
 @api_keys_bp.route('/api/api_keys/save', methods=['POST'])
@@ -253,6 +277,22 @@ def api_delete_key():
 
     delete_setting(AI_PROVIDERS[provider_id]['key_setting'])
     return jsonify({'success': True})
+
+
+@api_keys_bp.route('/api/api_keys/effort', methods=['POST'])
+@login_required
+def api_set_effort():
+    """Définit le niveau d'effort de raisonnement OpenAI (GPT-5 / o-series)."""
+    if session.get('profil') not in PROFILS_AUTORISES:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+
+    data = request.get_json() or {}
+    effort = (data.get('effort') or '').strip()
+    if effort not in EFFORT_LEVELS:
+        return jsonify({'error': "Niveau d'effort invalide"}), 400
+
+    save_setting('openai_reasoning_effort', effort)
+    return jsonify({'success': True, 'effort': effort})
 
 
 @api_keys_bp.route('/api/api_keys/status')

--- a/blueprints/chatbot.py
+++ b/blueprints/chatbot.py
@@ -234,14 +234,17 @@ def _get_api_key_for_model(model):
 
 def _call_openai(api_key, messages, model):
     """Appel API OpenAI pour le chatbot."""
-    from blueprints.api_keys import is_openai_reasoning_model
+    from blueprints.api_keys import is_openai_reasoning_model, get_openai_reasoning_effort
     payload = {
         "model": model,
         "messages": messages,
         "max_completion_tokens": 1000,
     }
     # Les modèles de raisonnement (o1/o3/o4, GPT-5) ne supportent pas temperature
-    if not is_openai_reasoning_model(model):
+    # mais acceptent reasoning_effort (low/medium/high/xhigh).
+    if is_openai_reasoning_model(model):
+        payload["reasoning_effort"] = get_openai_reasoning_effort()
+    else:
         payload["temperature"] = 0.7
     resp = http_requests.post(
         "https://api.openai.com/v1/chat/completions",

--- a/blueprints/pesee_alisfa.py
+++ b/blueprints/pesee_alisfa.py
@@ -252,7 +252,7 @@ def _get_api_key_for_model(model):
 
 def call_openai(api_key, messages, model="gpt-4o"):
     """Appel API OpenAI avec température 0 et seed fixe."""
-    from blueprints.api_keys import is_openai_reasoning_model
+    from blueprints.api_keys import is_openai_reasoning_model, get_openai_reasoning_effort
     is_reasoning = is_openai_reasoning_model(model)
 
     payload = {
@@ -261,8 +261,11 @@ def call_openai(api_key, messages, model="gpt-4o"):
         "response_format": {"type": "json_object"},
         "max_completion_tokens": 8000,
     }
-    # Les modèles de raisonnement (o1/o3/o4, GPT-5) ne supportent ni temperature ni seed
-    if not is_reasoning:
+    # Les modèles de raisonnement (o1/o3/o4, GPT-5) ne supportent ni temperature ni
+    # seed, mais acceptent reasoning_effort (low/medium/high/xhigh).
+    if is_reasoning:
+        payload["reasoning_effort"] = get_openai_reasoning_effort()
+    else:
         payload["temperature"] = 0
         payload["seed"] = 42
 

--- a/templates/gestion_cles_api.html
+++ b/templates/gestion_cles_api.html
@@ -78,6 +78,19 @@
             <span class="ak-model-tag {{ 'ak-gratuit' if 'gratuit' in m.label else '' }}">{{ m.label }}</span>
             {% endfor %}
         </div>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:14px;padding-top:12px;border-top:1px dashed var(--gray-200);">
+            <label for="akEffort" style="font-size:13px;font-weight:600;color:var(--gray-700);">
+                Effort de raisonnement <span style="font-weight:400;color:var(--gray-500);">(modèles GPT-5)</span>
+            </label>
+            <select id="akEffort" class="ak-key-input" style="width:auto;min-width:130px;padding:8px 12px;font-family:inherit;">
+                {% for lvl in effort_levels %}
+                <option value="{{ lvl }}" {{ 'selected' if reasoning_effort == lvl else '' }}>{{ lvl }}</option>
+                {% endfor %}
+            </select>
+            <button class="ak-btn ak-btn-outline" id="akEffortSaveBtn" onclick="akSaveEffort()">Enregistrer</button>
+            <span class="ak-success" id="akSuccessEffort" style="margin-top:0;"></span>
+            <span class="ak-error" id="akErrorEffort" style="margin-top:0;"></span>
+        </div>
         {% if providers_status.openai.has_key %}
         <div class="ak-btn-row">
             <button class="ak-btn ak-btn-outline" onclick="akToggleEdit('openai')">Modifier la cle</button>
@@ -275,6 +288,38 @@ async function akDeleteKey(provider) {
     } catch(e) {
         alert('Erreur : ' + e.message);
     }
+}
+
+async function akSaveEffort() {
+    const sel = document.getElementById('akEffort');
+    const errEl = document.getElementById('akErrorEffort');
+    const succEl = document.getElementById('akSuccessEffort');
+    const btn = document.getElementById('akEffortSaveBtn');
+
+    errEl.style.display = 'none';
+    succEl.style.display = 'none';
+    btn.disabled = true;
+
+    try {
+        const res = await fetch('/api/api_keys/effort', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({effort: sel.value}),
+        });
+        const data = await res.json();
+        if (data.success) {
+            succEl.textContent = 'Effort enregistre : ' + data.effort;
+            succEl.style.display = 'inline-block';
+        } else {
+            errEl.textContent = data.error || 'Erreur inconnue';
+            errEl.style.display = 'inline-block';
+        }
+    } catch(e) {
+        errEl.textContent = 'Erreur reseau : ' + e.message;
+        errEl.style.display = 'inline-block';
+    }
+
+    btn.disabled = false;
 }
 
 async function akSaveChatbotModel() {

--- a/tests/test_ai_models.py
+++ b/tests/test_ai_models.py
@@ -17,6 +17,7 @@ import os
 from blueprints.api_keys import (
     AI_PROVIDERS, MODEL_TO_PROVIDER, get_provider_for_model,
     get_available_models, anthropic_supports_temperature, is_openai_reasoning_model,
+    EFFORT_LEVELS, get_openai_reasoning_effort,
 )
 from blueprints import pesee_alisfa
 
@@ -62,6 +63,12 @@ class TestCatalogueModeles:
         assert 'claude-sonnet-4-5-20250929' not in anthropic_ids
         assert 'claude-opus-4-6' not in anthropic_ids
 
+    def test_modeles_openai_a_jour(self):
+        """Les nouveaux modèles OpenAI (GPT-5.5 / GPT-5.4) sont proposés."""
+        openai_ids = [m['id'] for m in AI_PROVIDERS['openai']['models']]
+        assert 'gpt-5.5' in openai_ids
+        assert 'gpt-5.4' in openai_ids
+
 
 class TestPredicatsCompatibilite:
     def test_anthropic_temperature(self):
@@ -72,6 +79,8 @@ class TestPredicatsCompatibilite:
         assert anthropic_supports_temperature('claude-fable-5') is False
 
     def test_openai_raisonnement(self):
+        assert is_openai_reasoning_model('gpt-5.5') is True
+        assert is_openai_reasoning_model('gpt-5.4') is True
         assert is_openai_reasoning_model('gpt-5.2') is True
         assert is_openai_reasoning_model('o3-mini') is True
         assert is_openai_reasoning_model('o1') is True
@@ -114,6 +123,61 @@ class TestPayloadOpenAI:
         payload = mock_post.call_args.kwargs['json']
         assert payload['temperature'] == 0
         assert payload['seed'] == 42
+
+
+class TestEffortRaisonnement:
+    def test_niveaux_effort(self):
+        assert EFFORT_LEVELS == ['low', 'medium', 'high', 'xhigh']
+
+    def test_defaut_medium(self, app):
+        with app.app_context():
+            assert get_openai_reasoning_effort() == 'medium'
+
+    def test_respecte_le_reglage(self, app):
+        from utils import save_setting
+        with app.app_context():
+            save_setting('openai_reasoning_effort', 'xhigh')
+            assert get_openai_reasoning_effort() == 'xhigh'
+
+    def test_valeur_invalide_retombe_sur_defaut(self, app):
+        from utils import save_setting
+        with app.app_context():
+            save_setting('openai_reasoning_effort', 'nawak')
+            assert get_openai_reasoning_effort() == 'medium'
+
+    def test_payload_reasoning_inclut_effort(self, app):
+        from utils import save_setting
+        with app.app_context():
+            save_setting('openai_reasoning_effort', 'high')
+            with patch.object(pesee_alisfa.http_requests, 'post',
+                              return_value=_fake_openai_response()) as mock_post:
+                pesee_alisfa.call_openai('sk-x', [{'role': 'user', 'content': 'hi'}], 'gpt-5.5')
+            payload = mock_post.call_args.kwargs['json']
+        assert payload['reasoning_effort'] == 'high'
+        assert 'temperature' not in payload and 'seed' not in payload
+
+    def test_payload_modele_standard_sans_effort(self, app):
+        with app.app_context():
+            with patch.object(pesee_alisfa.http_requests, 'post',
+                              return_value=_fake_openai_response()) as mock_post:
+                pesee_alisfa.call_openai('sk-x', [{'role': 'user', 'content': 'hi'}], 'gpt-4.1-mini')
+            payload = mock_post.call_args.kwargs['json']
+        assert 'reasoning_effort' not in payload
+
+    def test_route_effort_enregistre(self, app, admin_client):
+        r = admin_client.post('/api/api_keys/effort', json={'effort': 'high'})
+        assert r.status_code == 200 and r.get_json()['effort'] == 'high'
+        from utils import get_setting
+        with app.app_context():
+            assert get_setting('openai_reasoning_effort') == 'high'
+
+    def test_route_effort_invalide_refusee(self, admin_client):
+        r = admin_client.post('/api/api_keys/effort', json={'effort': 'nawak'})
+        assert r.status_code == 400
+
+    def test_route_effort_refuse_salarie(self, auth_client):
+        r = auth_client.post('/api/api_keys/effort', json={'effort': 'high'})
+        assert r.status_code == 403
 
 
 class TestModelesDisponibles:


### PR DESCRIPTION
## Objectif

Mettre à jour les modèles d'IA OpenAI (ajout de **GPT-5.5** et **GPT-5.4**) et permettre le choix du **paramètre d'effort de raisonnement** (low / medium / high / xhigh).

## Ce qui change

- **Catalogue OpenAI** (`api_keys.py`) : ajout de `gpt-5.5` (recommandé) et `gpt-5.4` ; `gpt-5.2` et `gpt-4.1-mini` conservés. Comme ils commencent par `gpt-5`, ils sont déjà reconnus comme modèles de raisonnement (pas de `temperature`/`seed`).
- **Effort de raisonnement** : nouveau réglage `openai_reasoning_effort` (valeurs `low`, `medium`, `high`, `xhigh` ; défaut `medium`), lu via un helper défensif `get_openai_reasoning_effort()` (toute erreur retombe sur le défaut, pour ne jamais casser un appel IA).
- **Application** : le paramètre `reasoning_effort` est ajouté au payload de **tous les appels OpenAI de raisonnement** — `chatbot._call_openai` et `pesee_alisfa.call_openai` (ce dernier servant aussi l'assistant RH et l'extraction de factures).
- **UI** : sélecteur d'effort sur la page **Gestion des clés API** (carte OpenAI) + route `POST /api/api_keys/effort` (directeur / comptable).

## Tests (`tests/test_ai_models.py`)

- Présence de `gpt-5.5` / `gpt-5.4` au catalogue, reconnus comme modèles de raisonnement.
- Helper d'effort : défaut `medium`, respect du réglage, valeur invalide → défaut.
- Payload : `reasoning_effort` présent pour un modèle de raisonnement, absent pour un modèle standard.
- Route : enregistrement, valeur invalide rejetée (400), accès refusé à un salarié (403).

**Suite complète verte (783 tests).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_