### PR TITLE
Centre de contrôle : modale seuils, bandeau indicateurs, recherche soldes de congés, liens email par domaine

### DIFF
--- a/blueprints/dashboard_direction.py
+++ b/blueprints/dashboard_direction.py
@@ -461,7 +461,8 @@ def _composer_digest(actions, quand):
         for a in actions[:8]
     )
     reste = f'<p style="color:#786b60;">… et {nb - 8} autre(s) action(s).</p>' if nb > 8 else ''
-    lien = url_for('dashboard_direction_bp.dashboard_direction', _external=True)
+    from email_service import construire_lien
+    lien = construire_lien('dashboard_direction_bp.dashboard_direction')
 
     contenu = f"""
     <h3 style="color:#667eea;margin:0 0 12px;font-size:16px;">Votre journée CS-PILOT</h3>

--- a/blueprints/dashboard_direction.py
+++ b/blueprints/dashboard_direction.py
@@ -507,6 +507,20 @@ def _envoyer_digest_du_jour(quand):
     return nb_envoyes
 
 
+def _digest_jour_envoi(quand, conn):
+    """Vrai si le digest peut partir ce jour-là : ni week-end, ni jour férié.
+
+    Évite d'accumuler plusieurs emails à traiter en arrivant après une coupure
+    (le lundi ou au retour d'un pont, on ne veut pas deux ou trois digests)."""
+    if quand.weekday() >= 5:   # 5 = samedi, 6 = dimanche
+        return False
+    ferie = conn.execute(
+        'SELECT 1 FROM jours_feries WHERE date = ?',
+        (quand.strftime('%Y-%m-%d'),)
+    ).fetchone()
+    return ferie is None
+
+
 @dashboard_direction_bp.before_app_request
 def _digest_tick():
     """Déclenche le digest au premier accès après DIGEST_HEURE.
@@ -514,7 +528,8 @@ def _digest_tick():
     Sans planificateur externe : n'importe quelle requête applicative après
     l'heure cible déclenche l'envoi, une seule fois par jour (réclamation
     atomique en base — INSERT OR IGNORE sur une clé datée — pour rester sûr
-    avec plusieurs workers). Ne doit jamais faire échouer la requête en cours.
+    avec plusieurs workers). Pas d'envoi le week-end ni les jours fériés. Ne
+    doit jamais faire échouer la requête en cours.
     """
     global _digest_date_traitee
     try:
@@ -534,6 +549,9 @@ def _digest_tick():
         # Réclamation atomique : un seul processus/worker envoie le digest.
         conn = get_db()
         try:
+            if not _digest_jour_envoi(quand, conn):
+                _digest_date_traitee = date_str   # week-end / férié : rien aujourd'hui
+                return
             cursor = conn.execute(
                 "INSERT OR IGNORE INTO app_settings (key, value) VALUES (?, 'envoye')",
                 (f'digest_direction_{date_str}',))

--- a/blueprints/notifications.py
+++ b/blueprints/notifications.py
@@ -10,6 +10,7 @@ from utils import login_required, get_setting, NOMS_MOIS
 from email_service import (
     get_email_config, save_email_config, set_email_enabled,
     is_email_configured, envoyer_email, notifier_relance_validation,
+    get_base_url, save_base_url,
 )
 
 notifications_bp = Blueprint('notifications_bp', __name__)
@@ -31,16 +32,19 @@ def configuration_email():
         sender = request.form.get('sender', '').strip()
         password = request.form.get('password', '').strip()
         sender_name = request.form.get('sender_name', 'CS-PILOT').strip()
+        base_url = request.form.get('base_url', '').strip()
 
         if not sender or not password:
             flash('L\'adresse email et le mot de passe sont obligatoires', 'error')
             return redirect(url_for('notifications_bp.configuration_email'))
 
         save_email_config(smtp_server, smtp_port, sender, password, sender_name)
+        save_base_url(base_url)
         flash('Configuration email enregistree avec succes', 'success')
         return redirect(url_for('notifications_bp.configuration_email'))
 
     config = get_email_config()
+    config['base_url'] = get_base_url() or ''
     # Masquer le mot de passe
     if config.get('password'):
         config['password_display'] = '*' * 8

--- a/email_service.py
+++ b/email_service.py
@@ -9,6 +9,9 @@ import logging
 import html as html_module
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+
+from flask import url_for
+
 from utils import get_setting, save_setting
 from database import get_db
 
@@ -24,11 +27,48 @@ EMAIL_SETTINGS_KEYS = {
     'enabled': 'email_enabled',
 }
 
+# Adresse publique du site (nom de domaine) pour les liens des emails.
+BASE_URL_SETTING = 'app_base_url'
+
 DEFAULTS = {
     'smtp_server': 'smtp.gmail.com',
     'smtp_port': '587',
     'sender_name': 'CS-PILOT',
 }
+
+
+def get_base_url():
+    """Adresse publique configurée (sans slash final), ou None."""
+    val = (get_setting(BASE_URL_SETTING) or '').strip()
+    return val.rstrip('/') or None
+
+
+def save_base_url(base_url):
+    """Enregistre (ou efface) l'adresse publique du site.
+
+    Normalise : ajoute https:// si le schéma manque, retire le slash final.
+    Une valeur vide efface le réglage (retour au comportement par défaut).
+    """
+    val = (base_url or '').strip().rstrip('/')
+    if val and not val.startswith(('http://', 'https://')):
+        val = 'https://' + val
+    save_setting(BASE_URL_SETTING, val)
+
+
+def construire_lien(endpoint, **values):
+    """URL absolue pour un email.
+
+    Utilise l'adresse publique configurée (nom de domaine) si elle existe, pour
+    éviter les liens en IP:port internes. À défaut, retombe sur l'hôte de la
+    requête courante (url_for _external), puis sur le chemin relatif.
+    """
+    base = get_base_url()
+    if base:
+        return base + url_for(endpoint, **values)
+    try:
+        return url_for(endpoint, _external=True, **values)
+    except Exception:
+        return url_for(endpoint, **values)
 
 
 def get_email_config():

--- a/search_engine.py
+++ b/search_engine.py
@@ -325,6 +325,13 @@ _RE_DEMANDE_CONGE = re.compile(
     r'\s+conges?\b'
 )
 
+# Soldes de congés de l'effectif : « solde(s) congé(s) », « total (des) congé(s) »,
+# « congé(s) restant(s) ». À traiter avant le mot-clé « solde » (→ trésorerie).
+_RE_SOLDE_CONGE = re.compile(
+    r'\b(?:solde|soldes|total|totaux)\b(?:\s+(?:de|d|des|du|les|le|la))*\s+conges?\b'
+    r'|\bconges?\b\s+restants?\b'
+)
+
 # Mots outils ignorés en tête de requête (« voir budget », « liste subventions »…)
 _MOTS_OUTILS = {'liste', 'listes', 'voir', 'afficher', 'montre', 'montrer', 'montrez',
                 'ouvre', 'ouvrir', 'les', 'la', 'le', 'des', 'du', 'de', 'mes', 'mon', 'ma'}
@@ -364,6 +371,9 @@ def analyser_recherche(conn, query, profil, today):
     # Déposer une demande de congés (direction et comptable y ont accès).
     if _RE_DEMANDE_CONGE.search(norm):
         return _redirect(url_for('recup_bp.demande_conge'), 'Demande de congés')
+    # Soldes de congés de l'effectif (avant le mot-clé « solde » → trésorerie).
+    if _RE_SOLDE_CONGE.search(norm):
+        return _redirect(url_for('infos_salaries_bp.soldes_conges'), 'Soldes de congés')
 
     # Retirer les mots outils en tête (« voir », « liste », « les »…) pour révéler le mot-clé.
     while reste and reste[0] in _MOTS_OUTILS:

--- a/templates/configuration_email.html
+++ b/templates/configuration_email.html
@@ -127,6 +127,15 @@
             </div>
 
             <div class="em-form-group">
+                <label>Adresse du site (nom de domaine)</label>
+                <input type="text" name="base_url" class="em-input"
+                       value="{{ config.base_url or '' }}"
+                       placeholder="https://cs-pilot.mon-centre.fr">
+                <div class="em-hint">Utilisee pour les liens dans les emails. Sans cela, les liens
+                    reprennent l'adresse interne (IP:port). Laissez vide en environnement local.</div>
+            </div>
+
+            <div class="em-form-group">
                 <label>Adresse email (expediteur)</label>
                 <input type="email" name="sender" class="em-input"
                        value="{{ config.sender or '' }}"

--- a/templates/dashboard_direction.html
+++ b/templates/dashboard_direction.html
@@ -51,19 +51,6 @@
     </div>
     {% endif %}
 
-    {# ── Indicateurs dans la normale (repliés) ── #}
-    <details class="cc-ok">
-        <summary>✅ {{ indicateurs_ok|length }} indicateurs dans la normale — effectif, ETP, absences, anomalies…</summary>
-        <div style="display:flex;flex-wrap:wrap;gap:1.5rem;padding:0.75rem 1.25rem 1rem;">
-            {% for ind in indicateurs_ok %}
-            <div style="display:flex;flex-direction:column;gap:2px;">
-                <span style="font-size:1.15rem;font-weight:700;color:var(--primary-dark);line-height:1;">{{ ind.valeur }}</span>
-                <span style="font-size:0.75rem;color:var(--gray-500);">{{ ind.libelle }}</span>
-            </div>
-            {% endfor %}
-        </div>
-    </details>
-
     {# ── À faire maintenant ── #}
     <div class="section actions-panel" style="padding:2rem 2.5rem;">
         <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin-bottom:1rem;padding-bottom:0.75rem;border-bottom:3px solid var(--primary);">
@@ -82,6 +69,20 @@
         </div>
     </div>
 
+    {# ── Indicateurs dans la normale (repliés) : sous la file, l'information
+         est secondaire puisque tout est au vert. ── #}
+    <details class="cc-ok">
+        <summary>✅ {{ indicateurs_ok|length }} indicateurs dans la normale — effectif, ETP, absences, anomalies…</summary>
+        <div style="display:flex;flex-wrap:wrap;gap:1.5rem;padding:0.75rem 1.25rem 1rem;">
+            {% for ind in indicateurs_ok %}
+            <div style="display:flex;flex-direction:column;gap:2px;">
+                <span style="font-size:1.15rem;font-weight:700;color:var(--primary-dark);line-height:1;">{{ ind.valeur }}</span>
+                <span style="font-size:0.75rem;color:var(--gray-500);">{{ ind.libelle }}</span>
+            </div>
+            {% endfor %}
+        </div>
+    </details>
+
     {# ── Aller plus loin ── #}
     <div class="section" style="padding:2rem 2.5rem;">
         <h2>🧭 Aller plus loin</h2>
@@ -99,32 +100,38 @@
     </div>
 </div>
 
-{# ── Fenêtre seuils d'alerte (classes modales globales de style.css) ── #}
+{# ── Fenêtre seuils d'alerte (classes modales globales de style.css :
+     en-tête à bord franc, corps et pied avec padding — .modal-content a
+     volontairement padding:0). ── #}
 <div id="ccSeuilsModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)ccFermerSeuils()">
     <div class="modal-content" style="max-width:480px;" role="dialog" aria-modal="true">
-        <button class="modal-close" type="button" onclick="ccFermerSeuils()" aria-label="Fermer">&times;</button>
-        <h2 style="margin:0 0 0.35rem;padding-bottom:0.6rem;border-bottom:3px solid var(--primary);font-size:1.25rem;">⚙ Seuils d'alerte</h2>
-        <p style="font-size:0.85rem;color:var(--gray-500);margin:0.5rem 0 1.25rem;">
-            Le tableau de bord n'affiche un indicateur que s'il franchit son seuil.
-            Ajustez-les à votre structure.</p>
-        <div style="display:flex;flex-direction:column;gap:1rem;">
-            <label class="cc-seuil-label">Trésorerie minimum (€)
-                <input type="number" id="ccSeuilTreso" value="{{ seuils.treso|int }}" min="0" step="1000"></label>
-            <label class="cc-seuil-label">Budget consommé (%)
-                <input type="number" id="ccSeuilBudget" value="{{ seuils.budget|int }}" min="0" max="200"></label>
-            <label class="cc-seuil-label">Solde congés conventionnels (jours)
-                <input type="number" id="ccSeuilConges" value="{{ seuils.conges|int }}" min="0" step="0.5"></label>
-            <label class="cc-seuil-label">Score de surcharge (/100)
-                <input type="number" id="ccSeuilSurcharge" value="{{ seuils.surcharge|int }}" min="0" max="100"></label>
-            <label class="cc-seuil-label" style="border-top:1px solid var(--gray-200);padding-top:1rem;">
-                <span>Digest quotidien par email<br>
-                    <span style="font-weight:400;font-size:0.78rem;color:var(--gray-500);">
-                        Envoyé à la direction et à la comptabilité au premier accès après 8 h.
-                        Les personnes en congé ce jour-là ne le reçoivent pas.</span></span>
-                <input type="checkbox" id="ccSeuilDigest" style="width:auto;" {% if seuils.digest %}checked{% endif %}>
-            </label>
+        <div class="modal-header">
+            <h3>⚙ Seuils d'alerte</h3>
+            <button class="modal-close" type="button" onclick="ccFermerSeuils()" aria-label="Fermer">&times;</button>
         </div>
-        <div style="display:flex;justify-content:flex-end;gap:0.75rem;margin-top:1.5rem;align-items:center;">
+        <div style="padding:0 1.5rem;">
+            <p style="font-size:0.85rem;color:var(--gray-500);margin:0 0 1.25rem;">
+                Le tableau de bord n'affiche un indicateur que s'il franchit son seuil.
+                Ajustez-les à votre structure.</p>
+            <div style="display:flex;flex-direction:column;gap:1rem;">
+                <label class="cc-seuil-label">Trésorerie minimum (€)
+                    <input type="number" id="ccSeuilTreso" value="{{ seuils.treso|int }}" min="0" step="1000"></label>
+                <label class="cc-seuil-label">Budget consommé (%)
+                    <input type="number" id="ccSeuilBudget" value="{{ seuils.budget|int }}" min="0" max="200"></label>
+                <label class="cc-seuil-label">Solde congés conventionnels (jours)
+                    <input type="number" id="ccSeuilConges" value="{{ seuils.conges|int }}" min="0" step="0.5"></label>
+                <label class="cc-seuil-label">Score de surcharge (/100)
+                    <input type="number" id="ccSeuilSurcharge" value="{{ seuils.surcharge|int }}" min="0" max="100"></label>
+                <label class="cc-seuil-label" style="border-top:1px solid var(--gray-200);padding-top:1rem;align-items:flex-start;">
+                    <span>Digest quotidien par email<br>
+                        <span style="font-weight:400;font-size:0.78rem;color:var(--gray-500);">
+                            Envoyé à la direction et à la comptabilité au premier accès après 8 h.
+                            Les personnes en congé ce jour-là ne le reçoivent pas.</span></span>
+                    <input type="checkbox" id="ccSeuilDigest" style="width:auto;margin-top:4px;" {% if seuils.digest %}checked{% endif %}>
+                </label>
+            </div>
+        </div>
+        <div style="display:flex;justify-content:flex-end;gap:0.75rem;padding:1.25rem 1.5rem 1.5rem;align-items:center;">
             <span id="ccSeuilsMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>
             <button class="btn btn-secondary" type="button" onclick="ccFermerSeuils()">Annuler</button>
             <button class="btn btn-primary" type="button" onclick="ccEnregistrerSeuils()">Enregistrer</button>

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -6,6 +6,7 @@ Couvre : accès, blocs principaux, exemples de recherche, seuils d'alerte
 KPI par exception (trésorerie, budget, congés conventionnels) et
 suggestions « Aller plus loin ».
 """
+import re
 from datetime import datetime
 
 
@@ -316,8 +317,11 @@ def test_digest_lien_utilise_le_nom_de_domaine(admin_client, db, sample_users, m
     email_service.save_base_url('cs-pilot.mon-centre.fr')
     admin_client.get('/dashboard_direction')
     contenu = envois[0][2]
-    assert 'https://cs-pilot.mon-centre.fr/dashboard_direction' in contenu
-    assert '127.0.0.1' not in contenu and 'localhost' not in contenu
+    # Comparaison exacte sur les liens extraits (membership de liste, pas une
+    # sous-chaîne d'URL — motif que CodeQL signale à juste titre ailleurs).
+    hrefs = re.findall(r'href="([^"]*)"', contenu)
+    assert 'https://cs-pilot.mon-centre.fr/dashboard_direction' in hrefs
+    assert not any('127.0.0.1' in h or 'localhost' in h for h in hrefs)
 
 
 def test_digest_pas_avant_huit_heures(admin_client, db, sample_users, monkeypatch):

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -272,8 +272,11 @@ def test_fragment_refuse_salarie(auth_client):
 #  Digest quotidien par email
 # ──────────────────────────────────────────────────────────────────────────
 
-def _preparer_digest(db, sample_users, monkeypatch, heure=9):
-    """Emails direction/comptable + horloge fixée + envois capturés."""
+def _preparer_digest(db, sample_users, monkeypatch, heure=9, jour=15):
+    """Emails direction/comptable + horloge fixée + envois capturés.
+
+    jour : quantième de juillet 2026 (15 = mercredi ouvré ; 18 = samedi ;
+    19 = dimanche)."""
     from datetime import datetime as dt
     import blueprints.dashboard_direction as dd
     import email_service
@@ -282,7 +285,7 @@ def _preparer_digest(db, sample_users, monkeypatch, heure=9):
     db.execute("UPDATE users SET email = 'compta@ex.fr' WHERE id = ?", (sample_users['comptable_id'],))
     db.commit()
 
-    quand = dt(2026, 7, 15, heure, 0, 0)
+    quand = dt(2026, 7, jour, heure, 0, 0)
     monkeypatch.setattr('utils.maintenant', lambda: quand)
     monkeypatch.setattr(dd, '_digest_date_traitee', None)
     monkeypatch.setattr(email_service, 'is_email_configured', lambda: True)
@@ -327,6 +330,25 @@ def test_digest_lien_utilise_le_nom_de_domaine(admin_client, db, sample_users, m
 def test_digest_pas_avant_huit_heures(admin_client, db, sample_users, monkeypatch):
     envois = _preparer_digest(db, sample_users, monkeypatch, heure=7)
     _seed_facture(db)
+    admin_client.get('/dashboard_direction')
+    assert envois == []
+
+
+def test_digest_pas_le_weekend(admin_client, db, sample_users, monkeypatch):
+    # Samedi 18 puis dimanche 19 juillet 2026 : aucun envoi.
+    for jour in (18, 19):
+        envois = _preparer_digest(db, sample_users, monkeypatch, jour=jour)
+        _seed_facture(db, fournisseur=f'F{jour}')
+        admin_client.get('/dashboard_direction')
+        assert envois == [], jour
+
+
+def test_digest_pas_les_jours_feries(admin_client, db, sample_users, monkeypatch):
+    # Mercredi 15 juillet 2026 déclaré férié → pas d'envoi.
+    envois = _preparer_digest(db, sample_users, monkeypatch, jour=15)
+    _seed_facture(db)
+    db.execute("INSERT INTO jours_feries (annee, date, libelle) VALUES (2026, '2026-07-15', 'Férié test')")
+    db.commit()
     admin_client.get('/dashboard_direction')
     assert envois == []
 

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -188,6 +188,15 @@ def test_fenetre_seuils_utilise_les_classes_modales_globales(admin_client):
     html = admin_client.get('/dashboard_direction').get_data(as_text=True)
     assert 'id="ccSeuilsModal" class="modal-overlay" style="display:none;"' in html
     assert 'ps-modal-overlay' not in html   # classes locales à la page budget
+    # En-tête à bord franc + corps padded (convention .modal-content padding:0).
+    assert '<div class="modal-header">' in html
+
+
+def test_indicateurs_normale_sous_les_actions(admin_client):
+    """Le bandeau « indicateurs dans la normale » passe SOUS la file d'actions
+    (information secondaire quand tout est au vert)."""
+    html = admin_client.get('/dashboard_direction').get_data(as_text=True)
+    assert html.index('À faire maintenant') < html.index('indicateurs dans la normale')
 
 
 def test_conges_sous_le_seuil_dans_la_normale(admin_client, db, sample_users):
@@ -278,7 +287,7 @@ def _preparer_digest(db, sample_users, monkeypatch, heure=9):
     monkeypatch.setattr(email_service, 'is_email_configured', lambda: True)
     envois = []
     monkeypatch.setattr(email_service, 'envoyer_email',
-                        lambda dest, sujet, contenu, prenom='': (envois.append((dest, sujet)), (True, 'ok'))[1])
+                        lambda dest, sujet, contenu, prenom='': (envois.append((dest, sujet, contenu)), (True, 'ok'))[1])
     return envois
 
 
@@ -296,6 +305,19 @@ def test_digest_envoye_une_seule_fois(admin_client, db, sample_users, monkeypatc
     envois.clear()
     admin_client.get('/dashboard_direction')
     assert envois == []
+
+
+def test_digest_lien_utilise_le_nom_de_domaine(admin_client, db, sample_users, monkeypatch):
+    """Le lien du digest reprend l'adresse publique configurée (nom de domaine)
+    plutôt que l'hôte interne (IP:port)."""
+    import email_service
+    envois = _preparer_digest(db, sample_users, monkeypatch)
+    _seed_facture(db)
+    email_service.save_base_url('cs-pilot.mon-centre.fr')
+    admin_client.get('/dashboard_direction')
+    contenu = envois[0][2]
+    assert 'https://cs-pilot.mon-centre.fr/dashboard_direction' in contenu
+    assert '127.0.0.1' not in contenu and 'localhost' not in contenu
 
 
 def test_digest_pas_avant_huit_heures(admin_client, db, sample_users, monkeypatch):

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -92,3 +92,41 @@ def test_publication_cse_sans_titre(monkeypatch):
     email_service.notifier_publication_cse([('a@b.c', 'Alice')], '', 'Bonjour')
     _, sujet, _ = captures[0]
     assert sujet == 'Nouveau message du CSE'
+
+
+# ── Adresse publique (nom de domaine) pour les liens des emails ──
+
+def test_base_url_normalisation(app, db):
+    with app.app_context():
+        email_service.save_base_url('cs-pilot.exemple.fr/')
+        assert email_service.get_base_url() == 'https://cs-pilot.exemple.fr'   # https ajouté, slash retiré
+        email_service.save_base_url('http://192.168.1.10:5000')
+        assert email_service.get_base_url() == 'http://192.168.1.10:5000'      # schéma explicite conservé
+        email_service.save_base_url('')
+        assert email_service.get_base_url() is None                            # effacement
+
+
+def test_construire_lien_avec_et_sans_base(app, db):
+    with app.test_request_context('/'):
+        # Sans base configurée : URL absolue reposant sur l'environnement (hôte
+        # de la requête en prod ; SERVER_NAME='localhost' dans les tests). On
+        # vérifie juste que c'est une URL absolue vers la bonne route.
+        email_service.save_base_url('')
+        lien = email_service.construire_lien('dashboard_direction_bp.dashboard_direction')
+        assert lien.startswith('http://') and lien.endswith('/dashboard_direction')
+        # Avec base configurée : le nom de domaine prend le dessus.
+        email_service.save_base_url('cs-pilot.mon-centre.fr')
+        lien = email_service.construire_lien('dashboard_direction_bp.dashboard_direction')
+        assert lien == 'https://cs-pilot.mon-centre.fr/dashboard_direction'
+
+
+def test_config_email_enregistre_base_url(admin_client, app):
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'secret', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587',
+        'base_url': 'cs-pilot.mon-centre.fr'})
+    with app.app_context():
+        assert email_service.get_base_url() == 'https://cs-pilot.mon-centre.fr'
+    html = admin_client.get('/configuration_email').get_data(as_text=True)
+    assert 'name="base_url"' in html
+    assert 'https://cs-pilot.mon-centre.fr' in html

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -5,6 +5,8 @@ Les demandes de congé réutilisent les mêmes constructeurs que les
 récupérations : le paramètre `type_libelle` doit adapter l'objet et le corps
 pour ne pas parler de « récupération » à propos d'un congé.
 """
+import re
+
 import email_service
 
 
@@ -128,5 +130,8 @@ def test_config_email_enregistre_base_url(admin_client, app):
     with app.app_context():
         assert email_service.get_base_url() == 'https://cs-pilot.mon-centre.fr'
     html = admin_client.get('/configuration_email').get_data(as_text=True)
-    assert 'name="base_url"' in html
-    assert 'https://cs-pilot.mon-centre.fr' in html
+    # Le champ est repris dans le formulaire, pré-rempli avec la valeur normalisée.
+    # (comparaison exacte de l'attribut value, pas une sous-chaîne d'URL)
+    m = re.search(r'name="base_url"[^>]*value="([^"]*)"', html)
+    assert m is not None, 'champ base_url absent du formulaire'
+    assert m.group(1) == 'https://cs-pilot.mon-centre.fr'

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -207,6 +207,20 @@ class TestMoteurRH:
         v = _analyse(app, db, 'heures Fatou')
         assert v['type'] == 'redirect' and '/vue_mensuelle' in v['url'] and 'user_id=' in v['url']
 
+    def test_soldes_conges(self, app, db, sample_users):
+        # « solde(s) congé(s) », « total (des) congé(s) », « congé(s) restant(s) »
+        # → page des soldes de congés.
+        for q in ('solde congés', 'soldes congé', 'total congés', 'total des congés',
+                  'congés restants', 'congé restant'):
+            v = _analyse(app, db, q)
+            assert v['type'] == 'redirect' and '/soldes_conges' in v['url'], q
+
+    def test_solde_seul_reste_tresorerie(self, app, db, sample_users):
+        # « solde » / « solde banque » (sans « congé ») restent la trésorerie.
+        for q in ('solde', 'solde banque'):
+            v = _analyse(app, db, q)
+            assert v['type'] == 'redirect' and '/tresorerie' in v['url'], q
+
     def test_salarie_et_contrat_ancre(self, app, db, sample_users):
         with app.app_context():
             _seed(db)


### PR DESCRIPTION
## Retours de prise en main

- **🪟 Fenêtre « Seuils d'alerte »** : elle s'affichait **tronquée et collée aux bords** — le contenu était placé directement dans `.modal-content` qui a volontairement `padding:0`. Reprise de la structure standard (`modal-header` à bord franc + corps/pied avec padding) : fenêtre propre, centrée, entièrement visible. *(re-vérifiée au navigateur)*
- **📉 Bandeau « X indicateurs dans la normale »** déplacé **sous** la file « À faire maintenant » — information secondaire quand tout est au vert, il ne repousse plus les actions vers le bas.
- **🔎 Recherche** : nouvelles intentions **« solde(s) congé(s) »**, **« total (des) congé(s) »**, **« congé(s) restant(s) »** → page Soldes de congés. Traitées **avant** le mot-clé « solde » pour ne pas les confondre avec la trésorerie ; « solde » / « solde banque » seuls **restent** la trésorerie.

## Liens des emails (nom de domaine)

- Le **digest quotidien** générait un lien en **IP:port interne** (`http://51.210.181.82:5000/…`) car `url_for(_external=True)` reprend l'hôte de la requête. Ajout d'un réglage **« Adresse du site (nom de domaine) »** dans la configuration email (`app_base_url`, normalisé : `https://` ajouté si absent, slash final retiré) et d'un helper `email_service.construire_lien()` qui l'utilise si présent, sinon retombe sur l'hôte de la requête.
- **Vérification des autres notifications** : elles n'ont **pas de lien cliquable** (texte « Connectez-vous à CS-PILOT ») — le digest était le seul concerné, rien d'autre à corriger.

## Vérification

- Tests : structure de la modale, placement du bandeau, intentions de recherche soldes (+ non-régression « solde » → trésorerie), normalisation/helper de lien, champ `base_url` du formulaire, lien du digest sur le domaine configuré. Suite complète verte : **864 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_