### PR TITLE
Fix monthly PDF export authorization

### DIFF
--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -12,6 +12,39 @@ from utils import (login_required, get_user_info, calculer_heures,
 exports_bp = Blueprint('exports_bp', __name__)
 
 
+def _peut_exporter_pdf_mensuel(conn, user_id_cible):
+    """Vérifie que l'utilisateur connecté peut exporter la fiche PDF cible.
+
+    Le PDF mensuel contient des informations RH nominatives : il doit suivre
+    le même modèle d'accès que la vue mensuelle.
+    """
+    if user_id_cible == session.get('user_id'):
+        return True
+
+    profil = session.get('profil')
+    if profil in ('directeur', 'comptable'):
+        return conn.execute(
+            "SELECT 1 FROM users WHERE id = ? AND actif = 1 AND profil != 'prestataire'",
+            (user_id_cible,)
+        ).fetchone() is not None
+
+    if profil == 'responsable':
+        responsable = conn.execute(
+            'SELECT secteur_id FROM users WHERE id = ?',
+            (session['user_id'],)
+        ).fetchone()
+        secteur_id = responsable['secteur_id'] if responsable else None
+        if not secteur_id:
+            return False
+
+        return conn.execute('''
+            SELECT 1 FROM users
+            WHERE id = ? AND actif = 1 AND profil != 'prestataire' AND secteur_id = ?
+        ''', (user_id_cible, secteur_id)).fetchone() is not None
+
+    return False
+
+
 @exports_bp.route('/export_pdf_mensuel')
 @login_required
 def export_pdf_mensuel():
@@ -32,6 +65,11 @@ def export_pdf_mensuel():
         return redirect(url_for('validation_bp.vue_mensuelle'))
     
     conn = get_db()
+
+    if not _peut_exporter_pdf_mensuel(conn, user_id_param):
+        flash('Accès non autorisé à cette fiche', 'error')
+        conn.close()
+        return redirect(url_for('validation_bp.vue_mensuelle'))
     
     # Vérifier que la fiche est verrouillée
     validation = conn.execute('''

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -330,3 +330,43 @@ class TestEnvFileGeneration:
         result = generate_env_file('/invalid/path/that/does/not/exist/.env')
 
         assert result is False
+
+
+class TestExportPdfMensuelAccessControl:
+    """Vérifie que l'export PDF mensuel respecte les droits d'accès RH."""
+
+    def _verrouiller_fiche(self, db, user_id, mois=1, annee=2025):
+        db.execute('''
+            INSERT INTO validations (
+                user_id, mois, annee, bloque,
+                validation_salarie, validation_responsable, validation_directeur,
+                date_salarie, date_responsable, date_directeur
+            ) VALUES (?, ?, ?, 1, 'Salarié', 'Responsable', 'Directeur',
+                      '2025-01-31', '2025-01-31', '2025-01-31')
+        ''', (user_id, mois, annee))
+        db.commit()
+
+    def test_salarie_ne_peut_pas_exporter_pdf_autre_salarie(self, app, db, auth_client, sample_users):
+        with app.app_context():
+            self._verrouiller_fiche(db, sample_users['responsable_id'])
+
+        response = auth_client.get(
+            f"/export_pdf_mensuel?user_id={sample_users['responsable_id']}&mois=1&annee=2025",
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert '/vue_mensuelle' in response.headers['Location']
+        assert response.headers.get('Content-Type') != 'application/pdf'
+
+    def test_directeur_peut_exporter_pdf_salarie(self, app, db, admin_client, sample_users):
+        with app.app_context():
+            self._verrouiller_fiche(db, sample_users['salarie_id'])
+
+        response = admin_client.get(
+            f"/export_pdf_mensuel?user_id={sample_users['salarie_id']}&mois=1&annee=2025",
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 200
+        assert response.headers['Content-Type'] == 'application/pdf'


### PR DESCRIPTION
### Motivation
- Corriger une faille d'autorisation permettant à un utilisateur authentifié de demander le PDF mensuel verrouillé d'un autre utilisateur via le paramètre `user_id`.
- Le PDF mensuel contient des données RH nominatives et doit respecter le même modèle d'accès que la vue mensuelle.

### Description
- Ajout de la fonction d'autorisation ` _peut_exporter_pdf_mensuel(conn, user_id_cible)` dans `blueprints/exports.py` pour centraliser la logique d'accès (accès à soi, direction/comptable pour utilisateurs actifs non `prestataire`, et responsable seulement pour son secteur).
- Vérification de l'autorisation avant toute génération du PDF dans `export_pdf_mensuel()` et redirection avec message d'erreur si l'accès est refusé.
- Ajout de tests de régression dans `tests/test_security.py` (`TestExportPdfMensuelAccessControl`) qui vérifient qu'un salarié ne peut pas exporter la fiche d'un autre salarié tandis qu'un directeur peut exporter la fiche d'un salarié autorisé.
- Modifications limitées aux fichiers `blueprints/exports.py` et `tests/test_security.py`.

### Testing
- Exécution ciblée : `pytest tests/test_security.py::TestExportPdfMensuelAccessControl -q` — tests verts.
- Exécution du module de tests sécurité : `pytest tests/test_security.py -q` — tests verts.
- Exécution de la suite complète : `pytest -q` — suite complète réussie (`814 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5051482bc0832381e3dc06066c0ce4)