### PR TITLE
Centre de contrôle : n'afficher que les factures à valider par la direction

### DIFF
--- a/blueprints/dashboard_direction.py
+++ b/blueprints/dashboard_direction.py
@@ -148,15 +148,11 @@ def _fmt_euro(valeur):
     return f"{valeur:,.0f}".replace(',', ' ') + ' €'
 
 
-def _construire_file_actions(conn, profil, user_id, seuils,
-                             factures_direction_seulement=False):
+def _construire_file_actions(conn, profil, user_id, seuils):
     """File d'actions étendue + liste des surcharges (partagé page / fragment).
 
     Le calcul de surcharge lit tout l'historique d'heures : en cas d'erreur il
     est neutralisé plutôt que de faire tomber le tableau de bord.
-
-    `factures_direction_seulement` (digest) : n'inclut que les factures à
-    valider par la direction, pas celles assignées à un secteur.
     """
     try:
         surcharges = _calculer_surcharges(conn, seuils['surcharge'])
@@ -164,8 +160,7 @@ def _construire_file_actions(conn, profil, user_id, seuils,
         logger.exception("Calcul des surcharges impossible")
         surcharges = []
     actions = construire_actions(conn, profil, user_id,
-                                 etendu=True, seuils=seuils, surcharges=surcharges,
-                                 factures_direction_seulement=factures_direction_seulement)
+                                 etendu=True, seuils=seuils, surcharges=surcharges)
     return actions, surcharges
 
 
@@ -496,8 +491,7 @@ def _envoyer_digest_du_jour(quand):
         if not destinataires:
             return 0
         seuils = _lire_seuils()
-        actions, _ = _construire_file_actions(conn, 'directeur', None, seuils,
-                                              factures_direction_seulement=True)
+        actions, _ = _construire_file_actions(conn, 'directeur', None, seuils)
         if not actions:
             return 0
         sujet, contenu = _composer_digest(actions, quand)

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -73,8 +73,7 @@ def _urgence_depot(d, today):
 
 
 def construire_actions(conn, profil, user_id, secteur_id=None,
-                       etendu=False, seuils=None, surcharges=None,
-                       factures_direction_seulement=False):
+                       etendu=False, seuils=None, surcharges=None):
     """Retourne la liste des actions à faire du tableau de bord d'un profil.
 
     - directeur / comptable : toutes les demandes en attente + toutes les
@@ -82,17 +81,12 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
     - responsable : demandes de son secteur + subventions dont il est assigné.
 
     En mode « étendu » (centre de contrôle direction), la liste s'enrichit
-    d'items actionnables en un clic : factures en attente d'approbation,
+    d'items actionnables en un clic : factures à valider par la direction,
     fiches du mois précédent à relancer, salariés en surcharge (liste
     `surcharges` calculée par l'appelant, filtrée par seuil) et soldes de
     congés conventionnels au-dessus du seuil. Chaque item porte alors un
     `id` stable et un `type` ('facture' / 'demande' / 'relance' / 'lien')
     avec les données nécessaires à l'action.
-
-    `factures_direction_seulement` restreint les factures à celles assignées
-    à la direction (`assigned_direction = 1`) — utilisé par le digest matinal
-    pour n'y mettre que ce que la direction doit valider, sans les factures
-    d'un secteur (qui relèvent de son responsable).
     """
     actions = []
     today = aujourd_hui()
@@ -241,34 +235,30 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
         })
 
     if etendu and profil in ('directeur', 'comptable'):
-        actions.extend(_actions_etendues(conn, profil, user_id, today, seuils, surcharges,
-                                         factures_direction_seulement))
+        actions.extend(_actions_etendues(conn, profil, user_id, today, seuils, surcharges))
 
     # Les plus urgents d'abord, puis par ordre d'insertion (déjà trié par date).
     actions.sort(key=lambda a: _ORDRE_URGENCE.get(a['urgence'], 2))
     return actions
 
 
-def _actions_etendues(conn, profil, user_id, today, seuils, surcharges,
-                      factures_direction_seulement=False):
+def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
     """Items supplémentaires du centre de contrôle direction / comptable."""
     actions = []
 
-    # 3. Factures en attente d'approbation (approbation en un clic). Même
-    # périmètre que la page d'approbation : une facture sans secteur ni
-    # assignation direction n'est pas encore entrée dans le circuit et ne doit
-    # pas pouvoir être approuvée depuis le tableau de bord.
-    # Le digest ne retient que les factures de la direction : celles d'un
-    # secteur sont à valider par son responsable, pas par la direction.
-    scope_factures = ('AND f.assigned_direction = 1' if factures_direction_seulement
-                      else 'AND (f.secteur_id IS NOT NULL OR f.assigned_direction = 1)')
-    rows = conn.execute(f'''
+    # 3. Factures à valider par la direction (approbation en un clic). On ne
+    # retient que les factures assignées à la direction (`assigned_direction =
+    # 1`) : celles rattachées à un secteur relèvent de son responsable (elles
+    # restent traitées sur la page d'approbation), et une facture non assignée
+    # n'est pas encore entrée dans le circuit. Le centre de contrôle direction
+    # n'affiche donc que ce que la direction doit réellement traiter.
+    rows = conn.execute('''
         SELECT f.id, f.numero_facture, f.montant_ttc, f.date_echeance,
                fr.nom AS fournisseur_nom
         FROM factures f
         LEFT JOIN fournisseurs fr ON f.fournisseur_id = fr.id
         WHERE f.approbation = 'en_attente'
-          {scope_factures}
+          AND f.assigned_direction = 1
         ORDER BY f.date_echeance ASC, f.date_facture ASC
         LIMIT 15
     ''').fetchall()

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -406,14 +406,16 @@ def test_digest_factures_limite_a_la_direction(admin_client, db, sample_users, m
     assert 'FOURN-SECTEUR' not in contenu   # facture de secteur exclue du digest
 
 
-def test_dashboard_montre_factures_secteur_et_direction(admin_client, db, sample_users):
-    """Le centre de contrôle (vue interactive) garde les deux : la restriction
-    « direction seulement » ne concerne que le digest."""
+def test_dashboard_exclut_les_factures_de_secteur(admin_client, db, sample_users):
+    """Le centre de contrôle direction n'affiche que les factures à valider par
+    la direction ; celles rattachées à un secteur (à valider par son
+    responsable) n'y figurent pas — elles restent sur la page d'approbation."""
     _seed_facture(db)                                        # EDF → direction
-    _seed_facture_secteur(db, sample_users['secteur_id'])   # FOURN-SECTEUR → secteur
+    fid_sec = _seed_facture_secteur(db, sample_users['secteur_id'])  # FOURN-SECTEUR → secteur
     html = admin_client.get('/dashboard_direction').get_data(as_text=True)
     assert 'Facture EDF' in html
-    assert 'Facture FOURN-SECTEUR' in html
+    assert 'Facture FOURN-SECTEUR' not in html
+    assert f'data-facture-id="{fid_sec}"' not in html
 
 
 def test_alerte_budget_presque_epuise(admin_client, db, sample_users):


### PR DESCRIPTION
## Contexte

Le digest matinal ne listait que les factures à valider par la direction (`assigned_direction = 1`), mais le **tableau de bord direction** (Centre de contrôle) continuait d'afficher aussi les factures rattachées à un secteur — celles-ci sont à valider par le **responsable du secteur**, pas par la direction. Elles encombraient donc la file « À faire maintenant » de la direction. On aligne la vue interactive sur la même règle que le digest.

## Changement

- `dashboard_actions.py` — `_actions_etendues` : les factures de la file d'actions du Centre de contrôle sont désormais restreintes à `assigned_direction = 1`.
  - Les factures **de secteur** (`secteur_id` renseigné) relèvent de leur responsable et restent traitées sur la **page d'approbation** — elles n'apparaissent plus sur le tableau de bord direction.
  - Une facture **non assignée** (ni secteur, ni direction) n'est toujours pas proposée (elle n'est pas encore dans le circuit) — comportement inchangé.
- Le paramètre `factures_direction_seulement`, introduit à la PR précédente pour le seul digest, devient inutile puisque tous les appels veulent ce périmètre : il est **retiré** (`construire_actions`, `_actions_etendues`, `_construire_file_actions`).

## Tests

`tests/test_dashboard_direction.py` :
- `test_dashboard_exclut_les_factures_de_secteur` (ex-`test_dashboard_montre_factures_secteur_et_direction`) : le Centre de contrôle affiche la facture direction mais **pas** la facture de secteur (ni son bouton un clic).
- `test_digest_factures_limite_a_la_direction` : inchangé, le digest reste correct.
- `test_facture_hors_circuit_sans_bouton` : inchangé (facture non assignée toujours exclue).

Suite complète verte (**880 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_