### PR TITLE
CSE : notifier le personnel par e-mail à chaque publication

### DIFF
--- a/blueprints/cse.py
+++ b/blueprints/cse.py
@@ -186,6 +186,52 @@ def get_message_actif(conn):
     ).fetchone()
 
 
+def _notifier_publication_par_email(conn, titre, contenu, date_validite, auteur_id):
+    """Diffuse la publication du CSE par e-mail au personnel (silencieux).
+
+    Même audience que la bannière du tableau de bord (personnel actif hors
+    prestataires), dans le respect du consentement de chacun (peut_envoyer_email).
+    Une erreur d'envoi ne doit jamais empêcher la publication : tout est encapsulé.
+
+    Returns:
+        nb_succes (int) : nombre de destinataires effectivement notifiés.
+    """
+    try:
+        from email_service import (is_email_configured, peut_envoyer_email,
+                                    notifier_publication_cse)
+        if not is_email_configured():
+            return 0
+
+        candidats = conn.execute(
+            '''
+            SELECT id, prenom FROM users
+            WHERE actif = 1 AND profil != 'prestataire'
+              AND email IS NOT NULL AND TRIM(email) != ''
+            '''
+        ).fetchall()
+
+        destinataires = []
+        for c in candidats:
+            peut, email = peut_envoyer_email(c['id'])
+            if peut and email:
+                destinataires.append((email, c['prenom']))
+
+        if not destinataires:
+            return 0
+
+        auteur = conn.execute(
+            'SELECT prenom, nom FROM users WHERE id = ?', (auteur_id,)
+        ).fetchone()
+        auteur_nom = f"{auteur['prenom']} {auteur['nom']}".strip() if auteur else ''
+
+        nb_succes, _echecs, _erreurs = notifier_publication_cse(
+            destinataires, titre, contenu, date_validite, auteur_nom
+        )
+        return nb_succes
+    except Exception:
+        return 0
+
+
 # ──────────────────────────────────────────────────────────────────────────
 #  Helpers métier : budget
 # ──────────────────────────────────────────────────────────────────────────
@@ -511,7 +557,19 @@ def creer_message():
             (titre or None, contenu, date_validite, session['user_id'])
         )
         conn.commit()
-        flash("Le message a été publié.", "success")
+
+        # Notification e-mail optionnelle (case cochée par défaut) : la publication
+        # reste faite même si l'envoi échoue ou n'est pas configuré.
+        nb_notifies = 0
+        if request.form.get('notifier_email'):
+            nb_notifies = _notifier_publication_par_email(
+                conn, titre, contenu, date_validite, session['user_id']
+            )
+
+        if nb_notifies:
+            flash(f"Le message a été publié et {nb_notifies} personne(s) notifiée(s) par e-mail.", "success")
+        else:
+            flash("Le message a été publié.", "success")
     finally:
         conn.close()
 

--- a/email_service.py
+++ b/email_service.py
@@ -111,6 +111,27 @@ def _build_html_email(sujet, contenu_html, destinataire_prenom=''):
     return html
 
 
+def _build_message(config, destinataire, sujet, contenu_html, destinataire_prenom=''):
+    """Construit le message MIME complet (en-tetes + corps HTML encapsule)."""
+    msg = MIMEMultipart('alternative')
+    msg['From'] = f"{config.get('sender_name', 'CS-PILOT')} <{config['sender']}>"
+    msg['To'] = destinataire
+    msg['Subject'] = f"[CS-PILOT] {sujet}"
+    html_body = _build_html_email(sujet, contenu_html, destinataire_prenom)
+    msg.attach(MIMEText(html_body, 'html', 'utf-8'))
+    return msg
+
+
+def _ouvrir_connexion_smtp(config):
+    """Ouvre une connexion SMTP authentifiee. A fermer par l'appelant (quit)."""
+    server = smtplib.SMTP(config['smtp_server'], int(config['smtp_port']), timeout=15)
+    server.ehlo()
+    server.starttls()
+    server.ehlo()
+    server.login(config['sender'], config['password'])
+    return server
+
+
 def envoyer_email(destinataire, sujet, contenu_html, destinataire_prenom=''):
     """Envoie un email via SMTP.
 
@@ -134,20 +155,10 @@ def envoyer_email(destinataire, sujet, contenu_html, destinataire_prenom=''):
     if not config.get('sender') or not config.get('password'):
         return False, "Configuration email incomplete"
 
-    msg = MIMEMultipart('alternative')
-    msg['From'] = f"{config.get('sender_name', 'CS-PILOT')} <{config['sender']}>"
-    msg['To'] = destinataire
-    msg['Subject'] = f"[CS-PILOT] {sujet}"
-
-    html_body = _build_html_email(sujet, contenu_html, destinataire_prenom)
-    msg.attach(MIMEText(html_body, 'html', 'utf-8'))
+    msg = _build_message(config, destinataire, sujet, contenu_html, destinataire_prenom)
 
     try:
-        server = smtplib.SMTP(config['smtp_server'], int(config['smtp_port']), timeout=15)
-        server.ehlo()
-        server.starttls()
-        server.ehlo()
-        server.login(config['sender'], config['password'])
+        server = _ouvrir_connexion_smtp(config)
         server.send_message(msg)
         server.quit()
         logger.info("Email envoye a %s : %s", destinataire, sujet)
@@ -164,12 +175,16 @@ def envoyer_email(destinataire, sujet, contenu_html, destinataire_prenom=''):
 
 
 def envoyer_email_multiple(destinataires, sujet, contenu_html):
-    """Envoie un meme email a plusieurs destinataires.
+    """Envoie un meme email a plusieurs destinataires sur une seule connexion SMTP.
+
+    Reutiliser la connexion evite d'ouvrir une session (connexion + TLS + login)
+    par destinataire : indispensable pour une diffusion a tout le personnel.
 
     Args:
         destinataires: liste de tuples (email, prenom)
         sujet: sujet de l'email
-        contenu_html: contenu HTML
+        contenu_html: contenu HTML (identique pour tous ; la salutation est
+            personnalisee par destinataire)
 
     Returns:
         (nb_succes: int, nb_echecs: int, erreurs: list)
@@ -178,18 +193,36 @@ def envoyer_email_multiple(destinataires, sujet, contenu_html):
     nb_echecs = 0
     erreurs = []
 
-    for email, prenom in destinataires:
-        if not email:
-            nb_echecs += 1
-            erreurs.append(f"{prenom}: pas d'adresse email")
-            continue
+    config = get_email_config()
+    if config.get('enabled') != 'true' or not config.get('sender') or not config.get('password'):
+        return 0, len(destinataires), ["Configuration email incomplete"]
 
-        ok, msg = envoyer_email(email, sujet, contenu_html, prenom)
-        if ok:
-            nb_succes += 1
-        else:
-            nb_echecs += 1
-            erreurs.append(f"{prenom} ({email}): {msg}")
+    server = None
+    try:
+        server = _ouvrir_connexion_smtp(config)
+        for email, prenom in destinataires:
+            if not email:
+                nb_echecs += 1
+                erreurs.append(f"{prenom}: pas d'adresse email")
+                continue
+            try:
+                server.send_message(_build_message(config, email, sujet, contenu_html, prenom))
+                nb_succes += 1
+                logger.info("Email envoye a %s : %s", email, sujet)
+            except Exception as e:
+                nb_echecs += 1
+                erreurs.append(f"{prenom} ({email}): {e}")
+    except Exception as e:
+        # Connexion / authentification impossible : tous les envois restants echouent.
+        logger.error("Erreur connexion SMTP (envoi multiple) : %s", str(e))
+        nb_echecs = len(destinataires) - nb_succes
+        erreurs.append(f"Connexion SMTP : {e}")
+    finally:
+        if server is not None:
+            try:
+                server.quit()
+            except Exception:
+                pass
 
     return nb_succes, nb_echecs, erreurs
 
@@ -363,3 +396,54 @@ def notifier_subvention_assignee(assignee_email, assignee_prenom, subvention_nom
     <p style="margin-top:16px;">Connectez-vous a CS-PILOT pour consulter le detail.</p>
     """
     return envoyer_email(assignee_email, f"Subvention {subvention_nom} - attribution", contenu, assignee_prenom)
+
+
+def notifier_publication_cse(destinataires, titre, contenu, date_validite=None, auteur_nom=''):
+    """Diffuse par e-mail une nouvelle publication du CSE au personnel.
+
+    Le meme message est envoye a tous les destinataires (la salutation reste
+    personnalisee). Le contenu saisi est du texte brut : il est echappe et ses
+    retours a la ligne sont convertis en <br>.
+
+    Args:
+        destinataires: liste de tuples (email, prenom)
+        titre: titre de la publication (facultatif)
+        contenu: corps du message (texte brut)
+        date_validite: date de fin de validite 'YYYY-MM-DD' (facultatif)
+        auteur_nom: nom de l'auteur de la publication (facultatif)
+
+    Returns:
+        (nb_succes: int, nb_echecs: int, erreurs: list)
+    """
+    _e = html_module.escape
+    titre_html = ''
+    if titre:
+        titre_html = (f'<p style="font-size:15px;font-weight:700;color:#111827;'
+                      f'margin:0 0 8px;">{_e(titre)}</p>')
+    corps_html = _e(contenu or '').replace('\n', '<br>')
+
+    meta_parts = []
+    if date_validite:
+        try:
+            j, m, a = date_validite[8:10], date_validite[5:7], date_validite[0:4]
+            meta_parts.append(f"Valable jusqu'au {j}/{m}/{a}")
+        except (IndexError, TypeError):
+            pass
+    if auteur_nom:
+        meta_parts.append(f"Publie par {_e(auteur_nom)}")
+    meta_html = ''
+    if meta_parts:
+        meta_html = (f'<p style="font-size:12px;color:#9ca3af;margin:16px 0 0;">'
+                     f'{" · ".join(meta_parts)}</p>')
+
+    contenu_html = f"""
+    <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">📢 Nouveau message du CSE</h3>
+    <div style="border-left:4px solid #667eea;background:#f9fafb;padding:12px 16px;border-radius:4px;">
+        {titre_html}
+        <div style="color:#374151;font-size:14px;line-height:1.7;">{corps_html}</div>
+    </div>
+    {meta_html}
+    <p style="margin-top:16px;">Ce message est egalement affiche sur votre tableau de bord CS-PILOT.</p>
+    """
+    sujet = f"Message du CSE : {titre}" if titre else "Nouveau message du CSE"
+    return envoyer_email_multiple(destinataires, sujet, contenu_html)

--- a/templates/cse_messages.html
+++ b/templates/cse_messages.html
@@ -59,6 +59,17 @@
                 <input type="date" id="date_validite" name="date_validite" required min="{{ aujourd_hui }}">
                 <small style="color:var(--gray-500);">Le message sera affiché jusqu'à cette date incluse.</small>
             </div>
+            <div class="form-group">
+                <label for="notifier_email" style="display:inline-flex;align-items:center;gap:0.5rem;font-weight:600;">
+                    <input type="checkbox" id="notifier_email" name="notifier_email" value="1" checked>
+                    📧 Prévenir le personnel par e-mail
+                </label>
+                <small style="display:block;color:var(--gray-500);margin-top:0.25rem;">
+                    Un e-mail reprenant le message est envoyé au personnel (en plus de l'affichage
+                    sur le tableau de bord). Les salariés ayant désactivé les notifications ne le
+                    reçoivent pas. Sans e-mail configuré, seule la bannière s'affiche.
+                </small>
+            </div>
             <div class="form-actions">
                 <button type="submit" class="btn btn-primary">📤 Publier le message</button>
             </div>

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -234,6 +234,115 @@ def test_archiver_message_manuellement(auth_client, db, sample_users):
     assert row['statut'] == 'archive'
 
 
+# ──────────────────────────────────────────────────────────────────────────
+#  Notification e-mail à la publication
+# ──────────────────────────────────────────────────────────────────────────
+
+def _preparer_emails(db, sample_users):
+    """Attribue e-mails et consentements pour tester la diffusion.
+
+    - direction : profil pro → reçoit toujours ;
+    - salarié auteur : consentement activé → reçoit ;
+    - responsable / comptable : pas d'e-mail → exclus.
+    """
+    db.execute("UPDATE users SET email = 'dir@ex.fr' WHERE id = ?",
+               (sample_users['directeur_id'],))
+    db.execute("UPDATE users SET email = 'sal@ex.fr', email_notifications_enabled = 1 WHERE id = ?",
+               (sample_users['salarie_id'],))
+    db.commit()
+
+
+def test_publication_diffuse_selon_audience_et_consentement(auth_client, db, sample_users, monkeypatch):
+    import email_service
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    _preparer_emails(db, sample_users)
+    # Salarié sans consentement → exclu ; prestataire → exclu (même avec e-mail).
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, email, email_notifications_enabled) "
+               "VALUES ('Sans', 'Consent', 'nc', 'x', 'salarie', 'nc@ex.fr', 0)")
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, email, email_notifications_enabled) "
+               "VALUES ('Presta', 'Taire', 'pr', 'x', 'prestataire', 'pr@ex.fr', 1)")
+    db.commit()
+
+    captures = {}
+    monkeypatch.setattr(email_service, 'is_email_configured', lambda: True)
+
+    def fake_notif(destinataires, titre, contenu, date_validite=None, auteur_nom=''):
+        captures['dests'] = destinataires
+        captures['titre'] = titre
+        return len(destinataires), 0, []
+    monkeypatch.setattr(email_service, 'notifier_publication_cse', fake_notif)
+
+    resp = auth_client.post(
+        '/cse/messages/creer',
+        data={'titre': 'Info', 'contenu': 'Coucou', 'date_validite': '2999-12-31',
+              'notifier_email': '1'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    emails = {e for e, _ in captures['dests']}
+    assert emails == {'dir@ex.fr', 'sal@ex.fr'}   # consentement OFF et prestataire exclus
+    assert captures['titre'] == 'Info'
+    assert 'notifiée(s) par e-mail' in resp.get_data(as_text=True)
+
+
+def test_publication_sans_case_n_envoie_pas(auth_client, db, sample_users, monkeypatch):
+    import email_service
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    _preparer_emails(db, sample_users)
+
+    appels = []
+    monkeypatch.setattr(email_service, 'is_email_configured', lambda: True)
+    monkeypatch.setattr(email_service, 'notifier_publication_cse',
+                        lambda *a, **k: appels.append(a) or (0, 0, []))
+
+    # Pas de champ notifier_email → aucune diffusion, mais le message est publié.
+    auth_client.post('/cse/messages/creer',
+                     data={'contenu': 'Silencieux', 'date_validite': '2999-12-31'},
+                     follow_redirects=True)
+    assert appels == []
+    n = db.execute("SELECT COUNT(*) AS n FROM cse_messages WHERE statut='actif'").fetchone()['n']
+    assert n == 1
+
+
+def test_publication_survit_a_une_erreur_email(auth_client, db, sample_users, monkeypatch):
+    import email_service
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    _preparer_emails(db, sample_users)
+
+    monkeypatch.setattr(email_service, 'is_email_configured', lambda: True)
+
+    def boom(*a, **k):
+        raise RuntimeError("SMTP indisponible")
+    monkeypatch.setattr(email_service, 'notifier_publication_cse', boom)
+
+    resp = auth_client.post(
+        '/cse/messages/creer',
+        data={'contenu': 'Malgré tout', 'date_validite': '2999-12-31', 'notifier_email': '1'},
+        follow_redirects=True,
+    )
+    # L'échec d'envoi est silencieux : la publication aboutit quand même.
+    assert resp.status_code == 200
+    n = db.execute("SELECT COUNT(*) AS n FROM cse_messages WHERE contenu='Malgré tout'").fetchone()['n']
+    assert n == 1
+
+
+def test_publication_sans_email_configure_publie_quand_meme(auth_client, db, sample_users, monkeypatch):
+    import email_service
+    _faire_membre(db, sample_users['salarie_id'], sample_users['directeur_id'])
+    _preparer_emails(db, sample_users)
+    monkeypatch.setattr(email_service, 'is_email_configured', lambda: False)
+
+    resp = auth_client.post(
+        '/cse/messages/creer',
+        data={'contenu': 'Sans SMTP', 'date_validite': '2999-12-31', 'notifier_email': '1'},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'Le message a été publié.' in html          # pas de mention d'e-mail
+    assert 'notifiée(s) par e-mail' not in html
+
+
 def test_banniere_sur_dashboard(auth_client, db, sample_users):
     _inserer_message(db, 'Info importante', '2999-12-31', statut='actif',
                      cree_par=sample_users['directeur_id'])

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -56,3 +56,39 @@ def test_email_conge_masque_les_heures_nulles(monkeypatch):
     _, contenu = calls[0]
     assert '0.00h' not in contenu       # pas de « - 0.00h » pour un congé
     assert '3 jour(s)' in contenu
+
+
+def test_publication_cse_construit_le_message(monkeypatch):
+    """La diffusion CSE échappe le texte, préserve les sauts de ligne et diffuse
+    le même message à tous les destinataires sur un seul envoi groupé."""
+    captures = []
+    monkeypatch.setattr(
+        email_service, 'envoyer_email_multiple',
+        lambda dests, sujet, contenu: (
+            captures.append((dests, sujet, contenu)), (len(dests), 0, []))[1]
+    )
+    dests = [('a@b.c', 'Alice'), ('d@e.f', 'Bob')]
+    nb_ok, nb_ko, _ = email_service.notifier_publication_cse(
+        dests, 'Réunion CSE', 'Ligne 1\nLigne 2 <b>', '2026-07-31', 'Marie Dupont')
+
+    assert (nb_ok, nb_ko) == (2, 0)
+    envoyes, sujet, contenu = captures[0]
+    assert envoyes == dests                      # diffusé à tout le monde
+    assert 'Réunion CSE' in sujet
+    assert 'Ligne 1<br>Ligne 2' in contenu       # sauts de ligne convertis
+    assert '&lt;b&gt;' in contenu                 # texte échappé (pas de HTML injecté)
+    assert 'message du cse' in contenu.lower()
+    assert '31/07/2026' in contenu               # date de validité formatée
+    assert 'Marie Dupont' in contenu
+
+
+def test_publication_cse_sans_titre(monkeypatch):
+    captures = []
+    monkeypatch.setattr(
+        email_service, 'envoyer_email_multiple',
+        lambda dests, sujet, contenu: (
+            captures.append((dests, sujet, contenu)), (len(dests), 0, []))[1]
+    )
+    email_service.notifier_publication_cse([('a@b.c', 'Alice')], '', 'Bonjour')
+    _, sujet, _ = captures[0]
+    assert sujet == 'Nouveau message du CSE'


### PR DESCRIPTION
## Contexte

Une publication du CSE n'était visible que via la **bannière du tableau de bord**. À la demande du personnel, une publication déclenche désormais **aussi un e-mail** reprenant le message.

## Ce qui change

**`email_service.py`**
- Nouvelle notification `notifier_publication_cse` : texte **échappé**, **sauts de ligne préservés**, avec titre / date de validité / auteur.
- `envoyer_email_multiple` **réutilise une seule connexion SMTP** au lieu d'en ouvrir une par destinataire (connexion + TLS + login) — indispensable pour une diffusion à tout le personnel. Extraction de `_build_message` / `_ouvrir_connexion_smtp` ; `envoyer_email` conserve **exactement** le même comportement.

**`blueprints/cse.py` — `creer_message`**
- Diffusion **optionnelle** : case « **Prévenir le personnel par e-mail** » cochée par défaut (une correction mineure peut donc être publiée sans spammer).
- **Même audience que la bannière** (personnel actif hors prestataires), dans le **respect du consentement** de chacun (`peut_envoyer_email`) : les profils pros reçoivent toujours, les salariés uniquement s'ils ont activé les notifications ; ceux qui les ont désactivées voient quand même la bannière.
- Envoi **après commit** et **silencieux** : un échec SMTP ou une absence de configuration n'empêche jamais la publication.

**`templates/cse_messages.html`** : case à cocher + explication concise.

## Tests

- `tests/test_email_notifications.py` : construction du message (échappement, `<br>`, sujet avec / sans titre).
- `tests/test_cse.py` : audience + consentement (salarié sans consentement et prestataire exclus), case décochée = aucun envoi, échec d'envoi silencieux, absence de configuration SMTP.
- Suite complète verte : **803 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_