### PR TITLE
Heures supp payées : déduction du compteur de récupération + trace

### DIFF
--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -7,7 +7,8 @@ from io import BytesIO
 from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
                    calculer_heures_reelles_jour, slot_horaire,
-                   get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS)
+                   get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
+                   total_hs_payees)
 
 exports_bp = Blueprint('exports_bp', __name__)
 
@@ -264,9 +265,14 @@ def export_pdf_mensuel():
             total_reel = calculer_heures_reelles_jour(h)
         
         solde_anterieur += (total_reel - total_theorique)
-    
-    solde_cumule = solde_anterieur + solde_mois
-    
+
+    # Heures supp payées (variables de paie, déduites du compteur) : mêmes
+    # règles que la vue mensuelle pour que le PDF signé colle au dashboard.
+    solde_anterieur -= total_hs_payees(conn, user_id_param,
+                                       annee=annee, mois=mois, avant=True)
+    hs_payees_mois = total_hs_payees(conn, user_id_param, annee=annee, mois=mois)
+    solde_cumule = solde_anterieur + solde_mois - hs_payees_mois
+
     conn.close()
     
     # Générer le PDF en paysage (optimisé pour 2 pages max)
@@ -373,8 +379,10 @@ def export_pdf_mensuel():
     bas_page = []
     
     # Soldes sur une seule ligne pour gagner de la place
-    soldes_text = f"""<b>Solde du mois :</b> {'+' if solde_mois > 0 else ''}{solde_mois:.2f}h  •  
-    <b>Solde antérieur :</b> {'+' if solde_anterieur > 0 else ''}{solde_anterieur:.2f}h  •  
+    hs_payees_txt = (f"  •  <b>H. supp payées ce mois :</b> -{hs_payees_mois:.2f}h"
+                     if hs_payees_mois else "")
+    soldes_text = f"""<b>Solde du mois :</b> {'+' if solde_mois > 0 else ''}{solde_mois:.2f}h  •
+    <b>Solde antérieur :</b> {'+' if solde_anterieur > 0 else ''}{solde_anterieur:.2f}h{hs_payees_txt}  •
     <b>Solde cumulé :</b> {'+' if solde_cumule > 0 else ''}{solde_cumule:.2f}h"""
     bas_page.append(Paragraph(soldes_text, normal_style))
     bas_page.append(Spacer(1, 0.4*cm))

--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -224,8 +224,14 @@ def export_pdf_mensuel():
     
     solde_mois = total_heures_reelles - total_heures_theoriques
     
-    # Calculer solde antérieur
-    solde_anterieur = 0
+    # Calculer solde antérieur — comme la vue mensuelle, on part du solde
+    # initial du salarié (le PDF signé doit coller au dashboard ; revue Codex :
+    # sans cette base, la déduction des heures payées rendrait le solde
+    # antérieur négatif à tort).
+    try:
+        solde_anterieur = user['solde_initial'] or 0
+    except (IndexError, KeyError, TypeError):
+        solde_anterieur = 0
     heures_anterieures = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin,
                heure_debut_aprem, heure_fin_aprem,

--- a/blueprints/recup.py
+++ b/blueprints/recup.py
@@ -3,12 +3,11 @@ Blueprint recup_bp.
 """
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash, make_response
 from datetime import datetime, timedelta
-import sqlite3
 from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
-                   calculer_heures_reelles_jour,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date,
-                   calculer_jours_ouvres, calculer_solde_recup, calculer_recup_partielle)
+                   calculer_jours_ouvres, calculer_solde_recup, calculer_recup_partielle,
+                   NOMS_MOIS)
 from email_service import (
     is_email_configured, peut_envoyer_email, notifier_nouvelle_demande_recup,
     notifier_demande_recup_validee_responsable, notifier_demande_recup_decision,
@@ -253,51 +252,11 @@ def demande_recup():
             flash('Période invalide', 'error')
             return redirect(url_for('recup_bp.demande_recup'))
 
-        # Récupérer le solde de récup disponible
+        # Solde de récup disponible : calcul partagé (utils), net des heures
+        # supp déjà payées via les variables de paie.
+        solde_recup = calculer_solde_recup(session['user_id'])
         conn = get_db()
-        
-        # Calculer le solde (similaire au dashboard)
-        heures = conn.execute('''
-            SELECT date, heure_debut_matin, heure_fin_matin,
-                   heure_debut_aprem, heure_fin_aprem,
-                   heure_debut_soir, heure_fin_soir, declaration_conforme
-            FROM heures_reelles
-            WHERE user_id = ?
-            ORDER BY date
-        ''', (session['user_id'],)).fetchall()
-        
-        # Récupérer le solde initial
-        try:
-            user_data = conn.execute('SELECT solde_initial FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-            solde_recup = user_data['solde_initial'] if user_data and user_data['solde_initial'] else 0
-        except (sqlite3.OperationalError, KeyError, TypeError):
-            solde_recup = 0
-        
-        for h in heures:
-            date_obj = datetime.strptime(h['date'], '%Y-%m-%d')
-            if date_obj.weekday() == 6:  # Dimanche
-                continue
-            
-            type_periode = get_type_periode(h['date'])
-            jour_semaine = date_obj.weekday()
-            
-            # Heures théoriques - UTILISER LE BON PLANNING À CETTE DATE
-            total_theorique = 0
-            if jour_semaine == 5:  # Samedi
-                total_theorique = 0
-            else:
-                planning = get_planning_valide_a_date(session['user_id'], type_periode, h['date'])
-                if planning:
-                    total_theorique = get_heures_theoriques_jour(planning, jour_semaine)
-            
-            # Heures réelles
-            if h['declaration_conforme']:
-                total_reel = total_theorique
-            else:
-                total_reel = calculer_heures_reelles_jour(h)
 
-            solde_recup += (total_reel - total_theorique)
-        
         # Calculer les heures EXACTES pour chaque jour de la période
         nb_heures = 0
         date_actuelle = datetime.strptime(date_debut, '%Y-%m-%d')
@@ -377,53 +336,9 @@ def demande_recup():
         
         return redirect(url_for('recup_bp.mes_demandes_recup'))
     
-    # GET : afficher le formulaire
-    conn = get_db()
-    
-    # Calculer le solde disponible (même logique que ci-dessus)
-    heures = conn.execute('''
-        SELECT date, heure_debut_matin, heure_fin_matin,
-               heure_debut_aprem, heure_fin_aprem,
-               heure_debut_soir, heure_fin_soir, declaration_conforme
-        FROM heures_reelles
-        WHERE user_id = ?
-        ORDER BY date
-    ''', (session['user_id'],)).fetchall()
-    
-    # Récupérer le solde initial
-    try:
-        user_data = conn.execute('SELECT solde_initial FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-        solde_recup = user_data['solde_initial'] if user_data and user_data['solde_initial'] else 0
-    except (sqlite3.OperationalError, KeyError, TypeError):
-        solde_recup = 0
-    
-    for h in heures:
-        date_obj = datetime.strptime(h['date'], '%Y-%m-%d')
-        if date_obj.weekday() == 6:  # Dimanche
-            continue
-        
-        type_periode = get_type_periode(h['date'])
-        jour_semaine = date_obj.weekday()
-        
-        # Heures théoriques - UTILISER LE BON PLANNING À CETTE DATE
-        total_theorique = 0
-        if jour_semaine == 5:
-            total_theorique = 0
-        else:
-            planning = get_planning_valide_a_date(session['user_id'], type_periode, h['date'])
-            if planning:
-                total_theorique = get_heures_theoriques_jour(planning, jour_semaine)
-        
-        # Heures réelles
-        if h['declaration_conforme']:
-            total_reel = total_theorique
-        else:
-            total_reel = calculer_heures_reelles_jour(h)
-
-        solde_recup += (total_reel - total_theorique)
-    
-    conn.close()
-    
+    # GET : afficher le formulaire — solde partagé (utils), net des heures
+    # supp déjà payées via les variables de paie.
+    solde_recup = calculer_solde_recup(session['user_id'])
     return render_template('demande_recup.html', solde_recup=solde_recup)
 
 @recup_bp.route('/mes_demandes_recup')
@@ -431,7 +346,7 @@ def demande_recup():
 def mes_demandes_recup():
     """Liste des demandes de récupération du salarié"""
     conn = get_db()
-    
+
     demandes = conn.execute('''
         SELECT d.*,
                u.nom || ' ' || u.prenom as demandeur_nom
@@ -440,10 +355,25 @@ def mes_demandes_recup():
         WHERE d.user_id = ?
         ORDER BY d.date_demande DESC
     ''', (session['user_id'],)).fetchall()
-    
+
+    # Heures supp payées (variables de paie, marquées « déduites du compteur »)
+    # : la trace visible côté salarié de ce qui a été payé plutôt que récupéré.
+    paiements_hs = [
+        {'libelle': f"Paie de {NOMS_MOIS[p['mois']].lower()} {p['annee']}",
+         'heures': p['heures_supps']}
+        for p in conn.execute('''
+            SELECT mois, annee, heures_supps
+            FROM variables_paie
+            WHERE user_id = ? AND hs_deduites_compteur = 1
+              AND heures_supps IS NOT NULL AND heures_supps > 0
+            ORDER BY annee DESC, mois DESC
+        ''', (session['user_id'],)).fetchall()
+    ]
+
     conn.close()
-    
-    return render_template('mes_demandes_recup.html', demandes=demandes)
+
+    return render_template('mes_demandes_recup.html', demandes=demandes,
+                           paiements_hs=paiements_hs)
 
 
 @recup_bp.route('/supprimer_demande_recup', methods=['POST'])
@@ -778,7 +708,7 @@ def historique_demandes_recup():
 
     demandes = list(demandes_recup) + list(demandes_conges)
     demandes.sort(key=lambda d: d['date_demande'], reverse=True)
-    
+
     # Statistiques
     stats = {
         'total': len(demandes),
@@ -787,10 +717,30 @@ def historique_demandes_recup():
         'total_jours_valides': sum(d['nb_jours'] for d in demandes if d['statut'] == 'validee'),
         'total_heures_valides': sum(_safe_nb_heures(d) for d in demandes if d['statut'] == 'validee')
     }
-    
+
+    # Heures supp payées (variables de paie, déduites du compteur de récup) :
+    # trace côté direction de ce qui a été réglé en paie plutôt que récupéré.
+    paiements_hs = [
+        {'salarie_nom': p['salarie_nom'], 'secteur_nom': p['secteur_nom'],
+         'libelle': f"Paie de {NOMS_MOIS[p['mois']].lower()} {p['annee']}",
+         'heures': p['heures_supps']}
+        for p in conn.execute('''
+            SELECT vp.mois, vp.annee, vp.heures_supps,
+                   u.nom || ' ' || u.prenom AS salarie_nom,
+                   s.nom AS secteur_nom
+            FROM variables_paie vp
+            JOIN users u ON vp.user_id = u.id
+            LEFT JOIN secteurs s ON u.secteur_id = s.id
+            WHERE vp.hs_deduites_compteur = 1
+              AND vp.heures_supps IS NOT NULL AND vp.heures_supps > 0
+            ORDER BY vp.annee DESC, vp.mois DESC, salarie_nom
+        ''').fetchall()
+    ]
+
     conn.close()
-    
-    return render_template('historique_demandes_recup.html', demandes=demandes, stats=stats)
+
+    return render_template('historique_demandes_recup.html', demandes=demandes,
+                           stats=stats, paiements_hs=paiements_hs)
 
 
 # ==================== DEMANDES DE CONGES ====================

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -8,7 +8,8 @@ from database import get_db
 from blueprints.delegations import MISSION_SUIVI_VALIDATIONS_RELANCES, user_has_delegation
 from utils import (login_required, get_user_info, calculer_heures,
                     calculer_heures_reelles_jour, slot_horaire,
-                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS)
+                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
+                    total_hs_payees)
 from app_options import get_option_bool
 from access_log import (journaliser_action, ACTION_VALIDATION_MOIS,
                         ACTION_DEVERROUILLAGE_MOIS)
@@ -609,7 +610,13 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
 
         solde_anterieur += (total_reel - total_theorique)
 
-    solde_cumule = solde_anterieur + solde_mois
+    # Heures supp payées (variables de paie, déduites du compteur) : les paies
+    # antérieures au mois affiché sortent du solde antérieur, celle du mois
+    # affiché sort du cumul — la fiche reste alignée sur le solde du dashboard.
+    solde_anterieur -= total_hs_payees(conn, user_id_a_afficher,
+                                       annee=annee, mois=mois, avant=True)
+    hs_payees_mois = total_hs_payees(conn, user_id_a_afficher, annee=annee, mois=mois)
+    solde_cumule = solde_anterieur + solde_mois - hs_payees_mois
 
     nb_jours_non_declares = sum(1 for j in journees if j.get('non_declare', False))
 
@@ -680,6 +687,7 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
         solde_mois=solde_mois,
         solde_anterieur=solde_anterieur,
         solde_cumule=solde_cumule,
+        hs_payees_mois=hs_payees_mois,
         mois_precedent=mois_precedent,
         annee_precedente=annee_precedente,
         mois_suivant=mois_suivant,

--- a/blueprints/variables_paie.py
+++ b/blueprints/variables_paie.py
@@ -11,7 +11,7 @@ from flask import (Blueprint, render_template, request, redirect,
                    url_for, session, flash)
 from datetime import datetime, date
 from database import get_db
-from utils import login_required, NOMS_MOIS
+from utils import login_required, NOMS_MOIS, calculer_solde_recup
 from access_log import (journaliser_action, ACTION_ENREG_VARIABLES_PAIE,
                         ACTION_CLOTURE_CONGES)
 
@@ -120,6 +120,9 @@ def variables_paie():
                 'nb_enfants': df.get('nb_enfants', 0),
                 'heures_reelles': None,
                 'heures_supps': None,
+                # Nouvelle saisie : les heures supp payees sont deduites du
+                # compteur de recup par defaut (decochable au cas par cas).
+                'hs_deduites_compteur': 1,
                 'transport': 0,
                 'acompte': 0,
                 'saisie_salaire': df.get('saisie_salaire', 0),
@@ -131,12 +134,24 @@ def variables_paie():
         # 0038, la colonne TEXT renvoie '0'/'1' et '0' serait considere
         # comme coche par le template.
         d['mutuelle'] = int(d.get('mutuelle') or 0)
+        # Lignes enregistrees avant la migration 0057 : NULL = non deduit.
+        d['hs_deduites_compteur'] = int(d.get('hs_deduites_compteur') or 0)
+        # Solde de recuperation actuel : aide a decider combien payer (et a
+        # solder pile un CDD qui part). Sans objet pour le directeur (forfait
+        # jours, pas de compteur d'heures).
+        solde_recup = None
+        if sal['profil'] != 'directeur':
+            try:
+                solde_recup = calculer_solde_recup(uid)
+            except Exception:
+                logger.exception("Solde recup indisponible pour user %s", uid)
         grille.append({
             'user_id': uid,
             'nom': sal['nom'],
             'prenom': sal['prenom'],
             'secteur': sal['secteur_nom'],
             'data': d,
+            'solde_recup': solde_recup,
             'saved': uid in donnees_mois,
         })
 
@@ -195,6 +210,9 @@ def enregistrer_variables_paie():
             heures_reelles = float(heures_reelles_str) if heures_reelles_str else None
             heures_supps_str = request.form.get(f'heures_supps_{uid}', '').strip()
             heures_supps = float(heures_supps_str) if heures_supps_str else None
+            # Heures supp payees deduites du compteur de recup (case a cocher,
+            # cochee par defaut pour une nouvelle saisie).
+            hs_deduites = 1 if request.form.get(f'hs_deduit_{uid}') else 0
             transport = request.form.get(f'transport_{uid}', 0, type=float)
             acompte = request.form.get(f'acompte_{uid}', 0, type=float)
             saisie_salaire = request.form.get(f'saisie_salaire_{uid}', 0, type=float)
@@ -229,23 +247,24 @@ def enregistrer_variables_paie():
                 conn.execute('''
                     UPDATE variables_paie
                     SET mutuelle = ?, nb_enfants = ?, heures_reelles = ?, heures_supps = ?,
+                        hs_deduites_compteur = ?,
                         transport = ?, acompte = ?,
                         saisie_salaire = ?, pret_avance = ?, autres_regularisation = ?,
                         commentaire = ?, saisi_par = ?, updated_at = CURRENT_TIMESTAMP
                     WHERE id = ?
                 ''', (mutuelle, nb_enfants, heures_reelles, heures_supps,
-                      transport, acompte,
+                      hs_deduites, transport, acompte,
                       saisie_salaire, pret_avance, autres_reg,
                       commentaire, session['user_id'], existing['id']))
             else:
                 conn.execute('''
                     INSERT INTO variables_paie
                     (user_id, mois, annee, mutuelle, nb_enfants, heures_reelles, heures_supps,
-                     transport, acompte,
+                     hs_deduites_compteur, transport, acompte,
                      saisie_salaire, pret_avance, autres_regularisation, commentaire, saisi_par)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''', (uid, mois, annee, mutuelle, nb_enfants, heures_reelles, heures_supps,
-                      transport, acompte,
+                      hs_deduites, transport, acompte,
                       saisie_salaire, pret_avance, autres_reg, commentaire, session['user_id']))
 
             # Mettre a jour les valeurs persistantes

--- a/database.py
+++ b/database.py
@@ -640,6 +640,7 @@ def init_db():
             commentaire TEXT,
             heures_reelles REAL,
             heures_supps REAL,
+            hs_deduites_compteur INTEGER,
             saisi_par INTEGER,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
             updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -1918,6 +1919,16 @@ def init_db():
     # Fallback indispensable : les bases creees par d'anciennes versions
     # d'init_db ont le schema TEXT alors que 0004 y est marquee appliquee.
     _corriger_types_variables_paie(cursor)
+
+    # Migration 0057 : heures supp payees deduites du compteur de recup.
+    # Nullable : NULL sur les lignes existantes = aucune deduction retroactive.
+    # Place APRES _corriger_types_variables_paie : la reconstruction eventuelle
+    # de la table (affinite TEXT) ne connait pas cette colonne, on la (re)cree
+    # donc systematiquement ensuite.
+    try:
+        cursor.execute("SELECT hs_deduites_compteur FROM variables_paie LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE variables_paie ADD COLUMN hs_deduites_compteur INTEGER")
 
     conn.commit()
     conn.close()

--- a/migrations/0057_hs_payees_compteur.py
+++ b/migrations/0057_hs_payees_compteur.py
@@ -1,0 +1,40 @@
+"""
+Migration 0057 : paiement des heures supplémentaires déduit du compteur de récup.
+
+Jusqu'ici, payer des heures supplémentaires (colonne « H. supps » des variables
+de paie) ne laissait aucune trace côté compteur : le solde de récupération du
+salarié restait plein, avec un risque de double compensation (heures payées
+PUIS récupérées) — problème surtout visible pour les CDD en fin de contrat.
+
+On ajoute `hs_deduites_compteur` à `variables_paie` : à 1, les heures supp
+payées ce mois-là sont déduites du solde de récupération (calculer_solde_recup)
+et apparaissent dans l'historique du salarié.
+
+La colonne est NULLABLE et vaut NULL sur les lignes existantes : les saisies
+antérieures à la migration ne déduisent rien rétroactivement. Le formulaire
+coche la déduction par défaut pour les nouvelles saisies.
+"""
+
+NOM = "Heures supp payées déduites du compteur de récup"
+DESCRIPTION = (
+    "Ajoute variables_paie.hs_deduites_compteur (INTEGER, nullable). À 1, les "
+    "heures supp payées du mois sont déduites du solde de récupération. NULL "
+    "sur l'existant : aucune déduction rétroactive."
+)
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    import sqlite3
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SELECT hs_deduites_compteur FROM variables_paie LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE variables_paie ADD COLUMN hs_deduites_compteur INTEGER")
+    conn.commit()
+
+
+def downgrade(conn):
+    """SQLite ne supporte pas DROP COLUMN simplement : downgrade non destructif
+    (la colonne reste, inerte tant que le code ne la lit pas)."""
+    pass

--- a/templates/historique_demandes_recup.html
+++ b/templates/historique_demandes_recup.html
@@ -148,5 +148,34 @@
         <p>Aucune demande dans l'historique</p>
     </div>
     {% endif %}
+
+    {% if paiements_hs %}
+    <div class="section" style="margin-top: 2rem;">
+        <h2 style="font-size: 1.1rem;">💶 Heures supplémentaires payées (déduites des compteurs)</h2>
+        <p class="subtitle" style="margin-bottom: 1rem;">Saisies dans les variables de paie avec déduction du compteur de récupération.</p>
+        <div class="table-responsive">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Salarié</th>
+                    <th>Secteur</th>
+                    <th>Paie</th>
+                    <th style="text-align: right;">Heures payées</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in paiements_hs %}
+                <tr>
+                    <td>{{ p.salarie_nom }}</td>
+                    <td>{{ p.secteur_nom or '-' }}</td>
+                    <td>{{ p.libelle }}</td>
+                    <td style="text-align: right;"><strong>− {{ '%.2f'|format(p.heures) }} h</strong></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
+    </div>
+    {% endif %}
 </div>
 {% endblock %}

--- a/templates/mes_demandes_recup.html
+++ b/templates/mes_demandes_recup.html
@@ -105,5 +105,30 @@
         <a href="{{ url_for('recup_bp.demande_recup') }}" class="btn btn-primary" style="margin-top: 1rem;">Créer ma première demande</a>
     </div>
     {% endif %}
+
+    {% if paiements_hs %}
+    <div class="section" style="margin-top: 2rem;">
+        <h2 style="font-size: 1.1rem;">💶 Heures supplémentaires payées</h2>
+        <p class="subtitle" style="margin-bottom: 1rem;">Heures réglées sur la paie et déduites de votre compteur de récupération.</p>
+        <div class="table-responsive">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Paie</th>
+                    <th style="text-align: right;">Heures payées</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in paiements_hs %}
+                <tr>
+                    <td>{{ p.libelle }}</td>
+                    <td style="text-align: right;"><strong>− {{ '%.2f'|format(p.heures) }} h</strong></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
+    </div>
+    {% endif %}
 </div>
 {% endblock %}

--- a/templates/variables_paie.html
+++ b/templates/variables_paie.html
@@ -34,7 +34,8 @@
                         <th style="min-width: 80px; background: #e8f5e9;">Mutuelle</th>
                         <th style="min-width: 80px; background: #e8f5e9;">Nb enfants</th>
                         <th style="min-width: 100px;">H. reelles</th>
-                        <th style="min-width: 100px;">H. supps</th>
+                        <th style="min-width: 90px;" title="Solde de recuperation actuel (heures supp payees deja deduites)">Solde recup</th>
+                        <th style="min-width: 130px;" title="Heures supplementaires payees ce mois. Cochez « deduire » pour les retirer du compteur de recuperation.">H. supps payees</th>
                         <th style="min-width: 100px;">Transport</th>
                         <th style="min-width: 100px;">Acompte</th>
                         <th style="min-width: 110px; background: #e8f5e9;">Saisie salaire</th>
@@ -69,11 +70,26 @@
                                    min="0" step="0.01" placeholder=""
                                    style="width: 90px; text-align: right;">
                         </td>
+                        <td style="text-align: right; white-space: nowrap;">
+                            {% if row.solde_recup is not none %}
+                                <span style="font-weight: 600; {% if row.solde_recup < 0 %}color: #c62828;{% endif %}">
+                                    {{ '%.2f'|format(row.solde_recup) }} h</span>
+                            {% else %}
+                                <span style="color: #9e9e9e;">&mdash;</span>
+                            {% endif %}
+                        </td>
                         <td>
                             <input type="number" name="heures_supps_{{ row.user_id }}"
                                    value="{{ row.data.heures_supps if row.data.heures_supps is not none else '' }}"
                                    min="0" step="0.01" placeholder=""
                                    style="width: 90px; text-align: right;">
+                            <label style="display: block; font-size: 0.72rem; color: #616161; margin-top: 2px; cursor: pointer; white-space: nowrap;"
+                                   title="Retire les heures payees du compteur de recuperation du salarie (trace conservee).">
+                                <input type="checkbox" name="hs_deduit_{{ row.user_id }}" value="1"
+                                       {% if row.data.hs_deduites_compteur %}checked{% endif %}
+                                       style="width: 13px; height: 13px; vertical-align: -2px; cursor: pointer;">
+                                deduire du compteur
+                            </label>
                         </td>
                         <td>
                             <input type="number" name="transport_{{ row.user_id }}"

--- a/templates/vue_mensuelle.html
+++ b/templates/vue_mensuelle.html
@@ -561,7 +561,7 @@
             <li><strong style="background: #dc2626; color: white; padding: 2px 6px; border-radius: 3px;">⚠️ Non déclaré</strong> : Jour passé qui doit être {% if declaration_conforme_active %}saisi ou déclaré{% else %}saisi{% endif %} (empêche la validation)</li>
             <li><strong style="background: #fff3cd; padding: 2px 6px;">Samedi</strong> : N'apparaît que s'il y a une saisie. 0h théorique = tout en heures supplémentaires</li>
         </ul>
-        <p><strong>Solde cumulé :</strong> Inclut les mois précédents ({{ "%.2f"|format(solde_anterieur) }}h) + ce mois ({{ "%.2f"|format(solde_mois) }}h)</p>
+        <p><strong>Solde cumulé :</strong> Inclut les mois précédents ({{ "%.2f"|format(solde_anterieur) }}h) + ce mois ({{ "%.2f"|format(solde_mois) }}h){% if hs_payees_mois %} − heures supp payées sur la paie de ce mois ({{ "%.2f"|format(hs_payees_mois) }}h){% endif %}. Les heures supp déjà payées sont déduites.</p>
         <p>
             <strong>Important :</strong>
             {% if declaration_conforme_active %}

--- a/tests/test_hs_payees.py
+++ b/tests/test_hs_payees.py
@@ -1,0 +1,195 @@
+"""
+Heures supplémentaires payées, déduites du compteur de récupération.
+
+Payer des heures supp (variables de paie, colonne « H. supps ») doit pouvoir
+les retirer du solde de récupération du salarié — sinon double compensation
+possible (payées PUIS récupérées), surtout pour les CDD en fin de contrat.
+La déduction est pilotée par la case « déduire du compteur » de la grille
+Variables Paie (cochée par défaut) ; les saisies antérieures à la migration
+0057 (hs_deduites_compteur à NULL) ne déduisent rien rétroactivement.
+"""
+from utils import calculer_solde_recup, total_hs_payees
+
+
+def _poser_solde_initial(db, user_id, heures):
+    db.execute('UPDATE users SET solde_initial = ? WHERE id = ?', (heures, user_id))
+    db.commit()
+
+
+def _payer_hs(client, user_id, heures, mois=3, annee=2026, deduire=True):
+    """Enregistre la grille variables paie avec des heures supp pour un salarié."""
+    data = {
+        'mois': str(mois), 'annee': str(annee),
+        'user_ids': str(user_id),
+        f'heures_supps_{user_id}': str(heures),
+    }
+    if deduire:
+        data[f'hs_deduit_{user_id}'] = '1'
+    return client.post('/variables_paie/enregistrer', data=data)
+
+
+def _payer_hs_db(db, user_id, heures, mois=3, annee=2026, deduit=1):
+    """Ligne de paie insérée en base (les fixtures client partagent la même
+    session : impossible de mixer comptable_client et auth_client)."""
+    db.execute('''INSERT INTO variables_paie
+                  (user_id, mois, annee, heures_supps, hs_deduites_compteur)
+                  VALUES (?, ?, ?, ?, ?)''',
+               (user_id, mois, annee, heures, deduit))
+    db.commit()
+
+
+# ── Déduction du solde ──
+
+def test_hs_payees_deduites_du_solde(comptable_client, app, db, sample_users):
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs(comptable_client, uid, 4, mois=3)
+    with app.app_context():
+        assert calculer_solde_recup(uid) == 6      # 10 - 4 payées
+
+
+def test_hs_payees_cumulees_sur_plusieurs_mois(comptable_client, app, db, sample_users):
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs(comptable_client, uid, 4, mois=3)
+    _payer_hs(comptable_client, uid, 2.5, mois=4)
+    with app.app_context():
+        assert calculer_solde_recup(uid) == 3.5    # 10 - 4 - 2.5
+
+
+def test_hs_non_deduites_si_case_decochee(comptable_client, app, db, sample_users):
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs(comptable_client, uid, 4, deduire=False)
+    with app.app_context():
+        assert calculer_solde_recup(uid) == 10     # payées mais hors compteur
+
+
+def test_lignes_anterieures_migration_non_deduites(app, db, sample_users):
+    """Saisies d'avant la migration 0057 : hs_deduites_compteur NULL → aucune
+    déduction rétroactive."""
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    db.execute('''INSERT INTO variables_paie (user_id, mois, annee, heures_supps)
+                  VALUES (?, 1, 2026, 8)''', (uid,))
+    db.commit()
+    with app.app_context():
+        assert calculer_solde_recup(uid) == 10
+
+
+def test_total_hs_payees_filtres_periode(comptable_client, app, db, sample_users):
+    """Le helper distingue « avant le mois » et « le mois précis » (fiche
+    mensuelle : solde antérieur vs cumul du mois)."""
+    from database import get_db
+    uid = sample_users['salarie_id']
+    _payer_hs(comptable_client, uid, 4, mois=3, annee=2026)
+    _payer_hs(comptable_client, uid, 2, mois=5, annee=2026)
+    with app.app_context():
+        conn = get_db()
+        try:
+            assert total_hs_payees(conn, uid) == 6
+            assert total_hs_payees(conn, uid, annee=2026, mois=5, avant=True) == 4
+            assert total_hs_payees(conn, uid, annee=2026, mois=5) == 2
+            assert total_hs_payees(conn, uid, annee=2026, mois=4) == 0
+        finally:
+            conn.close()
+
+
+# ── Grille Variables Paie ──
+
+def test_grille_affiche_solde_recup(comptable_client, db, sample_users):
+    _poser_solde_initial(db, sample_users['salarie_id'], 7.5)
+    html = comptable_client.get('/variables_paie').get_data(as_text=True)
+    assert 'Solde recup' in html
+    assert '7.50 h' in html
+    assert 'deduire du compteur' in html
+
+
+def test_grille_case_cochee_par_defaut_et_persistee(comptable_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    # Avant toute saisie : case cochée par défaut pour ce salarié.
+    html = comptable_client.get('/variables_paie?mois=3&annee=2026').get_data(as_text=True)
+    assert f'name="hs_deduit_{uid}" value="1"\n                                       checked' in html \
+        or 'checked' in html.split(f'name="hs_deduit_{uid}"')[1][:120]
+    # Décochée à l'enregistrement → l'état est repris décoché.
+    _payer_hs(comptable_client, uid, 4, mois=3, deduire=False)
+    html = comptable_client.get('/variables_paie?mois=3&annee=2026').get_data(as_text=True)
+    assert 'checked' not in html.split(f'name="hs_deduit_{uid}"')[1][:120]
+
+
+def test_vue_salarie_dashboard_utilise_le_solde_net(auth_client, db, sample_users):
+    """Le salarié voit partout le solde net des heures payées (dashboard via
+    calculer_solde_recup — vérifié indirectement par le formulaire de demande)."""
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs_db(db, uid, 4, mois=3)
+    html = auth_client.get('/demande_recup').get_data(as_text=True)
+    assert '6.00' in html      # solde affiché net
+
+
+# ── Traces ──
+
+def test_trace_salarie_mes_demandes(auth_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    _payer_hs_db(db, uid, 4, mois=3, annee=2026)
+    html = auth_client.get('/mes_demandes_recup').get_data(as_text=True)
+    assert 'Heures supplémentaires payées' in html
+    assert 'Paie de mars 2026' in html
+    assert '4.00 h' in html
+
+
+def test_trace_salarie_absente_sans_paiement(auth_client, sample_users):
+    html = auth_client.get('/mes_demandes_recup').get_data(as_text=True)
+    assert 'Heures supplémentaires payées' not in html
+
+
+def test_trace_salarie_ignore_hs_non_deduites(auth_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    _payer_hs_db(db, uid, 4, mois=3, deduit=0)
+    html = auth_client.get('/mes_demandes_recup').get_data(as_text=True)
+    assert 'Heures supplémentaires payées' not in html
+
+
+def test_trace_historique_direction(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    _payer_hs_db(db, uid, 4, mois=3, annee=2026)
+    html = admin_client.get('/historique_demandes_recup').get_data(as_text=True)
+    assert 'Heures supplémentaires payées' in html
+    assert 'Martin Jean' in html
+    assert 'Paie de mars 2026' in html
+
+
+# ── Fiche mensuelle (vue + PDF alignés sur le compteur) ──
+
+def test_vue_mensuelle_deduit_les_hs_payees(auth_client, db, sample_users):
+    """Paiement sur la paie de mars → le solde cumulé d'avril (mois suivant)
+    l'intègre via le solde antérieur ; celui de mars via le cumul du mois."""
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs_db(db, uid, 4, mois=3, annee=2026)
+
+    # Fiche d'avril : les 4 h payées en mars sortent du solde antérieur.
+    html = auth_client.get(f'/vue_mensuelle?user_id={uid}&mois=4&annee=2026').get_data(as_text=True)
+    assert '6.00h' in html      # 10 (initial) - 4 (payées avant avril)
+
+    # Fiche de mars : mention explicite du paiement du mois.
+    html = auth_client.get(f'/vue_mensuelle?user_id={uid}&mois=3&annee=2026').get_data(as_text=True)
+    assert 'payées sur la paie de ce mois (4.00h)' in html
+
+
+def test_export_pdf_avec_hs_payees(admin_client, db, sample_users):
+    """Le PDF de la fiche mensuelle se génère avec un paiement le mois même
+    (ligne « H. supp payées ce mois » du bloc soldes)."""
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs_db(db, uid, 4, mois=3, annee=2026)
+    # Le PDF n'est disponible que pour un mois validé/bloqué.
+    db.execute('''INSERT INTO validations (user_id, mois, annee, validation_salarie,
+                  validation_responsable, validation_directeur, date_salarie,
+                  date_responsable, date_directeur, bloque)
+                  VALUES (?, 3, 2026, 'Jean M.', 'Marie D.', 'Dir', '2026-04-01',
+                          '2026-04-02', '2026-04-03', 1)''', (uid,))
+    db.commit()
+    r = admin_client.get(f'/export_pdf_mensuel?user_id={uid}&mois=3&annee=2026')
+    assert r.status_code == 200
+    assert r.data[:4] == b'%PDF'

--- a/tests/test_hs_payees.py
+++ b/tests/test_hs_payees.py
@@ -177,19 +177,63 @@ def test_vue_mensuelle_deduit_les_hs_payees(auth_client, db, sample_users):
     assert 'payées sur la paie de ce mois (4.00h)' in html
 
 
-def test_export_pdf_avec_hs_payees(admin_client, db, sample_users):
-    """Le PDF de la fiche mensuelle se génère avec un paiement le mois même
-    (ligne « H. supp payées ce mois » du bloc soldes)."""
-    uid = sample_users['salarie_id']
-    _poser_solde_initial(db, uid, 10)
-    _payer_hs_db(db, uid, 4, mois=3, annee=2026)
-    # Le PDF n'est disponible que pour un mois validé/bloqué.
+def _texte_pdf(data):
+    """Concatène les flux décompressés du PDF (le texte y est en clair).
+
+    ReportLab encode ses flux en ASCII85 puis Flate ; on tente les deux
+    décodages (a85 -> zlib, puis zlib direct) et on ignore le reste (polices…).
+    """
+    import base64
+    import re
+    import zlib
+    morceaux = []
+    for m in re.findall(rb'stream\r?\n(.*?)endstream', data, re.S):
+        m = m.strip()
+        for decode in (lambda b: zlib.decompress(base64.a85decode(b, adobe=True)),
+                       zlib.decompress):
+            try:
+                morceaux.append(decode(m))
+                break
+            except Exception:
+                continue
+    return b''.join(morceaux)
+
+
+def _valider_mois(db, uid, mois, annee):
+    """Le PDF n'est disponible que pour un mois validé/bloqué."""
     db.execute('''INSERT INTO validations (user_id, mois, annee, validation_salarie,
                   validation_responsable, validation_directeur, date_salarie,
                   date_responsable, date_directeur, bloque)
-                  VALUES (?, 3, 2026, 'Jean M.', 'Marie D.', 'Dir', '2026-04-01',
-                          '2026-04-02', '2026-04-03', 1)''', (uid,))
+                  VALUES (?, ?, ?, 'Jean M.', 'Marie D.', 'Dir', '2026-04-01',
+                          '2026-04-02', '2026-04-03', 1)''', (uid, mois, annee))
     db.commit()
+
+
+def test_export_pdf_avec_hs_payees(admin_client, db, sample_users):
+    """PDF du mois du paiement : part du solde initial (revue Codex), affiche
+    la ligne « H. supp payées ce mois » et un cumul aligné sur le dashboard."""
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs_db(db, uid, 4, mois=3, annee=2026)
+    _valider_mois(db, uid, 3, 2026)
     r = admin_client.get(f'/export_pdf_mensuel?user_id={uid}&mois=3&annee=2026')
     assert r.status_code == 200
     assert r.data[:4] == b'%PDF'
+    texte = _texte_pdf(r.data)
+    assert b'+10.00h' in texte     # solde antérieur = solde initial (pas 0)
+    assert b'-4.00h' in texte      # H. supp payées ce mois
+    assert b'+6.00h' in texte      # cumulé : 10 + 0 - 4, comme le dashboard
+
+
+def test_export_pdf_mois_suivant_deduit_les_paies_anterieures(admin_client, db, sample_users):
+    """PDF d'un mois postérieur au paiement : les heures payées sortent du
+    solde antérieur (10 - 4 = 6), toujours aligné sur le dashboard."""
+    uid = sample_users['salarie_id']
+    _poser_solde_initial(db, uid, 10)
+    _payer_hs_db(db, uid, 4, mois=3, annee=2026)
+    _valider_mois(db, uid, 4, 2026)
+    r = admin_client.get(f'/export_pdf_mensuel?user_id={uid}&mois=4&annee=2026')
+    assert r.status_code == 200
+    texte = _texte_pdf(r.data)
+    assert b'+6.00h' in texte      # solde antérieur net des 4 h payées en mars
+    assert b'-4.00h' not in texte  # pas de ligne « payées ce mois » en avril

--- a/utils.py
+++ b/utils.py
@@ -583,6 +583,32 @@ def calculer_stats_forfait_jour(user_id, annee):
     return stats
 
 
+def total_hs_payees(conn, user_id, annee=None, mois=None, avant=False):
+    """Total des heures supplémentaires payées ET marquées « déduites du
+    compteur » (variables_paie.hs_deduites_compteur = 1) pour un salarié.
+
+    - sans filtre : toutes (déduction du solde de récupération global) ;
+    - annee/mois avec avant=True : paies STRICTEMENT antérieures à ce mois
+      (solde antérieur de la fiche mensuelle) ;
+    - annee/mois : la paie de ce mois précis (« dont X h payées ce mois »).
+
+    Les lignes antérieures à la migration 0057 ont hs_deduites_compteur à NULL
+    et ne déduisent rien (pas d'effet rétroactif).
+    """
+    sql = ('SELECT COALESCE(SUM(heures_supps), 0) AS total FROM variables_paie '
+           'WHERE user_id = ? AND hs_deduites_compteur = 1 AND heures_supps IS NOT NULL')
+    params = [user_id]
+    if annee is not None and mois is not None:
+        if avant:
+            sql += ' AND (annee < ? OR (annee = ? AND mois < ?))'
+            params += [annee, annee, mois]
+        else:
+            sql += ' AND annee = ? AND mois = ?'
+            params += [annee, mois]
+    row = conn.execute(sql, params).fetchone()
+    return row['total'] or 0
+
+
 def calculer_solde_recup(user_id):
     """Calcule le solde de récupération total d'un salarié.
     Utilisé par dashboard et demande_recup pour éviter la duplication."""
@@ -626,6 +652,10 @@ def calculer_solde_recup(user_id):
                 total_reel = calculer_heures_reelles_jour(h)
 
             solde += (total_reel - total_theorique)
+
+        # Heures supp payées (variables de paie, marquées « déduites du
+        # compteur ») : payées, donc plus à récupérer.
+        solde -= total_hs_payees(conn, user_id)
 
         return solde
     finally:


### PR DESCRIPTION
## Contexte

Quand des heures supplémentaires sont **payées** (notamment pour les CDD, en cours ou en fin de contrat), rien ne permettait de l'enregistrer côté compteur : le solde de récupération du salarié restait plein, avec un risque de **double compensation** (heures payées PUIS récupérées), et aucune trace visible.

La grille **Variables Paie** avait déjà la colonne « H. supps » (transmise au cabinet de paie) mais elle était déconnectée du compteur. Cette PR branche le paiement là où la décision se prend, sans double saisie — même logique que la clôture mensuelle des congés déjà portée par cette page.

## Changements

### Enregistrement & déduction
- **Migration 0057** : colonne `variables_paie.hs_deduites_compteur` (INTEGER, nullable). À 1, les heures supp payées du mois sont **déduites du solde de récupération**. `NULL` sur les lignes existantes → **aucune déduction rétroactive** des saisies passées.
- **Grille Variables Paie** : case « déduire du compteur » sous la saisie « H. supps payées » (cochée par défaut pour une nouvelle saisie, décochable au cas par cas), et nouvelle colonne « **Solde récup** » par salarié (— pour le directeur, forfait jours) — pratique pour doser le paiement et solder pile un CDD qui part.
- `utils.calculer_solde_recup` déduit les paiements marqués ; nouveau helper `total_hs_payees(conn, user_id, annee, mois, avant)` (tout / paies antérieures à un mois / un mois précis).
- Au passage : les **deux calculs de solde dupliqués** de `demande_recup` (POST + GET) sont rebranchés sur `calculer_solde_recup` (≈ 80 lignes de duplication supprimées) — le solde affiché au salarié est partout le solde net.

### Trace
- **Salarié** — « Mes demandes de récupération » : section « Heures supplémentaires payées » (« Paie de mars 2026 — −4.00 h »).
- **Direction/comptable** — historique des demandes : tableau des paiements (salarié, secteur, paie, heures).

### Cohérence fiche mensuelle
- **Vue mensuelle + PDF signé** : les paies antérieures au mois affiché sortent du solde antérieur ; la paie du mois affiché est mentionnée (« H. supp payées ce mois : −4.00h ») et déduite du solde cumulé. Le PDF signé reste aligné sur le compteur du dashboard.

## Tests

`tests/test_hs_payees.py` — 14 cas : déduction (case cochée / décochée / lignes pré-migration à NULL), cumul multi-mois, filtres période du helper, grille (solde affiché, état de la case persisté), solde net côté salarié, traces (présence/absence), vue mensuelle (solde antérieur + mention du mois), génération réelle du PDF avec paiement.

Vérifié en navigateur (Playwright) : grille Variables Paie — soldes corrects (12,5 − 3,5 = 9,00 h), solde négatif en rouge, tiret pour le directeur, case cochée persistée.

Suite complète verte (**894 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_