### PR TITLE
Budget prévisionnel : sommes compta cliquables → détail des opérations

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -977,6 +977,68 @@ def budget_previsionnel():
         conn.close()
 
 
+@budget_bp.route('/api/budget-previsionnel/detail')
+@login_required
+def api_budget_previsionnel_detail():
+    """Opérations comptables (FEC) derrière une somme d'une colonne compta.
+
+    Reproduit exactement le filtrage de _compute_budget_previsionnel (compte +
+    année + rattachement au secteur via les codes autorisés, et éventuellement le
+    plafond de mois pour la colonne N en mode « actualisé ») afin que le détail
+    corresponde à la somme affichée.
+    """
+    profil = session.get('profil')
+    if not _can_access_budget_previsionnel(profil):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+
+    compte = (request.args.get('compte') or '').strip()
+    annee = request.args.get('annee', type=int)
+    secteur_id = request.args.get('secteur_id', type=int)
+    global_mode = request.args.get('global') == '1'
+    mois_max = request.args.get('mois_max', type=int)
+    if not compte or not annee:
+        return jsonify({'operations': []})
+
+    conn = get_db()
+    try:
+        # Le responsable est verrouillé sur son propre secteur (comme la page).
+        if profil == 'responsable':
+            global_mode = False
+            user = conn.execute('SELECT secteur_id FROM users WHERE id = ?',
+                                (session.get('user_id'),)).fetchone()
+            secteur_id = user['secteur_id'] if user else None
+
+        allowed_codes = set()
+        if secteur_id and not global_mode:
+            allowed_codes = _secteur_allowed_codes(conn, secteur_id)
+
+        query = ('SELECT annee, mois, libelle, code_analytique, montant '
+                 'FROM bilan_fec_donnees WHERE compte_num = ? AND annee = ?')
+        params = [compte, annee]
+        if mois_max and 1 <= mois_max <= 12:
+            query += ' AND mois <= ?'
+            params.append(mois_max)
+        query += ' ORDER BY mois, id'
+        rows = conn.execute(query, params).fetchall()
+
+        operations = []
+        for r in rows:
+            if not global_mode and secteur_id and not _code_allowed(
+                    r['code_analytique'], compte, allowed_codes):
+                continue
+            m = r['mois']
+            operations.append({
+                'annee': r['annee'],
+                'mois': m,
+                'mois_nom': NOMS_MOIS[m] if m and 1 <= m <= 12 else '',
+                'libelle': r['libelle'] or '',
+                'montant': round(float(r['montant'] or 0), 2),
+            })
+        return jsonify({'operations': operations})
+    finally:
+        conn.close()
+
+
 @budget_bp.route('/api/budget-previsionnel/config', methods=['POST'])
 @login_required
 def api_budget_previsionnel_config_save():

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1007,10 +1007,15 @@ def api_budget_previsionnel_detail():
             user = conn.execute('SELECT secteur_id FROM users WHERE id = ?',
                                 (session.get('user_id'),)).fetchone()
             secteur_id = user['secteur_id'] if user else None
+            if not secteur_id:
+                return jsonify({'error': 'Aucun secteur associé à votre compte'}), 403
 
-        allowed_codes = set()
-        if secteur_id and not global_mode:
-            allowed_codes = _secteur_allowed_codes(conn, secteur_id)
+        # Hors mode global, un secteur est OBLIGATOIRE pour délimiter le périmètre :
+        # sans lui on ne renvoie rien (jamais toutes les opérations du compte).
+        if not global_mode and not secteur_id:
+            return jsonify({'operations': []})
+
+        allowed_codes = _secteur_allowed_codes(conn, secteur_id) if not global_mode else set()
 
         query = ('SELECT annee, mois, libelle, code_analytique, montant '
                  'FROM bilan_fec_donnees WHERE compte_num = ? AND annee = ?')
@@ -1023,7 +1028,7 @@ def api_budget_previsionnel_detail():
 
         operations = []
         for r in rows:
-            if not global_mode and secteur_id and not _code_allowed(
+            if not global_mode and not _code_allowed(
                     r['code_analytique'], compte, allowed_codes):
                 continue
             m = r['mois']

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -8,6 +8,10 @@
 .budget-prev-table th:last-child, .budget-prev-table td:last-child { border-right: none; }
 .budget-prev-table tbody tr:nth-child(even) { background: var(--gray-050, #fafbfc); }
 .budget-prev-table .bp-col-num { text-align: right; white-space: nowrap; }
+/* Sommes compta cliquables : lien sans soulignement + indice à côté des titres. */
+.bp-detail { cursor: pointer; color: var(--primary, #2563eb); text-decoration: none; }
+.bp-detail:hover { text-decoration: none; opacity: 0.7; }
+.bp-detail-hint { font-size: 0.78rem; font-weight: 400; color: var(--gray-500, #6b7280); }
 .budget-prev-table .bp-col-compte { width: 90px; }
 .budget-prev-table .bp-col-libelle { width: 270px; }
 .budget-prev-table .bp-col-value { width: 95px; }
@@ -340,6 +344,19 @@
     </div>
 </div>
 
+<!-- Fenêtre de détail des opérations comptables derrière une somme -->
+<div id="bpDetailModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)this.style.display='none'">
+    <div class="modal-content" style="max-width:700px;">
+        <div class="modal-header">
+            <h3 id="bpDetailTitle">Détail du compte</h3>
+            <button class="modal-close" onclick="this.closest('.modal-overlay').style.display='none'">&times;</button>
+        </div>
+        <div class="modal-body" style="padding:0 1.5rem 1.5rem;">
+            <div id="bpDetailContent"></div>
+        </div>
+    </div>
+</div>
+
 <script>
 var isReadOnly = {{ 'true' if profil == 'responsable' else 'false' }};
 var canEditPs = {{ 'true' if profil in ['directeur', 'comptable'] else 'false' }};
@@ -402,8 +419,18 @@ function renderBudgetTable(targetId, rows, meta, globalMode){
     const type = document.getElementById('typeBudget').value;
     const nTemp = type === 'initial' ? 'N+1 Temp.' : 'N Temp.';
     const nDef = type === 'initial' ? 'N+1 Déf.' : 'N Déf.';
-    const html = '<h3>Charges</h3>' + buildTable(charges, nTemp, nDef, globalMode) +
-                 '<h3 style="margin-top:18px;">Produits</h3>' + buildTable(produits, nTemp, nDef, globalMode);
+    // Contexte de « drill-down » : les colonnes compta (N-2/N-1/N) deviennent
+    // cliquables et affichent les opérations sous-jacentes. En « actualisé », la
+    // colonne N est un cumul partiel (mois <= last_month) : on passe ce plafond.
+    const ctx = {
+        annee: parseInt(document.getElementById('anneeBudget').value),
+        secteur: document.getElementById('secteurBudget').value,
+        global: globalMode,
+        moisMax: (type === 'actualise' && meta && meta.last_month) ? meta.last_month : 0
+    };
+    const hint = ' <span class="bp-detail-hint">(Cliquez les sommes pour afficher le détail)</span>';
+    const html = '<h3>Charges' + hint + '</h3>' + buildTable(charges, nTemp, nDef, globalMode, ctx) +
+                 '<h3 style="margin-top:18px;">Produits' + hint + '</h3>' + buildTable(produits, nTemp, nDef, globalMode, ctx);
     document.getElementById(targetId).innerHTML = html;
     bindBudgetInputHandlers(targetId);
     bindPsButtons(targetId);
@@ -431,8 +458,17 @@ function bindBudgetInputHandlers(targetId){
     });
 }
 
-function buildTable(rows, labelTemp, labelDef, globalMode){
+function buildTable(rows, labelTemp, labelDef, globalMode, ctx){
     if (!rows.length) return '<p style="color:var(--text-muted);">Aucune donnée disponible.</p>';
+    ctx = ctx || {};
+    // Cellule d'une colonne compta (N-2/N-1/N) : cliquable pour voir le détail.
+    function comptaCell(compte, anneeCol, value, moisMax){
+        const attrs = 'data-compte="' + escapeHtml(compte) + '" data-annee-col="' + anneeCol + '"' +
+            (ctx.global ? ' data-global="1"' : ' data-secteur="' + escapeHtml(ctx.secteur || '') + '"') +
+            (moisMax ? ' data-mois-max="' + moisMax + '"' : '');
+        return '<td class="bp-col-num"><span class="bp-detail" ' + attrs +
+            ' onclick="bpVoirDetail(this)">' + fmt(value) + '</span></td>';
+    }
     let html = '<div class="bp-table-scroll"><table class="data-table budget-prev-table"><colgroup>' +
       '<col class="bp-col-compte"><col class="bp-col-libelle"><col class="bp-col-value"><col class="bp-col-value"><col class="bp-col-value"><col class="bp-col-input"><col class="bp-col-input"><col class="bp-col-comment">' +
       '</colgroup><thead><tr>' +
@@ -472,7 +508,9 @@ function buildTable(rows, labelTemp, labelDef, globalMode){
             : '';
         html += '<tr' + rowStyle + '>' +
           '<td>' + escapeHtml(r.compte_num) + '</td><td>' + escapeHtml(r.libelle) + psBtn + paieBtn + '</td>' +
-          '<td class="bp-col-num">' + fmt(r['N-2']) + '</td><td class="bp-col-num">' + fmt(r['N-1']) + '</td><td class="bp-col-num">' + fmt(r['N']) + '</td>' +
+          comptaCell(r.compte_num, ctx.annee - 2, r['N-2'], 0) +
+          comptaCell(r.compte_num, ctx.annee - 1, r['N-1'], 0) +
+          comptaCell(r.compte_num, ctx.annee, r['N'], ctx.moisMax) +
           '<td class="bp-col-num">' + tempInput + '</td><td class="bp-col-num">' + defInput + '</td><td>' + commentInput + '</td></tr>';
     }
     pushCatTotal();
@@ -487,6 +525,42 @@ function renderResult(targetId, totaux){
       ' € = <strong>' + fmt(totaux.resultat_temp) + ' €</strong><br>' +
       'Définitif : Produits ' + fmt(totaux.produits_def) + ' € - Charges ' + fmt(totaux.charges_def) +
       ' € = <strong>' + fmt(totaux.resultat_def) + ' €</strong>';
+}
+
+// Détail d'une somme compta : ouvre la fenêtre et liste les opérations (FEC).
+function bpVoirDetail(el){
+    const d = el.dataset;
+    const compte = d.compte, annee = d.anneeCol;
+    let url = '/api/budget-previsionnel/detail?compte=' + encodeURIComponent(compte) +
+              '&annee=' + encodeURIComponent(annee);
+    if (d.global === '1') url += '&global=1';
+    else if (d.secteur) url += '&secteur_id=' + encodeURIComponent(d.secteur);
+    if (d.moisMax) url += '&mois_max=' + encodeURIComponent(d.moisMax);
+
+    document.getElementById('bpDetailTitle').textContent = 'Détail du compte ' + compte + ' — ' + annee;
+    document.getElementById('bpDetailContent').innerHTML = '<p>Chargement…</p>';
+    document.getElementById('bpDetailModal').style.display = 'flex';
+
+    fetch(url).then(r => r.json()).then(data => {
+        const ops = data.operations || [];
+        if (!ops.length){
+            document.getElementById('bpDetailContent').innerHTML = '<p>Aucune opération trouvée.</p>';
+            return;
+        }
+        let total = 0;
+        let html = '<table class="data-table"><thead><tr><th>Mois</th><th>Libellé</th>' +
+                   '<th style="text-align:right;">Montant</th></tr></thead><tbody>';
+        for (const op of ops){
+            total += Number(op.montant || 0);
+            html += '<tr><td>' + escapeHtml(op.mois_nom) + '</td><td>' + escapeHtml(op.libelle) +
+                    '</td><td style="text-align:right;">' + fmt(op.montant) + ' €</td></tr>';
+        }
+        html += '</tbody><tfoot><tr><th colspan="2" style="text-align:right;">Total</th>' +
+                '<th style="text-align:right;">' + fmt(total) + ' €</th></tr></tfoot></table>';
+        document.getElementById('bpDetailContent').innerHTML = html;
+    }).catch(() => {
+        document.getElementById('bpDetailContent').innerHTML = '<p>Erreur réseau.</p>';
+    });
 }
 
 const saveTimers = {};

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -275,6 +275,24 @@ def test_api_budget_previsionnel_detail_refuse_salarie(auth_client):
     assert r.status_code == 403
 
 
+def test_api_budget_previsionnel_detail_responsable_sans_secteur_refuse(app, db, resp_client, sample_users):
+    # Sécurité : un responsable autorisé mais SANS secteur ne doit pas récupérer
+    # toutes les opérations du compte (fuite) — l'accès est refusé (403).
+    from app_options import set_option_bool
+    n = datetime.now().year
+    with app.app_context():
+        set_option_bool('budget_previsionnel_responsable_autorise', True)
+        db.execute("UPDATE users SET secteur_id = NULL WHERE id = ?", (sample_users['responsable_id'],))
+        # Une opération existe pour ce compte/année : elle ne doit PAS fuiter.
+        db.execute("INSERT INTO bilan_fec_imports (fichier_nom, annee, nb_ecritures) VALUES ('bi.txt', ?, 1)", (n,))
+        imp = db.execute('SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1').fetchone()['id']
+        db.execute('INSERT INTO bilan_fec_donnees (compte_num, libelle, code_analytique, annee, mois, montant, import_id) '
+                   'VALUES (?, ?, ?, ?, ?, ?, ?)', ('601000', 'X', 'ANA-X', n, 1, 500, imp))
+        db.commit()
+    r = resp_client.get(f'/api/budget-previsionnel/detail?compte=601000&annee={n}')
+    assert r.status_code == 403
+
+
 def test_budget_previsionnel_sommes_cliquables_et_modale(admin_client):
     # La page embarque l'indice, la fenêtre de détail, le handler et le style lien.
     html = admin_client.get('/budget-previsionnel').get_data(as_text=True)

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -228,6 +228,62 @@ def test_api_budget_previsionnel_actualise_combine_n_partiel_et_n_1(app, db, adm
     assert row_charge['temp'] == 1200.0
 
 
+def test_api_budget_previsionnel_detail_liste_les_operations(app, db, admin_client, sample_users):
+    # Le détail d'une somme compta liste les opérations FEC, filtrées par secteur.
+    n = datetime.now().year
+    secteur_id = sample_users['secteur_id']
+    with app.app_context():
+        db.execute('INSERT INTO budget_prev_config_codes (code_analytique, secteur_id) VALUES (?, ?)',
+                   ('ANA-DET', secteur_id))
+        db.execute("INSERT INTO bilan_fec_imports (fichier_nom, annee, nb_ecritures) VALUES ('bi.txt', ?, 3)", (n,))
+        imp = db.execute('SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1').fetchone()['id']
+        for mois, montant in [(1, 100), (2, 250)]:
+            db.execute('INSERT INTO bilan_fec_donnees (compte_num, libelle, code_analytique, annee, mois, montant, import_id) '
+                       'VALUES (?, ?, ?, ?, ?, ?, ?)', ('601000', 'Charge', 'ANA-DET', n, mois, montant, imp))
+        # Opération d'un autre secteur (code non autorisé) : doit être exclue.
+        db.execute('INSERT INTO bilan_fec_donnees (compte_num, libelle, code_analytique, annee, mois, montant, import_id) '
+                   'VALUES (?, ?, ?, ?, ?, ?, ?)', ('601000', 'Autre', 'ANA-AUTRE', n, 3, 999, imp))
+        db.commit()
+
+    r = admin_client.get(f'/api/budget-previsionnel/detail?compte=601000&annee={n}&secteur_id={secteur_id}')
+    ops = r.get_json()['operations']
+    assert sorted(o['montant'] for o in ops) == [100.0, 250.0]  # l'opération hors secteur est exclue
+    assert all(o['mois_nom'] for o in ops)
+
+
+def test_api_budget_previsionnel_detail_respecte_mois_max(app, db, admin_client, sample_users):
+    # En « actualisé », la colonne N est partielle : le détail respecte mois_max.
+    n = datetime.now().year
+    secteur_id = sample_users['secteur_id']
+    with app.app_context():
+        db.execute('INSERT INTO budget_prev_config_codes (code_analytique, secteur_id) VALUES (?, ?)',
+                   ('ANA-MM', secteur_id))
+        db.execute("INSERT INTO bilan_fec_imports (fichier_nom, annee, nb_ecritures) VALUES ('bi.txt', ?, 3)", (n,))
+        imp = db.execute('SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1').fetchone()['id']
+        for mois in (1, 2, 5):
+            db.execute('INSERT INTO bilan_fec_donnees (compte_num, libelle, code_analytique, annee, mois, montant, import_id) '
+                       'VALUES (?, ?, ?, ?, ?, ?, ?)', ('601000', 'C', 'ANA-MM', n, mois, 100, imp))
+        db.commit()
+
+    r = admin_client.get(f'/api/budget-previsionnel/detail?compte=601000&annee={n}&secteur_id={secteur_id}&mois_max=2')
+    ops = r.get_json()['operations']
+    assert [o['mois'] for o in ops] == [1, 2]  # le mois 5 est exclu
+
+
+def test_api_budget_previsionnel_detail_refuse_salarie(auth_client):
+    r = auth_client.get('/api/budget-previsionnel/detail?compte=601000&annee=2026')
+    assert r.status_code == 403
+
+
+def test_budget_previsionnel_sommes_cliquables_et_modale(admin_client):
+    # La page embarque l'indice, la fenêtre de détail, le handler et le style lien.
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert 'Cliquez les sommes pour afficher le détail' in html
+    assert 'bpDetailModal' in html
+    assert 'bpVoirDetail' in html
+    assert 'bp-detail' in html
+
+
 def test_api_budget_previsionnel_save_line_refuse_responsable(resp_client, sample_users):
     secteur_id = sample_users['secteur_id']
     response = resp_client.post('/api/budget-previsionnel/save-line', json={


### PR DESCRIPTION
## Objectif

Sur la page **budget-prévisionnel**, rendre les sommes des colonnes qui dépendent de la comptabilité cliquables pour afficher les opérations correspondantes — comme sur **bilan-secteurs**.

## Ce qui change

- **Colonnes cliquables = N-2, N-1, N** (les montants issus de la compta / FEC). Les colonnes **calculées ou saisies** (N+1 Temp., N+1 Déf., Commentaire) et les **totaux de catégorie** ne sont pas cliquables.
- **Lien sans soulignement** : les sommes sont affichées en couleur primaire, curseur main, **sans underline** (comme demandé).
- **Mention** « *(Cliquez les sommes pour afficher le détail)* » à côté des titres **Charges** et **Produits**.
- **Fenêtre de détail** : une modale (style `.modal-overlay` partagé) liste les opérations (mois, libellé, montant) avec un total de contrôle.

## Correction fine

Le nouvel endpoint `GET /api/budget-previsionnel/detail` **reproduit exactement** le filtrage de `_compute_budget_previsionnel` pour que le détail totalise la somme affichée :
- rattachement au secteur via les **codes autorisés** (`budget_prev_config_codes` + `comptabilite_comptes`, logique `_code_allowed`) — pas un simple `secteur_id` ;
- **plafond de mois** (`mois_max`) pour la colonne **N** en mode « actualisé » (cumul partiel) ;
- mode **global** (directeur/comptable) sans filtre secteur ; responsable verrouillé sur son secteur.

## Tests

`tests/test_budget.py` : liste des opérations, **exclusion des opérations hors secteur**, respect de `mois_max`, accès refusé au salarié (403), et présence du câblage dans la page.

**Suite complète verte (787 tests).** Vérifié au navigateur : 9 sommes cliquables sans soulignement, la modale affiche les opérations qui totalisent la somme (ex. N = 750 → 400 + 350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_