### PR TITLE
Budget actualisé : fiches de travail par compte + colonnes Initial/Écart

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -830,6 +830,28 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
                 'commentaire': s['commentaire'] or ''
             }
 
+    # En budget actualisé, le budget initial (définitif) de la même année est
+    # affiché en face pour mesurer l'écart d'atterrissage. En vue globale, on
+    # consolide l'initial de tous les secteurs.
+    initial_map = {}
+    if type_budget == 'actualise':
+        if global_mode:
+            init_rows = conn.execute('''
+                SELECT compte_num, SUM(valeur_def) AS total_def
+                FROM budget_prev_saisies
+                WHERE type_budget = 'initial' AND annee = ?
+                GROUP BY compte_num
+            ''', (annee,)).fetchall()
+        elif secteur_id:
+            init_rows = conn.execute('''
+                SELECT compte_num, valeur_def AS total_def
+                FROM budget_prev_saisies
+                WHERE type_budget = 'initial' AND annee = ? AND secteur_id = ?
+            ''', (annee, secteur_id)).fetchall()
+        else:
+            init_rows = []
+        initial_map = {r['compte_num']: float(r['total_def'] or 0) for r in init_rows}
+
     accounts = []
     for compte, vals in totals.items():
         n2 = round(vals['N-2'], 2)
@@ -866,7 +888,7 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
         saved_temp = save_data.get('valeur_temp')
         if saved_temp is not None:
             temp = float(saved_temp)
-        accounts.append({
+        account = {
             'compte_num': compte,
             'libelle': vals['libelle'],
             'categorie': compte[:2],
@@ -878,7 +900,10 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
             'temp': round(temp, 2),
             'def': round(float(save_data.get('valeur_def', 0)), 2),
             'commentaire': save_data.get('commentaire', '')
-        })
+        }
+        if type_budget == 'actualise':
+            account['initial'] = round(initial_map.get(compte, 0.0), 2)
+        accounts.append(account)
 
     accounts.sort(key=lambda r: r['compte_num'])
     salary_brut = None
@@ -1860,6 +1885,256 @@ def api_ps_simulation_save():
 
         conn.commit()
         return jsonify({'success': True, 'total': total, 'reported': True, 'computed': computed})
+    finally:
+        conn.close()
+
+
+# ============================================================
+# FICHE DE TRAVAIL (BUDGET ACTUALISÉ, COMPTES NON PARAMÉTRÉS)
+# ============================================================
+
+# Méthodes de projection des mois restants (après le mois d'arrêté du réel).
+FICHE_METHODES = {
+    'n1': 'N-1 mois par mois',
+    'moyenne_n1_n2': 'moyenne N-1 / N-2',
+    'tendance': 'tendance du réel',
+    'solde_initial': 'solde du budget initial',
+    'manuel': 'saisie mensuelle',
+}
+
+
+def _fiche_contexte(conn, compte_num, annee, secteur_id):
+    """Contexte de calcul d'une fiche : réel mensuel N / N-1 / N-2 du compte
+    (périmètre analytique du secteur), mois d'arrêté du réel (même définition
+    que le tableau : dernier mois importé de l'année N, tous comptes du
+    secteur confondus) et budget initial définitif du compte."""
+    allowed_codes = _secteur_allowed_codes(conn, secteur_id) if secteur_id else set()
+
+    def code_ok(code, compte):
+        if not secteur_id:
+            return True
+        return _code_allowed(code, compte, allowed_codes)
+
+    mensuels = {annee: {}, annee - 1: {}, annee - 2: {}}
+    last_month = 0
+    rows = conn.execute('''
+        SELECT compte_num, code_analytique, annee, mois, montant
+        FROM bilan_fec_donnees
+        WHERE annee IN (?, ?, ?)
+          AND (compte_num LIKE '6%' OR compte_num LIKE '7%')
+    ''', (annee - 2, annee - 1, annee)).fetchall()
+    for r in rows:
+        if not code_ok(r['code_analytique'], r['compte_num']):
+            continue
+        mois = r['mois']
+        if not mois or not (1 <= mois <= 12):
+            continue
+        if r['annee'] == annee:
+            last_month = max(last_month, mois)
+        if r['compte_num'] != compte_num:
+            continue
+        par_mois = mensuels[r['annee']]
+        par_mois[mois] = par_mois.get(mois, 0.0) + float(r['montant'] or 0)
+
+    init_row = conn.execute('''
+        SELECT valeur_def FROM budget_prev_saisies
+        WHERE type_budget = 'initial' AND annee = ? AND secteur_id = ? AND compte_num = ?
+    ''', (annee, secteur_id, compte_num)).fetchone()
+    budget_initial = float(init_row['valeur_def'] or 0) if init_row else 0.0
+
+    return {
+        'reel': mensuels[annee],
+        'n1': mensuels[annee - 1],
+        'n2': mensuels[annee - 2],
+        'last_month': last_month,
+        'budget_initial': budget_initial,
+    }
+
+
+def _compute_fiche_travail(donnees, contexte):
+    """Calcule une fiche de travail : réel à date + projection des mois
+    restants selon la méthode choisie + lignes d'ajustement. Le total est
+    recalculé côté serveur (source de vérité, le JS ne fait qu'un aperçu)."""
+    d = donnees if isinstance(donnees, dict) else {}
+    methode = d.get('methode') if d.get('methode') in FICHE_METHODES else 'n1'
+    reel = contexte['reel']
+    n1 = contexte['n1']
+    n2 = contexte['n2']
+    last_month = contexte['last_month']
+
+    mois_reel = {m: round(reel.get(m, 0.0), 2) for m in range(1, last_month + 1)}
+    total_reel = sum(mois_reel.values())
+    restants = range(last_month + 1, 13)
+
+    saisis = d.get('mois_prevus') or {}
+    mois_prevus = {}
+    for m in restants:
+        if methode == 'n1':
+            val = n1.get(m, 0.0)
+        elif methode == 'moyenne_n1_n2':
+            val = (n1.get(m, 0.0) + n2.get(m, 0.0)) / 2.0
+        elif methode == 'tendance':
+            val = (total_reel / last_month) if last_month else 0.0
+        elif methode == 'solde_initial':
+            nb_restants = 12 - last_month
+            val = (contexte['budget_initial'] - total_reel) / nb_restants if nb_restants else 0.0
+        else:  # manuel
+            val = _ps_num(saisis.get(str(m), saisis.get(m)))
+        mois_prevus[m] = round(val, 2)
+    total_prevu = sum(mois_prevus.values())
+
+    ajustements = []
+    for a in (d.get('ajustements') or []):
+        if not isinstance(a, dict):
+            continue
+        montant = _ps_num(a.get('montant'))
+        libelle = str(a.get('libelle') or '').strip()
+        if not montant and not libelle:
+            continue
+        ajustements.append({'libelle': libelle, 'montant': round(montant, 2)})
+    total_ajustements = sum(a['montant'] for a in ajustements)
+
+    return {
+        'methode': methode,
+        'mois_reel': mois_reel,
+        'mois_prevus': mois_prevus,
+        'ajustements': ajustements,
+        'total_reel': round(total_reel, 2),
+        'total_prevu': round(total_prevu, 2),
+        'total_ajustements': round(total_ajustements, 2),
+        'total': round(total_reel + total_prevu + total_ajustements, 2),
+    }
+
+
+def _fiche_commentaire_auto(computed, last_month):
+    """Commentaire de traçabilité écrit sur le compte au report du total."""
+    label = FICHE_METHODES.get(computed['methode'], computed['methode'])
+    if last_month:
+        base = f"Fiche : réel à fin {NOMS_MOIS[last_month].lower()} + {label}"
+    else:
+        base = f"Fiche : {label}"
+    nb = len(computed['ajustements'])
+    if nb:
+        base += f", {nb} ajustement(s)"
+    return base
+
+
+@budget_bp.route('/api/budget-previsionnel/fiche-travail')
+@login_required
+def api_fiche_travail_get():
+    """Fiche de travail d'un compte (budget actualisé) : saisie enregistrée +
+    contexte de calcul (réel mensuel, références N-1/N-2, budget initial)."""
+    profil = session.get('profil')
+    if not _can_access_budget_previsionnel(profil):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    compte_num = (request.args.get('compte_num') or '').strip()
+    annee = request.args.get('annee', type=int)
+    secteur_id = request.args.get('secteur_id', type=int)
+    type_budget = request.args.get('type_budget', 'actualise')
+    if type_budget != 'actualise':
+        return jsonify({'error': 'La fiche de travail est réservée au budget actualisé'}), 400
+
+    conn = get_db()
+    try:
+        # Un responsable ne consulte que son secteur (même règle que la page).
+        if profil == 'responsable':
+            user = conn.execute('SELECT secteur_id FROM users WHERE id = ?',
+                                (session.get('user_id'),)).fetchone()
+            if not user or not user['secteur_id']:
+                return jsonify({'error': 'Aucun secteur associé'}), 400
+            secteur_id = user['secteur_id']
+        if not compte_num or not annee or not secteur_id:
+            return jsonify({'error': 'Compte, secteur et année requis'}), 400
+
+        contexte = _fiche_contexte(conn, compte_num, annee, secteur_id)
+        row = conn.execute('''
+            SELECT donnees, total, updated_at FROM budget_fiches_travail
+            WHERE compte_num = ? AND annee = ? AND secteur_id = ? AND type_budget = ?
+        ''', (compte_num, annee, secteur_id, type_budget)).fetchone()
+        donnees = None
+        if row:
+            try:
+                donnees = json.loads(row['donnees']) if row['donnees'] else None
+            except (ValueError, TypeError):
+                donnees = None
+        return jsonify({
+            'found': bool(row),
+            'donnees': donnees,
+            'total': row['total'] if row else None,
+            'updated_at': row['updated_at'] if row else None,
+            'contexte': {
+                'reel_mensuel': contexte['reel'],
+                'n1_mensuel': contexte['n1'],
+                'n2_mensuel': contexte['n2'],
+                'last_month': contexte['last_month'],
+                'last_month_label': (NOMS_MOIS[contexte['last_month']]
+                                     if 1 <= contexte['last_month'] <= 12 else ''),
+                'budget_initial': round(contexte['budget_initial'], 2),
+                'methodes': FICHE_METHODES,
+            },
+        })
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/fiche-travail', methods=['POST'])
+@login_required
+def api_fiche_travail_save():
+    """Enregistre une fiche de travail et reporte le total sur la valeur
+    définitive du compte, avec un commentaire auto traçant la méthode."""
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+
+    data = request.get_json() or {}
+    compte_num = (data.get('compte_num') or '').strip()
+    annee = data.get('annee')
+    secteur_id = data.get('secteur_id')
+    type_budget = data.get('type_budget')
+    donnees = data.get('donnees') or {}
+    if not isinstance(donnees, dict):
+        donnees = {}
+    if not compte_num or not annee or not secteur_id:
+        return jsonify({'error': 'Compte, secteur et année requis'}), 400
+    if type_budget != 'actualise':
+        return jsonify({'error': 'La fiche de travail est réservée au budget actualisé'}), 400
+
+    conn = get_db()
+    try:
+        contexte = _fiche_contexte(conn, compte_num, int(annee), int(secteur_id))
+        computed = _compute_fiche_travail(donnees, contexte)
+        total = computed['total']
+        commentaire = _fiche_commentaire_auto(computed, contexte['last_month'])
+
+        conn.execute('''
+            INSERT INTO budget_fiches_travail
+            (compte_num, annee, secteur_id, type_budget, donnees, total, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(compte_num, annee, secteur_id, type_budget) DO UPDATE SET
+                donnees = excluded.donnees,
+                total = excluded.total,
+                updated_by = excluded.updated_by,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (compte_num, int(annee), int(secteur_id), type_budget,
+              json.dumps(donnees), total, user_id))
+
+        # Report sur la valeur définitive du compte + commentaire auto de
+        # traçabilité, en préservant la valeur temporaire éventuelle.
+        conn.execute('''
+            INSERT INTO budget_prev_saisies
+            (type_budget, annee, secteur_id, compte_num, valeur_def, commentaire, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(type_budget, annee, secteur_id, compte_num) DO UPDATE SET
+                valeur_def = excluded.valeur_def,
+                commentaire = excluded.commentaire,
+                updated_by = excluded.updated_by,
+                updated_at = CURRENT_TIMESTAMP
+        ''', (type_budget, int(annee), int(secteur_id), compte_num, total, commentaire, user_id))
+
+        conn.commit()
+        return jsonify({'success': True, 'total': total, 'commentaire': commentaire,
+                        'reported': True, 'computed': computed})
     finally:
         conn.close()
 

--- a/database.py
+++ b/database.py
@@ -1602,6 +1602,27 @@ def init_db():
         )
     ''')
 
+    # Fiches de travail du budget actualisé (comptes non paramétrés PS / paie,
+    # migration 0056) : construction du définitif = réel à date + projection
+    # (méthode au choix) + ajustements. Détail stocké en JSON ; total = montant
+    # reporté sur la valeur définitive du compte.
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS budget_fiches_travail (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL,
+            annee INTEGER NOT NULL,
+            secteur_id INTEGER NOT NULL,
+            type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
+            donnees TEXT,
+            total REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE CASCADE,
+            FOREIGN KEY (updated_by) REFERENCES users(id),
+            UNIQUE(compte_num, annee, secteur_id, type_budget)
+        )
+    ''')
+
     # ===== Tables module Planificateur de taches / Time Blocking (migration 0049) =====
 
     # Definitions des taches recurrentes (generent des occurrences de taches).

--- a/migrations/0056_fiches_travail_budget.py
+++ b/migrations/0056_fiches_travail_budget.py
@@ -1,0 +1,41 @@
+"""
+Migration 0056 : Fiches de travail du budget actualisé.
+
+Table budget_fiches_travail : pour chaque compte non paramétré (ni PS, ni
+paie), la fiche construit la valeur définitive du budget actualisé à partir
+du réel à date + une projection sur les mois restants (méthode au choix :
+N-1, moyenne N-1/N-2, tendance du réel, solde du budget initial, saisie
+mensuelle) + des lignes d'ajustement libres. Le détail est stocké en JSON,
+le total est reporté sur la valeur définitive du compte.
+"""
+
+NOM = "Fiches de travail budget actualisé"
+DESCRIPTION = (
+    "Ajoute la table budget_fiches_travail (réel + projection + ajustements "
+    "par compte) pour la construction du budget actualisé."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    conn.cursor().execute('''
+        CREATE TABLE IF NOT EXISTS budget_fiches_travail (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            compte_num TEXT NOT NULL,
+            annee INTEGER NOT NULL,
+            secteur_id INTEGER NOT NULL,
+            type_budget TEXT NOT NULL CHECK(type_budget IN ('initial', 'actualise')),
+            donnees TEXT,
+            total REAL DEFAULT 0,
+            updated_by INTEGER,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (secteur_id) REFERENCES secteurs(id) ON DELETE CASCADE,
+            FOREIGN KEY (updated_by) REFERENCES users(id),
+            UNIQUE(compte_num, annee, secteur_id, type_budget)
+        )
+    ''')
+
+
+def downgrade(conn):
+    """Supprime la table des fiches de travail."""
+    conn.cursor().execute('DROP TABLE IF EXISTS budget_fiches_travail')

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -473,7 +473,10 @@ body {
     max-width: 1400px;
     margin: 2rem auto;
     padding: 0 2rem;
-    animation: fadeIn var(--transition-normal) both;
+    /* Pas de fill-mode : une animation d'opacité retenue (both/forwards) laisse
+       le conteneur créer un contexte d'empilement permanent, qui piège les
+       modales internes (z-index 10000) SOUS la sidebar (z-index 100). */
+    animation: fadeIn var(--transition-normal);
 }
 
 .form-container,

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}CS-PILOT{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=18">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=19">
     <script>
         (function(){var t=localStorage.getItem('theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark');})();
     </script>

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -502,13 +502,15 @@ function buildTable(rows, labelTemp, labelDef, globalMode, ctx){
     let currentCat = null, catTotals = {n2:0,n1:0,n:0,initial:0,temp:0,def:0,ecart:0};
     function pushCatTotal(){
         if (!currentCat) return;
+        // Cellules Déf./Écart taguées : rafraîchies en direct pendant la saisie
+        // d'une valeur définitive, sans re-rendre le tableau (focus conservé).
         html += '<tr class="bp-cat-total"><td colspan="2">Total catégorie ' + currentCat + '</td>' +
           '<td class="bp-col-num">' + fmt(catTotals.n2) + '</td><td class="bp-col-num">' + fmt(catTotals.n1) + '</td>' +
           '<td class="bp-col-num">' + fmt(catTotals.n) + '</td>' +
           (actualise ? '<td class="bp-col-num">' + fmt(catTotals.initial) + '</td>' : '') +
           '<td class="bp-col-num">' + fmt(catTotals.temp) + '</td>' +
-          '<td class="bp-col-num">' + fmt(catTotals.def) + '</td>' +
-          (actualise ? '<td class="bp-col-num">' + fmtEcart(catTotals.ecart) + '</td>' : '') +
+          '<td class="bp-col-num" data-bp-cat-def="' + escapeHtml(currentCat) + '">' + fmt(catTotals.def) + '</td>' +
+          (actualise ? '<td class="bp-col-num" data-bp-cat-ecart="' + escapeHtml(currentCat) + '">' + fmtEcart(catTotals.ecart) + '</td>' : '') +
           '<td></td></tr>';
     }
     for (const r of rows){
@@ -565,13 +567,28 @@ function fmtEcart(ecart){
     const style = Math.abs(ecart) < 0.005 ? 'color:var(--text-muted);' : 'font-weight:600;';
     return '<span style="' + style + '">' + signe + fmt(ecart) + '</span>';
 }
+// Rafraîchit en direct, après édition d'une valeur définitive : l'écart de la
+// ligne, les totaux Déf./Écart de sa catégorie et le compte de résultat.
+// Scopé sur #budgetTables : l'onglet global (lecture seule) a ses propres
+// cellules pour les mêmes comptes et ne doit pas recevoir de valeurs secteur.
 function updateEcartCell(compte){
     const row = currentRows.find(r => r.compte_num === compte);
-    if (!row || row.initial === undefined) return;
-    document.querySelectorAll('[data-bp-ecart-compte]').forEach(function(el){
-        if (el.getAttribute('data-bp-ecart-compte') !== compte) return;
-        el.innerHTML = fmtEcart(ecartValue(row));
-    });
+    const root = document.getElementById('budgetTables');
+    if (!row || !root) return;
+    if (row.initial !== undefined){
+        root.querySelectorAll('[data-bp-ecart-compte]').forEach(function(el){
+            if (el.getAttribute('data-bp-ecart-compte') !== compte) return;
+            el.innerHTML = fmtEcart(ecartValue(row));
+        });
+    }
+    const rowsCat = currentRows.filter(r => r.categorie === row.categorie);
+    const defCell = root.querySelector('[data-bp-cat-def="' + row.categorie + '"]');
+    if (defCell) defCell.textContent = fmt(rowsCat.reduce((s, r) => s + Number(r.def || 0), 0));
+    if (row.initial !== undefined){
+        const ecartCell = root.querySelector('[data-bp-cat-ecart="' + row.categorie + '"]');
+        if (ecartCell) ecartCell.innerHTML = fmtEcart(rowsCat.reduce((s, r) => s + ecartValue(r), 0));
+    }
+    renderResultFromRows();
 }
 
 function renderResult(targetId, totaux){

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -344,6 +344,18 @@
     </div>
 </div>
 
+<!-- Fiche de travail d'un compte (budget actualisé) : réel + projection + ajustements -->
+<div id="ficheTravailModal" class="ps-modal-overlay" onclick="if(event.target===this)closeFicheTravail()">
+    <div class="ps-modal" role="dialog" aria-modal="true">
+        <div class="ps-modal-header">
+            <h3 id="ficheTitle">Fiche de travail</h3>
+            <button class="modal-close" type="button" onclick="closeFicheTravail()" aria-label="Fermer">&times;</button>
+        </div>
+        <div class="ps-modal-body" id="ficheBody"></div>
+        <div class="ps-modal-footer" id="ficheFooter"></div>
+    </div>
+</div>
+
 <!-- Fenêtre de détail des opérations comptables derrière une somme -->
 <div id="bpDetailModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)this.style.display='none'">
     <div class="modal-content" style="max-width:700px;">
@@ -426,7 +438,8 @@ function renderBudgetTable(targetId, rows, meta, globalMode){
         annee: parseInt(document.getElementById('anneeBudget').value),
         secteur: document.getElementById('secteurBudget').value,
         global: globalMode,
-        moisMax: (type === 'actualise' && meta && meta.last_month) ? meta.last_month : 0
+        moisMax: (type === 'actualise' && meta && meta.last_month) ? meta.last_month : 0,
+        actualise: type === 'actualise'
     };
     const hint = ' <span class="bp-detail-hint">(Cliquez les sommes pour afficher le détail)</span>';
     const html = '<h3>Charges' + hint + '</h3>' + buildTable(charges, nTemp, nDef, globalMode, ctx) +
@@ -449,6 +462,7 @@ function bindBudgetInputHandlers(targetId){
     root.querySelectorAll('input[data-bp-def-compte]').forEach((input) => {
         input.addEventListener('input', function(){
             queueSave(this.dataset.bpDefCompte || '', this.value, null);
+            updateEcartCell(this.dataset.bpDefCompte || '');
         });
     });
     root.querySelectorAll('input[data-bp-comment-compte]').forEach((input) => {
@@ -469,26 +483,42 @@ function buildTable(rows, labelTemp, labelDef, globalMode, ctx){
         return '<td class="bp-col-num"><span class="bp-detail" ' + attrs +
             ' onclick="bpVoirDetail(this)">' + fmt(value) + '</span></td>';
     }
+    // En actualisé : colonnes « Budget initial » (définitif du budget initial de
+    // la même année) et « Écart » = (Définitif si saisi, sinon Temporaire) − initial.
+    const actualise = !!ctx.actualise;
     let html = '<div class="bp-table-scroll"><table class="data-table budget-prev-table"><colgroup>' +
-      '<col class="bp-col-compte"><col class="bp-col-libelle"><col class="bp-col-value"><col class="bp-col-value"><col class="bp-col-value"><col class="bp-col-input"><col class="bp-col-input"><col class="bp-col-comment">' +
+      '<col class="bp-col-compte"><col class="bp-col-libelle"><col class="bp-col-value"><col class="bp-col-value"><col class="bp-col-value">' +
+      (actualise ? '<col class="bp-col-value">' : '') +
+      '<col class="bp-col-input"><col class="bp-col-input">' +
+      (actualise ? '<col class="bp-col-value">' : '') +
+      '<col class="bp-col-comment">' +
       '</colgroup><thead><tr>' +
-      '<th>Compte</th><th>Libellé</th><th class="bp-col-num">N-2</th><th class="bp-col-num">N-1</th><th class="bp-col-num">N</th><th class="bp-col-num">' + labelTemp + '</th><th class="bp-col-num">' + labelDef + '</th><th>Commentaire</th>' +
+      '<th>Compte</th><th>Libellé</th><th class="bp-col-num">N-2</th><th class="bp-col-num">N-1</th><th class="bp-col-num">N</th>' +
+      (actualise ? '<th class="bp-col-num" title="Valeur définitive du budget initial de l\'année">Initial</th>' : '') +
+      '<th class="bp-col-num">' + labelTemp + '</th><th class="bp-col-num">' + labelDef + '</th>' +
+      (actualise ? '<th class="bp-col-num" title="Définitif (sinon Temporaire) − Budget initial">Écart</th>' : '') +
+      '<th>Commentaire</th>' +
       '</tr></thead><tbody>';
-    let currentCat = null, catTotals = {n2:0,n1:0,n:0,temp:0,def:0};
+    let currentCat = null, catTotals = {n2:0,n1:0,n:0,initial:0,temp:0,def:0,ecart:0};
     function pushCatTotal(){
         if (!currentCat) return;
         html += '<tr class="bp-cat-total"><td colspan="2">Total catégorie ' + currentCat + '</td>' +
           '<td class="bp-col-num">' + fmt(catTotals.n2) + '</td><td class="bp-col-num">' + fmt(catTotals.n1) + '</td>' +
-          '<td class="bp-col-num">' + fmt(catTotals.n) + '</td><td class="bp-col-num">' + fmt(catTotals.temp) + '</td>' +
-          '<td class="bp-col-num">' + fmt(catTotals.def) + '</td><td></td></tr>';
+          '<td class="bp-col-num">' + fmt(catTotals.n) + '</td>' +
+          (actualise ? '<td class="bp-col-num">' + fmt(catTotals.initial) + '</td>' : '') +
+          '<td class="bp-col-num">' + fmt(catTotals.temp) + '</td>' +
+          '<td class="bp-col-num">' + fmt(catTotals.def) + '</td>' +
+          (actualise ? '<td class="bp-col-num">' + fmtEcart(catTotals.ecart) + '</td>' : '') +
+          '<td></td></tr>';
     }
     for (const r of rows){
         if (currentCat !== r.categorie){
             pushCatTotal();
             currentCat = r.categorie;
-            catTotals = {n2:0,n1:0,n:0,temp:0,def:0};
+            catTotals = {n2:0,n1:0,n:0,initial:0,temp:0,def:0,ecart:0};
         }
         catTotals.n2 += r['N-2']; catTotals.n1 += r['N-1']; catTotals.n += r['N']; catTotals.temp += r.temp; catTotals.def += r.def;
+        if (actualise){ catTotals.initial += Number(r.initial || 0); catTotals.ecart += ecartValue(r); }
         const isBrut = (salaryMeta && salaryMeta.salary_brut_account === r.compte_num);
         const rowStyle = isBrut ? ' style="background:#fff7d6;"' : '';
         const tempInput = (!globalMode && !isReadOnly && isBrut)
@@ -506,16 +536,42 @@ function buildTable(rows, labelTemp, labelDef, globalMode, ctx){
         const paieBtn = (!globalMode && canEditPs && salaryMeta && salaryMeta.salary_brut_account === r.compte_num)
             ? '<button type="button" class="btn btn-sm btn-secondary bp-ps-btn" data-paie-compte="' + escapeHtml(r.compte_num) + '" title="Ouvrir le simulateur de paie">🧮 Paie</button>'
             : '';
+        const ficheBtn = (actualise && !globalMode && !psComptes[r.compte_num] && !r.is_salary)
+            ? '<button type="button" class="btn btn-sm btn-secondary bp-ps-btn" data-fiche-compte="' + escapeHtml(r.compte_num) + '" title="Fiche de travail : réel + projection + ajustements">📋 Fiche</button>'
+            : '';
         html += '<tr' + rowStyle + '>' +
-          '<td>' + escapeHtml(r.compte_num) + '</td><td>' + escapeHtml(r.libelle) + psBtn + paieBtn + '</td>' +
+          '<td>' + escapeHtml(r.compte_num) + '</td><td>' + escapeHtml(r.libelle) + psBtn + paieBtn + ficheBtn + '</td>' +
           comptaCell(r.compte_num, ctx.annee - 2, r['N-2'], 0) +
           comptaCell(r.compte_num, ctx.annee - 1, r['N-1'], 0) +
           comptaCell(r.compte_num, ctx.annee, r['N'], ctx.moisMax) +
-          '<td class="bp-col-num">' + tempInput + '</td><td class="bp-col-num">' + defInput + '</td><td>' + commentInput + '</td></tr>';
+          (actualise ? '<td class="bp-col-num">' + fmt(r.initial) + '</td>' : '') +
+          '<td class="bp-col-num">' + tempInput + '</td><td class="bp-col-num">' + defInput + '</td>' +
+          (actualise ? '<td class="bp-col-num"><span data-bp-ecart-compte="' + escapeHtml(r.compte_num) + '">' + fmtEcart(ecartValue(r)) + '</span></td>' : '') +
+          '<td>' + commentInput + '</td></tr>';
     }
     pushCatTotal();
     html += '</tbody></table></div>';
     return html;
+}
+
+// Écart d'atterrissage d'une ligne (actualisé) : Définitif si saisi, sinon
+// Temporaire, moins le budget initial du compte.
+function ecartValue(r){
+    const retenu = Number(r.def || 0) !== 0 ? Number(r.def) : Number(r.temp || 0);
+    return retenu - Number(r.initial || 0);
+}
+function fmtEcart(ecart){
+    const signe = ecart > 0 ? '+' : '';
+    const style = Math.abs(ecart) < 0.005 ? 'color:var(--text-muted);' : 'font-weight:600;';
+    return '<span style="' + style + '">' + signe + fmt(ecart) + '</span>';
+}
+function updateEcartCell(compte){
+    const row = currentRows.find(r => r.compte_num === compte);
+    if (!row || row.initial === undefined) return;
+    document.querySelectorAll('[data-bp-ecart-compte]').forEach(function(el){
+        if (el.getAttribute('data-bp-ecart-compte') !== compte) return;
+        el.innerHTML = fmtEcart(ecartValue(row));
+    });
 }
 
 function renderResult(targetId, totaux){
@@ -667,6 +723,9 @@ function bindPsButtons(targetId){
     });
     root.querySelectorAll('button[data-paie-compte]').forEach(function(btn){
         btn.addEventListener('click', function(){ openPaieSimulator(this.dataset.paieCompte || ''); });
+    });
+    root.querySelectorAll('button[data-fiche-compte]').forEach(function(btn){
+        btn.addEventListener('click', function(){ openFicheTravail(this.dataset.ficheCompte || ''); });
     });
 }
 
@@ -1450,6 +1509,280 @@ function savePsSimulator(){
             renderResultFromRows();
         }
         if (msg) msg.textContent = '✓ Enregistré · total reporté : ' + fmt(data.total) + ' €';
+    }).catch(function(){ if (msg) msg.textContent = ''; alert('Erreur réseau lors de l\'enregistrement'); });
+}
+
+// ===================== Fiche de travail (budget actualisé) =====================
+// Comptes non paramétrés (ni PS, ni paie) : le définitif se construit dans une
+// fiche = réel à date (verrouillé) + projection des mois restants (méthode au
+// choix) + lignes d'ajustement. Le serveur recalcule et reporte le total.
+var ficheSim = null;  // { compte, libelle, ctx, state, contexte }
+var FICHE_METHODES_JS = {
+    n1: 'N-1 mois par mois',
+    moyenne_n1_n2: 'Moyenne N-1 / N-2',
+    tendance: 'Tendance du réel',
+    solde_initial: 'Solde du budget initial',
+    manuel: 'Saisie mensuelle'
+};
+var FICHE_METHODES_HINTS = {
+    n1: 'Chaque mois restant reprend le montant du même mois en N-1.',
+    moyenne_n1_n2: 'Chaque mois restant = moyenne du même mois en N-1 et N-2.',
+    tendance: 'Chaque mois restant = moyenne mensuelle du réel déjà comptabilisé.',
+    solde_initial: 'Le reste (budget initial − réel à date) est réparti sur les mois restants.',
+    manuel: 'Saisissez librement chaque mois restant.'
+};
+
+function openFicheTravail(compteNum){
+    var ctx = getCurrentBudgetContext();
+    var rowMeta = currentRows.find(function(r){ return r.compte_num === compteNum; });
+    ficheSim = {compte: compteNum, libelle: rowMeta ? rowMeta.libelle : '', ctx: ctx, state: null, contexte: null};
+    document.getElementById('ficheTitle').textContent =
+        'Fiche de travail — ' + compteNum + (ficheSim.libelle ? ' (' + ficheSim.libelle + ')' : '') +
+        ' — budget actualisé ' + ctx.annee;
+    var url = '/api/budget-previsionnel/fiche-travail?compte_num=' + encodeURIComponent(compteNum) +
+        '&annee=' + ctx.annee + '&secteur_id=' + ctx.secteur_id + '&type_budget=' + encodeURIComponent(ctx.type_budget);
+    fetch(url).then(r => r.json()).then(function(d){
+        if (d && d.error){ alert(d.error); return; }
+        ficheSim.contexte = (d && d.contexte) || {reel_mensuel:{}, n1_mensuel:{}, n2_mensuel:{}, last_month:0, budget_initial:0};
+        ficheSim.state = mergeFicheState(d && d.found ? d.donnees : null);
+        renderFicheTravail();
+        recomputeFiche();
+        document.getElementById('ficheTravailModal').classList.add('open');
+    }).catch(function(){ alert('Erreur réseau lors du chargement de la fiche'); });
+}
+function closeFicheTravail(){ document.getElementById('ficheTravailModal').classList.remove('open'); ficheSim = null; }
+document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && document.getElementById('ficheTravailModal').classList.contains('open')) closeFicheTravail();
+});
+
+function mergeFicheState(saved){
+    var st = {methode: 'n1', mois_prevus: {}, ajustements: []};
+    if (saved && typeof saved === 'object'){
+        if (FICHE_METHODES_JS[saved.methode]) st.methode = saved.methode;
+        if (saved.mois_prevus && typeof saved.mois_prevus === 'object') st.mois_prevus = Object.assign({}, saved.mois_prevus);
+        if (Array.isArray(saved.ajustements)){
+            st.ajustements = saved.ajustements.filter(function(a){ return a && typeof a === 'object'; })
+                .map(function(a){ return {libelle: a.libelle || '', montant: a.montant != null ? a.montant : ''}; });
+        }
+    }
+    return st;
+}
+
+function ficheMois(map, m){
+    if (!map) return 0;
+    var v = map[m] !== undefined ? map[m] : map[String(m)];
+    return psNum(v);
+}
+
+// Aperçu client — même logique que le serveur (qui reste la source de vérité).
+function computeFicheClient(){
+    var cx = ficheSim.contexte, st = ficheSim.state;
+    var lastMonth = cx.last_month || 0;
+    var totalReel = 0, m;
+    for (m = 1; m <= lastMonth; m++) totalReel += ficheMois(cx.reel_mensuel, m);
+    var prevus = {};
+    for (m = lastMonth + 1; m <= 12; m++){
+        var val;
+        if (st.methode === 'n1') val = ficheMois(cx.n1_mensuel, m);
+        else if (st.methode === 'moyenne_n1_n2') val = (ficheMois(cx.n1_mensuel, m) + ficheMois(cx.n2_mensuel, m)) / 2;
+        else if (st.methode === 'tendance') val = lastMonth ? totalReel / lastMonth : 0;
+        else if (st.methode === 'solde_initial') val = (12 - lastMonth) ? (psNum(cx.budget_initial) - totalReel) / (12 - lastMonth) : 0;
+        else val = ficheMois(st.mois_prevus, m);
+        prevus[m] = val;
+    }
+    var totalPrevu = 0; Object.keys(prevus).forEach(function(k){ totalPrevu += prevus[k]; });
+    var totalAjust = 0;
+    (st.ajustements || []).forEach(function(a){ totalAjust += psNum(a.montant); });
+    return {total_reel: totalReel, mois_prevus: prevus, total_prevu: totalPrevu,
+            total_ajustements: totalAjust, total: totalReel + totalPrevu + totalAjust};
+}
+
+function renderFicheTravail(){
+    var cx = ficheSim.contexte, st = ficheSim.state;
+    var lastMonth = cx.last_month || 0;
+    var dis = canEditPs ? '' : ' disabled';
+    var totN1 = 0, totN2 = 0, m;
+    for (m = 1; m <= 12; m++){ totN1 += ficheMois(cx.n1_mensuel, m); totN2 += ficheMois(cx.n2_mensuel, m); }
+
+    var html = '<div class="ps-legend">' +
+        (lastMonth
+            ? 'Réel comptabilisé jusqu\'à <strong>fin ' + escapeHtml(cx.last_month_label || '') + '</strong> (verrouillé). '
+            : 'Aucun réel importé pour l\'année : toute l\'année est projetée. ') +
+        'Modifier un mois projeté bascule automatiquement en « Saisie mensuelle ».<br>' +
+        'Budget initial du compte : <strong>' + fmt(cx.budget_initial) + ' €</strong> · Réalisé N-1 : ' + fmt(totN1) +
+        ' € · Réalisé N-2 : ' + fmt(totN2) + ' €</div>';
+
+    html += '<div class="ps-params" style="align-items:center;gap:12px;">' +
+        '<div class="ps-field" style="margin:0;"><label>Méthode de projection</label>' +
+        '<select class="ps-input" id="ficheMethode" style="text-align:left;min-width:230px;"' + dis + '>' +
+        Object.keys(FICHE_METHODES_JS).map(function(k){
+            return '<option value="' + k + '"' + (st.methode === k ? ' selected' : '') + '>' + FICHE_METHODES_JS[k] + '</option>';
+        }).join('') + '</select></div>' +
+        '<div id="ficheMethodeHint" style="font-size:.78rem;color:var(--text-muted);flex:1;min-width:200px;"></div></div>';
+
+    html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr><th style="text-align:left;"></th>';
+    for (m = 1; m <= 12; m++) html += '<th>' + MOIS_COURT[m-1] + '</th>';
+    html += '<th class="bp-ps-calc">Total</th></tr></thead><tbody>';
+
+    html += '<tr><td style="text-align:left;font-weight:600;">Réel ' + ficheSim.ctx.annee + '</td>';
+    for (m = 1; m <= 12; m++){
+        html += (m <= lastMonth)
+            ? '<td class="bp-ps-calc">' + fmt(ficheMois(cx.reel_mensuel, m)) + '</td>'
+            : '<td style="color:var(--text-muted);text-align:center;">—</td>';
+    }
+    html += '<td class="bp-ps-calc" id="fiche-total-reel"></td></tr>';
+
+    html += '<tr><td style="text-align:left;font-weight:600;">Projection</td>';
+    for (m = 1; m <= 12; m++){
+        html += (m <= lastMonth)
+            ? '<td style="color:var(--text-muted);text-align:center;">—</td>'
+            : '<td><input class="ps-input" type="number" step="0.01" data-fiche-mois="' + m + '"' + dis + '></td>';
+    }
+    html += '<td class="bp-ps-calc" id="fiche-total-prevu"></td></tr>';
+
+    html += '<tr><td style="text-align:left;color:var(--text-muted);">Rappel N-1</td>';
+    for (m = 1; m <= 12; m++) html += '<td style="color:var(--text-muted);">' + fmt(ficheMois(cx.n1_mensuel, m)) + '</td>';
+    html += '<td style="color:var(--text-muted);">' + fmt(totN1) + '</td></tr>';
+    html += '<tr><td style="text-align:left;color:var(--text-muted);">Rappel N-2</td>';
+    for (m = 1; m <= 12; m++) html += '<td style="color:var(--text-muted);">' + fmt(ficheMois(cx.n2_mensuel, m)) + '</td>';
+    html += '<td style="color:var(--text-muted);">' + fmt(totN2) + '</td></tr>';
+    html += '</tbody></table></div>';
+
+    html += '<h4 style="margin:14px 0 6px;color:var(--primary);">Ajustements (+/−)</h4>';
+    html += '<div id="ficheAjustements"></div>';
+    if (canEditPs) html += '<button class="btn btn-sm btn-secondary" type="button" onclick="ficheAddAjustement()">+ Ajouter un ajustement</button>';
+
+    html += '<div class="ps-params" style="margin-top:14px;justify-content:flex-end;gap:18px;font-size:.9rem;">' +
+        '<div>Réel : <strong id="fiche-syn-reel"></strong></div>' +
+        '<div>Projection : <strong id="fiche-syn-prevu"></strong></div>' +
+        '<div>Ajustements : <strong id="fiche-syn-ajust"></strong></div>' +
+        '<div style="font-size:1rem;">Total fiche : <strong id="fiche-syn-total"></strong></div></div>';
+
+    document.getElementById('ficheBody').innerHTML = html;
+    document.getElementById('ficheFooter').innerHTML = canEditPs
+        ? '<span id="ficheSaveMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>' +
+          '<button class="btn btn-secondary" type="button" onclick="closeFicheTravail()">Annuler</button>' +
+          '<button class="btn btn-primary" type="button" onclick="saveFicheTravail()">💾 Enregistrer et reporter en définitif</button>'
+        : '<span style="margin-right:auto;color:var(--text-muted);">Lecture seule</span>' +
+          '<button class="btn btn-secondary" type="button" onclick="closeFicheTravail()">Fermer</button>';
+
+    renderFicheAjustements();
+    bindFicheInputs();
+}
+
+function bindFicheInputs(){
+    var sel = document.getElementById('ficheMethode');
+    if (sel) sel.addEventListener('change', function(){
+        var st = ficheSim.state;
+        // Passage volontaire en manuel : on repart des valeurs de la méthode
+        // précédente plutôt que de zéros.
+        if (this.value === 'manuel' && st.methode !== 'manuel'){
+            var c = computeFicheClient();
+            st.mois_prevus = {};
+            Object.keys(c.mois_prevus).forEach(function(k){ st.mois_prevus[k] = Math.round(c.mois_prevus[k] * 100) / 100; });
+        }
+        st.methode = this.value;
+        recomputeFiche();
+    });
+    document.querySelectorAll('#ficheBody input[data-fiche-mois]').forEach(function(el){
+        el.addEventListener('input', function(){
+            var st = ficheSim.state;
+            var m = parseInt(this.dataset.ficheMois, 10);
+            if (st.methode !== 'manuel'){
+                // Édition directe d'un mois projeté : on fige la projection
+                // courante puis on bascule en saisie mensuelle.
+                var c = computeFicheClient();
+                st.mois_prevus = {};
+                Object.keys(c.mois_prevus).forEach(function(k){ st.mois_prevus[k] = Math.round(c.mois_prevus[k] * 100) / 100; });
+                st.methode = 'manuel';
+                var sel2 = document.getElementById('ficheMethode');
+                if (sel2) sel2.value = 'manuel';
+            }
+            st.mois_prevus[m] = this.value;
+            recomputeFiche();
+        });
+    });
+}
+
+function renderFicheAjustements(){
+    var wrap = document.getElementById('ficheAjustements');
+    if (!wrap || !ficheSim) return;
+    var st = ficheSim.state;
+    var dis = canEditPs ? '' : ' disabled';
+    if (!(st.ajustements || []).length){
+        wrap.innerHTML = '<p style="color:var(--text-muted);font-size:.85rem;margin:4px 0 8px;">' +
+            'Aucun ajustement — ajoutez par exemple une facture attendue, une résiliation, une régularisation…</p>';
+        return;
+    }
+    wrap.innerHTML = st.ajustements.map(function(a, i){
+        return '<div style="display:flex;gap:8px;margin-bottom:6px;align-items:center;">' +
+            '<input class="ps-input" style="flex:1;text-align:left;" placeholder="Libellé (ex. facture attendue en novembre)"' +
+            ' value="' + escapeHtml(a.libelle || '') + '" data-fiche-aj="' + i + '" data-fiche-akey="libelle"' + dis + '>' +
+            '<input class="ps-input" type="number" step="0.01" style="width:130px;" placeholder="Montant ±"' +
+            ' value="' + psAttr(a.montant) + '" data-fiche-aj="' + i + '" data-fiche-akey="montant"' + dis + '>' +
+            (canEditPs ? '<button class="btn btn-sm btn-danger" type="button" onclick="ficheRemoveAjustement(' + i + ')">×</button>' : '') +
+            '</div>';
+    }).join('');
+    wrap.querySelectorAll('[data-fiche-aj]').forEach(function(el){
+        el.addEventListener('input', function(){
+            var i = parseInt(this.dataset.ficheAj, 10);
+            if (ficheSim.state.ajustements[i]) ficheSim.state.ajustements[i][this.dataset.ficheAkey] = this.value;
+            recomputeFiche();
+        });
+    });
+}
+function ficheAddAjustement(){
+    if (!ficheSim) return;
+    ficheSim.state.ajustements.push({libelle:'', montant:''});
+    renderFicheAjustements(); recomputeFiche();
+}
+function ficheRemoveAjustement(i){
+    if (!ficheSim) return;
+    ficheSim.state.ajustements.splice(i, 1);
+    renderFicheAjustements(); recomputeFiche();
+}
+
+function recomputeFiche(){
+    if (!ficheSim) return;
+    var c = computeFicheClient();
+    var st = ficheSim.state;
+    document.querySelectorAll('#ficheBody input[data-fiche-mois]').forEach(function(el){
+        if (el === document.activeElement) return;  // ne pas écraser la saisie en cours
+        var m = parseInt(el.dataset.ficheMois, 10);
+        var v = (st.methode === 'manuel') ? ficheMois(st.mois_prevus, m) : (c.mois_prevus[m] || 0);
+        el.value = Math.round(v * 100) / 100;
+    });
+    psSet('fiche-total-reel', fmt(c.total_reel));
+    psSet('fiche-total-prevu', fmt(c.total_prevu));
+    psSet('fiche-syn-reel', fmt(c.total_reel) + ' €');
+    psSet('fiche-syn-prevu', fmt(c.total_prevu) + ' €');
+    psSet('fiche-syn-ajust', fmt(c.total_ajustements) + ' €');
+    psSet('fiche-syn-total', fmt(c.total) + ' €');
+    var hint = document.getElementById('ficheMethodeHint');
+    if (hint) hint.textContent = FICHE_METHODES_HINTS[st.methode] || '';
+}
+
+function saveFicheTravail(){
+    if (!ficheSim || !canEditPs) return;
+    var ctx = ficheSim.ctx || getCurrentBudgetContext();
+    var msg = document.getElementById('ficheSaveMsg');
+    if (msg) msg.textContent = 'Enregistrement…';
+    fetch('/api/budget-previsionnel/fiche-travail', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({
+            compte_num: ficheSim.compte, annee: ctx.annee, secteur_id: ctx.secteur_id,
+            type_budget: ctx.type_budget, donnees: ficheSim.state
+        })
+    }).then(r => r.json()).then(function(data){
+        if (!data.success){ if (msg) msg.textContent = ''; alert(data.error || 'Erreur lors de l\'enregistrement'); return; }
+        var row = currentRows.find(function(r){ return r.compte_num === ficheSim.compte; });
+        if (row){
+            row.def = Number(data.total || 0);
+            if (data.commentaire) row.commentaire = data.commentaire;
+            renderBudgetTable('budgetTables', currentRows, salaryMeta, false);
+            renderResultFromRows();
+        }
+        if (msg) msg.textContent = '✓ Enregistré · reporté en définitif : ' + fmt(data.total) + ' €';
     }).catch(function(){ if (msg) msg.textContent = ''; alert('Erreur réseau lors de l\'enregistrement'); });
 }
 

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1211,3 +1211,139 @@ def test_paie_temps_hebdo_absent_temps_plein(app, db, admin_client):
         'annee': annee, 'secteur_id': sid, 'type_budget': 'initial', 'compte_num': '641000', 'donnees': donnees})
     assert r.status_code == 200
     assert abs(r.get_json()['total'] - 23000.0) < 0.01
+
+
+# ============================================================
+# Fiche de travail (budget actualisé)
+# ============================================================
+
+def _setup_fiche_secteur(db, annee):
+    """Secteur + code analytique + réel mensuel du compte 606000 :
+    N : jan/fév/mars = 100/200/300 (arrêté à fin mars) ;
+    N-1 : 12 × 50 ; N-2 : 12 × 100 ; budget initial définitif = 1 500 €."""
+    db.execute("INSERT INTO secteurs (nom, type_secteur) VALUES ('Fiche test','accueil_loisirs')")
+    sid = db.execute("SELECT id FROM secteurs WHERE nom='Fiche test'").fetchone()['id']
+    db.execute("INSERT INTO budget_prev_config_codes (code_analytique, secteur_id) VALUES ('ANA-FT', ?)", (sid,))
+    db.execute("INSERT INTO bilan_fec_imports (fichier_nom, annee, nb_ecritures) VALUES ('ft.txt', ?, 1)", (annee,))
+    imp = db.execute('SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1').fetchone()['id']
+    for mois, montant in ((1, 100), (2, 200), (3, 300)):
+        db.execute("INSERT INTO bilan_fec_donnees (compte_num, code_analytique, annee, mois, montant, import_id) "
+                   "VALUES ('606000', 'ANA-FT', ?, ?, ?, ?)", (annee, mois, montant, imp))
+    for mois in range(1, 13):
+        db.execute("INSERT INTO bilan_fec_donnees (compte_num, code_analytique, annee, mois, montant, import_id) "
+                   "VALUES ('606000', 'ANA-FT', ?, ?, 50, ?)", (annee - 1, mois, imp))
+        db.execute("INSERT INTO bilan_fec_donnees (compte_num, code_analytique, annee, mois, montant, import_id) "
+                   "VALUES ('606000', 'ANA-FT', ?, ?, 100, ?)", (annee - 2, mois, imp))
+    db.execute("INSERT INTO budget_prev_saisies (type_budget, annee, secteur_id, compte_num, valeur_def) "
+               "VALUES ('initial', ?, ?, '606000', 1500)", (annee, sid))
+    db.commit()
+    return sid
+
+
+def test_fiche_travail_contexte(app, db, admin_client):
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)
+    r = admin_client.get(f'/api/budget-previsionnel/fiche-travail?compte_num=606000'
+                         f'&annee={annee}&secteur_id={sid}&type_budget=actualise')
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data['found'] is False
+    cx = data['contexte']
+    assert cx['last_month'] == 3
+    assert cx['budget_initial'] == 1500.0
+    assert cx['reel_mensuel']['2'] == 200.0     # clés JSON sérialisées en chaînes
+    assert cx['n1_mensuel']['12'] == 50.0
+    assert cx['n2_mensuel']['7'] == 100.0
+
+
+def test_fiche_travail_methodes_et_report(app, db, admin_client):
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)
+        # Valeur temporaire corrigée à la main : elle doit être préservée.
+        db.execute("INSERT INTO budget_prev_saisies (type_budget, annee, secteur_id, compte_num, valeur_temp, valeur_def) "
+                   "VALUES ('actualise', ?, ?, '606000', 999, 0)", (annee, sid))
+        db.commit()
+
+    def poster(donnees):
+        r = admin_client.post('/api/budget-previsionnel/fiche-travail', json={
+            'compte_num': '606000', 'annee': annee, 'secteur_id': sid,
+            'type_budget': 'actualise', 'donnees': donnees})
+        assert r.status_code == 200
+        return r.get_json()
+
+    # Réel jan-mars = 600. N-1 avr-déc : 9 × 50 = 450.
+    assert poster({'methode': 'n1'})['total'] == 1050.0
+    # Moyenne N-1/N-2 : (50 + 100) / 2 × 9 = 675.
+    assert poster({'methode': 'moyenne_n1_n2'})['total'] == 1275.0
+    # Tendance : 600 / 3 = 200 par mois × 9 = 1800.
+    assert poster({'methode': 'tendance'})['total'] == 2400.0
+    # Solde du budget initial : le total atterrit sur l'initial.
+    assert poster({'methode': 'solde_initial'})['total'] == 1500.0
+    # Saisie mensuelle + ajustements (600 + 10 + 20 + 100 − 30).
+    data = poster({'methode': 'manuel', 'mois_prevus': {'4': 10, '12': 20},
+                   'ajustements': [{'libelle': 'Facture attendue', 'montant': 100},
+                                   {'libelle': 'Avoir', 'montant': -30}]})
+    assert data['total'] == 700.0
+    assert 'saisie mensuelle' in data['commentaire']
+    assert '2 ajustement(s)' in data['commentaire']
+
+    with app.app_context():
+        row = db.execute("SELECT valeur_temp, valeur_def, commentaire FROM budget_prev_saisies "
+                         "WHERE type_budget='actualise' AND annee=? AND secteur_id=? AND compte_num='606000'",
+                         (annee, sid)).fetchone()
+    assert row['valeur_def'] == 700.0
+    assert row['valeur_temp'] == 999            # la correction manuelle reste
+    assert row['commentaire'].startswith('Fiche : réel à fin mars')
+
+    # La fiche est persistée et rechargeable.
+    r = admin_client.get(f'/api/budget-previsionnel/fiche-travail?compte_num=606000'
+                         f'&annee={annee}&secteur_id={sid}&type_budget=actualise')
+    d = r.get_json()
+    assert d['found'] is True
+    assert d['donnees']['methode'] == 'manuel'
+    assert d['total'] == 700.0
+
+
+def test_fiche_travail_reservee_actualise(app, db, admin_client):
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)
+    r = admin_client.get(f'/api/budget-previsionnel/fiche-travail?compte_num=606000'
+                         f'&annee={annee}&secteur_id={sid}&type_budget=initial')
+    assert r.status_code == 400
+    r = admin_client.post('/api/budget-previsionnel/fiche-travail', json={
+        'compte_num': '606000', 'annee': annee, 'secteur_id': sid,
+        'type_budget': 'initial', 'donnees': {'methode': 'n1'}})
+    assert r.status_code == 400
+
+
+def test_fiche_travail_responsable_lecture_seule_et_secteur_force(app, db, resp_client, sample_users):
+    """Un responsable consulte la fiche de SON secteur uniquement (le secteur
+    demandé est ignoré) et ne peut pas enregistrer."""
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)   # secteur étranger au responsable
+    r = resp_client.get(f'/api/budget-previsionnel/fiche-travail?compte_num=606000'
+                        f'&annee={annee}&secteur_id={sid}&type_budget=actualise')
+    assert r.status_code == 200
+    # Forcé sur son secteur (sans données) : aucun réel du secteur « Fiche test ».
+    assert r.get_json()['contexte']['last_month'] == 0
+    r = resp_client.post('/api/budget-previsionnel/fiche-travail', json={
+        'compte_num': '606000', 'annee': annee, 'secteur_id': sid,
+        'type_budget': 'actualise', 'donnees': {'methode': 'n1'}})
+    assert r.status_code == 403
+
+
+def test_api_budget_previsionnel_actualise_inclut_budget_initial(app, db, admin_client):
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)
+    r = admin_client.get(f'/api/budget-previsionnel/donnees?type_budget=actualise&annee={annee}&secteur_id={sid}')
+    row = next(x for x in r.get_json()['rows'] if x['compte_num'] == '606000')
+    assert row['initial'] == 1500.0
+    # En budget initial, la colonne n'existe pas.
+    r2 = admin_client.get(f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&secteur_id={sid}')
+    row2 = next(x for x in r2.get_json()['rows'] if x['compte_num'] == '606000')
+    assert 'initial' not in row2


### PR DESCRIPTION
## Contexte

La construction du **budget actualisé** reposait sur un chiffre annuel saisi à la main par compte (la colonne Temporaire restant un guide auto : réel à date + N‑1 restant). Cette PR ajoute des **fiches de travail par compte** — sur le modèle des fiches PS/paie — pour construire la valeur définitive à partir du réel et d'une projection explicite, plus l'affichage du **budget initial** et de l'**écart** d'atterrissage.

## Fiche de travail (bouton « 📋 Fiche »)

Sur chaque compte **non paramétré** (ni PS, ni comptes de paie 63x/64x), en budget actualisé uniquement :

- **Grille 12 mois** : réel comptabilisé pré‑rempli et **verrouillé** jusqu'au mois d'arrêté ; lignes de rappel N‑1 / N‑2.
- **Méthode de projection** des mois restants :
  | Méthode | Calcul |
  |---|---|
  | N‑1 mois par mois | saisonnalité de l'an dernier (= calcul du Temporaire, rendu explicite) |
  | Moyenne N‑1/N‑2 | lisse une année atypique |
  | Tendance du réel | moyenne mensuelle du réel à date |
  | Solde du budget initial | reste = initial − réel, réparti sur les mois restants |
  | Saisie mensuelle | libre ; **modifier un mois projeté y bascule automatiquement** en repartant des valeurs de la méthode en cours |
- **Lignes d'ajustement** (libellé + montant ±) : facture attendue, résiliation, régularisation…
- **Total = réel + projection + ajustements**, recalculé côté serveur (source de vérité) et **reporté en Définitif** avec un **commentaire auto de traçabilité** (ex. « Fiche : réel à fin mars + tendance du réel, 2 ajustement(s) »). La valeur temporaire éventuelle est préservée — elle reste le guide rapide.
- Persistance sur le modèle des fiches PS/paie : table `budget_fiches_travail` (JSON par compte/année/secteur/type de budget), **migration 0056** idempotente + miroir `init_db`. Responsables en lecture seule (limités à leur secteur), enregistrement direction/comptable.

## Colonnes « Initial » et « Écart » (vue actualisé)

- Le **budget initial définitif** de l'année s'affiche en face de chaque compte (consolidé tous secteurs en vue globale).
- **Écart** = (Définitif si saisi, sinon Temporaire) − Initial, mis à jour **en direct** pendant la saisie, totalisé par catégorie.

## Correctif d'empilement des modales (bug préexistant trouvé en vérifiant)

`.container` portait `animation: fadeIn … both` : une animation d'**opacité retenue** (fill‑mode `both`) laisse le conteneur créer un **contexte d'empilement permanent**, qui peint toutes les modales internes (z‑index 10000) **sous la sidebar** (z‑index 100). Les simulateurs **PS et paie étaient déjà tronqués** d'environ 260 px à gauche sur les écrans < 1970 px. Suppression du fill‑mode (rendu strictement identique, l'animation joue toujours) + bump du cache‑buster CSS (`?v=19`).

## Tests

- `tests/test_budget.py` (+5) : contexte de fiche (réel mensuel, mois d'arrêté, budget initial), **les 5 méthodes** avec valeurs exactes, report en définitif + commentaire auto + préservation de la valeur temporaire, restriction à l'actualisé (400), responsable lecture seule + secteur forcé (403 en écriture), colonne `initial` présente en actualisé / absente en initial.
- **Suite complète verte : 812 tests.**
- **Parcours navigateur complet** (Chromium/Playwright) : colonnes, ouverture de fiche, changement de méthode, ajustements, bascule auto en saisie mensuelle, report en définitif, rechargement de la fiche persistée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_