### PR TITLE
Points de compétence : autoriser les décimales (2 chiffres)

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -2344,7 +2344,8 @@ def api_paie_simulation_save():
             conn.execute(
                 'UPDATE users SET pesee = ?, competence = ?, maintien = ? WHERE id = ?',
                 (int(float(pesee)) if str(pesee).strip() not in ('', 'None') else None,
-                 int(float(comp)) if str(comp).strip() not in ('', 'None') else None,
+                 # Les points de compétence peuvent comporter des décimales (ex. 4,25).
+                 float(comp) if str(comp).strip() not in ('', 'None') else None,
                  float(maint) if str(maint).strip() not in ('', 'None') else 0,
                  uid)
             )

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -306,7 +306,8 @@ def modifier_pesee():
     pesee_val = request.form.get('pesee', '').strip()
     pesee = int(pesee_val) if pesee_val else None
     competence_val = request.form.get('competence', '').strip()
-    competence = int(competence_val) if competence_val else None
+    # Les points de compétence peuvent comporter des décimales (ex. 4,25).
+    competence = float(competence_val) if competence_val else None
     maintien_val = request.form.get('maintien', '').strip()
     maintien = float(maintien_val) if maintien_val else 0
 

--- a/templates/bilan_action.html
+++ b/templates/bilan_action.html
@@ -334,7 +334,7 @@ function salaryRow(onglet, s, i){
         + '<td>' + inp('temps_hebdo', '0.5') + '</td>'
         + '<td>' + inp('pesee', '1') + '</td>'
         + '<td>' + inp('anciennete', '1') + '</td>'
-        + '<td>' + inp('competence', '1') + '</td>'
+        + '<td>' + inp('competence', '0.01') + '</td>'
         + '<td>' + inp('maintien', '0.01') + '</td>'
         + '<td class="tright"><span id="c_' + onglet + '_brutm_' + i + '">0,00</span></td>'
         + '<td>' + inp('heures_action', '1') + '</td>'

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -1618,7 +1618,7 @@ function renderPaieSimulator(){
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="pesee"', ov.pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="nouvelle_pesee"', ov.nouvelle_pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="anciennete"', ov.anciennete, '1') + '</td>' +
-                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="competence"', ov.competence, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="competence"', ov.competence, '0.01') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="maintien"', ov.maintien, '0.01') + '</td>' +
                 months.map(function(m){ return '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-' + m + '"></td>'; }).join('') +
                 '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-tot"></td></tr>';

--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -81,7 +81,7 @@
             <input type="number" id="pesee" name="pesee" value="{{ salarie.pesee if salarie.pesee is not none else '' }}"
                    placeholder="Points" style="width: 120px; padding: 6px 10px;" min="0">
             <label for="competence" style="font-weight: 600; margin: 0;">Points de compétence :</label>
-            <input type="number" id="competence" name="competence" value="{{ salarie.competence if salarie.competence is not none else '' }}"
+            <input type="number" id="competence" name="competence" step="0.01" value="{{ salarie.competence if salarie.competence is not none else '' }}"
                    placeholder="Points" style="width: 120px; padding: 6px 10px;" min="0">
             <label for="maintien" style="font-weight: 600; margin: 0;">Maintien de salaire (€/mois) :</label>
             <input type="number" id="maintien" name="maintien" step="0.01" value="{{ salarie.maintien if salarie.maintien is not none else '' }}"

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -933,6 +933,20 @@ def test_paie_simulation_persiste_pesee_competence(app, db, admin_client):
     assert u['pesee'] == 120 and u['competence'] == 5
 
 
+def test_paie_simulation_persiste_competence_decimale(app, db, admin_client):
+    """Les points de compétence acceptent 2 décimales (ex. 4,25) sans troncature."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'employes': {str(uid): {'pesee': 120, 'competence': 4.25, 'anciennete': 3, 'nouvelle_pesee': ''}},
+               'ajouts': [], 'fermetures': []}
+    admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': donnees})
+    with app.app_context():
+        u = db.execute("SELECT competence FROM users WHERE id=?", (uid,)).fetchone()
+    assert u['competence'] == 4.25
+
+
 def test_paie_simulation_refuse_responsable(resp_client, sample_users):
     sid = sample_users['secteur_id']
     r = resp_client.post('/api/budget-previsionnel/paie-simulation', json={

--- a/tests/test_infos_salaries.py
+++ b/tests/test_infos_salaries.py
@@ -1,0 +1,35 @@
+"""
+Fiche salarié (infos_salaries) : édition de la pesée et des points de compétence.
+
+Les points de compétence peuvent comporter des décimales (ex. 4,25) : la
+saisie ne doit plus être bloquée à un entier ni tronquée à l'enregistrement.
+"""
+
+
+def test_competence_accepte_les_decimales(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    admin_client.post('/infos_salaries/pesee', data={
+        'user_id': uid, 'pesee': '100', 'competence': '4.25', 'maintien': '0',
+    }, follow_redirects=True)
+    row = db.execute("SELECT competence FROM users WHERE id = ?", (uid,)).fetchone()
+    assert row['competence'] == 4.25
+
+
+def test_competence_entiere_reste_valide(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    admin_client.post('/infos_salaries/pesee', data={
+        'user_id': uid, 'pesee': '100', 'competence': '6', 'maintien': '0',
+    }, follow_redirects=True)
+    row = db.execute("SELECT competence FROM users WHERE id = ?", (uid,)).fetchone()
+    assert row['competence'] == 6
+
+
+def test_competence_vide_remet_a_null(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    db.execute("UPDATE users SET competence = 5 WHERE id = ?", (uid,))
+    db.commit()
+    admin_client.post('/infos_salaries/pesee', data={
+        'user_id': uid, 'pesee': '100', 'competence': '', 'maintien': '0',
+    }, follow_redirects=True)
+    row = db.execute("SELECT competence FROM users WHERE id = ?", (uid,)).fetchone()
+    assert row['competence'] is None


### PR DESCRIPTION
## Problème

Sur la fiche salarié (`infos_salaries`), le champ **Points de compétence** était bloqué à un **entier** alors qu'il peut comporter jusqu'à **2 décimales** (ex. 4,25). Même limite dans les endroits où cette valeur est modifiable.

## Correctif — partout où la valeur est éditable

| Emplacement | Avant | Après |
|---|---|---|
| **Fiche salarié** (`infos_salaries`) | `type="number"` sans `step` (→ entiers) ; enregistrement `int()` | `step="0.01"` ; enregistrement `float()` |
| **Simulateur de paie — budget prévisionnel** | input step `1` ; persistance `int(float(...))` | input step `0.01` ; persistance `float(...)` |
| **Simulateur de paie — bilan d'action** | input step `1` | input step `0.01` |

## Notes

- La colonne `users.competence` est en **affinité INTEGER** : SQLite y stocke une valeur décimale **sans perte** (stockée en REAL). Aucune migration nécessaire ; un nombre entier reste stocké et relu comme entier.
- Le **calcul de paie** (côté serveur `_num`/`_ps_num` et live JS `num`/`psNum`) utilisait **déjà** `float`/`parseFloat` — seule la saisie et la persistance bloquaient les décimales.
- La pesée ALISFA n'est volontairement pas touchée (hors demande).

## Tests

- `tests/test_infos_salaries.py` : compétence décimale (4,25), entière (6), vidée (→ NULL).
- `tests/test_budget.py` : persistance d'une compétence décimale depuis le simulateur (le test existant sur une valeur entière reste vert).
- Suite complète verte : **807 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_