### PR TITLE
Contrats : modifier la date de fin sans supprimer/re-saisir

### DIFF
--- a/access_log.py
+++ b/access_log.py
@@ -42,6 +42,7 @@ ACTION_CLOTURE_CONGES = 'cloture_conges'
 ACTION_ENREG_VARIABLES_PAIE = 'enregistrement_variables_paie'
 ACTION_MAJ_STATUT_PREPA_PAIE = 'maj_statut_prepa_paie'
 ACTION_AJOUT_CONTRAT = 'ajout_contrat'
+ACTION_MODIF_DATE_FIN_CONTRAT = 'modif_date_fin_contrat'
 ACTION_AJOUT_PDF_CONTRAT = 'ajout_pdf_contrat'
 ACTION_ENREG_DOCUMENT_SALARIE = 'enregistrement_document_salarie'
 ACTION_GENERATION_CONTRAT = 'generation_contrat'
@@ -59,6 +60,7 @@ ACTIONS_LABELS = {
     ACTION_ENREG_VARIABLES_PAIE: 'Enregistrement des variables de paie',
     ACTION_MAJ_STATUT_PREPA_PAIE: 'Mise à jour du statut de préparation de paie',
     ACTION_AJOUT_CONTRAT: 'Ajout d\'un contrat',
+    ACTION_MODIF_DATE_FIN_CONTRAT: 'Modification de la date de fin d\'un contrat',
     ACTION_AJOUT_PDF_CONTRAT: 'Ajout du PDF d\'un contrat',
     ACTION_ENREG_DOCUMENT_SALARIE: 'Enregistrement d\'un document salarié',
     ACTION_GENERATION_CONTRAT: 'Génération d\'un contrat',

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -19,6 +19,21 @@ logger = logging.getLogger(__name__)
 
 infos_salaries_bp = Blueprint('infos_salaries_bp', __name__)
 
+
+def _date_iso_valide(valeur):
+    """Vrai si la valeur est une date ISO (AAAA-MM-JJ) réelle.
+
+    Les dates de contrat sont stockées en TEXT et comparées lexicographiquement
+    partout (fenêtres prépa paie, échéances CDD…) : une valeur mal formée
+    (« zzz » trie après toute date ISO) fausserait silencieusement ces vues.
+    """
+    from datetime import datetime
+    try:
+        datetime.strptime(valeur, '%Y-%m-%d')
+        return True
+    except (ValueError, TypeError):
+        return False
+
 DOCUMENTS_DIR = os.path.join(DATA_DIR, 'documents')
 
 TYPES_CONTRAT = ['CDI', 'CDD', 'CEE', 'Autre']
@@ -352,6 +367,13 @@ def ajouter_contrat():
 
     if type_contrat not in TYPES_CONTRAT:
         flash("Type de contrat invalide.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+    # Dates stockées en TEXT et comparées lexicographiquement partout : refuser
+    # toute valeur non ISO avant enregistrement (même garde que la modification
+    # de date de fin).
+    if not _date_iso_valide(date_debut) or (date_fin and not _date_iso_valide(date_fin)):
+        flash("Date invalide (format attendu : AAAA-MM-JJ).", 'error')
         return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
 
     conn = get_db()
@@ -712,6 +734,11 @@ def modifier_date_fin_contrat(contrat_id):
 
     user_id = contrat['user_id']
     date_fin = request.form.get('date_fin', '').strip() or None
+
+    if date_fin and not _date_iso_valide(date_fin):
+        conn.close()
+        flash("Date de fin invalide (format attendu : AAAA-MM-JJ).", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
 
     if date_fin and date_fin < contrat['date_debut']:
         conn.close()

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -12,7 +12,8 @@ from flask import (Blueprint, render_template, request, redirect,
 from database import get_db, DATA_DIR
 from utils import login_required
 from access_log import (journaliser_action, ACTION_AJOUT_CONTRAT,
-                        ACTION_AJOUT_PDF_CONTRAT, ACTION_ENREG_DOCUMENT_SALARIE)
+                        ACTION_AJOUT_PDF_CONTRAT, ACTION_ENREG_DOCUMENT_SALARIE,
+                        ACTION_MODIF_DATE_FIN_CONTRAT)
 
 logger = logging.getLogger(__name__)
 
@@ -681,6 +682,71 @@ def telecharger_contrat(contrat_id):
 
     return send_file(chemin, as_attachment=True,
                      download_name=contrat['fichier_nom'] or contrat['fichier_path'])
+
+
+@infos_salaries_bp.route('/infos_salaries/contrat/<int:contrat_id>/date_fin', methods=['POST'])
+@login_required
+def modifier_date_fin_contrat(contrat_id):
+    """Modifier la date de fin d'un contrat sans le supprimer/re-saisir.
+
+    Cas d'usage : CDD sans terme précis (remplacement) saisi avec sa durée
+    minimale comme date de fin — à prolonger quand la durée réelle dépasse,
+    sans perdre le PDF ni l'historique du contrat. Une date vide remet le
+    contrat « en cours » (sans terme connu).
+    """
+    if not _peut_gerer():
+        flash("Acces non autorise.", 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    conn = get_db()
+    contrat = conn.execute('SELECT * FROM contrats WHERE id = ?', (contrat_id,)).fetchone()
+    if not contrat:
+        conn.close()
+        flash("Contrat introuvable.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries'))
+
+    if not _est_salarie_visible(conn, contrat['user_id']):
+        conn.close()
+        flash("Acces non autorise.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries'))
+
+    user_id = contrat['user_id']
+    date_fin = request.form.get('date_fin', '').strip() or None
+
+    if date_fin and date_fin < contrat['date_debut']:
+        conn.close()
+        flash("La date de fin ne peut pas etre anterieure a la date de debut "
+              f"({contrat['date_debut']}).", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+    ancienne = contrat['date_fin']
+    try:
+        conn.execute('UPDATE contrats SET date_fin = ? WHERE id = ?',
+                     (date_fin, contrat_id))
+        journaliser_action(
+            conn, ACTION_MODIF_DATE_FIN_CONTRAT,
+            cible_type='user', cible_id=user_id,
+            details=f"type={contrat['type_contrat']}, "
+                    f"{ancienne or 'sans terme'} -> {date_fin or 'sans terme'}",
+        )
+        conn.commit()
+        if date_fin:
+            flash(f"Date de fin du contrat {contrat['type_contrat']} mise a jour : "
+                  f"{date_fin}.", 'success')
+        else:
+            flash(f"Date de fin retiree : le contrat {contrat['type_contrat']} "
+                  "est desormais en cours (sans terme).", 'success')
+    except Exception:
+        conn.rollback()
+        logger.exception(
+            "Echec modification date de fin (contrat_id=%s, par=%s)",
+            contrat_id, session.get('user_id')
+        )
+        flash("Erreur lors de l'enregistrement. L'incident a ete journalise.", 'error')
+    finally:
+        conn.close()
+
+    return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
 
 
 @infos_salaries_bp.route('/infos_salaries/supprimer_contrat/<int:contrat_id>', methods=['POST'])

--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -164,7 +164,24 @@
                 <tr>
                     <td><span class="badge badge-info">{{ c.type_contrat }}</span></td>
                     <td>{{ c.date_debut }}</td>
-                    <td>{{ c.date_fin or '-' }}</td>
+                    <td style="white-space: nowrap;">
+                        <span id="df-aff-{{ c.id }}">
+                            {{ c.date_fin or '-' }}
+                            <button type="button" class="btn btn-sm" onclick="dfEditer({{ c.id }})"
+                                    title="Modifier la date de fin (prolonger un CDD, corriger une date) sans supprimer le contrat"
+                                    style="padding: 1px 6px;">✏️</button>
+                        </span>
+                        <form id="df-form-{{ c.id }}" method="POST"
+                              action="{{ url_for('infos_salaries_bp.modifier_date_fin_contrat', contrat_id=c.id) }}"
+                              style="display: none; align-items: center; gap: 0.3rem;">
+                            <input type="date" name="date_fin" value="{{ c.date_fin or '' }}"
+                                   min="{{ c.date_debut }}"
+                                   title="Laissez vide pour un contrat en cours (sans terme)">
+                            <button type="submit" class="btn btn-primary btn-sm" style="padding: 1px 8px;">OK</button>
+                            <button type="button" class="btn btn-sm" onclick="dfAnnuler({{ c.id }})"
+                                    style="padding: 1px 6px;">✕</button>
+                        </form>
+                    </td>
                     <td>{{ (("%.2f"|format(c.temps_hebdo)).rstrip('0').rstrip('.') ~ 'h') if c.temps_hebdo else '-' }}</td>
                     <td>{{ c.forfait or '-' }}</td>
                     <td>{{ c.nbr_jours if c.nbr_jours else '-' }}</td>
@@ -279,6 +296,14 @@
 </div>
 
 <script>
+function dfEditer(id) {
+    document.getElementById('df-aff-' + id).style.display = 'none';
+    document.getElementById('df-form-' + id).style.display = 'inline-flex';
+}
+function dfAnnuler(id) {
+    document.getElementById('df-form-' + id).style.display = 'none';
+    document.getElementById('df-aff-' + id).style.display = '';
+}
 document.addEventListener('DOMContentLoaded', function() {
     var typeSelect = document.getElementById('type_contrat');
     if (typeSelect) {

--- a/tests/test_infos_salaries.py
+++ b/tests/test_infos_salaries.py
@@ -33,3 +33,79 @@ def test_competence_vide_remet_a_null(admin_client, db, sample_users):
     }, follow_redirects=True)
     row = db.execute("SELECT competence FROM users WHERE id = ?", (uid,)).fetchone()
     assert row['competence'] is None
+
+
+# ── Modification de la date de fin d'un contrat (sans supprimer/re-saisir) ──
+#
+# Cas d'usage : CDD sans terme précis saisi avec sa durée minimale comme date
+# de fin — à prolonger quand le remplacement se poursuit, sans perdre le PDF
+# ni l'historique. Date vide = contrat remis « en cours ».
+
+def _creer_cdd(db, user_id, date_debut='2026-01-01', date_fin='2026-06-30'):
+    cur = db.execute(
+        "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+        "VALUES (?, 'CDD', ?, ?)", (user_id, date_debut, date_fin))
+    db.commit()
+    return cur.lastrowid
+
+
+def test_modifier_date_fin_prolonge_le_cdd(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    r = admin_client.post(f'/infos_salaries/contrat/{cid}/date_fin',
+                          data={'date_fin': '2026-09-15'}, follow_redirects=True)
+    assert 'mise a jour' in r.get_data(as_text=True)
+    row = db.execute("SELECT date_fin FROM contrats WHERE id = ?", (cid,)).fetchone()
+    assert row['date_fin'] == '2026-09-15'
+
+
+def test_date_fin_vide_remet_le_contrat_en_cours(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    r = admin_client.post(f'/infos_salaries/contrat/{cid}/date_fin',
+                          data={'date_fin': ''}, follow_redirects=True)
+    assert 'en cours' in r.get_data(as_text=True)
+    row = db.execute("SELECT date_fin FROM contrats WHERE id = ?", (cid,)).fetchone()
+    assert row['date_fin'] is None
+
+
+def test_date_fin_avant_le_debut_refusee(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    r = admin_client.post(f'/infos_salaries/contrat/{cid}/date_fin',
+                          data={'date_fin': '2025-12-01'}, follow_redirects=True)
+    assert 'anterieure a la date de debut' in r.get_data(as_text=True)
+    row = db.execute("SELECT date_fin FROM contrats WHERE id = ?", (cid,)).fetchone()
+    assert row['date_fin'] == '2026-06-30'    # inchangée
+
+
+def test_modification_date_fin_refusee_au_salarie(client, db, sample_users):
+    from tests.conftest import _login
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    _login(client, 'salarie_test', 'sal123')
+    client.post(f'/infos_salaries/contrat/{cid}/date_fin',
+                data={'date_fin': '2026-09-15'}, follow_redirects=True)
+    row = db.execute("SELECT date_fin FROM contrats WHERE id = ?", (cid,)).fetchone()
+    assert row['date_fin'] == '2026-06-30'    # inchangée
+
+
+def test_modification_date_fin_journalisee(admin_client, db, sample_users):
+    """La prolongation laisse une trace d'audit (ancienne -> nouvelle date)."""
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    admin_client.post(f'/infos_salaries/contrat/{cid}/date_fin',
+                      data={'date_fin': '2026-09-15'}, follow_redirects=True)
+    log = db.execute(
+        "SELECT details FROM journal_actions WHERE action = 'modif_date_fin_contrat' "
+        "ORDER BY id DESC LIMIT 1").fetchone()
+    assert log is not None
+    assert '2026-06-30 -> 2026-09-15' in log['details']
+
+
+def test_fiche_affiche_le_formulaire_date_fin(admin_client, db, sample_users):
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    html = admin_client.get(f'/infos_salaries?user_id={uid}').get_data(as_text=True)
+    assert f'df-form-{cid}' in html
+    assert f'/infos_salaries/contrat/{cid}/date_fin' in html

--- a/tests/test_infos_salaries.py
+++ b/tests/test_infos_salaries.py
@@ -109,3 +109,32 @@ def test_fiche_affiche_le_formulaire_date_fin(admin_client, db, sample_users):
     html = admin_client.get(f'/infos_salaries?user_id={uid}').get_data(as_text=True)
     assert f'df-form-{cid}' in html
     assert f'/infos_salaries/contrat/{cid}/date_fin' in html
+
+
+def test_date_fin_mal_formee_refusee(admin_client, db, sample_users):
+    """Une valeur non ISO (ex. « zzz », qui trie après toute date) est refusée
+    avant enregistrement — les fenêtres de contrat comparent des chaînes
+    (revue Codex)."""
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    for mauvaise in ('zzz', '15/09/2026', '2026-13-45'):
+        r = admin_client.post(f'/infos_salaries/contrat/{cid}/date_fin',
+                              data={'date_fin': mauvaise}, follow_redirects=True)
+        assert 'Date de fin invalide' in r.get_data(as_text=True), mauvaise
+    row = db.execute("SELECT date_fin FROM contrats WHERE id = ?", (cid,)).fetchone()
+    assert row['date_fin'] == '2026-06-30'    # inchangée
+
+
+def test_ajout_contrat_dates_mal_formees_refusees(admin_client, db, sample_users):
+    """Même garde sur l'ajout de contrat (dates début/fin)."""
+    uid = sample_users['salarie_id']
+    r = admin_client.post('/infos_salaries/contrat', data={
+        'user_id': uid, 'type_contrat': 'CDD',
+        'date_debut': 'zzz', 'date_fin': ''}, follow_redirects=True)
+    assert 'Date invalide' in r.get_data(as_text=True)
+    r = admin_client.post('/infos_salaries/contrat', data={
+        'user_id': uid, 'type_contrat': 'CDD',
+        'date_debut': '2026-01-01', 'date_fin': '31/12/2026'}, follow_redirects=True)
+    assert 'Date invalide' in r.get_data(as_text=True)
+    nb = db.execute("SELECT COUNT(*) AS nb FROM contrats WHERE user_id = ?", (uid,)).fetchone()
+    assert nb['nb'] == 0    # rien enregistré


### PR DESCRIPTION
## Contexte

Prolonger un CDD demandait de **supprimer le contrat et le re-saisir** — en perdant le PDF attaché et l'auteur d'origine. Cas concret (suite de #209) : un **CDD sans terme précis** (remplacement « jusqu'au retour de… ») est saisi avec sa **durée minimale** comme date de fin ; quand le remplacement se poursuit, il faut corriger la date en place, sinon le salarié disparaît des vues qui reposent sur la fenêtre de contrat (prépa paie, présence effectif, échéances CDD…).

## Changements

- **Fiche salarié** (`infos_salaries`) : bouton ✏️ sur la date de fin de chaque contrat → petit **formulaire en place** (input date pré-rempli, `min` = date de début, OK / annuler). **Date vide = contrat remis « en cours »** (sans terme) — utile pour un CDD sans terme précis dont on ne connaît pas l'échéance.
- **Route** `POST /infos_salaries/contrat/<id>/date_fin` :
  - mêmes gardes que la suppression (direction / comptable / responsable limité à son secteur) ;
  - refus d'une date de fin **antérieure à la date de début** ;
  - **journal d'audit** : nouvelle action `modif_date_fin_contrat` avec le détail « ancienne → nouvelle » (ou « sans terme »).
- Le PDF du contrat, l'auteur et la date de saisie d'origine sont **conservés**.

## Tests

`tests/test_infos_salaries.py` — 6 nouveaux cas : prolongation effective, date vide → contrat « en cours » (NULL), date antérieure au début refusée (valeur inchangée), accès refusé à un salarié, trace d'audit « 2026-06-30 → 2026-09-15 », formulaire présent sur la fiche.

Vérifié en navigateur (Playwright) : ouverture de l'éditeur en place, saisie 15/09/2026, enregistrement, nouvelle date affichée + message de confirmation.

Suite complète verte (**904 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_