### PR TITLE
Créneau « soir » optionnel (saisie + planning)

### DIFF
--- a/blueprints/dashboard.py
+++ b/blueprints/dashboard.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from database import get_db
 from blueprints.prevention_sante import compute_prevention_messages
 from utils import (login_required, get_user_info, calculer_heures,
+                   calculer_heures_reelles_jour,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date,
                    calculer_solde_recup)
 
@@ -38,6 +39,7 @@ def dashboard():
         heures = conn.execute('''
             SELECT date, heure_debut_matin, heure_fin_matin,
                    heure_debut_aprem, heure_fin_aprem,
+                   heure_debut_soir, heure_fin_soir,
                    commentaire, type_saisie, declaration_conforme
             FROM heures_reelles
             WHERE user_id = ?
@@ -65,9 +67,7 @@ def dashboard():
             if h['declaration_conforme']:
                 total_reel = total_theorique
             else:
-                heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-                heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-                total_reel = heures_matin + heures_aprem
+                total_reel = calculer_heures_reelles_jour(h)
 
             ecart = total_reel - total_theorique
 
@@ -77,6 +77,8 @@ def dashboard():
                 'heure_fin_matin': h['heure_fin_matin'],
                 'heure_debut_aprem': h['heure_debut_aprem'],
                 'heure_fin_aprem': h['heure_fin_aprem'],
+                'heure_debut_soir': h['heure_debut_soir'],
+                'heure_fin_soir': h['heure_fin_soir'],
                 'commentaire': h['commentaire'],
                 'total_reel': total_reel,
                 'total_theorique': total_theorique,

--- a/blueprints/dashboard_comptable.py
+++ b/blueprints/dashboard_comptable.py
@@ -6,6 +6,7 @@ from flask import Blueprint, render_template, session, redirect, url_for, flash
 from datetime import datetime
 from database import get_db
 from utils import (login_required, NOMS_MOIS, get_user_info, calculer_heures,
+                   calculer_heures_reelles_jour,
                    get_heures_theoriques_jour, get_type_periode,
                    get_planning_valide_a_date, calculer_solde_recup)
 from dashboard_actions import construire_actions
@@ -37,6 +38,7 @@ def dashboard_comptable():
     heures = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin,
                heure_debut_aprem, heure_fin_aprem,
+               heure_debut_soir, heure_fin_soir,
                commentaire, type_saisie, declaration_conforme
         FROM heures_reelles
         WHERE user_id = ?
@@ -58,9 +60,7 @@ def dashboard_comptable():
         if h['declaration_conforme']:
             total_reel = total_theorique
         else:
-            heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-            heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-            total_reel = heures_matin + heures_aprem
+            total_reel = calculer_heures_reelles_jour(h)
         heures_enrichies.append({
             'date': h['date'],
             'total_reel': total_reel,

--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
+                   calculer_heures_reelles_jour, slot_horaire,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS)
 
 exports_bp = Blueprint('exports_bp', __name__)
@@ -104,8 +105,10 @@ def export_pdf_mensuel():
                 matin_fin = planning_dict.get(f'{jour_nom}_matin_fin')
                 aprem_debut = planning_dict.get(f'{jour_nom}_aprem_debut')
                 aprem_fin = planning_dict.get(f'{jour_nom}_aprem_fin')
-                
-                # Formater les horaires théoriques
+                soir_debut = planning_dict.get(f'{jour_nom}_soir_debut')
+                soir_fin = planning_dict.get(f'{jour_nom}_soir_fin')
+
+                # Formater les horaires théoriques (3 créneaux)
                 horaires_parts = []
                 if matin_debut and matin_fin:
                     horaires_parts.append(f"{matin_debut}-{matin_fin}")
@@ -113,7 +116,10 @@ def export_pdf_mensuel():
                 if aprem_debut and aprem_fin:
                     horaires_parts.append(f"{aprem_debut}-{aprem_fin}")
                     heures_theo_jour += calculer_heures(aprem_debut, aprem_fin)
-                
+                if soir_debut and soir_fin:
+                    horaires_parts.append(f"{soir_debut}-{soir_fin}")
+                    heures_theo_jour += calculer_heures(soir_debut, soir_fin)
+
                 if horaires_parts:
                     horaires_theo_str = " / ".join(horaires_parts)
                 else:
@@ -145,7 +151,10 @@ def export_pdf_mensuel():
                     if h['heure_debut_aprem'] and h['heure_fin_aprem']:
                         horaires_parts_reelles.append(f"{h['heure_debut_aprem']}-{h['heure_fin_aprem']}")
                         heures_reelles_jour += calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-                    
+                    if slot_horaire(h, 'heure_debut_soir') and slot_horaire(h, 'heure_fin_soir'):
+                        horaires_parts_reelles.append(f"{h['heure_debut_soir']}-{h['heure_fin_soir']}")
+                        heures_reelles_jour += calculer_heures(h['heure_debut_soir'], h['heure_fin_soir'])
+
                     if horaires_parts_reelles:
                         horaires_reels_str = " / ".join(horaires_parts_reelles)
                     else:
@@ -180,8 +189,9 @@ def export_pdf_mensuel():
     solde_anterieur = 0
     heures_anterieures = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin,
-               heure_debut_aprem, heure_fin_aprem, declaration_conforme, type_saisie
-        FROM heures_reelles 
+               heure_debut_aprem, heure_fin_aprem,
+               heure_debut_soir, heure_fin_soir, declaration_conforme, type_saisie
+        FROM heures_reelles
         WHERE user_id = ? AND date < ?
         ORDER BY date
     ''', (user_id_param, premier_jour.strftime('%Y-%m-%d'))).fetchall()
@@ -201,21 +211,9 @@ def export_pdf_mensuel():
         
         total_theorique = 0
         if planning_ant:
-            # Convertir Row en dict
-            planning_ant_dict = dict(planning_ant)
-            noms_jours_minuscule = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi']
-            jour_nom = noms_jours_minuscule[jour_semaine_ant_pdf]
-            
-            matin_debut = planning_ant_dict.get(f'{jour_nom}_matin_debut')
-            matin_fin = planning_ant_dict.get(f'{jour_nom}_matin_fin')
-            aprem_debut = planning_ant_dict.get(f'{jour_nom}_aprem_debut')
-            aprem_fin = planning_ant_dict.get(f'{jour_nom}_aprem_fin')
-            
-            if matin_debut and matin_fin:
-                total_theorique += calculer_heures(matin_debut, matin_fin)
-            if aprem_debut and aprem_fin:
-                total_theorique += calculer_heures(aprem_debut, aprem_fin)
-        
+            # Heures théoriques du jour (3 créneaux, gérés par le helper commun).
+            total_theorique = get_heures_theoriques_jour(planning_ant, jour_semaine_ant_pdf)
+
         # Calculer les heures réelles
         if h.get('type_saisie') == 'recup_journee':
             # Récupération = 0h réelles
@@ -224,10 +222,8 @@ def export_pdf_mensuel():
             # Déclaration conforme = heures théoriques
             total_reel = total_theorique
         else:
-            # Saisie manuelle
-            heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-            heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-            total_reel = heures_matin + heures_aprem
+            # Saisie manuelle (matin + après-midi + soir)
+            total_reel = calculer_heures_reelles_jour(h)
         
         solde_anterieur += (total_reel - total_theorique)
     

--- a/blueprints/mon_equipe.py
+++ b/blueprints/mon_equipe.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from app_options import get_option_bool
 from database import get_db
 from utils import (login_required, get_type_periode, get_planning_valide_a_date,
-                   calculer_heures)
+                   calculer_heures, slot_horaire)
 
 mon_equipe_bp = Blueprint('mon_equipe_bp', __name__)
 
@@ -103,6 +103,14 @@ def _calculer_presences_horaires(grille):
                     ))
                 except (ValueError, IndexError):
                     pass
+            if jour.get('soir') and jour['soir'][0] and jour['soir'][1]:
+                try:
+                    plages.append((
+                        _hhmm_to_minutes(jour['soir'][0]),
+                        _hhmm_to_minutes(jour['soir'][1]),
+                    ))
+                except (ValueError, IndexError):
+                    pass
 
             if not plages:
                 continue
@@ -159,6 +167,14 @@ def _calculer_presences_creche(grille):
                     ))
                 except (ValueError, IndexError):
                     pass
+            if jour.get('soir') and jour['soir'][0] and jour['soir'][1]:
+                try:
+                    plages.append((
+                        _hhmm_to_minutes(jour['soir'][0]),
+                        _hhmm_to_minutes(jour['soir'][1]),
+                    ))
+                except (ValueError, IndexError):
+                    pass
 
             if not plages:
                 continue
@@ -205,6 +221,14 @@ def _calculer_presence_responsable(grille):
                     plages.append((
                         _hhmm_to_minutes(jour['aprem'][0]),
                         _hhmm_to_minutes(jour['aprem'][1]),
+                    ))
+                except (ValueError, IndexError):
+                    pass
+            if jour.get('soir') and jour['soir'][0] and jour['soir'][1]:
+                try:
+                    plages.append((
+                        _hhmm_to_minutes(jour['soir'][0]),
+                        _hhmm_to_minutes(jour['soir'][1]),
                     ))
                 except (ValueError, IndexError):
                     pass
@@ -350,6 +374,7 @@ def _construire_grille(conn, membres, lundi):
     heures_rows = conn.execute(f'''
         SELECT user_id, date, heure_debut_matin, heure_fin_matin,
                heure_debut_aprem, heure_fin_aprem,
+               heure_debut_soir, heure_fin_soir,
                type_saisie, declaration_conforme, commentaire
         FROM heures_reelles
         WHERE user_id IN ({placeholders})
@@ -393,6 +418,7 @@ def _construire_grille(conn, membres, lundi):
                 'absence': None,
                 'matin': None,
                 'aprem': None,
+                'soir': None,
                 'type_saisie': None,
                 'commentaire': None,
             }
@@ -445,6 +471,10 @@ def _construire_grille(conn, membres, lundi):
                             planning[f'{jour_nom}_aprem_debut'],
                             planning[f'{jour_nom}_aprem_fin']
                         )
+                        sd = slot_horaire(planning, f'{jour_nom}_soir_debut')
+                        sf = slot_horaire(planning, f'{jour_nom}_soir_fin')
+                        if sd or sf:
+                            jour_info['soir'] = (sd, sf)
                     jour_info['type_saisie'] = 'conforme'
 
                 else:
@@ -453,6 +483,8 @@ def _construire_grille(conn, membres, lundi):
                         jour_info['matin'] = (hr['heure_debut_matin'], hr['heure_fin_matin'])
                     if hr['heure_debut_aprem'] or hr['heure_fin_aprem']:
                         jour_info['aprem'] = (hr['heure_debut_aprem'], hr['heure_fin_aprem'])
+                    if slot_horaire(hr, 'heure_debut_soir') or slot_horaire(hr, 'heure_fin_soir'):
+                        jour_info['soir'] = (hr['heure_debut_soir'], hr['heure_fin_soir'])
 
             else:
                 # Pas de saisie : afficher le planning theorique en grise
@@ -464,10 +496,14 @@ def _construire_grille(conn, membres, lundi):
                     mf = planning[f'{jour_nom}_matin_fin']
                     ad = planning[f'{jour_nom}_aprem_debut']
                     af = planning[f'{jour_nom}_aprem_fin']
+                    sd = slot_horaire(planning, f'{jour_nom}_soir_debut')
+                    sf = slot_horaire(planning, f'{jour_nom}_soir_fin')
                     if md or mf:
                         jour_info['matin'] = (md, mf)
                     if ad or af:
                         jour_info['aprem'] = (ad, af)
+                    if sd or sf:
+                        jour_info['soir'] = (sd, sf)
                 jour_info['type_saisie'] = 'theorique'
 
             jours.append(jour_info)

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -103,7 +103,7 @@ def _horaires_par_date(conn, user_id, debut, fin):
     09:00-12:30 / 13:30-17:30 en general, et 09:00-12:30 / 14:00-18:00 pour la
     direction (au forfait jours, sans horaires precis).
     """
-    from utils import get_planning_valide_a_date, get_type_periode
+    from utils import get_planning_valide_a_date, get_type_periode, slot_horaire
 
     a_un_planning = conn.execute(
         'SELECT 1 FROM planning_theorique WHERE user_id = ? LIMIT 1', (user_id,)
@@ -126,8 +126,9 @@ def _horaires_par_date(conn, user_id, debut, fin):
                     jn = JOURS_NOMS_PLANNING[d.weekday()]
                     intervalles = []
                     for col_d, col_f in ((f'{jn}_matin_debut', f'{jn}_matin_fin'),
-                                         (f'{jn}_aprem_debut', f'{jn}_aprem_fin')):
-                        dm, fm = moteur._to_min(planning[col_d]), moteur._to_min(planning[col_f])
+                                         (f'{jn}_aprem_debut', f'{jn}_aprem_fin'),
+                                         (f'{jn}_soir_debut', f'{jn}_soir_fin')):
+                        dm, fm = moteur._to_min(slot_horaire(planning, col_d)), moteur._to_min(slot_horaire(planning, col_f))
                         if dm is not None and fm is not None and fm > dm:
                             intervalles.append((dm, fm))
                     if intervalles:

--- a/blueprints/planning.py
+++ b/blueprints/planning.py
@@ -153,48 +153,35 @@ def planning_theorique():
         horaires = {}
         total_hebdo = 0
 
+        # Créneaux d'une journée : matin + après-midi + soir (3e optionnel).
+        creneaux = ('matin_debut', 'matin_fin', 'aprem_debut', 'aprem_fin',
+                    'soir_debut', 'soir_fin')
         for jour in jours:
-            matin_debut = request.form.get(f'{jour}_matin_debut') or None
-            matin_fin = request.form.get(f'{jour}_matin_fin') or None
-            aprem_debut = request.form.get(f'{jour}_aprem_debut') or None
-            aprem_fin = request.form.get(f'{jour}_aprem_fin') or None
-
-            horaires[f'{jour}_matin_debut'] = matin_debut
-            horaires[f'{jour}_matin_fin'] = matin_fin
-            horaires[f'{jour}_aprem_debut'] = aprem_debut
-            horaires[f'{jour}_aprem_fin'] = aprem_fin
-
-            # Calculer les heures du jour
-            if matin_debut and matin_fin:
-                total_hebdo += calculer_heures(matin_debut, matin_fin)
-            if aprem_debut and aprem_fin:
-                total_hebdo += calculer_heures(aprem_debut, aprem_fin)
+            for suffixe in creneaux:
+                horaires[f'{jour}_{suffixe}'] = request.form.get(f'{jour}_{suffixe}') or None
+            # Calculer les heures du jour (3 créneaux)
+            for slot in ('matin', 'aprem', 'soir'):
+                total_hebdo += calculer_heures(horaires[f'{jour}_{slot}_debut'],
+                                               horaires[f'{jour}_{slot}_fin'])
 
         conn = get_db()
         try:
-            # CRÉER un nouveau planning (historisation) avec type_alternance
-            conn.execute('''
-                INSERT INTO planning_theorique
-                (user_id, type_periode, date_debut_validite, type_alternance,
-                 lundi_matin_debut, lundi_matin_fin, lundi_aprem_debut, lundi_aprem_fin,
-                 mardi_matin_debut, mardi_matin_fin, mardi_aprem_debut, mardi_aprem_fin,
-                 mercredi_matin_debut, mercredi_matin_fin, mercredi_aprem_debut, mercredi_aprem_fin,
-                 jeudi_matin_debut, jeudi_matin_fin, jeudi_aprem_debut, jeudi_aprem_fin,
-                 vendredi_matin_debut, vendredi_matin_fin, vendredi_aprem_debut, vendredi_aprem_fin,
-                 total_hebdo)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (user_id_cible, type_periode, date_debut_validite, type_alternance,
-                  horaires['lundi_matin_debut'], horaires['lundi_matin_fin'],
-                  horaires['lundi_aprem_debut'], horaires['lundi_aprem_fin'],
-                  horaires['mardi_matin_debut'], horaires['mardi_matin_fin'],
-                  horaires['mardi_aprem_debut'], horaires['mardi_aprem_fin'],
-                  horaires['mercredi_matin_debut'], horaires['mercredi_matin_fin'],
-                  horaires['mercredi_aprem_debut'], horaires['mercredi_aprem_fin'],
-                  horaires['jeudi_matin_debut'], horaires['jeudi_matin_fin'],
-                  horaires['jeudi_aprem_debut'], horaires['jeudi_aprem_fin'],
-                  horaires['vendredi_matin_debut'], horaires['vendredi_matin_fin'],
-                  horaires['vendredi_aprem_debut'], horaires['vendredi_aprem_fin'],
-                  total_hebdo))
+            # CRÉER un nouveau planning (historisation). Les colonnes de créneaux
+            # sont générées depuis les constantes (jours × créneaux) : aucune
+            # donnée utilisateur n'entre dans le SQL, seulement des valeurs liées.
+            slot_cols, slot_vals = [], []
+            for jour in jours:
+                for suffixe in creneaux:
+                    slot_cols.append(f'{jour}_{suffixe}')
+                    slot_vals.append(horaires[f'{jour}_{suffixe}'])
+            colonnes = ('user_id, type_periode, date_debut_validite, type_alternance, '
+                        + ', '.join(slot_cols) + ', total_hebdo')
+            placeholders = ', '.join(['?'] * (4 + len(slot_cols) + 1))
+            conn.execute(
+                f'INSERT INTO planning_theorique ({colonnes}) VALUES ({placeholders})',
+                [user_id_cible, type_periode, date_debut_validite, type_alternance]
+                + slot_vals + [total_hebdo]
+            )
 
             # Si alternance, enregistrer la date de référence
             if type_alternance in ['semaine_1', 'semaine_2'] and date_reference:

--- a/blueprints/prevention_sante.py
+++ b/blueprints/prevention_sante.py
@@ -73,7 +73,8 @@ def compute_prevention_messages(conn, user_id: int, today=None) -> list[Preventi
 
     rows = conn.execute(
         """
-        SELECT date, heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem, declaration_conforme
+        SELECT date, heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem,
+               heure_debut_soir, heure_fin_soir, declaration_conforme
         FROM heures_reelles
         WHERE user_id = ? AND date >= ? AND date <= ?
         ORDER BY date

--- a/blueprints/recup.py
+++ b/blueprints/recup.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import sqlite3
 from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
+                   calculer_heures_reelles_jour,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date,
                    calculer_jours_ouvres, calculer_solde_recup, calculer_recup_partielle)
 from email_service import (
@@ -75,11 +76,13 @@ def _reporter_recup_partielle(conn, demande, demande_id):
     conn.execute('''
         INSERT INTO heures_reelles
         (user_id, date, type_saisie, commentaire, declaration_conforme,
-         heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem)
-        VALUES (?, ?, 'recup_partielle', ?, 0, ?, ?, ?, ?)
+         heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem,
+         heure_debut_soir, heure_fin_soir)
+        VALUES (?, ?, 'recup_partielle', ?, 0, ?, ?, ?, ?, ?, ?)
     ''', (user_id, date_str, commentaire,
           calcul['matin_debut'], calcul['matin_fin'],
-          calcul['aprem_debut'], calcul['aprem_fin']))
+          calcul['aprem_debut'], calcul['aprem_fin'],
+          calcul.get('soir_debut'), calcul.get('soir_fin')))
     return True
 
 
@@ -256,8 +259,9 @@ def demande_recup():
         # Calculer le solde (similaire au dashboard)
         heures = conn.execute('''
             SELECT date, heure_debut_matin, heure_fin_matin,
-                   heure_debut_aprem, heure_fin_aprem, declaration_conforme
-            FROM heures_reelles 
+                   heure_debut_aprem, heure_fin_aprem,
+                   heure_debut_soir, heure_fin_soir, declaration_conforme
+            FROM heures_reelles
             WHERE user_id = ?
             ORDER BY date
         ''', (session['user_id'],)).fetchall()
@@ -290,10 +294,8 @@ def demande_recup():
             if h['declaration_conforme']:
                 total_reel = total_theorique
             else:
-                heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-                heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-                total_reel = heures_matin + heures_aprem
-            
+                total_reel = calculer_heures_reelles_jour(h)
+
             solde_recup += (total_reel - total_theorique)
         
         # Calculer les heures EXACTES pour chaque jour de la période
@@ -381,8 +383,9 @@ def demande_recup():
     # Calculer le solde disponible (même logique que ci-dessus)
     heures = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin,
-               heure_debut_aprem, heure_fin_aprem, declaration_conforme
-        FROM heures_reelles 
+               heure_debut_aprem, heure_fin_aprem,
+               heure_debut_soir, heure_fin_soir, declaration_conforme
+        FROM heures_reelles
         WHERE user_id = ?
         ORDER BY date
     ''', (session['user_id'],)).fetchall()
@@ -415,10 +418,8 @@ def demande_recup():
         if h['declaration_conforme']:
             total_reel = total_theorique
         else:
-            heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-            heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-            total_reel = heures_matin + heures_aprem
-        
+            total_reel = calculer_heures_reelles_jour(h)
+
         solde_recup += (total_reel - total_theorique)
     
     conn.close()

--- a/blueprints/rh_statistiques.py
+++ b/blueprints/rh_statistiques.py
@@ -81,6 +81,7 @@ def rh_statistiques():
         SELECT hr.user_id, hr.date,
                hr.heure_debut_matin, hr.heure_fin_matin,
                hr.heure_debut_aprem, hr.heure_fin_aprem,
+               hr.heure_debut_soir, hr.heure_fin_soir,
                hr.declaration_conforme
         FROM heures_reelles hr
         JOIN users u ON hr.user_id = u.id

--- a/blueprints/saisie.py
+++ b/blueprints/saisie.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 import json
 from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
+                    calculer_heures_reelles_jour, slot_horaire,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date,
                     calculer_solde_recup)
 from app_options import get_option_bool
@@ -87,6 +88,8 @@ def saisie_heures():
                 'heure_fin_matin',
                 'heure_debut_aprem',
                 'heure_fin_aprem',
+                'heure_debut_soir',
+                'heure_fin_soir',
             ))
         )
         declaration_conforme = request.form.get('declaration_conforme') if declaration_conforme_active else (
@@ -99,6 +102,8 @@ def saisie_heures():
             heure_fin_matin = None
             heure_debut_aprem = None
             heure_fin_aprem = None
+            heure_debut_soir = None
+            heure_fin_soir = None
             type_saisie = 'declaration_conforme'
             if not commentaire:
                 commentaire = 'Déclaration conforme au planning'
@@ -109,6 +114,8 @@ def saisie_heures():
             heure_fin_matin = None
             heure_debut_aprem = None
             heure_fin_aprem = None
+            heure_debut_soir = None
+            heure_fin_soir = None
             type_saisie = 'recup_journee'
             if not commentaire:
                 commentaire = 'Récupération journée complète'
@@ -118,6 +125,9 @@ def saisie_heures():
             heure_fin_matin = request.form.get('heure_fin_matin') or None
             heure_debut_aprem = request.form.get('heure_debut_aprem') or None
             heure_fin_aprem = request.form.get('heure_fin_aprem') or None
+            # Créneau soir optionnel (proposé uniquement en période de vacances).
+            heure_debut_soir = request.form.get('heure_debut_soir') or None
+            heure_fin_soir = request.form.get('heure_fin_soir') or None
             type_saisie = 'heures_modifiees'
             declaration_conforme_val = 0
         
@@ -131,15 +141,19 @@ def saisie_heures():
                     'heure_fin_matin': anciennes_donnees['heure_fin_matin'],
                     'heure_debut_aprem': anciennes_donnees['heure_debut_aprem'],
                     'heure_fin_aprem': anciennes_donnees['heure_fin_aprem'],
+                    'heure_debut_soir': slot_horaire(anciennes_donnees, 'heure_debut_soir'),
+                    'heure_fin_soir': slot_horaire(anciennes_donnees, 'heure_fin_soir'),
                     'commentaire': anciennes_donnees['commentaire'],
                     'type_saisie': anciennes_donnees['type_saisie']
                 })
-            
+
             nouvelles_valeurs = json.dumps({
                 'heure_debut_matin': heure_debut_matin,
                 'heure_fin_matin': heure_fin_matin,
                 'heure_debut_aprem': heure_debut_aprem,
                 'heure_fin_aprem': heure_fin_aprem,
+                'heure_debut_soir': heure_debut_soir,
+                'heure_fin_soir': heure_fin_soir,
                 'commentaire': commentaire,
                 'type_saisie': type_saisie
             })
@@ -162,21 +176,14 @@ def saisie_heures():
                 
                 # 2. Détection gros changement d'heures
                 if anciennes_donnees['type_saisie'] != 'recup_journee' and type_saisie != 'recup_journee':
-                    # Calculer les heures avant et après
-                    heures_avant = 0
-                    if anciennes_donnees['heure_debut_matin'] and anciennes_donnees['heure_fin_matin']:
-                        heures_avant += calculer_heures(anciennes_donnees['heure_debut_matin'], 
-                                                        anciennes_donnees['heure_fin_matin'])
-                    if anciennes_donnees['heure_debut_aprem'] and anciennes_donnees['heure_fin_aprem']:
-                        heures_avant += calculer_heures(anciennes_donnees['heure_debut_aprem'], 
-                                                        anciennes_donnees['heure_fin_aprem'])
-                    
-                    heures_apres = 0
-                    if heure_debut_matin and heure_fin_matin:
-                        heures_apres += calculer_heures(heure_debut_matin, heure_fin_matin)
-                    if heure_debut_aprem and heure_fin_aprem:
-                        heures_apres += calculer_heures(heure_debut_aprem, heure_fin_aprem)
-                    
+                    # Calculer les heures avant et après (3 créneaux inclus)
+                    heures_avant = calculer_heures_reelles_jour(anciennes_donnees)
+                    heures_apres = calculer_heures_reelles_jour({
+                        'heure_debut_matin': heure_debut_matin, 'heure_fin_matin': heure_fin_matin,
+                        'heure_debut_aprem': heure_debut_aprem, 'heure_fin_aprem': heure_fin_aprem,
+                        'heure_debut_soir': heure_debut_soir, 'heure_fin_soir': heure_fin_soir,
+                    })
+
                     ecart = abs(heures_apres - heures_avant)
                     if ecart > SEUIL_ECART_ANOMALIE_HEURES:
                         # ANOMALIE ALERTE : Gros changement d'heures
@@ -219,11 +226,11 @@ def saisie_heures():
                         if planning:
                             total_theorique = get_heures_theoriques_jour(planning, date_saisie.weekday())
 
-                    heures_apres = 0
-                    if heure_debut_matin and heure_fin_matin:
-                        heures_apres += calculer_heures(heure_debut_matin, heure_fin_matin)
-                    if heure_debut_aprem and heure_fin_aprem:
-                        heures_apres += calculer_heures(heure_debut_aprem, heure_fin_aprem)
+                    heures_apres = calculer_heures_reelles_jour({
+                        'heure_debut_matin': heure_debut_matin, 'heure_fin_matin': heure_fin_matin,
+                        'heure_debut_aprem': heure_debut_aprem, 'heure_fin_aprem': heure_fin_aprem,
+                        'heure_debut_soir': heure_debut_soir, 'heure_fin_soir': heure_fin_soir,
+                    })
 
                     ecart = abs(heures_apres - total_theorique)
                     if ecart > SEUIL_ECART_ANOMALIE_HEURES:
@@ -238,12 +245,14 @@ def saisie_heures():
             
             # Enregistrer la modification
             conn.execute('''
-                INSERT OR REPLACE INTO heures_reelles 
-                (user_id, date, heure_debut_matin, heure_fin_matin, 
-                 heure_debut_aprem, heure_fin_aprem, commentaire, type_saisie, declaration_conforme)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT OR REPLACE INTO heures_reelles
+                (user_id, date, heure_debut_matin, heure_fin_matin,
+                 heure_debut_aprem, heure_fin_aprem, heure_debut_soir, heure_fin_soir,
+                 commentaire, type_saisie, declaration_conforme)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''', (user_id_cible, date, heure_debut_matin, heure_fin_matin,
-                  heure_debut_aprem, heure_fin_aprem, commentaire, type_saisie, declaration_conforme_val))
+                  heure_debut_aprem, heure_fin_aprem, heure_debut_soir, heure_fin_soir,
+                  commentaire, type_saisie, declaration_conforme_val))
             
             # Enregistrer dans l'historique
             conn.execute('''
@@ -311,6 +320,12 @@ def saisie_heures():
 
     next_page = request.args.get('next', '')
 
+    # Le 3e créneau « soir » n'est proposé qu'en période de vacances (personnel
+    # d'entretien). On l'affiche aussi si une saisie soir existe déjà pour ce jour.
+    est_vacances = get_type_periode(date_defaut) == 'vacances'
+    a_soir = bool(heures_existantes and (heures_existantes.get('heure_debut_soir')
+                                         or heures_existantes.get('heure_fin_soir')))
+
     return render_template('saisie_heures.html',
                           date_defaut=date_defaut,
                           heures_existantes=heures_existantes,
@@ -319,4 +334,6 @@ def saisie_heures():
                           next_page=next_page,
                           solde_recup=solde_recup,
                           mois_verrouille=mois_verrouille,
+                          soir_disponible=est_vacances or a_soir,
+                          soir_rempli=a_soir,
                           declaration_conforme_active=declaration_conforme_active)

--- a/blueprints/suivi.py
+++ b/blueprints/suivi.py
@@ -72,7 +72,8 @@ def _get_score_category(score):
 
 def _calculate_surcharge_alert(conn, user, today, feries_set, planning_cache, type_periode_cache):
     rows = conn.execute('''
-        SELECT date, heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem, declaration_conforme
+        SELECT date, heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem,
+               heure_debut_soir, heure_fin_soir, declaration_conforme
         FROM heures_reelles
         WHERE user_id = ? AND date <= ?
         ORDER BY date

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -7,6 +7,7 @@ import json
 from database import get_db
 from blueprints.delegations import MISSION_SUIVI_VALIDATIONS_RELANCES, user_has_delegation
 from utils import (login_required, get_user_info, calculer_heures,
+                    calculer_heures_reelles_jour, slot_horaire,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS)
 from app_options import get_option_bool
 from access_log import (journaliser_action, ACTION_VALIDATION_MOIS,
@@ -15,13 +16,16 @@ from access_log import (journaliser_action, ACTION_VALIDATION_MOIS,
 validation_bp = Blueprint('validation_bp', __name__)
 
 
-def _formater_horaires(matin_debut=None, matin_fin=None, aprem_debut=None, aprem_fin=None):
-    """Formate les horaires d'une journée pour l'affichage."""
+def _formater_horaires(matin_debut=None, matin_fin=None, aprem_debut=None, aprem_fin=None,
+                       soir_debut=None, soir_fin=None):
+    """Formate les horaires d'une journée pour l'affichage (3 créneaux)."""
     plages = []
     if matin_debut and matin_fin:
         plages.append(f"{matin_debut} - {matin_fin}")
     if aprem_debut and aprem_fin:
         plages.append(f"{aprem_debut} - {aprem_fin}")
+    if soir_debut and soir_fin:
+        plages.append(f"{soir_debut} - {soir_fin}")
     return ' / '.join(plages) if plages else '-'
 
 
@@ -490,14 +494,14 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
                     horaires_reels = horaires_theoriques
                 else:
                     est_saisi = True
-                    heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-                    heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-                    heures_reelles_jour = heures_matin + heures_aprem
+                    heures_reelles_jour = calculer_heures_reelles_jour(h)
                     horaires_reels = _formater_horaires(
                         h['heure_debut_matin'],
                         h['heure_fin_matin'],
                         h['heure_debut_aprem'],
                         h['heure_fin_aprem'],
+                        slot_horaire(h, 'heure_debut_soir'),
+                        slot_horaire(h, 'heure_fin_soir'),
                     )
 
                 type_saisie = h['type_saisie']
@@ -579,7 +583,8 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
 
     heures_anterieures = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin,
-               heure_debut_aprem, heure_fin_aprem, declaration_conforme
+               heure_debut_aprem, heure_fin_aprem,
+               heure_debut_soir, heure_fin_soir, declaration_conforme
         FROM heures_reelles
         WHERE user_id = ? AND date < ?
         ORDER BY date
@@ -600,9 +605,7 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
         if h['declaration_conforme']:
             total_reel = total_theorique
         else:
-            heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-            heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-            total_reel = heures_matin + heures_aprem
+            total_reel = calculer_heures_reelles_jour(h)
 
         solde_anterieur += (total_reel - total_theorique)
 

--- a/blueprints/worktime_metrics.py
+++ b/blueprints/worktime_metrics.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
+from utils import slot_horaire
+
 
 MIN_BREAK_MINUTES = 20
 BUSINESS_DAYS_PER_WEEK = 5
@@ -142,6 +144,10 @@ def day_segments_from_row(row) -> list[tuple[str, str]]:
         segments.append((row["heure_debut_matin"], row["heure_fin_matin"]))
     if row["heure_debut_aprem"] and row["heure_fin_aprem"]:
         segments.append((row["heure_debut_aprem"], row["heure_fin_aprem"]))
+    soir_debut = slot_horaire(row, "heure_debut_soir")
+    soir_fin = slot_horaire(row, "heure_fin_soir")
+    if soir_debut and soir_fin:
+        segments.append((soir_debut, soir_fin))
     return segments
 
 
@@ -155,11 +161,15 @@ def day_segments_from_planning(planning, date_obj) -> list[tuple[str, str]]:
     matin_fin = planning[f"{jour_nom}_matin_fin"]
     aprem_debut = planning[f"{jour_nom}_aprem_debut"]
     aprem_fin = planning[f"{jour_nom}_aprem_fin"]
+    soir_debut = slot_horaire(planning, f"{jour_nom}_soir_debut")
+    soir_fin = slot_horaire(planning, f"{jour_nom}_soir_fin")
 
     if matin_debut and matin_fin:
         segments.append((matin_debut, matin_fin))
     if aprem_debut and aprem_fin:
         segments.append((aprem_debut, aprem_fin))
+    if soir_debut and soir_fin:
+        segments.append((soir_debut, soir_fin))
     return segments
 
 

--- a/database.py
+++ b/database.py
@@ -267,22 +267,32 @@ def init_db():
             lundi_matin_fin TEXT,
             lundi_aprem_debut TEXT,
             lundi_aprem_fin TEXT,
+            lundi_soir_debut TEXT,
+            lundi_soir_fin TEXT,
             mardi_matin_debut TEXT,
             mardi_matin_fin TEXT,
             mardi_aprem_debut TEXT,
             mardi_aprem_fin TEXT,
+            mardi_soir_debut TEXT,
+            mardi_soir_fin TEXT,
             mercredi_matin_debut TEXT,
             mercredi_matin_fin TEXT,
             mercredi_aprem_debut TEXT,
             mercredi_aprem_fin TEXT,
+            mercredi_soir_debut TEXT,
+            mercredi_soir_fin TEXT,
             jeudi_matin_debut TEXT,
             jeudi_matin_fin TEXT,
             jeudi_aprem_debut TEXT,
             jeudi_aprem_fin TEXT,
+            jeudi_soir_debut TEXT,
+            jeudi_soir_fin TEXT,
             vendredi_matin_debut TEXT,
             vendredi_matin_fin TEXT,
             vendredi_aprem_debut TEXT,
             vendredi_aprem_fin TEXT,
+            vendredi_soir_debut TEXT,
+            vendredi_soir_fin TEXT,
             total_hebdo REAL,
             FOREIGN KEY (user_id) REFERENCES users(id)
         )
@@ -326,6 +336,8 @@ def init_db():
             heure_fin_matin TEXT,
             heure_debut_aprem TEXT,
             heure_fin_aprem TEXT,
+            heure_debut_soir TEXT,
+            heure_fin_soir TEXT,
             commentaire TEXT,
             type_saisie TEXT DEFAULT 'heures_sup',
             declaration_conforme INTEGER DEFAULT 0,
@@ -1822,6 +1834,22 @@ def init_db():
         cursor.execute("SELECT synonymes FROM secteurs LIMIT 1")
     except sqlite3.OperationalError:
         cursor.execute("ALTER TABLE secteurs ADD COLUMN synonymes TEXT")
+
+    # Migration 0055 : 3e creneau optionnel « soir » (personnel d'entretien en
+    # periode de vacances). Colonnes nullables : les plannings/saisies existants
+    # restent inchanges (soir vide = 0 heure).
+    for col in ('heure_debut_soir', 'heure_fin_soir'):
+        try:
+            cursor.execute(f"SELECT {col} FROM heures_reelles LIMIT 1")
+        except sqlite3.OperationalError:
+            cursor.execute(f"ALTER TABLE heures_reelles ADD COLUMN {col} TEXT")
+    for _jour in ('lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi'):
+        for _suffixe in ('soir_debut', 'soir_fin'):
+            col = f"{_jour}_{_suffixe}"
+            try:
+                cursor.execute(f"SELECT {col} FROM planning_theorique LIMIT 1")
+            except sqlite3.OperationalError:
+                cursor.execute(f"ALTER TABLE planning_theorique ADD COLUMN {col} TEXT")
 
     # Migration : ajouter temps_hebdo si n'existe pas dans contrats
     try:

--- a/migrations/0055_creneau_soir.py
+++ b/migrations/0055_creneau_soir.py
@@ -1,0 +1,48 @@
+"""
+Migration 0055 : troisième créneau optionnel « soir ».
+
+Le personnel d'entretien travaille parfois en trois créneaux dans la journée,
+notamment en période de vacances. On ajoute un créneau « soir » (début/fin) en
+plus de « matin » et « après-midi » :
+- sur les heures réelles saisies (`heures_reelles`) ;
+- sur le planning théorique hebdomadaire (`planning_theorique`), pour chaque
+  jour ouvré (lundi → vendredi).
+
+Les colonnes sont NULLABLES : les plannings et saisies existants restent
+inchangés (un créneau soir vide compte pour 0 heure). Côté interface, le créneau
+n'est proposé qu'en contexte « vacances » et reste activable ponctuellement.
+"""
+
+NOM = "Créneau soir optionnel (entretien / vacances)"
+DESCRIPTION = (
+    "Ajoute un 3e créneau « soir » (début/fin) aux heures réelles et au planning "
+    "théorique (par jour). Colonnes nullables, rétrocompatibles."
+)
+
+JOURS = ('lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi')
+
+
+def _ajouter_colonne(cursor, table, colonne):
+    """Ajoute une colonne TEXT si elle n'existe pas déjà (idempotent)."""
+    import sqlite3
+    try:
+        cursor.execute(f"SELECT {colonne} FROM {table} LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute(f"ALTER TABLE {table} ADD COLUMN {colonne} TEXT")
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    cursor = conn.cursor()
+    for colonne in ('heure_debut_soir', 'heure_fin_soir'):
+        _ajouter_colonne(cursor, 'heures_reelles', colonne)
+    for jour in JOURS:
+        _ajouter_colonne(cursor, 'planning_theorique', f'{jour}_soir_debut')
+        _ajouter_colonne(cursor, 'planning_theorique', f'{jour}_soir_fin')
+    conn.commit()
+
+
+def downgrade(conn):
+    """SQLite ne supporte pas DROP COLUMN simplement : downgrade non destructif
+    (les colonnes soir restent, inertes)."""
+    pass

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1058,7 +1058,9 @@ a.btn-icon:-webkit-any-link {
 
 .time-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    /* 2 créneaux (matin/après-midi) par défaut, 3 quand le « soir » optionnel
+       est ajouté ; reflow automatique et passage à 1 colonne sur mobile. */
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 2rem;
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -114,6 +114,9 @@
                         {% else %}
                         -
                         {% endif %}
+                        {% if h.heure_debut_soir %}
+                        <br><span style="color: var(--gray-500);">🌙 {{ h.heure_debut_soir }} - {{ h.heure_fin_soir }}</span>
+                        {% endif %}
                     </td>
                     <td data-label="Total jour"><strong>{{ "%.2f"|format(h.total_reel) }}h</strong></td>
                     <td data-label="Écart">

--- a/templates/historique_modifications.html
+++ b/templates/historique_modifications.html
@@ -123,6 +123,9 @@
                                 <table style="width: 100%; font-size: 0.9rem;">
                                     <tr><td><strong>Matin :</strong></td><td>{{ m.anciennes_valeurs_obj.heure_debut_matin or '-' }} → {{ m.anciennes_valeurs_obj.heure_fin_matin or '-' }}</td></tr>
                                     <tr><td><strong>Après-midi :</strong></td><td>{{ m.anciennes_valeurs_obj.heure_debut_aprem or '-' }} → {{ m.anciennes_valeurs_obj.heure_fin_aprem or '-' }}</td></tr>
+                                    {% if m.anciennes_valeurs_obj.heure_debut_soir or m.anciennes_valeurs_obj.heure_fin_soir %}
+                                    <tr><td><strong>Soir :</strong></td><td>{{ m.anciennes_valeurs_obj.heure_debut_soir or '-' }} → {{ m.anciennes_valeurs_obj.heure_fin_soir or '-' }}</td></tr>
+                                    {% endif %}
                                     <tr><td><strong>Type :</strong></td><td>{{ m.anciennes_valeurs_obj.type_saisie }}</td></tr>
                                     <tr><td><strong>Commentaire :</strong></td><td>{{ m.anciennes_valeurs_obj.commentaire or '-' }}</td></tr>
                                 </table>
@@ -139,6 +142,9 @@
                                 <table style="width: 100%; font-size: 0.9rem;">
                                     <tr><td><strong>Matin :</strong></td><td>{{ m.nouvelles_valeurs_obj.heure_debut_matin or '-' }} → {{ m.nouvelles_valeurs_obj.heure_fin_matin or '-' }}</td></tr>
                                     <tr><td><strong>Après-midi :</strong></td><td>{{ m.nouvelles_valeurs_obj.heure_debut_aprem or '-' }} → {{ m.nouvelles_valeurs_obj.heure_fin_aprem or '-' }}</td></tr>
+                                    {% if m.nouvelles_valeurs_obj.heure_debut_soir or m.nouvelles_valeurs_obj.heure_fin_soir %}
+                                    <tr><td><strong>Soir :</strong></td><td>{{ m.nouvelles_valeurs_obj.heure_debut_soir or '-' }} → {{ m.nouvelles_valeurs_obj.heure_fin_soir or '-' }}</td></tr>
+                                    {% endif %}
                                     <tr><td><strong>Type :</strong></td><td>{{ m.nouvelles_valeurs_obj.type_saisie }}</td></tr>
                                     <tr><td><strong>Commentaire :</strong></td><td>{{ m.nouvelles_valeurs_obj.commentaire or '-' }}</td></tr>
                                 </table>

--- a/templates/mon_equipe.html
+++ b/templates/mon_equipe.html
@@ -73,7 +73,7 @@
                     <span class="card-label">Recuperation</span>
                 </div>
 
-                {% elif jour.matin or jour.aprem %}
+                {% elif jour.matin or jour.aprem or jour.soir %}
                 <!-- Horaires -->
                 <div class="day-card card-present {% if jour.type_saisie == 'theorique' %}card-theorique{% endif %}">
                     {% if jour.matin and jour.matin[0] and jour.matin[1] %}
@@ -85,6 +85,11 @@
                     <div class="slot slot-aprem">{{ jour.aprem[0] }} - {{ jour.aprem[1] }}</div>
                     {% elif jour.aprem and jour.aprem[0] %}
                     <div class="slot slot-aprem">{{ jour.aprem[0] }} - ...</div>
+                    {% endif %}
+                    {% if jour.soir and jour.soir[0] and jour.soir[1] %}
+                    <div class="slot slot-soir">🌙 {{ jour.soir[0] }} - {{ jour.soir[1] }}</div>
+                    {% elif jour.soir and jour.soir[0] %}
+                    <div class="slot slot-soir">🌙 {{ jour.soir[0] }} - ...</div>
                     {% endif %}
                 </div>
 
@@ -134,7 +139,7 @@
                     <div class="day-card card-recup">
                         <span class="card-label">Recuperation</span>
                     </div>
-                    {% elif jour.matin or jour.aprem %}
+                    {% elif jour.matin or jour.aprem or jour.soir %}
                     <div class="day-card card-present {% if jour.type_saisie == 'theorique' %}card-theorique{% endif %}">
                         {% if jour.matin and jour.matin[0] and jour.matin[1] %}
                         <div class="slot slot-matin">{{ jour.matin[0] }} - {{ jour.matin[1] }}</div>
@@ -145,6 +150,11 @@
                         <div class="slot slot-aprem">{{ jour.aprem[0] }} - {{ jour.aprem[1] }}</div>
                         {% elif jour.aprem and jour.aprem[0] %}
                         <div class="slot slot-aprem">{{ jour.aprem[0] }} - ...</div>
+                        {% endif %}
+                        {% if jour.soir and jour.soir[0] and jour.soir[1] %}
+                        <div class="slot slot-soir">🌙 {{ jour.soir[0] }} - {{ jour.soir[1] }}</div>
+                        {% elif jour.soir and jour.soir[0] %}
+                        <div class="slot slot-soir">🌙 {{ jour.soir[0] }} - ...</div>
                         {% endif %}
                     </div>
                     {% else %}
@@ -462,6 +472,7 @@
 .slot { white-space: nowrap; font-weight: 600; }
 .slot-matin { margin-bottom: 2px; }
 .slot-aprem { font-size: 0.76rem; }
+.slot-soir { font-size: 0.74rem; color: var(--gray-500); margin-top: 2px; }
 
 /* ---- Legend ---- */
 .equipe-legend {

--- a/templates/planning_theorique.html
+++ b/templates/planning_theorique.html
@@ -545,6 +545,11 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!useSpecificVacationPlanning && (!typePeriodeSelect.value || typePeriodeSelect.value === 'vacances')) {
             typePeriodeSelect.value = 'periode_scolaire';
         }
+        // Une affectation programmatique de .value ne déclenche pas l'événement
+        // « change » : on re-synchronise le créneau soir à la main, sinon des heures
+        // de soirée saisies en vacances resteraient visibles/actives (et soumises)
+        // après un repli en période scolaire.
+        gererCreneauSoir();
     }
     
     // Gestion affichage date de référence selon type d'alternance

--- a/templates/planning_theorique.html
+++ b/templates/planning_theorique.html
@@ -98,6 +98,7 @@
                             <th>Jour</th>
                             <th>Matin</th>
                             <th>Après-midi</th>
+                            <th>Soir</th>
                             <th>Total</th>
                         </tr>
                     </thead>
@@ -106,11 +107,13 @@
                             <td data-label="Jour"><strong>Lundi</strong></td>
                             <td data-label="Matin">{{ p.lundi_matin_debut or '-' }} - {{ p.lundi_matin_fin or '-' }}</td>
                             <td data-label="Après-midi">{{ p.lundi_aprem_debut or '-' }} - {{ p.lundi_aprem_fin or '-' }}</td>
+                            <td data-label="Soir">{% if p.lundi_soir_debut or p.lundi_soir_fin %}{{ p.lundi_soir_debut or '-' }} - {{ p.lundi_soir_fin or '-' }}{% else %}—{% endif %}</td>
                             <td data-label="Total">
-                                {% if (p.lundi_matin_debut and p.lundi_matin_fin) or (p.lundi_aprem_debut and p.lundi_aprem_fin) %}
+                                {% if (p.lundi_matin_debut and p.lundi_matin_fin) or (p.lundi_aprem_debut and p.lundi_aprem_fin) or (p.lundi_soir_debut and p.lundi_soir_fin) %}
                                 {% set h_matin = (p.lundi_matin_fin.split(':')[0]|int * 60 + p.lundi_matin_fin.split(':')[1]|int - p.lundi_matin_debut.split(':')[0]|int * 60 - p.lundi_matin_debut.split(':')[1]|int) / 60 if p.lundi_matin_debut and p.lundi_matin_fin else 0 %}
                                 {% set h_aprem = (p.lundi_aprem_fin.split(':')[0]|int * 60 + p.lundi_aprem_fin.split(':')[1]|int - p.lundi_aprem_debut.split(':')[0]|int * 60 - p.lundi_aprem_debut.split(':')[1]|int) / 60 if p.lundi_aprem_debut and p.lundi_aprem_fin else 0 %}
-                                {{ "%.1f"|format(h_matin + h_aprem) }}h
+                                {% set h_soir = (p.lundi_soir_fin.split(':')[0]|int * 60 + p.lundi_soir_fin.split(':')[1]|int - p.lundi_soir_debut.split(':')[0]|int * 60 - p.lundi_soir_debut.split(':')[1]|int) / 60 if p.lundi_soir_debut and p.lundi_soir_fin else 0 %}
+                                {{ "%.1f"|format(h_matin + h_aprem + h_soir) }}h
                                 {% else %}
                                 Non travaillé
                                 {% endif %}
@@ -120,11 +123,13 @@
                             <td data-label="Jour"><strong>Mardi</strong></td>
                             <td data-label="Matin">{{ p.mardi_matin_debut or '-' }} - {{ p.mardi_matin_fin or '-' }}</td>
                             <td data-label="Après-midi">{{ p.mardi_aprem_debut or '-' }} - {{ p.mardi_aprem_fin or '-' }}</td>
+                            <td data-label="Soir">{% if p.mardi_soir_debut or p.mardi_soir_fin %}{{ p.mardi_soir_debut or '-' }} - {{ p.mardi_soir_fin or '-' }}{% else %}—{% endif %}</td>
                             <td data-label="Total">
-                                {% if (p.mardi_matin_debut and p.mardi_matin_fin) or (p.mardi_aprem_debut and p.mardi_aprem_fin) %}
+                                {% if (p.mardi_matin_debut and p.mardi_matin_fin) or (p.mardi_aprem_debut and p.mardi_aprem_fin) or (p.mardi_soir_debut and p.mardi_soir_fin) %}
                                 {% set h_matin = (p.mardi_matin_fin.split(':')[0]|int * 60 + p.mardi_matin_fin.split(':')[1]|int - p.mardi_matin_debut.split(':')[0]|int * 60 - p.mardi_matin_debut.split(':')[1]|int) / 60 if p.mardi_matin_debut and p.mardi_matin_fin else 0 %}
                                 {% set h_aprem = (p.mardi_aprem_fin.split(':')[0]|int * 60 + p.mardi_aprem_fin.split(':')[1]|int - p.mardi_aprem_debut.split(':')[0]|int * 60 - p.mardi_aprem_debut.split(':')[1]|int) / 60 if p.mardi_aprem_debut and p.mardi_aprem_fin else 0 %}
-                                {{ "%.1f"|format(h_matin + h_aprem) }}h
+                                {% set h_soir = (p.mardi_soir_fin.split(':')[0]|int * 60 + p.mardi_soir_fin.split(':')[1]|int - p.mardi_soir_debut.split(':')[0]|int * 60 - p.mardi_soir_debut.split(':')[1]|int) / 60 if p.mardi_soir_debut and p.mardi_soir_fin else 0 %}
+                                {{ "%.1f"|format(h_matin + h_aprem + h_soir) }}h
                                 {% else %}
                                 Non travaillé
                                 {% endif %}
@@ -134,11 +139,13 @@
                             <td data-label="Jour"><strong>Mercredi</strong></td>
                             <td data-label="Matin">{{ p.mercredi_matin_debut or '-' }} - {{ p.mercredi_matin_fin or '-' }}</td>
                             <td data-label="Après-midi">{{ p.mercredi_aprem_debut or '-' }} - {{ p.mercredi_aprem_fin or '-' }}</td>
+                            <td data-label="Soir">{% if p.mercredi_soir_debut or p.mercredi_soir_fin %}{{ p.mercredi_soir_debut or '-' }} - {{ p.mercredi_soir_fin or '-' }}{% else %}—{% endif %}</td>
                             <td data-label="Total">
-                                {% if (p.mercredi_matin_debut and p.mercredi_matin_fin) or (p.mercredi_aprem_debut and p.mercredi_aprem_fin) %}
+                                {% if (p.mercredi_matin_debut and p.mercredi_matin_fin) or (p.mercredi_aprem_debut and p.mercredi_aprem_fin) or (p.mercredi_soir_debut and p.mercredi_soir_fin) %}
                                 {% set h_matin = (p.mercredi_matin_fin.split(':')[0]|int * 60 + p.mercredi_matin_fin.split(':')[1]|int - p.mercredi_matin_debut.split(':')[0]|int * 60 - p.mercredi_matin_debut.split(':')[1]|int) / 60 if p.mercredi_matin_debut and p.mercredi_matin_fin else 0 %}
                                 {% set h_aprem = (p.mercredi_aprem_fin.split(':')[0]|int * 60 + p.mercredi_aprem_fin.split(':')[1]|int - p.mercredi_aprem_debut.split(':')[0]|int * 60 - p.mercredi_aprem_debut.split(':')[1]|int) / 60 if p.mercredi_aprem_debut and p.mercredi_aprem_fin else 0 %}
-                                {{ "%.1f"|format(h_matin + h_aprem) }}h
+                                {% set h_soir = (p.mercredi_soir_fin.split(':')[0]|int * 60 + p.mercredi_soir_fin.split(':')[1]|int - p.mercredi_soir_debut.split(':')[0]|int * 60 - p.mercredi_soir_debut.split(':')[1]|int) / 60 if p.mercredi_soir_debut and p.mercredi_soir_fin else 0 %}
+                                {{ "%.1f"|format(h_matin + h_aprem + h_soir) }}h
                                 {% else %}
                                 Non travaillé
                                 {% endif %}
@@ -148,11 +155,13 @@
                             <td data-label="Jour"><strong>Jeudi</strong></td>
                             <td data-label="Matin">{{ p.jeudi_matin_debut or '-' }} - {{ p.jeudi_matin_fin or '-' }}</td>
                             <td data-label="Après-midi">{{ p.jeudi_aprem_debut or '-' }} - {{ p.jeudi_aprem_fin or '-' }}</td>
+                            <td data-label="Soir">{% if p.jeudi_soir_debut or p.jeudi_soir_fin %}{{ p.jeudi_soir_debut or '-' }} - {{ p.jeudi_soir_fin or '-' }}{% else %}—{% endif %}</td>
                             <td data-label="Total">
-                                {% if (p.jeudi_matin_debut and p.jeudi_matin_fin) or (p.jeudi_aprem_debut and p.jeudi_aprem_fin) %}
+                                {% if (p.jeudi_matin_debut and p.jeudi_matin_fin) or (p.jeudi_aprem_debut and p.jeudi_aprem_fin) or (p.jeudi_soir_debut and p.jeudi_soir_fin) %}
                                 {% set h_matin = (p.jeudi_matin_fin.split(':')[0]|int * 60 + p.jeudi_matin_fin.split(':')[1]|int - p.jeudi_matin_debut.split(':')[0]|int * 60 - p.jeudi_matin_debut.split(':')[1]|int) / 60 if p.jeudi_matin_debut and p.jeudi_matin_fin else 0 %}
                                 {% set h_aprem = (p.jeudi_aprem_fin.split(':')[0]|int * 60 + p.jeudi_aprem_fin.split(':')[1]|int - p.jeudi_aprem_debut.split(':')[0]|int * 60 - p.jeudi_aprem_debut.split(':')[1]|int) / 60 if p.jeudi_aprem_debut and p.jeudi_aprem_fin else 0 %}
-                                {{ "%.1f"|format(h_matin + h_aprem) }}h
+                                {% set h_soir = (p.jeudi_soir_fin.split(':')[0]|int * 60 + p.jeudi_soir_fin.split(':')[1]|int - p.jeudi_soir_debut.split(':')[0]|int * 60 - p.jeudi_soir_debut.split(':')[1]|int) / 60 if p.jeudi_soir_debut and p.jeudi_soir_fin else 0 %}
+                                {{ "%.1f"|format(h_matin + h_aprem + h_soir) }}h
                                 {% else %}
                                 Non travaillé
                                 {% endif %}
@@ -162,11 +171,13 @@
                             <td data-label="Jour"><strong>Vendredi</strong></td>
                             <td data-label="Matin">{{ p.vendredi_matin_debut or '-' }} - {{ p.vendredi_matin_fin or '-' }}</td>
                             <td data-label="Après-midi">{{ p.vendredi_aprem_debut or '-' }} - {{ p.vendredi_aprem_fin or '-' }}</td>
+                            <td data-label="Soir">{% if p.vendredi_soir_debut or p.vendredi_soir_fin %}{{ p.vendredi_soir_debut or '-' }} - {{ p.vendredi_soir_fin or '-' }}{% else %}—{% endif %}</td>
                             <td data-label="Total">
-                                {% if (p.vendredi_matin_debut and p.vendredi_matin_fin) or (p.vendredi_aprem_debut and p.vendredi_aprem_fin) %}
+                                {% if (p.vendredi_matin_debut and p.vendredi_matin_fin) or (p.vendredi_aprem_debut and p.vendredi_aprem_fin) or (p.vendredi_soir_debut and p.vendredi_soir_fin) %}
                                 {% set h_matin = (p.vendredi_matin_fin.split(':')[0]|int * 60 + p.vendredi_matin_fin.split(':')[1]|int - p.vendredi_matin_debut.split(':')[0]|int * 60 - p.vendredi_matin_debut.split(':')[1]|int) / 60 if p.vendredi_matin_debut and p.vendredi_matin_fin else 0 %}
                                 {% set h_aprem = (p.vendredi_aprem_fin.split(':')[0]|int * 60 + p.vendredi_aprem_fin.split(':')[1]|int - p.vendredi_aprem_debut.split(':')[0]|int * 60 - p.vendredi_aprem_debut.split(':')[1]|int) / 60 if p.vendredi_aprem_debut and p.vendredi_aprem_fin else 0 %}
-                                {{ "%.1f"|format(h_matin + h_aprem) }}h
+                                {% set h_soir = (p.vendredi_soir_fin.split(':')[0]|int * 60 + p.vendredi_soir_fin.split(':')[1]|int - p.vendredi_soir_debut.split(':')[0]|int * 60 - p.vendredi_soir_debut.split(':')[1]|int) / 60 if p.vendredi_soir_debut and p.vendredi_soir_fin else 0 %}
+                                {{ "%.1f"|format(h_matin + h_aprem + h_soir) }}h
                                 {% else %}
                                 Non travaillé
                                 {% endif %}
@@ -175,7 +186,7 @@
                     </tbody>
                     <tfoot>
                         <tr>
-                            <td colspan="3"><strong>Total hebdomadaire</strong></td>
+                            <td colspan="4"><strong>Total hebdomadaire</strong></td>
                             <td><strong>{{ "%.2f"|format(p.total_hebdo) }}h</strong></td>
                         </tr>
                     </tfoot>
@@ -275,6 +286,17 @@
                             <input type="time" id="lundi_aprem_fin" name="lundi_aprem_fin">
                         </div>
                     </div>
+                    <div class="time-section soir-section" style="display:none;">
+                        <h4>🌙 Soir</h4>
+                        <div class="form-group">
+                            <label for="lundi_soir_debut">Heure d'arrivée</label>
+                            <input type="time" id="lundi_soir_debut" name="lundi_soir_debut" disabled>
+                        </div>
+                        <div class="form-group">
+                            <label for="lundi_soir_fin">Heure de départ</label>
+                            <input type="time" id="lundi_soir_fin" name="lundi_soir_fin" disabled>
+                        </div>
+                    </div>
                 </div>
             </div>
             
@@ -302,6 +324,17 @@
                         <div class="form-group">
                             <label for="mardi_aprem_fin">Heure de départ</label>
                             <input type="time" id="mardi_aprem_fin" name="mardi_aprem_fin">
+                        </div>
+                    </div>
+                    <div class="time-section soir-section" style="display:none;">
+                        <h4>🌙 Soir</h4>
+                        <div class="form-group">
+                            <label for="mardi_soir_debut">Heure d'arrivée</label>
+                            <input type="time" id="mardi_soir_debut" name="mardi_soir_debut" disabled>
+                        </div>
+                        <div class="form-group">
+                            <label for="mardi_soir_fin">Heure de départ</label>
+                            <input type="time" id="mardi_soir_fin" name="mardi_soir_fin" disabled>
                         </div>
                     </div>
                 </div>
@@ -333,6 +366,17 @@
                             <input type="time" id="mercredi_aprem_fin" name="mercredi_aprem_fin">
                         </div>
                     </div>
+                    <div class="time-section soir-section" style="display:none;">
+                        <h4>🌙 Soir</h4>
+                        <div class="form-group">
+                            <label for="mercredi_soir_debut">Heure d'arrivée</label>
+                            <input type="time" id="mercredi_soir_debut" name="mercredi_soir_debut" disabled>
+                        </div>
+                        <div class="form-group">
+                            <label for="mercredi_soir_fin">Heure de départ</label>
+                            <input type="time" id="mercredi_soir_fin" name="mercredi_soir_fin" disabled>
+                        </div>
+                    </div>
                 </div>
             </div>
             
@@ -362,6 +406,17 @@
                             <input type="time" id="jeudi_aprem_fin" name="jeudi_aprem_fin">
                         </div>
                     </div>
+                    <div class="time-section soir-section" style="display:none;">
+                        <h4>🌙 Soir</h4>
+                        <div class="form-group">
+                            <label for="jeudi_soir_debut">Heure d'arrivée</label>
+                            <input type="time" id="jeudi_soir_debut" name="jeudi_soir_debut" disabled>
+                        </div>
+                        <div class="form-group">
+                            <label for="jeudi_soir_fin">Heure de départ</label>
+                            <input type="time" id="jeudi_soir_fin" name="jeudi_soir_fin" disabled>
+                        </div>
+                    </div>
                 </div>
             </div>
             
@@ -389,6 +444,17 @@
                         <div class="form-group">
                             <label for="vendredi_aprem_fin">Heure de départ</label>
                             <input type="time" id="vendredi_aprem_fin" name="vendredi_aprem_fin">
+                        </div>
+                    </div>
+                    <div class="time-section soir-section" style="display:none;">
+                        <h4>🌙 Soir</h4>
+                        <div class="form-group">
+                            <label for="vendredi_soir_debut">Heure d'arrivée</label>
+                            <input type="time" id="vendredi_soir_debut" name="vendredi_soir_debut" disabled>
+                        </div>
+                        <div class="form-group">
+                            <label for="vendredi_soir_fin">Heure de départ</label>
+                            <input type="time" id="vendredi_soir_fin" name="vendredi_soir_fin" disabled>
                         </div>
                     </div>
                 </div>
@@ -514,11 +580,27 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
     
+    // Le 3e créneau « soir » n'est proposé qu'en période de vacances : on affiche
+    // les sections soir uniquement quand « Vacances scolaires » est sélectionné,
+    // et on désactive leurs champs sinon (pour ne rien soumettre en scolaire).
+    function gererCreneauSoir() {
+        const estVacances = typePeriodeSelect.value === 'vacances';
+        document.querySelectorAll('form .soir-section').forEach(function(section) {
+            section.style.display = estVacances ? '' : 'none';
+            section.querySelectorAll('input[type="time"]').forEach(function(inp) {
+                inp.disabled = !estVacances;
+                if (!estVacances) inp.value = '';
+            });
+        });
+    }
+
     // Déclencher au chargement et au changement
     vacationPlanningCheckbox.addEventListener('change', gererOptionPlanningVacances);
     typeAlternanceSelect.addEventListener('change', toggleDateReference);
+    typePeriodeSelect.addEventListener('change', gererCreneauSoir);
     gererOptionPlanningVacances();
     toggleDateReference(); // Initial
+    gererCreneauSoir(); // Initial
 });
 </script>
 {% endblock %}

--- a/templates/saisie_heures.html
+++ b/templates/saisie_heures.html
@@ -46,6 +46,15 @@
                 <span style="font-size: 0.9rem; font-weight: 600; color: var(--gray-700);">Horaires réels</span>
                 <span class="ctx-help ctx-help--below" onclick="toggleCtxHelp(event, this)">?<span class="ctx-help-bubble">Saisissez vos heures réelles de travail, pas vos heures théoriques. Un écart supérieur à 3 heures par rapport à votre planning déclenchera une anomalie visible par la direction — ce n'est pas bloquant mais sera examiné.</span></span>
             </div>
+            {% if soir_disponible %}
+            <div class="form-group" style="margin-bottom: 0.75rem;">
+                <label style="display: flex; align-items: center; gap: 0.4rem;">
+                    <input type="checkbox" id="toggle_soir" onchange="toggleSoir()" {% if soir_rempli %}checked{% endif %}>
+                    <strong>🌙 Ajouter un créneau du soir</strong>
+                    <span class="ctx-help ctx-help--below" onclick="toggleCtxHelp(event, this)">?<span class="ctx-help-bubble">Troisième créneau optionnel — utile notamment au personnel d'entretien en période de vacances. Cochez pour saisir des horaires de soirée en plus du matin et de l'après-midi.</span></span>
+                </label>
+            </div>
+            {% endif %}
             <div class="time-grid">
                 <div class="time-section">
                     <h3>🌅 Matin</h3>
@@ -73,11 +82,29 @@
                     </div>
                     <div class="form-group">
                         <label for="heure_fin_aprem">Heure de départ</label>
-                        <input type="time" id="heure_fin_aprem" name="heure_fin_aprem" 
+                        <input type="time" id="heure_fin_aprem" name="heure_fin_aprem"
                                value="{{ heures_existantes.heure_fin_aprem or '' if heures_existantes else '' }}"
                                {% if heures_existantes and heures_existantes.type_saisie == 'recup_journee' %}disabled{% endif %}>
                     </div>
                 </div>
+
+                {% if soir_disponible %}
+                <div class="time-section" id="soir-section" {% if not soir_rempli %}style="display:none;"{% endif %}>
+                    <h3>🌙 Soir</h3>
+                    <div class="form-group">
+                        <label for="heure_debut_soir">Heure d'arrivée</label>
+                        <input type="time" id="heure_debut_soir" name="heure_debut_soir"
+                               value="{{ heures_existantes.heure_debut_soir or '' if heures_existantes else '' }}"
+                               {% if (heures_existantes and heures_existantes.type_saisie == 'recup_journee') or not soir_rempli %}disabled{% endif %}>
+                    </div>
+                    <div class="form-group">
+                        <label for="heure_fin_soir">Heure de départ</label>
+                        <input type="time" id="heure_fin_soir" name="heure_fin_soir"
+                               value="{{ heures_existantes.heure_fin_soir or '' if heures_existantes else '' }}"
+                               {% if (heures_existantes and heures_existantes.type_saisie == 'recup_journee') or not soir_rempli %}disabled{% endif %}>
+                    </div>
+                </div>
+                {% endif %}
             </div>
         </div>
         
@@ -206,7 +233,22 @@
             });
         }
     }
-    
+
+    // Affiche/masque le 3e créneau optionnel « soir » et active/désactive ses champs.
+    function toggleSoir() {
+        const checkbox = document.getElementById('toggle_soir');
+        const section = document.getElementById('soir-section');
+        if (!checkbox || !section) return;
+        const inputs = section.querySelectorAll('input[type="time"]');
+        if (checkbox.checked) {
+            section.style.display = '';
+            inputs.forEach(i => { i.disabled = false; });
+        } else {
+            section.style.display = 'none';
+            inputs.forEach(i => { i.disabled = true; i.value = ''; });
+        }
+    }
+
     // Recharger la page quand on change la date pour charger les données de cette date
     document.getElementById('date').addEventListener('change', function() {
         const dateSelectionnee = this.value;

--- a/templates/suivi_anomalies.html
+++ b/templates/suivi_anomalies.html
@@ -133,6 +133,9 @@
                                         {% if anom.ancienne_valeur_obj.heure_debut_aprem %}
                                         <li><strong>Après-midi :</strong> {{ anom.ancienne_valeur_obj.heure_debut_aprem }} - {{ anom.ancienne_valeur_obj.heure_fin_aprem }}</li>
                                         {% endif %}
+                                        {% if anom.ancienne_valeur_obj.heure_debut_soir %}
+                                        <li><strong>Soir :</strong> {{ anom.ancienne_valeur_obj.heure_debut_soir }} - {{ anom.ancienne_valeur_obj.heure_fin_soir }}</li>
+                                        {% endif %}
                                         {% if anom.ancienne_valeur_obj.commentaire %}
                                         <li><strong>Commentaire :</strong> {{ anom.ancienne_valeur_obj.commentaire }}</li>
                                         {% endif %}
@@ -151,6 +154,9 @@
                                         {% endif %}
                                         {% if anom.nouvelle_valeur_obj.heure_debut_aprem %}
                                         <li><strong>Après-midi :</strong> {{ anom.nouvelle_valeur_obj.heure_debut_aprem }} - {{ anom.nouvelle_valeur_obj.heure_fin_aprem }}</li>
+                                        {% endif %}
+                                        {% if anom.nouvelle_valeur_obj.heure_debut_soir %}
+                                        <li><strong>Soir :</strong> {{ anom.nouvelle_valeur_obj.heure_debut_soir }} - {{ anom.nouvelle_valeur_obj.heure_fin_soir }}</li>
                                         {% endif %}
                                         {% if anom.nouvelle_valeur_obj.commentaire %}
                                         <li><strong>Commentaire :</strong> {{ anom.nouvelle_valeur_obj.commentaire }}</li>

--- a/tests/test_creneau_soir.py
+++ b/tests/test_creneau_soir.py
@@ -1,0 +1,128 @@
+"""
+Tests du 3e créneau optionnel « soir ».
+
+Le personnel d'entretien travaille parfois en trois créneaux (matin / après-midi
+/ soir), notamment en période de vacances. Le créneau soir est optionnel, proposé
+en contexte vacances, et doit compter dans tous les totaux d'heures.
+"""
+from datetime import date
+
+from utils import (calculer_heures_reelles_jour, get_heures_theoriques_jour,
+                   calculer_recup_partielle)
+from blueprints.worktime_metrics import (day_segments_from_row,
+                                          compute_segments_metrics)
+
+
+class TestCalculSoir:
+    def test_heures_reelles_jour_additionne_les_trois_creneaux(self):
+        row = {
+            'heure_debut_matin': '08:00', 'heure_fin_matin': '12:00',   # 4h
+            'heure_debut_aprem': '13:00', 'heure_fin_aprem': '16:00',   # 3h
+            'heure_debut_soir': '18:00', 'heure_fin_soir': '20:00',     # 2h
+        }
+        assert calculer_heures_reelles_jour(row) == 9.0
+
+    def test_heures_reelles_jour_tolere_soir_absent(self):
+        # Ancienne ligne / SELECT sans colonne soir : le soir vaut 0, pas d'erreur.
+        row = {
+            'heure_debut_matin': '08:00', 'heure_fin_matin': '12:00',
+            'heure_debut_aprem': '13:00', 'heure_fin_aprem': '16:00',
+        }
+        assert calculer_heures_reelles_jour(row) == 7.0
+
+    def test_heures_theoriques_jour_inclut_le_soir(self):
+        planning = {
+            'lundi_matin_debut': '09:00', 'lundi_matin_fin': '12:00',   # 3h
+            'lundi_aprem_debut': '13:00', 'lundi_aprem_fin': '16:00',   # 3h
+            'lundi_soir_debut': '17:00', 'lundi_soir_fin': '19:00',     # 2h
+        }
+        assert get_heures_theoriques_jour(planning, 0) == 8.0
+
+    def test_recup_partielle_conserve_le_soir(self):
+        planning = {
+            'lundi_matin_debut': '09:00', 'lundi_matin_fin': '12:00',
+            'lundi_aprem_debut': '13:00', 'lundi_aprem_fin': '16:00',
+            'lundi_soir_debut': '18:00', 'lundi_soir_fin': '20:00',
+        }
+        # Absence toute l'après-midi : le matin et le soir restent travaillés.
+        res = calculer_recup_partielle(planning, 0, '13:00', '16:00')
+        assert res is not None
+        assert res['heures_theoriques'] == 8.0      # 3 + 3 + 2
+        assert res['heures_recup'] == 3.0           # l'après-midi retirée
+        assert res['soir_debut'] == '18:00' and res['soir_fin'] == '20:00'
+
+
+class TestMetriquesTempsSoir:
+    """Le soir doit compter dans les métriques temps de travail (alerte surcharge)."""
+
+    def test_day_segments_inclut_le_soir(self):
+        row = {
+            'heure_debut_matin': '08:00', 'heure_fin_matin': '12:00',
+            'heure_debut_aprem': '13:00', 'heure_fin_aprem': '16:00',
+            'heure_debut_soir': '18:00', 'heure_fin_soir': '20:00',
+        }
+        segments = day_segments_from_row(row)
+        assert segments == [('08:00', '12:00'), ('13:00', '16:00'), ('18:00', '20:00')]
+        metrics = compute_segments_metrics(date(2025, 1, 13), segments)
+        assert metrics['worked_hours'] == 9.0
+
+    def test_day_segments_tolere_soir_absent(self):
+        # Ligne issue d'un SELECT sans colonne soir : pas d'erreur, soir ignoré.
+        row = {
+            'heure_debut_matin': '08:00', 'heure_fin_matin': '12:00',
+            'heure_debut_aprem': '13:00', 'heure_fin_aprem': '16:00',
+        }
+        segments = day_segments_from_row(row)
+        assert segments == [('08:00', '12:00'), ('13:00', '16:00')]
+        assert compute_segments_metrics(date(2025, 1, 13), segments)['worked_hours'] == 7.0
+
+
+class TestSaisieSoir:
+    def test_saisie_enregistre_le_creneau_soir(self, auth_client, app, db, sample_users):
+        date_test = '2025-01-13'  # lundi
+        with app.app_context():
+            auth_client.post('/saisie_heures', data={
+                'date': date_test,
+                'heure_debut_matin': '08:00', 'heure_fin_matin': '12:00',
+                'heure_debut_aprem': '13:00', 'heure_fin_aprem': '16:00',
+                'heure_debut_soir': '18:00', 'heure_fin_soir': '20:00',
+            }, follow_redirects=True)
+            row = db.execute("SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?",
+                             (sample_users['salarie_id'], date_test)).fetchone()
+        assert row['heure_debut_soir'] == '18:00'
+        assert row['heure_fin_soir'] == '20:00'
+
+    def test_toggle_soir_reserve_aux_vacances(self, auth_client, app, db, sample_users):
+        # Sans période de vacances : date scolaire → pas de champ soir proposé
+        # (la fonction JS toggleSoir existe toujours, mais pas la case ni la section).
+        html_scol = auth_client.get('/saisie_heures?date=2025-01-13').get_data(as_text=True)
+        assert 'id="toggle_soir"' not in html_scol
+        assert 'id="soir-section"' not in html_scol
+        # On déclare une période de vacances couvrant la date → champ soir proposé.
+        with app.app_context():
+            db.execute("INSERT INTO periodes_vacances (nom, date_debut, date_fin) "
+                       "VALUES ('Vac test', '2025-01-01', '2025-01-31')")
+            db.commit()
+        html_vac = auth_client.get('/saisie_heures?date=2025-01-13').get_data(as_text=True)
+        assert 'id="toggle_soir"' in html_vac
+        assert 'id="soir-section"' in html_vac
+        assert 'créneau du soir' in html_vac
+
+
+class TestPlanningSoir:
+    def test_planning_enregistre_le_soir_et_le_total_hebdo(self, resp_client, app, db, sample_users):
+        with app.app_context():
+            resp_client.post('/planning_theorique', data={
+                'user_id': sample_users['salarie_id'],
+                'type_periode': 'vacances',
+                'type_alternance': 'fixe',
+                'date_debut_validite': '2025-01-01',
+                'lundi_matin_debut': '09:00', 'lundi_matin_fin': '12:00',   # 3h
+                'lundi_aprem_debut': '13:00', 'lundi_aprem_fin': '16:00',   # 3h
+                'lundi_soir_debut': '17:00', 'lundi_soir_fin': '19:00',     # 2h
+            }, follow_redirects=True)
+            row = db.execute("SELECT * FROM planning_theorique WHERE user_id = ? "
+                             "ORDER BY id DESC LIMIT 1", (sample_users['salarie_id'],)).fetchone()
+        assert row['lundi_soir_debut'] == '17:00'
+        assert row['lundi_soir_fin'] == '19:00'
+        assert row['total_hebdo'] == 8.0

--- a/utils.py
+++ b/utils.py
@@ -181,6 +181,31 @@ def calculer_heures(debut, fin):
         return 0
 
 
+def slot_horaire(row, key):
+    """Lit une valeur de créneau d'un Row/dict de manière tolérante.
+
+    Renvoie None si la clé est absente (ancienne ligne sans colonne « soir », ou
+    SELECT n'ayant pas récupéré la colonne), sans lever d'exception.
+    """
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+def calculer_heures_reelles_jour(row):
+    """Total d'heures d'une saisie (heures_reelles) : matin + après-midi + soir.
+
+    Le créneau « soir » (optionnel, personnel d'entretien en vacances) est
+    additionné aux deux créneaux habituels ; absent/vide, il compte pour 0.
+    """
+    return (
+        calculer_heures(slot_horaire(row, 'heure_debut_matin'), slot_horaire(row, 'heure_fin_matin'))
+        + calculer_heures(slot_horaire(row, 'heure_debut_aprem'), slot_horaire(row, 'heure_fin_aprem'))
+        + calculer_heures(slot_horaire(row, 'heure_debut_soir'), slot_horaire(row, 'heure_fin_soir'))
+    )
+
+
 def get_heures_theoriques_jour(planning, jour_semaine):
     """Récupère les heures théoriques pour un jour de la semaine (0=lundi, 4=vendredi)"""
     if not planning or jour_semaine < 0 or jour_semaine > 4:
@@ -193,11 +218,15 @@ def get_heures_theoriques_jour(planning, jour_semaine):
     matin_fin = planning[f'{jour_nom}_matin_fin']
     aprem_debut = planning[f'{jour_nom}_aprem_debut']
     aprem_fin = planning[f'{jour_nom}_aprem_fin']
+    # Créneau soir optionnel (peut être absent d'un planning historisé ancien).
+    soir_debut = slot_horaire(planning, f'{jour_nom}_soir_debut')
+    soir_fin = slot_horaire(planning, f'{jour_nom}_soir_fin')
 
     heures_matin = calculer_heures(matin_debut, matin_fin)
     heures_aprem = calculer_heures(aprem_debut, aprem_fin)
+    heures_soir = calculer_heures(soir_debut, soir_fin)
 
-    return heures_matin + heures_aprem
+    return heures_matin + heures_aprem + heures_soir
 
 
 def _heure_vers_minutes(h):
@@ -297,22 +326,30 @@ def calculer_recup_partielle(planning, jour_semaine, abs_debut, abs_fin):
     matin_fin = planning[f'{jour_nom}_matin_fin']
     aprem_debut = planning[f'{jour_nom}_aprem_debut']
     aprem_fin = planning[f'{jour_nom}_aprem_fin']
+    # Créneau soir optionnel (vacances) : peut être absent d'un planning ancien.
+    soir_debut = slot_horaire(planning, f'{jour_nom}_soir_debut')
+    soir_fin = slot_horaire(planning, f'{jour_nom}_soir_fin')
 
     heures_theoriques = (
         calculer_heures(matin_debut, matin_fin)
         + calculer_heures(aprem_debut, aprem_fin)
+        + calculer_heures(soir_debut, soir_fin)
     )
     if heures_theoriques <= 0:
         return None
 
     segs_matin = _soustraire_creneau(matin_debut, matin_fin, abs_debut, abs_fin)
     segs_aprem = _soustraire_creneau(aprem_debut, aprem_fin, abs_debut, abs_fin)
+    segs_soir = _soustraire_creneau(soir_debut, soir_fin, abs_debut, abs_fin)
 
     matin_d, matin_f = _fusionner_segments(segs_matin)
     aprem_d, aprem_f = _fusionner_segments(segs_aprem)
+    soir_d, soir_f = _fusionner_segments(segs_soir)
 
     heures_travaillees = (
-        calculer_heures(matin_d, matin_f) + calculer_heures(aprem_d, aprem_f)
+        calculer_heures(matin_d, matin_f)
+        + calculer_heures(aprem_d, aprem_f)
+        + calculer_heures(soir_d, soir_f)
     )
     heures_recup = round(heures_theoriques - heures_travaillees, 2)
 
@@ -322,6 +359,8 @@ def calculer_recup_partielle(planning, jour_semaine, abs_debut, abs_fin):
         'matin_fin': matin_f,
         'aprem_debut': aprem_d,
         'aprem_fin': aprem_f,
+        'soir_debut': soir_d,
+        'soir_fin': soir_f,
         'heures_theoriques': heures_theoriques,
     }
 
@@ -558,7 +597,8 @@ def calculer_solde_recup(user_id):
 
         heures = conn.execute('''
             SELECT date, heure_debut_matin, heure_fin_matin,
-                   heure_debut_aprem, heure_fin_aprem, declaration_conforme
+                   heure_debut_aprem, heure_fin_aprem,
+                   heure_debut_soir, heure_fin_soir, declaration_conforme
             FROM heures_reelles
             WHERE user_id = ?
             ORDER BY date
@@ -583,9 +623,7 @@ def calculer_solde_recup(user_id):
             if h['declaration_conforme']:
                 total_reel = total_theorique
             else:
-                heures_matin = calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
-                heures_aprem = calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
-                total_reel = heures_matin + heures_aprem
+                total_reel = calculer_heures_reelles_jour(h)
 
             solde += (total_reel - total_theorique)
 


### PR DESCRIPTION
## Contexte

Le personnel d'entretien travaille parfois en **trois créneaux** dans la journée (matin / après‑midi / **soir**), notamment en période de vacances. Comme c'est rare, le 3ᵉ créneau est **optionnel** et **réservé au contexte vacances**, mais **activable ponctuellement**. Une fois saisi, il doit compter **partout** dans les totaux d'heures (aucun sous‑comptage).

## Modèle de données

- `heures_reelles` : `heure_debut_soir` / `heure_fin_soir`.
- `planning_theorique` : `{jour}_soir_debut` / `{jour}_soir_fin` pour les 5 jours.
- Colonnes **nullables** → soir absent = 0 h : les saisies et plannings existants restent strictement inchangés.
- Migration idempotente `0055_creneau_soir.py` + miroir dans `init_db` (création + repli `ALTER` défensif).

## Calcul complet (aucun sous‑comptage)

- Helpers `utils` : `slot_horaire()` (lecture tolérante aux colonnes absentes) et `calculer_heures_reelles_jour()` (total matin + après‑midi + soir).
- Le soir est intégré à `get_heures_theoriques_jour`, `calculer_solde_recup`, `calculer_recup_partielle` et aux segments « worktime ».
- **Tous** les `SELECT heures_reelles` qui calculent un total récupèrent désormais le soir : validation, prépa paie, récup, exports PDF, dashboards direction/comptable, **alerte surcharge** (bug de sous‑comptage corrigé), mon équipe, stats RH/prévention.
- Les jours d'**absence** et de **récup journée** laissent le soir `NULL` (aucune heure travaillée), au même titre que le matin et l'après‑midi.

## Affichage optionnel, réservé aux vacances

- **Saisie** : le créneau soir n'est proposé (case à cocher 🌙, masquée par défaut) que si la date tombe en période de vacances ; il est réaffiché automatiquement s'il est déjà rempli.
- **Planning** : la section soir n'apparaît que pour un planning de type « vacances » (piloté par le sélecteur de type de période).
- Le *gating* est **purement UI** ; la couche données/calcul reste générique (le soir compte partout où il existe).

## Tests

- `tests/test_creneau_soir.py` : calculs (3 créneaux, tolérance soir absent), métriques temps de travail (alerte surcharge), récup partielle, saisie, planning + total hebdo, et gating réservé aux vacances.
- Suite complète verte : **795 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_