### PR TITLE
Centre de contrôle : retours de test (modale seuils, page Soldes de congés, détails des demandes)

### DIFF
--- a/blueprints/dashboard_direction.py
+++ b/blueprints/dashboard_direction.py
@@ -322,8 +322,8 @@ def dashboard_direction():
         alertes_seuil.append({
             'etiquette': 'Congés conventionnels à planifier', 'couleur': '#8b5cf6', 'icone': '🏖️',
             'valeur': f"{conges_hauts['nb']} salarié(s)",
-            'detail': f"solde ≥ {seuils['conges']:g} j (max : {maxi} j)".replace('.', ','),
-            'lien': url_for('infos_salaries_bp.infos_salaries'), 'lien_texte': 'Voir les soldes',
+            'detail': f"solde ≥ {seuils['conges']:g} j (salarié max : {maxi} j)".replace('.', ','),
+            'lien': url_for('infos_salaries_bp.soldes_conges'), 'lien_texte': 'Voir les soldes',
         })
     if surcharges:
         alertes_seuil.append({

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -711,3 +711,53 @@ def supprimer_contrat(contrat_id):
 
     flash("Contrat supprime.", 'success')
     return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+
+@infos_salaries_bp.route('/soldes_conges')
+@login_required
+def soldes_conges():
+    """Soldes de congés de l'ensemble des salariés (direction / comptable).
+
+    Vue synthétique : congés payés (à prendre, pris, solde), congés
+    conventionnels et total restant, triés du plus gros solde au plus petit.
+    Les congés conventionnels au-dessus du seuil du centre de contrôle sont
+    mis en évidence.
+    """
+    if session.get('profil') not in ('directeur', 'comptable'):
+        flash("Acces non autorise.", 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    from blueprints.dashboard_direction import _lire_seuils
+    seuil_conges = _lire_seuils()['conges']
+
+    conn = get_db()
+    try:
+        rows = conn.execute('''
+            SELECT u.id, u.nom, u.prenom,
+                   COALESCE(s.nom, 'Sans secteur') AS secteur_nom,
+                   COALESCE(u.cp_a_prendre, 0) AS cp_a_prendre,
+                   COALESCE(u.cp_pris, 0) AS cp_pris,
+                   COALESCE(u.cc_solde, 0) AS cc_solde
+            FROM users u
+            LEFT JOIN secteurs s ON s.id = u.secteur_id
+            WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+            ORDER BY u.nom COLLATE NOCASE, u.prenom COLLATE NOCASE
+        ''').fetchall()
+    finally:
+        conn.close()
+
+    salaries = []
+    for r in rows:
+        solde_cp = r['cp_a_prendre'] - r['cp_pris']
+        salaries.append({
+            'id': r['id'], 'nom': r['nom'], 'prenom': r['prenom'],
+            'secteur': r['secteur_nom'],
+            'cp_a_prendre': r['cp_a_prendre'], 'cp_pris': r['cp_pris'],
+            'solde_cp': solde_cp, 'cc_solde': r['cc_solde'],
+            'total': solde_cp + r['cc_solde'],
+            'cc_au_dessus_seuil': r['cc_solde'] >= seuil_conges,
+        })
+    salaries.sort(key=lambda s: -s['total'])
+
+    return render_template('soldes_conges.html', salaries=salaries,
+                           seuil_conges=seuil_conges)

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -16,7 +16,7 @@ from flask import url_for
 
 from blueprints.delegations import (MISSION_SUIVI_VALIDATIONS_RELANCES,
                                     user_has_delegation)
-from utils import NOMS_MOIS, aujourd_hui
+from utils import NOMS_MOIS, aujourd_hui, calculer_solde_recup
 
 _ORDRE_URGENCE = {'retard': 0, 'urgent': 1, 'normal': 2}
 
@@ -34,6 +34,20 @@ def _to_date(valeur):
 def _fr(d):
     """date -> 'JJ/MM/AAAA'."""
     return d.strftime('%d/%m/%Y') if d else ''
+
+
+def _fr_num(x):
+    """Nombre -> notation française compacte ('3', '3,5')."""
+    return f"{x:g}".replace('.', ',')
+
+
+def _periode_demande(r):
+    """« du 20/07/2026 au 24/07/2026 (5 j) » — ou « le 20/07/2026 (1 j) »."""
+    debut, fin = _to_date(r['date_debut']), _to_date(r['date_fin'])
+    if not debut:
+        return ''
+    quand = f"le {_fr(debut)}" if (not fin or fin == debut) else f"du {_fr(debut)} au {_fr(fin)}"
+    return f"{quand} ({_fr_num(r['nb_jours'])} j)"
 
 
 def _urgence_echeance(d, today):
@@ -88,34 +102,87 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
         scope_clause = ''
         scope_params = ()
 
-    for table, cle, type_lbl in (('demandes_recup', 'recup', 'récupération'),
-                                 ('demandes_conges', 'conge', 'congé')):
-        rows = conn.execute(
-            f"""SELECT d.id, d.date_demande, d.statut, u.nom, u.prenom
-                FROM {table} d JOIN users u ON u.id = d.user_id
-                WHERE {statut_clause} {scope_clause}
-                ORDER BY d.date_demande ASC
-                LIMIT 25""",
-            scope_params
-        ).fetchall()
-        for r in rows:
-            depot = _to_date(r['date_demande'])
-            detail = f"déposée le {_fr(depot)}" if depot else "en attente de validation"
-            if r['statut'] == 'en_attente_direction':
-                detail += " — validée responsable, à valider"
-            actions.append({
-                'id': f"dem-{cle}-{r['id']}",
-                'categorie': 'validation',
-                'type': 'demande',
-                'demande_id': r['id'],
-                'demande_type': cle,
-                'icone': '📋',
-                'titre': f"Demande de {type_lbl} : {r['prenom']} {r['nom']}",
-                'detail': detail,
-                'lien': url_for('recup_bp.validation_demandes_recup'),
-                'lien_texte': 'Valider',
-                'urgence': _urgence_depot(depot, today),
-            })
+    # Récupérations : dates de la période + solde de récupération du salarié.
+    rows = conn.execute(
+        f"""SELECT d.id, d.date_demande, d.statut, d.date_debut, d.date_fin,
+                   d.nb_jours, d.nb_heures, u.id AS uid, u.nom, u.prenom
+            FROM demandes_recup d JOIN users u ON u.id = d.user_id
+            WHERE {statut_clause} {scope_clause}
+            ORDER BY d.date_demande ASC
+            LIMIT 25""",
+        scope_params
+    ).fetchall()
+    for r in rows:
+        depot = _to_date(r['date_demande'])
+        parts = [p for p in (_periode_demande(r),
+                             f"déposée le {_fr(depot)}" if depot else '') if p]
+        parts.append('validée responsable, à valider'
+                     if r['statut'] == 'en_attente_direction'
+                     else 'en attente du responsable')
+        try:
+            solde_h = calculer_solde_recup(r['uid'])
+            if r['nb_heures']:
+                parts.append(f"solde récup après validation : "
+                             f"{solde_h - r['nb_heures']:.1f} h".replace('.', ','))
+            else:
+                parts.append(f"solde récup actuel : {solde_h:.1f} h".replace('.', ','))
+        except Exception:
+            pass   # le solde est une aide, jamais bloquant
+        actions.append({
+            'id': f"dem-recup-{r['id']}",
+            'categorie': 'validation',
+            'type': 'demande',
+            'demande_id': r['id'],
+            'demande_type': 'recup',
+            'icone': '📋',
+            'titre': f"Demande de récupération : {r['prenom']} {r['nom']}",
+            'detail': ' — '.join(parts),
+            'lien': url_for('recup_bp.validation_demandes_recup'),
+            'lien_texte': 'Valider',
+            'urgence': _urgence_depot(depot, today),
+        })
+
+    # Congés : dates + solde du compteur concerné APRÈS validation (CP ou
+    # congés conventionnels), pour valider en connaissance de cause.
+    rows = conn.execute(
+        f"""SELECT d.id, d.date_demande, d.statut, d.date_debut, d.date_fin,
+                   d.nb_jours, d.type_conge, u.nom, u.prenom,
+                   COALESCE(u.cp_a_prendre, 0) AS cp_a_prendre,
+                   COALESCE(u.cp_pris, 0) AS cp_pris,
+                   COALESCE(u.cc_solde, 0) AS cc_solde
+            FROM demandes_conges d JOIN users u ON u.id = d.user_id
+            WHERE {statut_clause} {scope_clause}
+            ORDER BY d.date_demande ASC
+            LIMIT 25""",
+        scope_params
+    ).fetchall()
+    for r in rows:
+        depot = _to_date(r['date_demande'])
+        parts = [p for p in (_periode_demande(r),
+                             f"déposée le {_fr(depot)}" if depot else '') if p]
+        parts.append('validée responsable, à valider'
+                     if r['statut'] == 'en_attente_direction'
+                     else 'en attente du responsable')
+        if r['type_conge'] == 'Congé payé':
+            apres = r['cp_a_prendre'] - r['cp_pris'] - r['nb_jours']
+            parts.append(f"solde CP après validation : {_fr_num(apres)} j")
+        elif r['type_conge'] == 'Congé conventionnel':
+            apres = r['cc_solde'] - r['nb_jours']
+            parts.append(f"solde CC après validation : {_fr_num(apres)} j")
+        type_lbl = (r['type_conge'] or 'congé').lower()
+        actions.append({
+            'id': f"dem-conge-{r['id']}",
+            'categorie': 'validation',
+            'type': 'demande',
+            'demande_id': r['id'],
+            'demande_type': 'conge',
+            'icone': '📋',
+            'titre': f"Demande de {type_lbl} : {r['prenom']} {r['nom']}",
+            'detail': ' — '.join(parts),
+            'lien': url_for('recup_bp.validation_demandes_recup'),
+            'lien_texte': 'Valider',
+            'urgence': _urgence_depot(depot, today),
+        })
 
     # 2. Subventions : étapes (sous-éléments) à échéance et non terminées.
     # Le responsable voit les étapes des subventions dont il est assigné (parent)

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,6 +69,7 @@
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
+                    <a href="{{ url_for('infos_salaries_bp.soldes_conges') }}">🏖️ Soldes de congés</a>
                     <a href="{{ url_for('presence_effectif_bp.presence_effectif') }}">🗓️ Présence effectif</a>
                     <a href="{{ url_for('rh_statistiques_bp.rh_statistiques') }}">📊 Statistiques RH</a>
                     <a href="{{ url_for('benevoles_bp.gestion_benevoles') }}">🤝 Bénévoles</a>
@@ -190,6 +191,7 @@
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
+                    <a href="{{ url_for('infos_salaries_bp.soldes_conges') }}">🏖️ Soldes de congés</a>
                     <a href="{{ url_for('rh_statistiques_bp.rh_statistiques') }}">📊 Statistiques RH</a>
                     <a href="{{ url_for('benevoles_bp.gestion_benevoles') }}">🤝 Bénévoles</a>
                     <a href="{{ url_for('pesee_alisfa_bp.pesee_alisfa') }}">⚖️ Pesée ALISFA</a>

--- a/templates/dashboard_direction.html
+++ b/templates/dashboard_direction.html
@@ -33,18 +33,19 @@
         <span id="ccProchaineBtns" style="display:flex;gap:6px;flex:0 0 auto;"></span>
     </div>
 
-    {# ── KPI par exception : seuils franchis ── #}
+    {# ── KPI par exception : seuils franchis. auto-fill (et non auto-fit) :
+         une alerte seule garde une largeur de carte au lieu de s'étirer. ── #}
     {% if alertes_seuil %}
-    <div style="display:grid;grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));gap:1rem;margin-bottom:1.5rem;">
+    <div style="display:grid;grid-template-columns:repeat(auto-fill, minmax(240px, 1fr));gap:0.9rem;margin-bottom:1.25rem;">
         {% for al in alertes_seuil %}
         <div class="cc-alerte">
             <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
                 <span style="font-size:0.72rem;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;color:{{ al.couleur }};">{{ al.etiquette }}</span>
-                <span style="font-size:1.2rem;">{{ al.icone }}</span>
+                <span style="font-size:1.1rem;">{{ al.icone }}</span>
             </div>
-            <div style="font-size:1.35rem;font-weight:700;color:var(--gray-900);line-height:1.15;">{{ al.valeur }}</div>
+            <div style="font-size:1.2rem;font-weight:700;color:var(--gray-900);line-height:1.15;">{{ al.valeur }}</div>
             <div style="font-size:0.8rem;color:var(--gray-500);">{{ al.detail }}</div>
-            <a href="{{ al.lien }}" style="font-size:0.82rem;font-weight:600;color:var(--primary);text-decoration:none;margin-top:0.25rem;">{{ al.lien_texte }} →</a>
+            <a href="{{ al.lien }}" style="font-size:0.82rem;font-weight:600;color:var(--primary);text-decoration:none;">{{ al.lien_texte }} →</a>
         </div>
         {% endfor %}
     </div>
@@ -98,36 +99,32 @@
     </div>
 </div>
 
-{# ── Fenêtre seuils d'alerte ── #}
-<div id="ccSeuilsModal" class="ps-modal-overlay" onclick="if(event.target===this)ccFermerSeuils()">
-    <div class="ps-modal" role="dialog" aria-modal="true" style="max-width:460px;">
-        <div class="ps-modal-header">
-            <h3>⚙ Seuils d'alerte</h3>
-            <button class="modal-close" type="button" onclick="ccFermerSeuils()" aria-label="Fermer">&times;</button>
+{# ── Fenêtre seuils d'alerte (classes modales globales de style.css) ── #}
+<div id="ccSeuilsModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)ccFermerSeuils()">
+    <div class="modal-content" style="max-width:480px;" role="dialog" aria-modal="true">
+        <button class="modal-close" type="button" onclick="ccFermerSeuils()" aria-label="Fermer">&times;</button>
+        <h2 style="margin:0 0 0.35rem;padding-bottom:0.6rem;border-bottom:3px solid var(--primary);font-size:1.25rem;">⚙ Seuils d'alerte</h2>
+        <p style="font-size:0.85rem;color:var(--gray-500);margin:0.5rem 0 1.25rem;">
+            Le tableau de bord n'affiche un indicateur que s'il franchit son seuil.
+            Ajustez-les à votre structure.</p>
+        <div style="display:flex;flex-direction:column;gap:1rem;">
+            <label class="cc-seuil-label">Trésorerie minimum (€)
+                <input type="number" id="ccSeuilTreso" value="{{ seuils.treso|int }}" min="0" step="1000"></label>
+            <label class="cc-seuil-label">Budget consommé (%)
+                <input type="number" id="ccSeuilBudget" value="{{ seuils.budget|int }}" min="0" max="200"></label>
+            <label class="cc-seuil-label">Solde congés conventionnels (jours)
+                <input type="number" id="ccSeuilConges" value="{{ seuils.conges|int }}" min="0" step="0.5"></label>
+            <label class="cc-seuil-label">Score de surcharge (/100)
+                <input type="number" id="ccSeuilSurcharge" value="{{ seuils.surcharge|int }}" min="0" max="100"></label>
+            <label class="cc-seuil-label" style="border-top:1px solid var(--gray-200);padding-top:1rem;">
+                <span>Digest quotidien par email<br>
+                    <span style="font-weight:400;font-size:0.78rem;color:var(--gray-500);">
+                        Envoyé à la direction et à la comptabilité au premier accès après 8 h.
+                        Les personnes en congé ce jour-là ne le reçoivent pas.</span></span>
+                <input type="checkbox" id="ccSeuilDigest" style="width:auto;" {% if seuils.digest %}checked{% endif %}>
+            </label>
         </div>
-        <div class="ps-modal-body">
-            <p style="font-size:0.85rem;color:var(--gray-500);margin:0 0 1.25rem;">
-                Le tableau de bord n'affiche un indicateur que s'il franchit son seuil.
-                Ajustez-les à votre structure.</p>
-            <div style="display:flex;flex-direction:column;gap:1rem;">
-                <label class="cc-seuil-label">Trésorerie minimum (€)
-                    <input type="number" id="ccSeuilTreso" value="{{ seuils.treso|int }}" min="0" step="1000"></label>
-                <label class="cc-seuil-label">Budget consommé (%)
-                    <input type="number" id="ccSeuilBudget" value="{{ seuils.budget|int }}" min="0" max="200"></label>
-                <label class="cc-seuil-label">Solde congés conventionnels (jours)
-                    <input type="number" id="ccSeuilConges" value="{{ seuils.conges|int }}" min="0" step="0.5"></label>
-                <label class="cc-seuil-label">Score de surcharge (/100)
-                    <input type="number" id="ccSeuilSurcharge" value="{{ seuils.surcharge|int }}" min="0" max="100"></label>
-                <label class="cc-seuil-label" style="border-top:1px solid var(--gray-200);padding-top:1rem;">
-                    <span>Digest quotidien par email<br>
-                        <span style="font-weight:400;font-size:0.78rem;color:var(--gray-500);">
-                            Envoyé à la direction et à la comptabilité au premier accès après 8 h.
-                            Les personnes en congé ce jour-là ne le reçoivent pas.</span></span>
-                    <input type="checkbox" id="ccSeuilDigest" style="width:auto;" {% if seuils.digest %}checked{% endif %}>
-                </label>
-            </div>
-        </div>
-        <div class="ps-modal-footer">
+        <div style="display:flex;justify-content:flex-end;gap:0.75rem;margin-top:1.5rem;align-items:center;">
             <span id="ccSeuilsMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>
             <button class="btn btn-secondary" type="button" onclick="ccFermerSeuils()">Annuler</button>
             <button class="btn btn-primary" type="button" onclick="ccEnregistrerSeuils()">Enregistrer</button>
@@ -161,8 +158,8 @@
 
 .cc-alerte {
     background: var(--white); border: 1px solid var(--gray-200); border-radius: 10px;
-    padding: 1rem 1.25rem; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05);
-    display: flex; flex-direction: column; gap: 0.35rem;
+    padding: 0.8rem 1rem; box-shadow: 0 1px 2px 0 rgba(0,0,0,0.05);
+    display: flex; flex-direction: column; gap: 0.3rem;
     transition: box-shadow .15s ease, transform .15s ease;
 }
 .cc-alerte:hover { box-shadow: 0 4px 12px -2px rgba(0,0,0,0.1); transform: translateY(-2px); }
@@ -347,8 +344,8 @@
     });
 
     // Seuils d'alerte
-    window.ccOuvrirSeuils = function () { document.getElementById('ccSeuilsModal').classList.add('open'); };
-    window.ccFermerSeuils = function () { document.getElementById('ccSeuilsModal').classList.remove('open'); };
+    window.ccOuvrirSeuils = function () { document.getElementById('ccSeuilsModal').style.display = 'flex'; };
+    window.ccFermerSeuils = function () { document.getElementById('ccSeuilsModal').style.display = 'none'; };
     window.ccEnregistrerSeuils = function () {
         var msg = document.getElementById('ccSeuilsMsg');
         msg.textContent = 'Enregistrement…';
@@ -377,7 +374,7 @@
     // Rafraîchissement automatique de la file toutes les 10 minutes : les
     // nouvelles demandes/factures apparaissent sans recharger la page.
     setInterval(function () {
-        if (document.getElementById('ccSeuilsModal').classList.contains('open')) return;
+        if (document.getElementById('ccSeuilsModal').style.display !== 'none') return;
         fetch('/api/dashboard-direction/actions-fragment')
             .then(function (r) { return r.ok ? r.text() : null; })
             .then(function (html) {

--- a/templates/soldes_conges.html
+++ b/templates/soldes_conges.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}Soldes de congés - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="form-container">
+    <h1>🏖️ Soldes de congés</h1>
+    <p class="subtitle">Vue d'ensemble des soldes de l'effectif — triés du plus gros solde restant au plus petit</p>
+
+    <div class="section" style="padding:1rem;">
+        {% if salaries %}
+        <div style="overflow-x:auto;">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Salarié</th>
+                        <th>Secteur</th>
+                        <th style="text-align:right;">CP à prendre</th>
+                        <th style="text-align:right;">CP pris</th>
+                        <th style="text-align:right;">Solde CP</th>
+                        <th style="text-align:right;" title="Seuil d'alerte du centre de contrôle : {{ '%g'|format(seuil_conges) }} j">Congés conv.</th>
+                        <th style="text-align:right;">Total restant</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for s in salaries %}
+                    <tr>
+                        <td><strong>{{ s.nom }}</strong> {{ s.prenom }}</td>
+                        <td>{{ s.secteur }}</td>
+                        <td style="text-align:right;">{{ '%g'|format(s.cp_a_prendre)|replace('.', ',') }}</td>
+                        <td style="text-align:right;">{{ '%g'|format(s.cp_pris)|replace('.', ',') }}</td>
+                        <td style="text-align:right;font-weight:600;">{{ '%g'|format(s.solde_cp)|replace('.', ',') }}</td>
+                        <td style="text-align:right;font-weight:600;">
+                            {% if s.cc_au_dessus_seuil %}
+                            <span class="badge" style="background:#8b5cf6;color:#fff;"
+                                  title="Au-dessus du seuil d'alerte ({{ '%g'|format(seuil_conges) }} j) — à planifier">
+                                {{ '%g'|format(s.cc_solde)|replace('.', ',') }}</span>
+                            {% else %}
+                            {{ '%g'|format(s.cc_solde)|replace('.', ',') }}
+                            {% endif %}
+                        </td>
+                        <td style="text-align:right;font-weight:700;">{{ '%g'|format(s.total)|replace('.', ',') }}</td>
+                        <td>
+                            <a class="btn btn-sm btn-secondary" style="white-space:nowrap;"
+                               href="{{ url_for('absences_bp.absences', search_user_id=s.id) }}"
+                               title="Poser / planifier une absence pour ce salarié">Planifier</a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+        <p class="no-data">Aucun salarié actif.</p>
+        {% endif %}
+    </div>
+
+    <div class="help-box">
+        <h4>ℹ️ Lecture</h4>
+        <ul>
+            <li><strong>Solde CP</strong> = congés payés à prendre − congés payés pris.</li>
+            <li><strong>Congés conv.</strong> : solde de congés conventionnels — surligné
+                lorsqu'il atteint le seuil d'alerte du centre de contrôle
+                ({{ '%g'|format(seuil_conges) }} j), signe qu'il est temps de les planifier.</li>
+            <li><strong>Planifier</strong> ouvre la page Absences pré-filtrée sur le salarié.</li>
+        </ul>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -134,9 +134,33 @@ def test_demande_en_attente_valider_refuser(admin_client, db, sample_users):
     db.commit()
     html = admin_client.get('/dashboard_direction').get_data(as_text=True)
     assert 'Demande de récupération : Jean Martin' in html
-    assert 'validée responsable, à valider' in html
+    assert 'le 20/07/2026 (1 j)' in html                  # dates de la période
+    assert 'validée responsable, à valider' in html       # étape responsable faite
+    assert 'solde récup après validation' in html         # aide à la décision
     assert 'data-cc-act="valider"' in html
     assert 'data-cc-act="refuser"' in html
+
+
+def test_demande_conge_affiche_dates_et_solde_apres(admin_client, db, sample_users):
+    """Le détail d'une demande de congé donne la période et le solde du
+    compteur concerné après validation."""
+    db.execute("UPDATE users SET cp_a_prendre = 10, cp_pris = 2, cc_solde = 8 WHERE id = ?",
+               (sample_users['salarie_id'],))
+    db.execute("INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, nb_jours, statut) "
+               "VALUES (?, 'Congé payé', '2026-07-20', '2026-07-22', 3, 'en_attente_direction')",
+               (sample_users['salarie_id'],))
+    db.execute("INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, nb_jours, statut) "
+               "VALUES (?, 'Congé conventionnel', '2026-08-03', '2026-08-04', 2, 'en_attente_responsable')",
+               (sample_users['salarie_id'],))
+    db.commit()
+    html = admin_client.get('/dashboard_direction').get_data(as_text=True)
+    assert 'Demande de congé payé : Jean Martin' in html
+    assert 'du 20/07/2026 au 22/07/2026 (3 j)' in html
+    assert 'solde CP après validation : 5 j' in html          # 10 − 2 − 3
+    assert 'Demande de congé conventionnel : Jean Martin' in html
+    assert 'du 03/08/2026 au 04/08/2026 (2 j)' in html
+    assert 'solde CC après validation : 6 j' in html          # 8 − 2
+    assert 'en attente du responsable' in html                # étape non faite
 
 
 def test_fiches_mois_precedent_a_relancer(admin_client, db, sample_users):
@@ -152,8 +176,18 @@ def test_conges_conventionnels_au_dessus_du_seuil(admin_client, db, sample_users
     html = admin_client.get('/dashboard_direction').get_data(as_text=True)
     # KPI par exception + action de planification.
     assert 'Congés conventionnels à planifier' in html
+    assert 'salarié max : 12 j' in html                 # libellé sans ambiguïté
+    assert '/soldes_conges' in html                      # lien vers la page des soldes
     assert 'Solde congés conventionnels élevé : Jean Martin' in html
     assert '12 j de congés conventionnels à planifier' in html
+
+
+def test_fenetre_seuils_utilise_les_classes_modales_globales(admin_client):
+    """La fenêtre des seuils doit être une vraie modale (classes globales de
+    style.css), pas un bloc rendu en bas de page."""
+    html = admin_client.get('/dashboard_direction').get_data(as_text=True)
+    assert 'id="ccSeuilsModal" class="modal-overlay" style="display:none;"' in html
+    assert 'ps-modal-overlay' not in html   # classes locales à la page budget
 
 
 def test_conges_sous_le_seuil_dans_la_normale(admin_client, db, sample_users):
@@ -312,3 +346,34 @@ def test_alerte_budget_presque_epuise(admin_client, db, sample_users):
     html = admin_client.get('/dashboard_direction').get_data(as_text=True)
     assert 'Budget presque épuisé' in html
     assert '93' in html                 # 46 500 / 50 000 = 93 %
+
+
+# ──────────────────────────────────────────────────────────────────────────
+#  Page « Soldes de congés »
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_soldes_conges_acces(admin_client, comptable_client=None):
+    assert admin_client.get('/soldes_conges').status_code == 200
+
+
+def test_soldes_conges_refuse_salarie(auth_client):
+    resp = auth_client.get('/soldes_conges', follow_redirects=True)
+    assert 'non autoris' in resp.get_data(as_text=True).lower()
+
+
+def test_soldes_conges_contenu(admin_client, db, sample_users):
+    db.execute("UPDATE users SET cp_a_prendre = 25, cp_pris = 10, cc_solde = 8 WHERE id = ?",
+               (sample_users['salarie_id'],))
+    db.execute("UPDATE users SET cp_a_prendre = 5, cp_pris = 1, cc_solde = 2 WHERE id = ?",
+               (sample_users['responsable_id'],))
+    db.commit()
+    html = admin_client.get('/soldes_conges').get_data(as_text=True)
+    assert 'Soldes de congés' in html
+    assert 'Martin' in html and 'Dupont' in html
+    # Martin : solde CP 15, CC 8 (au-dessus du seuil 5 → badge), total 23.
+    assert '>15<' in html and '>23<' in html
+    assert 'Au-dessus du seuil' in html
+    # Tri : Martin (23) avant Dupont (6).
+    assert html.index('Martin') < html.index('Dupont')
+    # Lien planifier vers la page absences pré-filtrée.
+    assert f"search_user_id={sample_users['salarie_id']}" in html


### PR DESCRIPTION
## Contexte

Corrections et compléments après la prise en main du centre de contrôle (PR #203).

## Corrections

- **🪟 Fenêtre « Seuils d'alerte »** : elle s'affichait **en bas de page** — les classes `ps-modal-*` n'existent que dans le CSS local de la page budget. Bascule sur les classes modales **globales** (`modal-overlay`/`modal-content`) : vraie fenêtre centrée, fermeture par clic hors zone ou Échap. *(Position vérifiée au navigateur.)*
- **📉 KPI compactes** : `auto-fill` (une alerte seule garde une largeur de carte au lieu de s'étirer sur toute la ligne) + paddings/corps réduits → « À faire maintenant » remonte.
- **✍️ Libellé congés** : « solde ≥ 5 j (**salarié max** : 24 j) » — pour ne pas laisser croire à un plafond de congés.

## Nouveautés

- **🏖️ Page « Soldes de congés »** (direction/comptable — la fiche salarié n'affichait pas les soldes, et aucune page ne montrait l'ensemble) : CP à prendre / pris / solde, congés conventionnels (**surlignés** au-dessus du seuil du centre de contrôle), total restant trié décroissant, bouton « Planifier » vers la page Absences pré-filtrée. Entrée de menu **RH & Paie** (direction et comptable). La carte d'alerte « Voir les soldes » pointe désormais ici.
- **📋 Demandes à valider enrichies** : le détail donne la **période** (« du 20/07/2026 au 24/07/2026 (5 j) »), l'état de l'étape responsable (« validée responsable, à valider » / « en attente du responsable ») et le **solde après validation** — CP ou congés conventionnels selon le type de congé, solde de récupération pour les récups.

## Vérification

- 7 tests ajoutés/renforcés (modale globale, page soldes : accès/contenu/tri/badge, détails des demandes CP/CC/récup, libellé, lien de la carte). Suite complète verte : **857 tests**.
- Parcours navigateur re-joué : modale centrée (position mesurée), détail enrichi visible dans le bandeau « prochaine action », actions un clic → base à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_