### PR TITLE
Page « Présence effectif » (direction / comptable)

### DIFF
--- a/app.py
+++ b/app.py
@@ -246,6 +246,7 @@ from blueprints.bilan_action import bilan_action_bp
 from blueprints.alsh import alsh_bp
 from blueprints.mise_a_jour import mise_a_jour_bp
 from blueprints.rh_statistiques import rh_statistiques_bp
+from blueprints.presence_effectif import presence_effectif_bp
 from blueprints.dashboard_responsable import dashboard_responsable_bp
 from blueprints.dashboard_comptable import dashboard_comptable_bp
 from blueprints.chatbot import chatbot_bp
@@ -303,6 +304,7 @@ app.register_blueprint(bilan_action_bp)
 app.register_blueprint(alsh_bp)
 app.register_blueprint(mise_a_jour_bp)
 app.register_blueprint(rh_statistiques_bp)
+app.register_blueprint(presence_effectif_bp)
 app.register_blueprint(chatbot_bp)
 app.register_blueprint(compte_resultat_bp)
 app.register_blueprint(indicateurs_financiers_bp)

--- a/blueprints/presence_effectif.py
+++ b/blueprints/presence_effectif.py
@@ -78,18 +78,22 @@ def _construire_matrice(conn, annee, mois, nb_jours):
     debut = _iso(annee, mois, 1)
     fin = _iso(annee, mois, nb_jours)
 
-    # Salariés en contrat sur la période (contrats chevauchant le mois). Les
-    # contrats clos restent visibles même si le compte a été désactivé (départ
-    # en cours d'année) ; un contrat ouvert exige un compte actif.
+    # Salariés en contrat sur la période (contrats chevauchant le mois),
+    # classés par secteur (les sans-secteur en dernier). Les contrats clos
+    # restent visibles même si le compte a été désactivé (départ en cours
+    # d'année) ; un contrat ouvert exige un compte actif.
     rows = conn.execute('''
-        SELECT u.id, u.nom, u.prenom, u.profil, c.date_debut, c.date_fin
+        SELECT u.id, u.nom, u.prenom, u.profil, c.date_debut, c.date_fin,
+               sec.nom AS secteur_nom
         FROM users u
+        LEFT JOIN secteurs sec ON sec.id = u.secteur_id
         JOIN contrats c ON c.user_id = u.id
         WHERE u.profil != 'prestataire'
           AND c.date_debut <= ?
           AND (c.date_fin IS NULL OR c.date_fin >= ?)
           AND (u.actif = 1 OR c.date_fin IS NOT NULL)
-        ORDER BY u.nom COLLATE NOCASE, u.prenom COLLATE NOCASE
+        ORDER BY (sec.nom IS NULL), sec.nom COLLATE NOCASE,
+                 u.nom COLLATE NOCASE, u.prenom COLLATE NOCASE
     ''', (fin, debut)).fetchall()
 
     salaries_map = {}
@@ -98,6 +102,7 @@ def _construire_matrice(conn, annee, mois, nb_jours):
         if r['id'] not in salaries_map:
             salaries_map[r['id']] = {
                 'nom': r['nom'], 'prenom': r['prenom'], 'profil': r['profil'],
+                'secteur': r['secteur_nom'] or 'Sans secteur',
                 'fenetres': [],
             }
             ordre.append(r['id'])
@@ -185,7 +190,7 @@ def _construire_matrice(conn, annee, mois, nb_jours):
                     absents_par_jour[j['num'] - 1] += 1
             cells.append({'cat': cat, 'title': f"{jour_iso} — {libelle}"})
         salaries.append({
-            'nom': s['nom'], 'prenom': s['prenom'],
+            'nom': s['nom'], 'prenom': s['prenom'], 'secteur': s['secteur'],
             'cells': cells, 'compteurs': compteurs,
         })
 

--- a/blueprints/presence_effectif.py
+++ b/blueprints/presence_effectif.py
@@ -29,12 +29,16 @@ MOTIF_VERS_CATEGORIE = {
 
 # Journées du calendrier forfait jour (direction) → catégorie. La direction
 # peut poser des journées directement dans son calendrier, sans fiche
-# d'absence : on lit donc aussi presence_forfait_jour.
+# d'absence : on lit donc aussi presence_forfait_jour. Le calendrier utilise
+# 'repos_forfait' et 'forfait_jour' comme synonymes (RTT du forfait jours) ;
+# un jour marqué 'ferie' reste neutre (ni présent, ni compté en absence).
 FORFAIT_VERS_CATEGORIE = {
     'conge_paye': 'conges',
     'conge_conv': 'conges',
     'forfait_jour': 'conges',
+    'repos_forfait': 'conges',
     'maladie': 'maladie',
+    'ferie': 'ferie',
 }
 
 # En cas de chevauchement de deux absences sur un même jour, la catégorie la

--- a/blueprints/presence_effectif.py
+++ b/blueprints/presence_effectif.py
@@ -1,0 +1,227 @@
+"""
+Blueprint presence_effectif_bp.
+
+Page « Présence effectif » (direction / comptable) : tableau mensuel des
+salariés en contrat sur la période — une colonne par jour du mois, un statut
+par case (présent, arrêt maladie, congés, récupération, autre absence) avec
+un code couleur bien visible. Les motifs non regroupés tombent dans « autre ».
+"""
+from calendar import monthrange
+from datetime import date
+
+from flask import (Blueprint, flash, redirect, render_template, request,
+                   session, url_for)
+
+from database import get_db
+from utils import login_required, NOMS_MOIS
+
+presence_effectif_bp = Blueprint('presence_effectif_bp', __name__)
+
+# Catégorie d'un motif d'absence ; tout motif non listé tombe dans « autre »
+# (congé parental, jour enfant malade, accident du travail, évènement
+# familial, sans solde, mi-temps thérapeutique…).
+MOTIF_VERS_CATEGORIE = {
+    'Arrêt maladie': 'maladie',
+    'Congé payé': 'conges',
+    'Congé conventionnel': 'conges',
+    'Forfait jour': 'conges',
+}
+
+# Journées du calendrier forfait jour (direction) → catégorie. La direction
+# peut poser des journées directement dans son calendrier, sans fiche
+# d'absence : on lit donc aussi presence_forfait_jour.
+FORFAIT_VERS_CATEGORIE = {
+    'conge_paye': 'conges',
+    'conge_conv': 'conges',
+    'forfait_jour': 'conges',
+    'maladie': 'maladie',
+}
+
+# En cas de chevauchement de deux absences sur un même jour, la catégorie la
+# plus « forte » l'emporte (plus petit = plus fort).
+_PRIORITE = {'maladie': 0, 'conges': 1, 'autre': 2, 'recup': 3}
+
+_JOUR_COURT = ('L', 'M', 'M', 'J', 'V', 'S', 'D')
+
+_LIBELLES = {
+    'present': 'Présent',
+    'maladie': 'Arrêt maladie',
+    'conges': 'Congés',
+    'recup': 'Récupération',
+    'autre': 'Autre absence',
+    'weekend': 'Week-end',
+    'ferie': 'Jour férié',
+    'hors': 'Hors contrat',
+}
+
+
+def _iso(annee, mois, jour):
+    return f"{annee:04d}-{mois:02d}-{jour:02d}"
+
+
+def _sous_contrat(fenetres, jour_iso):
+    """Vrai si le jour (ISO) est couvert par au moins une fenêtre de contrat."""
+    for debut, fin in fenetres:
+        if debut <= jour_iso and (fin is None or jour_iso <= fin):
+            return True
+    return False
+
+
+def _construire_matrice(conn, annee, mois, nb_jours):
+    """Construit la matrice salariés × jours du mois.
+
+    Retourne (jours, salaries, absents_par_jour) :
+    - jours : [{num, lettre, is_weekend, is_ferie, ferie_libelle, is_today}]
+    - salaries : [{nom, prenom, cells: [{cat, title}], compteurs: {...}}]
+    - absents_par_jour : nombre d'absents (maladie+congés+récup+autre) par jour.
+    """
+    debut = _iso(annee, mois, 1)
+    fin = _iso(annee, mois, nb_jours)
+
+    # Salariés en contrat sur la période (contrats chevauchant le mois). Les
+    # contrats clos restent visibles même si le compte a été désactivé (départ
+    # en cours d'année) ; un contrat ouvert exige un compte actif.
+    rows = conn.execute('''
+        SELECT u.id, u.nom, u.prenom, u.profil, c.date_debut, c.date_fin
+        FROM users u
+        JOIN contrats c ON c.user_id = u.id
+        WHERE u.profil != 'prestataire'
+          AND c.date_debut <= ?
+          AND (c.date_fin IS NULL OR c.date_fin >= ?)
+          AND (u.actif = 1 OR c.date_fin IS NOT NULL)
+        ORDER BY u.nom COLLATE NOCASE, u.prenom COLLATE NOCASE
+    ''', (fin, debut)).fetchall()
+
+    salaries_map = {}
+    ordre = []
+    for r in rows:
+        if r['id'] not in salaries_map:
+            salaries_map[r['id']] = {
+                'nom': r['nom'], 'prenom': r['prenom'], 'profil': r['profil'],
+                'fenetres': [],
+            }
+            ordre.append(r['id'])
+        salaries_map[r['id']]['fenetres'].append((r['date_debut'], r['date_fin']))
+
+    # Statut par (user, jour) : {jour_iso: (categorie, libelle)}
+    statuts = {uid: {} for uid in salaries_map}
+
+    def poser(uid, jour_iso, categorie, libelle):
+        if uid not in statuts:
+            return
+        actuel = statuts[uid].get(jour_iso)
+        if actuel and _PRIORITE.get(actuel[0], 9) <= _PRIORITE.get(categorie, 9):
+            return
+        statuts[uid][jour_iso] = (categorie, libelle)
+
+    # Absences chevauchant le mois : catégorie selon le motif.
+    for a in conn.execute('''
+        SELECT user_id, motif, date_debut, date_fin FROM absences
+        WHERE date_debut <= ? AND date_fin >= ?
+    ''', (fin, debut)).fetchall():
+        categorie = MOTIF_VERS_CATEGORIE.get(a['motif'], 'autre')
+        for jour in range(1, nb_jours + 1):
+            jour_iso = _iso(annee, mois, jour)
+            if a['date_debut'] <= jour_iso <= a['date_fin']:
+                poser(a['user_id'], jour_iso, categorie, a['motif'])
+
+    # Journées de récupération validées (matérialisées dans heures_reelles).
+    for r in conn.execute('''
+        SELECT user_id, date FROM heures_reelles
+        WHERE date BETWEEN ? AND ? AND type_saisie = 'recup_journee'
+    ''', (debut, fin)).fetchall():
+        poser(r['user_id'], r['date'], 'recup', 'Récupération')
+
+    # Calendrier forfait jour (direction) : journées posées sans fiche
+    # d'absence (le type 'travaille' reste un jour présent).
+    for f in conn.execute('''
+        SELECT user_id, date, type_journee FROM presence_forfait_jour
+        WHERE date BETWEEN ? AND ?
+    ''', (debut, fin)).fetchall():
+        categorie = FORFAIT_VERS_CATEGORIE.get(f['type_journee'])
+        if categorie is None and f['type_journee'] != 'travaille':
+            categorie = 'autre'
+        if categorie:
+            poser(f['user_id'], f['date'], categorie,
+                  f"Forfait jour : {f['type_journee'].replace('_', ' ')}")
+
+    feries = {r['date']: r['libelle'] for r in conn.execute(
+        'SELECT date, libelle FROM jours_feries WHERE date BETWEEN ? AND ?',
+        (debut, fin)).fetchall()}
+
+    aujourd_hui = date.today().isoformat()
+    jours = []
+    for jour in range(1, nb_jours + 1):
+        jour_iso = _iso(annee, mois, jour)
+        semaine = date(annee, mois, jour).weekday()
+        jours.append({
+            'num': jour,
+            'iso': jour_iso,
+            'lettre': _JOUR_COURT[semaine],
+            'is_weekend': semaine >= 5,
+            'is_ferie': jour_iso in feries,
+            'ferie_libelle': feries.get(jour_iso, ''),
+            'is_today': jour_iso == aujourd_hui,
+        })
+
+    salaries = []
+    absents_par_jour = [0] * nb_jours
+    for uid in ordre:
+        s = salaries_map[uid]
+        cells = []
+        compteurs = {'maladie': 0, 'conges': 0, 'recup': 0, 'autre': 0}
+        for j in jours:
+            jour_iso = j['iso']
+            if not _sous_contrat(s['fenetres'], jour_iso):
+                cat, libelle = 'hors', _LIBELLES['hors']
+            elif j['is_weekend']:
+                cat, libelle = 'weekend', _LIBELLES['weekend']
+            elif j['is_ferie']:
+                cat, libelle = 'ferie', f"Férié : {j['ferie_libelle']}"
+            else:
+                cat, libelle = statuts[uid].get(jour_iso, ('present', _LIBELLES['present']))
+                if cat in compteurs:
+                    compteurs[cat] += 1
+                    absents_par_jour[j['num'] - 1] += 1
+            cells.append({'cat': cat, 'title': f"{jour_iso} — {libelle}"})
+        salaries.append({
+            'nom': s['nom'], 'prenom': s['prenom'],
+            'cells': cells, 'compteurs': compteurs,
+        })
+
+    return jours, salaries, absents_par_jour
+
+
+@presence_effectif_bp.route('/presence-effectif')
+@login_required
+def presence_effectif():
+    """Tableau mensuel de présence de l'effectif (direction / comptable)."""
+    if session.get('profil') not in ('directeur', 'comptable'):
+        flash('Accès non autorisé', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    aujourd_hui = date.today()
+    mois = request.args.get('mois', type=int) or aujourd_hui.month
+    annee = request.args.get('annee', type=int) or aujourd_hui.year
+    mois = min(max(mois, 1), 12)
+    annee = min(max(annee, 2000), 2100)
+    nb_jours = monthrange(annee, mois)[1]
+
+    conn = get_db()
+    try:
+        jours, salaries, absents_par_jour = _construire_matrice(conn, annee, mois, nb_jours)
+    finally:
+        conn.close()
+
+    prec_annee, prec_mois = (annee - 1, 12) if mois == 1 else (annee, mois - 1)
+    suiv_annee, suiv_mois = (annee + 1, 1) if mois == 12 else (annee, mois + 1)
+
+    return render_template(
+        'presence_effectif.html',
+        annee=annee, mois=mois, mois_nom=NOMS_MOIS[mois],
+        annees=list(range(aujourd_hui.year - 3, aujourd_hui.year + 2)),
+        noms_mois=NOMS_MOIS,
+        jours=jours, salaries=salaries, absents_par_jour=absents_par_jour,
+        prec_mois=prec_mois, prec_annee=prec_annee,
+        suiv_mois=suiv_mois, suiv_annee=suiv_annee,
+    )

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,6 +69,7 @@
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
+                    <a href="{{ url_for('presence_effectif_bp.presence_effectif') }}">🗓️ Présence effectif</a>
                     <a href="{{ url_for('rh_statistiques_bp.rh_statistiques') }}">📊 Statistiques RH</a>
                     <a href="{{ url_for('benevoles_bp.gestion_benevoles') }}">🤝 Bénévoles</a>
                     <a href="{{ url_for('pesee_alisfa_bp.pesee_alisfa') }}">⚖️ Pesée ALISFA</a>
@@ -154,6 +155,7 @@
                     <a href="{{ url_for('saisie_bp.saisie_heures') }}">✏️ Saisir heures</a>
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Mon planning</a>
                     <a href="{{ url_for('mon_equipe_bp.mon_equipe') }}">👥 Mon équipe</a>
+                    <a href="{{ url_for('presence_effectif_bp.presence_effectif') }}">🗓️ Présence effectif</a>
                 </div>
             </div>
             <div class="sidebar-section">

--- a/templates/presence_effectif.html
+++ b/templates/presence_effectif.html
@@ -61,7 +61,15 @@
                     </tr>
                 </thead>
                 <tbody>
+                    {% set ns = namespace(secteur=None) %}
                     {% for s in salaries %}
+                    {% if s.secteur != ns.secteur %}
+                    {% set ns.secteur = s.secteur %}
+                    <tr class="pe-secteur">
+                        <td class="pe-nom">🏢 {{ s.secteur }}</td>
+                        <td colspan="{{ jours|length + 1 }}"></td>
+                    </tr>
+                    {% endif %}
                     <tr>
                         <td class="pe-nom"><strong>{{ s.nom }}</strong> {{ s.prenom }}</td>
                         {% for c in s.cells %}
@@ -160,6 +168,14 @@
     color: var(--gray-500, #6b7280);
 }
 .pe-jour-off { background: var(--gray-100, #f3f4f6); }
+.pe-secteur td {
+    background: var(--gray-100, #eef1f4);
+    font-weight: 700;
+    text-align: left;
+    padding: 5px 10px;
+    border-top: 2px solid var(--gray-300, #d1d5db);
+}
+[data-theme="dark"] .pe-secteur td { background: var(--gray-200); }
 .pe-today { outline: 2px solid var(--primary, #667eea); outline-offset: -2px; }
 .pe-cell { font-weight: 700; min-width: 26px; }
 

--- a/templates/presence_effectif.html
+++ b/templates/presence_effectif.html
@@ -1,0 +1,201 @@
+{% extends "base.html" %}
+
+{% block title %}Présence effectif - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="form-container">
+    <h1>🗓️ Présence effectif</h1>
+    <p class="subtitle">Salariés en contrat sur {{ mois_nom|lower }} {{ annee }} — statut jour par jour</p>
+
+    {# ── Navigation mois ── #}
+    <div class="section" style="padding:1rem;">
+        <form method="GET" action="{{ url_for('presence_effectif_bp.presence_effectif') }}"
+              style="display:flex;gap:0.75rem;align-items:center;flex-wrap:wrap;">
+            <a class="btn btn-secondary" style="padding:6px 12px;"
+               href="{{ url_for('presence_effectif_bp.presence_effectif', mois=prec_mois, annee=prec_annee) }}">◀</a>
+            <select name="mois" onchange="this.form.submit()">
+                {% for m in range(1, 13) %}
+                <option value="{{ m }}" {% if m == mois %}selected{% endif %}>{{ noms_mois[m] }}</option>
+                {% endfor %}
+            </select>
+            <select name="annee" onchange="this.form.submit()">
+                {% for a in annees %}
+                <option value="{{ a }}" {% if a == annee %}selected{% endif %}>{{ a }}</option>
+                {% endfor %}
+            </select>
+            <a class="btn btn-secondary" style="padding:6px 12px;"
+               href="{{ url_for('presence_effectif_bp.presence_effectif', mois=suiv_mois, annee=suiv_annee) }}">▶</a>
+            <span style="margin-left:auto;color:var(--gray-500);font-size:0.85rem;">
+                {{ salaries|length }} salarié(s) en contrat sur la période
+            </span>
+        </form>
+    </div>
+
+    {# ── Légende ── #}
+    <div class="pe-legende">
+        <span class="pe-chip pe-present">P Présent</span>
+        <span class="pe-chip pe-maladie">M Arrêt maladie</span>
+        <span class="pe-chip pe-conges">C Congés</span>
+        <span class="pe-chip pe-recup">R Récupération</span>
+        <span class="pe-chip pe-autre">A Autre absence</span>
+        <span class="pe-chip pe-ferie">F Férié</span>
+        <span class="pe-chip pe-weekend">Week-end</span>
+        <span class="pe-chip pe-hors">Hors contrat</span>
+    </div>
+
+    {# ── Tableau ── #}
+    <div class="section" style="padding:1rem;">
+        {% if salaries %}
+        <div class="pe-scroll">
+            <table class="pe-table">
+                <thead>
+                    <tr>
+                        <th class="pe-nom">Salarié</th>
+                        {% for j in jours %}
+                        <th class="pe-jour {% if j.is_weekend or j.is_ferie %}pe-jour-off{% endif %} {% if j.is_today %}pe-today{% endif %}"
+                            {% if j.is_ferie %}title="{{ j.ferie_libelle }}"{% endif %}>
+                            <span class="pe-jour-lettre">{{ j.lettre }}</span>{{ j.num }}
+                        </th>
+                        {% endfor %}
+                        <th class="pe-total" title="Jours d'absence du mois : Maladie / Congés / Récup / Autre">M / C / R / A</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for s in salaries %}
+                    <tr>
+                        <td class="pe-nom"><strong>{{ s.nom }}</strong> {{ s.prenom }}</td>
+                        {% for c in s.cells %}
+                        <td class="pe-cell pe-{{ c.cat }} {% if jours[loop.index0].is_today %}pe-today{% endif %}" title="{{ c.title }}">
+                            {%- if c.cat == 'present' -%}P
+                            {%- elif c.cat == 'maladie' -%}M
+                            {%- elif c.cat == 'conges' -%}C
+                            {%- elif c.cat == 'recup' -%}R
+                            {%- elif c.cat == 'autre' -%}A
+                            {%- elif c.cat == 'ferie' -%}F
+                            {%- endif -%}
+                        </td>
+                        {% endfor %}
+                        <td class="pe-total">
+                            <span class="pe-mini pe-maladie">{{ s.compteurs.maladie }}</span>
+                            <span class="pe-mini pe-conges">{{ s.compteurs.conges }}</span>
+                            <span class="pe-mini pe-recup">{{ s.compteurs.recup }}</span>
+                            <span class="pe-mini pe-autre">{{ s.compteurs.autre }}</span>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td class="pe-nom" style="font-weight:600;">Absents</td>
+                        {% for j in jours %}
+                        <td class="pe-cell pe-absents {% if j.is_weekend or j.is_ferie %}pe-jour-off{% endif %}">
+                            {%- if not j.is_weekend and not j.is_ferie and absents_par_jour[loop.index0] -%}
+                            {{ absents_par_jour[loop.index0] }}
+                            {%- endif -%}
+                        </td>
+                        {% endfor %}
+                        <td class="pe-total"></td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+        {% else %}
+        <p class="no-data">Aucun salarié en contrat sur cette période.</p>
+        {% endif %}
+    </div>
+
+    <div class="help-box">
+        <h4>ℹ️ Lecture du tableau</h4>
+        <ul>
+            <li><strong>Congés</strong> regroupe : congé payé, congé conventionnel et forfait jour (direction).</li>
+            <li><strong>Autre absence</strong> regroupe les motifs restants : congé parental, jour enfant malade,
+                accident du travail, évènement familial, sans solde, mi-temps thérapeutique…
+                Le motif exact s'affiche au survol de la case.</li>
+            <li><strong>Récupération</strong> : journées de récupération validées.</li>
+            <li>La colonne <strong>M / C / R / A</strong> totalise les jours d'absence du mois par catégorie.</li>
+            <li>La ligne <strong>Absents</strong> compte les absents par jour (hors week-ends et fériés).</li>
+        </ul>
+    </div>
+</div>
+
+<style>
+.pe-legende {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0 0 1rem;
+}
+.pe-chip {
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+.pe-scroll { overflow-x: auto; }
+.pe-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.8rem;
+}
+.pe-table th, .pe-table td {
+    border: 1px solid var(--gray-200, #e5e7eb);
+    text-align: center;
+    padding: 4px 2px;
+}
+.pe-nom {
+    text-align: left !important;
+    white-space: nowrap;
+    padding: 4px 10px !important;
+    position: sticky;
+    left: 0;
+    background: var(--white, #fff);
+    z-index: 2;
+    min-width: 160px;
+}
+.pe-jour { min-width: 26px; font-weight: 600; }
+.pe-jour-lettre {
+    display: block;
+    font-weight: 400;
+    font-size: 0.65rem;
+    color: var(--gray-500, #6b7280);
+}
+.pe-jour-off { background: var(--gray-100, #f3f4f6); }
+.pe-today { outline: 2px solid var(--primary, #667eea); outline-offset: -2px; }
+.pe-cell { font-weight: 700; min-width: 26px; }
+
+/* Code couleur — volontairement contrasté pour une lecture immédiate. */
+.pe-present { background: #d9f2e5; color: #0a7d43; }
+.pe-maladie { background: #dc2626; color: #fff; }
+.pe-conges  { background: #f59e0b; color: #fff; }
+.pe-recup   { background: #2563eb; color: #fff; }
+.pe-autre   { background: #8b5cf6; color: #fff; }
+.pe-ferie   { background: #e5e7eb; color: #6b7280; }
+.pe-weekend { background: #f3f4f6; color: #9ca3af; }
+.pe-hors    {
+    background: repeating-linear-gradient(45deg, #f8f9fa, #f8f9fa 4px, #eceff1 4px, #eceff1 8px);
+    color: transparent;
+}
+.pe-absents { font-weight: 700; color: #b91c1c; background: var(--white, #fff); }
+.pe-total { white-space: nowrap; padding: 4px 6px !important; }
+.pe-mini {
+    display: inline-block;
+    min-width: 20px;
+    padding: 1px 4px;
+    border-radius: 4px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    margin: 0 1px;
+}
+
+/* Thème sombre : on garde les couleurs de statut (absolues), on adapte fonds neutres. */
+[data-theme="dark"] .pe-nom { background: var(--gray-100); }
+[data-theme="dark"] .pe-jour-off { background: var(--gray-200); }
+[data-theme="dark"] .pe-weekend { background: var(--gray-200); color: var(--gray-500); }
+[data-theme="dark"] .pe-ferie { background: var(--gray-300); color: var(--gray-600); }
+[data-theme="dark"] .pe-present { background: #14532d; color: #bbf7d0; }
+[data-theme="dark"] .pe-absents { background: var(--gray-100); }
+[data-theme="dark"] .pe-hors {
+    background: repeating-linear-gradient(45deg, var(--gray-100), var(--gray-100) 4px, var(--gray-200) 4px, var(--gray-200) 8px);
+}
+</style>
+{% endblock %}

--- a/tests/test_presence_effectif.py
+++ b/tests/test_presence_effectif.py
@@ -1,0 +1,179 @@
+"""
+Tests de la page « Présence effectif » (direction / comptable).
+
+Tableau mensuel des salariés en contrat sur la période : un statut par jour
+(présent, arrêt maladie, congés, récupération, autre absence), week-ends et
+fériés neutralisés, jours hors contrat distincts.
+"""
+from blueprints.presence_effectif import _construire_matrice
+
+
+def _contrat(db, user_id, debut='2025-01-01', fin=None):
+    db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+               "VALUES (?, 'CDI', ?, ?)", (user_id, debut, fin))
+    db.commit()
+
+
+def _absence(db, user_id, motif, debut, fin, saisi_par):
+    db.execute("INSERT INTO absences (user_id, motif, date_debut, date_fin, jours_ouvres, saisi_par) "
+               "VALUES (?, ?, ?, ?, 1, ?)", (user_id, motif, debut, fin, saisi_par))
+    db.commit()
+
+
+def _ligne(salaries, nom):
+    return next(s for s in salaries if s['nom'] == nom)
+
+
+def _cat(ligne, jour):
+    return ligne['cells'][jour - 1]['cat']
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Accès
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_salarie_refuse(auth_client):
+    resp = auth_client.get('/presence-effectif', follow_redirects=True)
+    assert 'Accès non autorisé' in resp.get_data(as_text=True)
+
+
+def test_responsable_refuse(resp_client):
+    resp = resp_client.get('/presence-effectif', follow_redirects=True)
+    assert 'Accès non autorisé' in resp.get_data(as_text=True)
+
+
+def test_directeur_accede(admin_client):
+    resp = admin_client.get('/presence-effectif')
+    assert resp.status_code == 200
+    assert 'Présence effectif' in resp.get_data(as_text=True)
+
+
+def test_comptable_accede(comptable_client):
+    resp = comptable_client.get('/presence-effectif')
+    assert resp.status_code == 200
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Liste des salariés en contrat sur la période
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_seuls_les_salaries_en_contrat_apparaissent(app, db, sample_users):
+    # Martin : contrat couvrant mars 2026 ; Dupont (responsable) : aucun contrat ;
+    # contrat terminé avant le mois → invisible.
+    _contrat(db, sample_users['salarie_id'])
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) "
+               "VALUES ('Parti', 'Depuis', 'parti', 'x', 'salarie', 0)")
+    parti_id = db.execute("SELECT id FROM users WHERE login='parti'").fetchone()['id']
+    _contrat(db, parti_id, debut='2024-01-01', fin='2025-12-31')
+    db.commit()
+
+    with app.app_context():
+        _, salaries, _ = _construire_matrice(db, 2026, 3, 31)
+    noms = [s['nom'] for s in salaries]
+    assert 'Martin' in noms
+    assert 'Dupont' not in noms          # pas de contrat
+    assert 'Parti' not in noms           # contrat clos avant la période
+
+
+def test_contrat_clos_reste_visible_le_mois_du_depart(app, db, sample_users):
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) "
+               "VALUES ('Sortant', 'Mimois', 'sortant', 'x', 'salarie', 0)")
+    uid = db.execute("SELECT id FROM users WHERE login='sortant'").fetchone()['id']
+    _contrat(db, uid, debut='2024-01-01', fin='2026-03-15')
+
+    with app.app_context():
+        _, salaries, _ = _construire_matrice(db, 2026, 3, 31)
+    ligne = _ligne(salaries, 'Sortant')
+    assert _cat(ligne, 13) == 'present'   # vendredi 13 mars : sous contrat
+    assert _cat(ligne, 17) == 'hors'      # mardi 17 mars : contrat terminé
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Statuts jour par jour
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_categories_par_motif(app, db, sample_users):
+    uid = sample_users['salarie_id']
+    saisi_par = sample_users['directeur_id']
+    _contrat(db, uid)
+    _absence(db, uid, 'Arrêt maladie', '2026-03-03', '2026-03-04', saisi_par)
+    _absence(db, uid, 'Congé payé', '2026-03-10', '2026-03-10', saisi_par)
+    _absence(db, uid, 'Evènement familial', '2026-03-12', '2026-03-12', saisi_par)
+    db.execute("INSERT INTO heures_reelles (user_id, date, type_saisie) "
+               "VALUES (?, '2026-03-17', 'recup_journee')", (uid,))
+    db.execute("INSERT INTO jours_feries (annee, date, libelle) "
+               "VALUES (2026, '2026-03-16', 'Férié test')")
+    db.commit()
+
+    with app.app_context():
+        jours, salaries, absents = _construire_matrice(db, 2026, 3, 31)
+    ligne = _ligne(salaries, 'Martin')
+
+    assert _cat(ligne, 2) == 'present'    # lundi 2 mars, rien de saisi
+    assert _cat(ligne, 3) == 'maladie'
+    assert _cat(ligne, 4) == 'maladie'
+    assert _cat(ligne, 10) == 'conges'
+    assert _cat(ligne, 12) == 'autre'     # motif non regroupé → autre
+    assert _cat(ligne, 17) == 'recup'
+    assert _cat(ligne, 16) == 'ferie'     # férié prioritaire
+    assert _cat(ligne, 1) == 'weekend'    # dimanche 1er mars
+    assert _cat(ligne, 7) == 'weekend'    # samedi 7 mars
+
+    # Compteurs mensuels par catégorie (jours ouvrés uniquement).
+    assert ligne['compteurs'] == {'maladie': 2, 'conges': 1, 'recup': 1, 'autre': 1}
+    # Ligne « Absents » : 1 absent le 3 mars (index 2), 0 le 2 mars (index 1).
+    assert absents[2] == 1
+    assert absents[1] == 0
+
+
+def test_absence_sur_weekend_reste_weekend(app, db, sample_users):
+    uid = sample_users['salarie_id']
+    _contrat(db, uid)
+    # Arrêt couvrant du vendredi 6 au lundi 9 : le week-end reste neutre.
+    _absence(db, uid, 'Arrêt maladie', '2026-03-06', '2026-03-09', sample_users['directeur_id'])
+
+    with app.app_context():
+        _, salaries, _ = _construire_matrice(db, 2026, 3, 31)
+    ligne = _ligne(salaries, 'Martin')
+    assert _cat(ligne, 6) == 'maladie'
+    assert _cat(ligne, 7) == 'weekend'
+    assert _cat(ligne, 8) == 'weekend'
+    assert _cat(ligne, 9) == 'maladie'
+    assert ligne['compteurs']['maladie'] == 2
+
+
+def test_forfait_jour_direction(app, db, sample_users):
+    """Une journée posée directement dans le calendrier forfait jour (sans fiche
+    d'absence) est classée : forfait_jour → congés ; travaille → présent."""
+    uid = sample_users['directeur_id']
+    _contrat(db, uid)
+    db.execute("INSERT INTO presence_forfait_jour (user_id, date, type_journee) "
+               "VALUES (?, '2026-03-05', 'forfait_jour')", (uid,))
+    db.execute("INSERT INTO presence_forfait_jour (user_id, date, type_journee) "
+               "VALUES (?, '2026-03-06', 'travaille')", (uid,))
+    db.commit()
+
+    with app.app_context():
+        _, salaries, _ = _construire_matrice(db, 2026, 3, 31)
+    ligne = _ligne(salaries, 'Admin')
+    assert _cat(ligne, 5) == 'conges'
+    assert _cat(ligne, 6) == 'present'
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Rendu de la page
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_rendu_page_avec_donnees(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    _contrat(db, uid)
+    _absence(db, uid, 'Arrêt maladie', '2026-03-03', '2026-03-04', sample_users['directeur_id'])
+
+    resp = admin_client.get('/presence-effectif?mois=3&annee=2026')
+    html = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'Martin' in html
+    assert 'pe-maladie' in html
+    assert '2026-03-03 — Arrêt maladie' in html    # motif exact en info-bulle
+    assert 'M / C / R / A' in html                  # colonne des compteurs
+    assert 'Mars 2026' in html or 'mars 2026' in html

--- a/tests/test_presence_effectif.py
+++ b/tests/test_presence_effectif.py
@@ -75,6 +75,28 @@ def test_seuls_les_salaries_en_contrat_apparaissent(app, db, sample_users):
     assert 'Parti' not in noms           # contrat clos avant la période
 
 
+def test_salaries_classes_par_secteur(app, db, sample_users):
+    """Les salariés sont regroupés par secteur (alphabétique), les comptes
+    sans secteur en dernier."""
+    _contrat(db, sample_users['salarie_id'])        # Martin — Secteur Test
+    _contrat(db, sample_users['directeur_id'])      # Admin — sans secteur
+    db.execute("INSERT INTO secteurs (nom) VALUES ('Autre Secteur')")
+    autre_id = db.execute("SELECT id FROM secteurs WHERE nom='Autre Secteur'").fetchone()['id']
+    db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif, secteur_id) "
+               "VALUES ('Zola', 'Emile', 'zola', 'x', 'salarie', 1, ?)", (autre_id,))
+    zola_id = db.execute("SELECT id FROM users WHERE login='zola'").fetchone()['id']
+    _contrat(db, zola_id)
+
+    with app.app_context():
+        _, salaries, _ = _construire_matrice(db, 2026, 3, 31)
+    ordre = [(s['secteur'], s['nom']) for s in salaries]
+    assert ordre == [
+        ('Autre Secteur', 'Zola'),
+        ('Secteur Test', 'Martin'),
+        ('Sans secteur', 'Admin'),
+    ]
+
+
 def test_contrat_clos_reste_visible_le_mois_du_depart(app, db, sample_users):
     db.execute("INSERT INTO users (nom, prenom, login, password, profil, actif) "
                "VALUES ('Sortant', 'Mimois', 'sortant', 'x', 'salarie', 0)")

--- a/tests/test_presence_effectif.py
+++ b/tests/test_presence_effectif.py
@@ -166,20 +166,27 @@ def test_absence_sur_weekend_reste_weekend(app, db, sample_users):
 
 def test_forfait_jour_direction(app, db, sample_users):
     """Une journée posée directement dans le calendrier forfait jour (sans fiche
-    d'absence) est classée : forfait_jour → congés ; travaille → présent."""
+    d'absence) est classée : forfait_jour / repos_forfait (RTT) → congés ;
+    travaille → présent ; ferie → neutre (non compté en absence)."""
     uid = sample_users['directeur_id']
     _contrat(db, uid)
-    db.execute("INSERT INTO presence_forfait_jour (user_id, date, type_journee) "
-               "VALUES (?, '2026-03-05', 'forfait_jour')", (uid,))
-    db.execute("INSERT INTO presence_forfait_jour (user_id, date, type_journee) "
-               "VALUES (?, '2026-03-06', 'travaille')", (uid,))
+    for jour, type_j in (('2026-03-05', 'forfait_jour'), ('2026-03-06', 'travaille'),
+                         ('2026-03-09', 'repos_forfait'), ('2026-03-10', 'ferie'),
+                         ('2026-03-11', 'sans_solde')):
+        db.execute("INSERT INTO presence_forfait_jour (user_id, date, type_journee) "
+                   "VALUES (?, ?, ?)", (uid, jour, type_j))
     db.commit()
 
     with app.app_context():
-        _, salaries, _ = _construire_matrice(db, 2026, 3, 31)
+        _, salaries, absents = _construire_matrice(db, 2026, 3, 31)
     ligne = _ligne(salaries, 'Admin')
     assert _cat(ligne, 5) == 'conges'
     assert _cat(ligne, 6) == 'present'
+    assert _cat(ligne, 9) == 'conges'     # repos forfait (RTT) = congés
+    assert _cat(ligne, 10) == 'ferie'     # férié posé au calendrier : neutre
+    assert _cat(ligne, 11) == 'autre'     # type non regroupé → autre
+    assert ligne['compteurs'] == {'maladie': 0, 'conges': 2, 'recup': 0, 'autre': 1}
+    assert absents[9] == 0                # le férié du 10 n'est pas compté absent
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Contexte

Nouvelle page **Présence effectif** : tableau mensuel des salariés **en contrat sur la période**, une colonne par jour du mois, un statut par case avec un **code couleur bien visible**.

## Statuts et regroupements

| Statut | Couleur | Contenu |
|---|---|---|
| **P** Présent | vert | jour ouvré sous contrat sans absence |
| **M** Arrêt maladie | rouge | motif « Arrêt maladie » |
| **C** Congés | orange | congé payé, congé conventionnel, forfait jour |
| **R** Récupération | bleu | journées de récupération validées |
| **A** Autre absence | violet | tous les motifs restants (congé parental, enfant malade, accident du travail, évènement familial, sans solde, mi‑temps thérapeutique…) — **motif exact au survol** |
| **F** / gris | — | fériés et week‑ends (neutralisés) |
| hachuré | — | hors contrat (embauche / départ en cours de mois) |

- En cas de chevauchement : maladie > congés > autre.
- **Direction** : le calendrier forfait jour est aussi lu (journées posées sans fiche d'absence).
- Colonne **M / C / R / A** : totaux du mois par catégorie ; ligne **Absents** : nombre d'absents par jour ouvré.
- Un contrat clos reste visible le mois du départ même si le compte est désactivé ; un contrat ouvert exige un compte actif.

## Accès & menu

- Page réservée **direction + comptable** (redirection sinon).
- Menu : sous « 👥 Mon équipe » (comptable) ; dans « 💼 RH & Paie » après « Absences » pour la direction (dont le menu n'a pas d'entrée « Mon équipe »).

## Vérification

- `tests/test_presence_effectif.py` : accès par profil, fenêtres de contrat, catégories par motif, priorité week‑end/férié, calendrier forfait jour, compteurs, rendu HTML.
- Suite complète verte : **824 tests**.
- Vérifié au navigateur avec un jeu de données réaliste (statuts, couleurs, hachures hors contrat, ligne Absents, lien menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_