### PR TITLE
Config email : robustesse + digest limité aux factures direction

### DIFF
--- a/blueprints/dashboard_direction.py
+++ b/blueprints/dashboard_direction.py
@@ -148,11 +148,15 @@ def _fmt_euro(valeur):
     return f"{valeur:,.0f}".replace(',', ' ') + ' €'
 
 
-def _construire_file_actions(conn, profil, user_id, seuils):
+def _construire_file_actions(conn, profil, user_id, seuils,
+                             factures_direction_seulement=False):
     """File d'actions étendue + liste des surcharges (partagé page / fragment).
 
     Le calcul de surcharge lit tout l'historique d'heures : en cas d'erreur il
     est neutralisé plutôt que de faire tomber le tableau de bord.
+
+    `factures_direction_seulement` (digest) : n'inclut que les factures à
+    valider par la direction, pas celles assignées à un secteur.
     """
     try:
         surcharges = _calculer_surcharges(conn, seuils['surcharge'])
@@ -160,7 +164,8 @@ def _construire_file_actions(conn, profil, user_id, seuils):
         logger.exception("Calcul des surcharges impossible")
         surcharges = []
     actions = construire_actions(conn, profil, user_id,
-                                 etendu=True, seuils=seuils, surcharges=surcharges)
+                                 etendu=True, seuils=seuils, surcharges=surcharges,
+                                 factures_direction_seulement=factures_direction_seulement)
     return actions, surcharges
 
 
@@ -491,7 +496,8 @@ def _envoyer_digest_du_jour(quand):
         if not destinataires:
             return 0
         seuils = _lire_seuils()
-        actions, _ = _construire_file_actions(conn, 'directeur', None, seuils)
+        actions, _ = _construire_file_actions(conn, 'directeur', None, seuils,
+                                              factures_direction_seulement=True)
         if not actions:
             return 0
         sujet, contenu = _composer_digest(actions, quand)

--- a/blueprints/notifications.py
+++ b/blueprints/notifications.py
@@ -37,9 +37,11 @@ def configuration_email():
         # Mot de passe conservé si le champ est laissé vide : on peut modifier
         # un autre réglage (domaine, expéditeur…) sans avoir à ressaisir le mot
         # de passe d'application — évite les erreurs de re-saisie / l'autofill.
+        est_gmail = 'gmail' in smtp_server.lower()
+        password_saisi = bool(password)
         if not password:
             password = (get_email_config().get('password') or '').strip()
-        elif 'gmail' in smtp_server.lower():
+        elif est_gmail:
             # Les mots de passe d'application Google se collent souvent avec les
             # espaces d'affichage (« xxxx xxxx xxxx xxxx »), ce que Gmail refuse.
             password = password.replace(' ', '')
@@ -50,6 +52,17 @@ def configuration_email():
 
         save_email_config(smtp_server, smtp_port, sender, password, sender_name)
         save_base_url(base_url)
+
+        # Un mot de passe d'application Google fait exactement 16 caractères. Une
+        # autre longueur trahit presque toujours la cause d'un échec d'authentif :
+        # espaces oubliés, ou mot de passe habituel saisi/autofillé à la place.
+        if password_saisi and est_gmail and len(password) != 16:
+            flash(
+                f'Attention : un mot de passe d\'application Google fait 16 caracteres, '
+                f'or celui saisi en fait {len(password)}. Verifiez que vous avez colle le '
+                f'mot de passe d\'application (et non votre mot de passe habituel).',
+                'warning',
+            )
         flash('Configuration email enregistree avec succes', 'success')
         return redirect(url_for('notifications_bp.configuration_email'))
 

--- a/blueprints/notifications.py
+++ b/blueprints/notifications.py
@@ -34,6 +34,16 @@ def configuration_email():
         sender_name = request.form.get('sender_name', 'CS-PILOT').strip()
         base_url = request.form.get('base_url', '').strip()
 
+        # Mot de passe conservé si le champ est laissé vide : on peut modifier
+        # un autre réglage (domaine, expéditeur…) sans avoir à ressaisir le mot
+        # de passe d'application — évite les erreurs de re-saisie / l'autofill.
+        if not password:
+            password = (get_email_config().get('password') or '').strip()
+        elif 'gmail' in smtp_server.lower():
+            # Les mots de passe d'application Google se collent souvent avec les
+            # espaces d'affichage (« xxxx xxxx xxxx xxxx »), ce que Gmail refuse.
+            password = password.replace(' ', '')
+
         if not sender or not password:
             flash('L\'adresse email et le mot de passe sont obligatoires', 'error')
             return redirect(url_for('notifications_bp.configuration_email'))

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -73,7 +73,8 @@ def _urgence_depot(d, today):
 
 
 def construire_actions(conn, profil, user_id, secteur_id=None,
-                       etendu=False, seuils=None, surcharges=None):
+                       etendu=False, seuils=None, surcharges=None,
+                       factures_direction_seulement=False):
     """Retourne la liste des actions à faire du tableau de bord d'un profil.
 
     - directeur / comptable : toutes les demandes en attente + toutes les
@@ -87,6 +88,11 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
     congés conventionnels au-dessus du seuil. Chaque item porte alors un
     `id` stable et un `type` ('facture' / 'demande' / 'relance' / 'lien')
     avec les données nécessaires à l'action.
+
+    `factures_direction_seulement` restreint les factures à celles assignées
+    à la direction (`assigned_direction = 1`) — utilisé par le digest matinal
+    pour n'y mettre que ce que la direction doit valider, sans les factures
+    d'un secteur (qui relèvent de son responsable).
     """
     actions = []
     today = aujourd_hui()
@@ -235,14 +241,16 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
         })
 
     if etendu and profil in ('directeur', 'comptable'):
-        actions.extend(_actions_etendues(conn, profil, user_id, today, seuils, surcharges))
+        actions.extend(_actions_etendues(conn, profil, user_id, today, seuils, surcharges,
+                                         factures_direction_seulement))
 
     # Les plus urgents d'abord, puis par ordre d'insertion (déjà trié par date).
     actions.sort(key=lambda a: _ORDRE_URGENCE.get(a['urgence'], 2))
     return actions
 
 
-def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
+def _actions_etendues(conn, profil, user_id, today, seuils, surcharges,
+                      factures_direction_seulement=False):
     """Items supplémentaires du centre de contrôle direction / comptable."""
     actions = []
 
@@ -250,13 +258,17 @@ def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
     # périmètre que la page d'approbation : une facture sans secteur ni
     # assignation direction n'est pas encore entrée dans le circuit et ne doit
     # pas pouvoir être approuvée depuis le tableau de bord.
-    rows = conn.execute('''
+    # Le digest ne retient que les factures de la direction : celles d'un
+    # secteur sont à valider par son responsable, pas par la direction.
+    scope_factures = ('AND f.assigned_direction = 1' if factures_direction_seulement
+                      else 'AND (f.secteur_id IS NOT NULL OR f.assigned_direction = 1)')
+    rows = conn.execute(f'''
         SELECT f.id, f.numero_facture, f.montant_ttc, f.date_echeance,
                fr.nom AS fournisseur_nom
         FROM factures f
         LEFT JOIN fournisseurs fr ON f.fournisseur_id = fr.id
         WHERE f.approbation = 'en_attente'
-          AND (f.secteur_id IS NOT NULL OR f.assigned_direction = 1)
+          {scope_factures}
         ORDER BY f.date_echeance ASC, f.date_facture ASC
         LIMIT 15
     ''').fetchall()

--- a/email_service.py
+++ b/email_service.py
@@ -172,6 +172,24 @@ def _ouvrir_connexion_smtp(config):
     return server
 
 
+def _message_auth_refusee(erreur):
+    """Message d'echec d'authentification incluant la reponse du serveur SMTP.
+
+    La reponse de Google (ex. « 535-5.7.8 Username and Password not accepted »)
+    pointe la cause exacte : mot de passe d'application invalide, validation en
+    deux etapes desactivee, mot de passe habituel saisi a la place… On la
+    remonte a l'utilisateur (le mot de passe n'y figure pas) plutot qu'un
+    message generique qui laisse deviner.
+    """
+    base = ("Echec d'authentification SMTP. Verifiez l'adresse email et le mot de passe "
+            "d'application (16 caracteres Gmail, sans espaces).")
+    reponse = getattr(erreur, 'smtp_error', None)
+    if isinstance(reponse, (bytes, bytearray)):
+        reponse = reponse.decode('utf-8', 'replace')
+    reponse = ' '.join(str(reponse).split()) if reponse else ''
+    return f"{base} Reponse du serveur : {reponse}" if reponse else base
+
+
 def envoyer_email(destinataire, sujet, contenu_html, destinataire_prenom=''):
     """Envoie un email via SMTP.
 
@@ -203,9 +221,9 @@ def envoyer_email(destinataire, sujet, contenu_html, destinataire_prenom=''):
         server.quit()
         logger.info("Email envoye a %s : %s", destinataire, sujet)
         return True, "Email envoye avec succes"
-    except smtplib.SMTPAuthenticationError:
-        logger.error("Echec authentification SMTP pour %s", config['sender'])
-        return False, "Echec d'authentification SMTP. Verifiez l'adresse email et le mot de passe d'application."
+    except smtplib.SMTPAuthenticationError as e:
+        logger.error("Echec authentification SMTP pour %s : %s", config['sender'], e)
+        return False, _message_auth_refusee(e)
     except smtplib.SMTPException as e:
         logger.error("Erreur SMTP : %s", str(e))
         return False, f"Erreur SMTP : {str(e)}"

--- a/templates/configuration_email.html
+++ b/templates/configuration_email.html
@@ -144,9 +144,10 @@
 
             <div class="em-form-group">
                 <label>Mot de passe d'application</label>
-                <input type="password" name="password" class="em-input"
-                       placeholder="{{ config.password_display or 'Mot de passe d\'application Google' }}" required>
-                <div class="em-hint">Mot de passe d'application Google (16 caracteres, sans espaces)</div>
+                <input type="password" name="password" class="em-input" autocomplete="new-password"
+                       placeholder="{% if config.password_display %}Laissez vide pour conserver le mot de passe actuel{% else %}Mot de passe d'application Google{% endif %}">
+                <div class="em-hint">Mot de passe d'application Google (16 caracteres, sans espaces).
+                    {% if config.password_display %}Un mot de passe est deja enregistre : laissez ce champ vide pour le conserver.{% endif %}</div>
             </div>
 
             <div class="em-row">

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -21,6 +21,18 @@ def _seed_facture(db, montant=1240.50, fournisseur='EDF', assignee=True):
     return db.execute("SELECT id FROM factures WHERE numero_facture='F-100'").fetchone()['id']
 
 
+def _seed_facture_secteur(db, secteur_id, fournisseur='FOURN-SECTEUR', numero='F-SEC'):
+    """Facture assignée à un secteur (à valider par son responsable, pas la direction)."""
+    db.execute("INSERT INTO fournisseurs (nom) VALUES (?)", (fournisseur,))
+    fid = db.execute("SELECT id FROM fournisseurs WHERE nom=?", (fournisseur,)).fetchone()['id']
+    db.execute("INSERT INTO factures (numero_facture, fournisseur_id, montant_ttc, approbation, "
+               "date_echeance, secteur_id, assigned_direction) "
+               "VALUES (?, ?, 500, 'en_attente', '2026-07-05', ?, 0)",
+               (numero, fid, secteur_id))
+    db.commit()
+    return db.execute("SELECT id FROM factures WHERE numero_facture=?", (numero,)).fetchone()['id']
+
+
 # ──────────────────────────────────────────────────────────────────────────
 #  Accès et structure
 # ──────────────────────────────────────────────────────────────────────────
@@ -379,6 +391,29 @@ def test_digest_exclut_les_personnes_en_conge(admin_client, db, sample_users, mo
 
     admin_client.get('/dashboard_direction')
     assert envois == []   # les deux destinataires sont en congé
+
+
+def test_digest_factures_limite_a_la_direction(admin_client, db, sample_users, monkeypatch):
+    """Le digest ne liste que les factures à valider par la direction ; celles
+    assignées à un secteur (à valider par son responsable) en sont exclues."""
+    envois = _preparer_digest(db, sample_users, monkeypatch)
+    _seed_facture(db)                                        # EDF → assignée direction
+    _seed_facture_secteur(db, sample_users['secteur_id'])   # FOURN-SECTEUR → secteur
+    admin_client.get('/dashboard_direction')
+    assert envois, 'un digest était attendu'
+    contenu = envois[0][2]
+    assert 'EDF' in contenu                 # facture direction listée
+    assert 'FOURN-SECTEUR' not in contenu   # facture de secteur exclue du digest
+
+
+def test_dashboard_montre_factures_secteur_et_direction(admin_client, db, sample_users):
+    """Le centre de contrôle (vue interactive) garde les deux : la restriction
+    « direction seulement » ne concerne que le digest."""
+    _seed_facture(db)                                        # EDF → direction
+    _seed_facture_secteur(db, sample_users['secteur_id'])   # FOURN-SECTEUR → secteur
+    html = admin_client.get('/dashboard_direction').get_data(as_text=True)
+    assert 'Facture EDF' in html
+    assert 'Facture FOURN-SECTEUR' in html
 
 
 def test_alerte_budget_presque_epuise(admin_client, db, sample_users):

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -135,3 +135,58 @@ def test_config_email_enregistre_base_url(admin_client, app):
     m = re.search(r'name="base_url"[^>]*value="([^"]*)"', html)
     assert m is not None, 'champ base_url absent du formulaire'
     assert m.group(1) == 'https://cs-pilot.mon-centre.fr'
+
+
+# ── Mot de passe conservé si le champ est laissé vide (édition d'un réglage) ──
+
+def test_config_email_conserve_mot_de_passe_si_vide(admin_client, app):
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'secret-initial', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''})
+    # On ne change QUE le domaine, mot de passe laissé vide → il doit être conservé.
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': '', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': 'cs-pilot.fr'})
+    with app.app_context():
+        assert email_service.get_email_config()['password'] == 'secret-initial'
+        assert email_service.get_base_url() == 'https://cs-pilot.fr'
+
+
+def test_config_email_nouveau_mot_de_passe_remplace(admin_client, app):
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'ancien', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''})
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'nouveau', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''})
+    with app.app_context():
+        assert email_service.get_email_config()['password'] == 'nouveau'
+
+
+def test_config_email_premiere_config_exige_mot_de_passe(admin_client, app):
+    # Aucun mot de passe existant + champ vide → refus (rien enregistré).
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': '', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''},
+        follow_redirects=True)
+    with app.app_context():
+        assert not email_service.get_email_config().get('password')
+
+
+def test_config_email_gmail_retire_les_espaces(admin_client, app):
+    # Mot de passe d'application collé avec les espaces d'affichage → nettoyé
+    # pour Gmail (Gmail refuse les espaces).
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'abcd efgh ijkl mnop', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''})
+    with app.app_context():
+        assert email_service.get_email_config()['password'] == 'abcdefghijklmnop'
+
+
+def test_config_email_non_gmail_preserve_les_espaces(admin_client, app):
+    # Autre serveur SMTP : un mot de passe avec espaces est conservé tel quel.
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'mon pass', 'sender_name': 'CS',
+        'smtp_server': 'smtp.ovh.net', 'smtp_port': '587', 'base_url': ''})
+    with app.app_context():
+        assert email_service.get_email_config()['password'] == 'mon pass'

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -6,6 +6,7 @@ récupérations : le paramètre `type_libelle` doit adapter l'objet et le corps
 pour ne pas parler de « récupération » à propos d'un congé.
 """
 import re
+import smtplib
 
 import email_service
 
@@ -190,3 +191,77 @@ def test_config_email_non_gmail_preserve_les_espaces(admin_client, app):
         'smtp_server': 'smtp.ovh.net', 'smtp_port': '587', 'base_url': ''})
     with app.app_context():
         assert email_service.get_email_config()['password'] == 'mon pass'
+
+
+# ── Diagnostic d'échec d'authentification : remonter la réponse du serveur ──
+
+def test_message_auth_inclut_la_reponse_du_serveur():
+    err = smtplib.SMTPAuthenticationError(
+        535, b'5.7.8 Username and Password not accepted. https://support.google.com/... - gsmtp')
+    msg = email_service._message_auth_refusee(err)
+    assert msg.lower().startswith("echec d'authentification")
+    assert 'Reponse du serveur' in msg
+    assert 'Username and Password not accepted' in msg   # la cause exacte est visible
+
+
+def test_message_auth_sans_reponse_serveur():
+    # Pas de corps de réponse → on garde le message générique, sans « None ».
+    err = smtplib.SMTPAuthenticationError(535, None)
+    msg = email_service._message_auth_refusee(err)
+    assert 'Reponse du serveur' not in msg
+    assert 'None' not in msg
+
+
+def test_envoyer_email_auth_refusee_remonte_la_reponse(app, db, monkeypatch):
+    with app.app_context():
+        email_service.save_email_config('smtp.gmail.com', '587', 'a@b.fr', 'x' * 16, 'CS')
+
+        def _refuser(config):
+            raise smtplib.SMTPAuthenticationError(
+                535, b'5.7.8 Username and Password not accepted')
+
+        monkeypatch.setattr(email_service, '_ouvrir_connexion_smtp', _refuser)
+        ok, msg = email_service.envoyer_email('dest@x.fr', 'Sujet', '<p>x</p>')
+    assert ok is False
+    assert 'Username and Password not accepted' in msg   # remonté à l'utilisateur
+
+
+# ── Avertissement de longueur : 16 caractères attendus pour Gmail ──
+
+def test_config_email_gmail_longueur_incorrecte_avertit(admin_client):
+    # « trop court » → espaces retirés → 9 caractères ≠ 16 → avertissement.
+    r = admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'trop court', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''},
+        follow_redirects=True)
+    assert 'or celui saisi en fait' in r.get_data(as_text=True)
+
+
+def test_config_email_gmail_16_caracteres_pas_d_avertissement(admin_client):
+    r = admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'abcdefghijklmnop', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''},
+        follow_redirects=True)
+    assert 'or celui saisi en fait' not in r.get_data(as_text=True)
+
+
+def test_config_email_champ_vide_pas_d_avertissement(admin_client):
+    # Config initiale valide puis on ne touche qu'au domaine : aucun avertissement
+    # (le mot de passe conservé n'est pas re-jugé).
+    admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'abcdefghijklmnop', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': ''})
+    r = admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': '', 'sender_name': 'CS',
+        'smtp_server': 'smtp.gmail.com', 'smtp_port': '587', 'base_url': 'cs-pilot.fr'},
+        follow_redirects=True)
+    assert 'or celui saisi en fait' not in r.get_data(as_text=True)
+
+
+def test_config_email_non_gmail_pas_d_avertissement_longueur(admin_client):
+    # Serveur non-Gmail : la règle des 16 caractères ne s'applique pas.
+    r = admin_client.post('/configuration_email', data={
+        'sender': 'a@b.fr', 'password': 'court', 'sender_name': 'CS',
+        'smtp_server': 'smtp.ovh.net', 'smtp_port': '587', 'base_url': ''},
+        follow_redirects=True)
+    assert 'or celui saisi en fait' not in r.get_data(as_text=True)


### PR DESCRIPTION
## Contexte

Après l'ajout du champ « adresse du site » (nom de domaine pour les liens des mails), l'authentification SMTP a cessé de fonctionner (« Échec d'authentification SMTP »). Cause : une **régression d'ergonomie** du formulaire, pas une erreur de saisie. Le champ mot de passe n'affiche jamais la valeur enregistrée (`********`) et était `required` : dès qu'on ré-enregistrait la config pour un autre motif (le domaine), il fallait ressaisir le mot de passe d'application — et une re-saisie erronée (espaces d'affichage Google, faute de frappe, autofill du navigateur) écrasait silencieusement le bon mot de passe.

Cette PR corrige la régression, rend l'échec auto-explicatif, et resserre le digest matinal.

## Changements

### 1. Mot de passe optionnel à la ré-édition (`blueprints/notifications.py`, `templates/configuration_email.html`)
- Champ laissé vide → l'ancien mot de passe est **conservé** (on peut changer domaine/expéditeur sans y toucher). La **première** configuration l'exige toujours.
- `autocomplete="new-password"` : empêche le navigateur d'injecter un identifiant enregistré.
- Gmail : les espaces d'affichage des mots de passe d'application (« xxxx xxxx xxxx xxxx ») sont **retirés automatiquement** (Gmail les refuse). Les autres serveurs SMTP conservent le mot de passe tel quel.

### 2. Diagnostic des échecs d'authentification (`email_service.py`, `blueprints/notifications.py`)
- Le message d'échec remonte désormais la **réponse réelle du serveur** (ex. « 535‑5.7.8 Username and Password not accepted »), qui pointe la cause exacte (mot de passe d'application invalide, validation en 2 étapes désactivée, mot de passe habituel saisi à la place). Le mot de passe ne figure pas dans cette réponse.
- À l'enregistrement d'un mot de passe Gmail, un **avertissement** signale toute longueur ≠ 16 caractères (après retrait des espaces) — trahit un mot de passe collé avec ses espaces ou le mot de passe habituel autofillé.

### 3. Digest : factures limitées à la direction (`dashboard_actions.py`, `blueprints/dashboard_direction.py`)
- Le digest matinal listait **toutes** les factures en attente, y compris celles assignées à un secteur (à valider par le responsable du secteur, pas la direction).
- Nouveau paramètre `factures_direction_seulement` : le digest ne retient que les factures `assigned_direction = 1`. **Le tableau de bord interactif garde sa vue complète** (sector + direction).

## Tests

- `tests/test_email_notifications.py` : conservation/remplacement du mot de passe, première config exigée, espaces Gmail, remontée de la réponse serveur (avec/sans corps), envoi refusé de bout en bout, avertissement de longueur.
- `tests/test_dashboard_direction.py` : le digest exclut une facture de secteur mais garde une facture direction ; le centre de contrôle affiche toujours les deux.

Suite complète verte (**880 tests**).

## Suite pour l'utilisateur

Le mot de passe stocké ayant été écrasé, il faut le ressaisir **une fois** : Configuration email → coller le mot de passe d'application Gmail (16 caractères, espaces désormais retirés automatiquement) → Enregistrer → tester. Ensuite, tout autre réglage se modifie sans le ressaisir (champ laissé vide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp