### PR TITLE
Équipe responsable : secteur OU rattachement direct (responsable_id)

### DIFF
--- a/blueprints/chatbot.py
+++ b/blueprints/chatbot.py
@@ -31,7 +31,8 @@ PAGE_PROMPTS = {
         "en précisant qu'il y trouvera une aide plus détaillée via l'assistant contextuel de cette page."
     ),
     'dashboard_responsable': (
-        "L'utilisateur est sur le tableau de bord Responsable. Cette page est scopée au secteur du responsable : "
+        "L'utilisateur est sur le tableau de bord Responsable. Cette page est scopée à son équipe "
+        "(salariés de son secteur + salariés qui lui sont directement rattachés, même d'un autre secteur) : "
         "équipe et ETP, absences, factures en attente d'approbation, récupérations, budget et subventions, "
         "validations à effectuer, et accès rapides. "
         "Aide l'utilisateur à comprendre ses indicateurs et à naviguer vers les bonnes pages."

--- a/blueprints/dashboard.py
+++ b/blueprints/dashboard.py
@@ -26,6 +26,17 @@ def dashboard():
         user = get_user_info(session['user_id'])
         if user and user['secteur_id']:
             return redirect(url_for('dashboard_responsable_bp.dashboard_responsable'))
+        # Sans secteur mais avec des rattachés directs (responsable_id), le
+        # tableau de bord responsable reste pertinent : même règle d'équipe.
+        if user:
+            conn = get_db()
+            a_rattaches = conn.execute(
+                'SELECT 1 FROM users WHERE responsable_id = ? AND actif = 1 LIMIT 1',
+                (session['user_id'],)
+            ).fetchone()
+            conn.close()
+            if a_rattaches:
+                return redirect(url_for('dashboard_responsable_bp.dashboard_responsable'))
     if profil == 'comptable':
         return redirect(url_for('dashboard_comptable_bp.dashboard_comptable'))
 

--- a/blueprints/dashboard_responsable.py
+++ b/blueprints/dashboard_responsable.py
@@ -55,15 +55,24 @@ def dashboard_responsable():
     ).fetchone()
     secteur_id = user_row['secteur_id'] if user_row else None
 
+    # L'équipe du responsable = salariés de son secteur + rattachés directs
+    # (users.responsable_id), même d'un autre secteur analytique (ex. agent
+    # d'entretien en secteur logistique encadré par la responsable crèche).
+    # Un responsable sans secteur mais avec des rattachés garde son tableau.
     if not secteur_id:
-        conn.close()
-        flash('Aucun secteur associe a votre compte', 'error')
-        return redirect(url_for('dashboard_bp.dashboard'))
+        a_rattaches = conn.execute(
+            'SELECT 1 FROM users WHERE responsable_id = ? AND actif = 1 LIMIT 1',
+            (session['user_id'],)
+        ).fetchone()
+        if not a_rattaches:
+            conn.close()
+            flash('Aucun secteur associe a votre compte', 'error')
+            return redirect(url_for('dashboard_bp.dashboard'))
 
     secteur_row = conn.execute(
         'SELECT id, nom FROM secteurs WHERE id = ?', (secteur_id,)
     ).fetchone()
-    secteur_nom = secteur_row['nom'] if secteur_row else 'Mon secteur'
+    secteur_nom = secteur_row['nom'] if secteur_row else 'Mon equipe'
 
     conges_user = conn.execute(
         'SELECT cp_a_prendre, cp_pris, cc_solde FROM users WHERE id = ?',
@@ -89,11 +98,11 @@ def dashboard_responsable():
                 GROUP BY user_id
             ) mc ON mc.user_id = c.user_id AND mc.max_id = c.id
         ) c ON c.user_id = u.id
-        WHERE u.actif = 1 AND u.secteur_id = ?
+        WHERE u.actif = 1 AND (u.secteur_id = ? OR u.responsable_id = ?)
           AND u.profil NOT IN ('directeur', 'prestataire')
           AND u.id != ?
         ORDER BY u.nom, u.prenom
-    ''', (today_str, today_str, secteur_id, session['user_id'])).fetchall()
+    ''', (today_str, today_str, secteur_id, session['user_id'], session['user_id'])).fetchall()
 
     nb_salaries = len(equipe)
 
@@ -119,21 +128,21 @@ def dashboard_responsable():
                u.nom as salarie_nom, u.prenom as salarie_prenom
         FROM absences a
         JOIN users u ON a.user_id = u.id
-        WHERE u.secteur_id = ?
+        WHERE (u.secteur_id = ? OR u.responsable_id = ?)
           AND a.date_debut <= ? AND a.date_fin >= ?
         ORDER BY u.nom, u.prenom
-    ''', (secteur_id, today_str, today_str)).fetchall()
+    ''', (secteur_id, session['user_id'], today_str, today_str)).fetchall()
 
     # Repartition par motif
     repartition_motifs = conn.execute('''
         SELECT a.motif, COUNT(*) as nb
         FROM absences a
         JOIN users u ON a.user_id = u.id
-        WHERE u.secteur_id = ?
+        WHERE (u.secteur_id = ? OR u.responsable_id = ?)
           AND a.date_debut <= ? AND a.date_fin >= ?
         GROUP BY a.motif
         ORDER BY nb DESC
-    ''', (secteur_id, today_str, today_str)).fetchall()
+    ''', (secteur_id, session['user_id'], today_str, today_str)).fetchall()
 
     # Stats absences mois en cours
     premier_jour_mois = today.replace(day=1).strftime('%Y-%m-%d')
@@ -147,9 +156,9 @@ def dashboard_responsable():
         SELECT COUNT(*) as nb, COALESCE(SUM(a.jours_ouvres), 0) as total_jours
         FROM absences a
         JOIN users u ON a.user_id = u.id
-        WHERE u.secteur_id = ?
+        WHERE (u.secteur_id = ? OR u.responsable_id = ?)
           AND a.date_debut <= ? AND a.date_fin >= ?
-    ''', (secteur_id, dernier_jour_mois_str, premier_jour_mois)).fetchone()
+    ''', (secteur_id, session['user_id'], dernier_jour_mois_str, premier_jour_mois)).fetchone()
 
     # ── 3. Validations mensuelles (secteur uniquement) ──
     mois_validation = request.args.get('val_mois', mois, type=int)
@@ -183,16 +192,18 @@ def dashboard_responsable():
     users_a_valider = conn.execute('''
         SELECT u.id, u.nom, u.prenom
         FROM users u
-        WHERE u.actif = 1 AND u.profil = 'salarie' AND u.secteur_id = ?
+        WHERE u.actif = 1 AND u.profil = 'salarie'
+          AND (u.secteur_id = ? OR u.responsable_id = ?)
         ORDER BY u.nom
-    ''', (secteur_id,)).fetchall()
+    ''', (secteur_id, session['user_id'])).fetchall()
 
     validations_map = {}
     validations_rows = conn.execute('''
         SELECT v.* FROM validations v
         JOIN users u ON v.user_id = u.id
-        WHERE v.mois = ? AND v.annee = ? AND u.secteur_id = ?
-    ''', (mois_validation, annee_validation, secteur_id)).fetchall()
+        WHERE v.mois = ? AND v.annee = ?
+          AND (u.secteur_id = ? OR u.responsable_id = ?)
+    ''', (mois_validation, annee_validation, secteur_id, session['user_id'])).fetchall()
     for v in validations_rows:
         validations_map[v['user_id']] = dict(v)
 
@@ -240,10 +251,10 @@ def dashboard_responsable():
                u.nom as demandeur_nom, u.prenom as demandeur_prenom
         FROM demandes_recup d
         JOIN users u ON d.user_id = u.id
-        WHERE u.secteur_id = ?
+        WHERE (u.secteur_id = ? OR u.responsable_id = ?)
           AND d.statut IN ('en_attente_responsable', 'en_attente_direction')
         ORDER BY d.date_demande ASC
-    ''', (secteur_id,)).fetchall()
+    ''', (secteur_id, session['user_id'])).fetchall()
 
     # ── 4b. Demandes de conges du secteur ──
     demandes_conges = conn.execute('''
@@ -252,10 +263,10 @@ def dashboard_responsable():
                u.nom as demandeur_nom, u.prenom as demandeur_prenom
         FROM demandes_conges d
         JOIN users u ON d.user_id = u.id
-        WHERE u.secteur_id = ?
+        WHERE (u.secteur_id = ? OR u.responsable_id = ?)
           AND d.statut IN ('en_attente_responsable', 'en_attente_direction')
         ORDER BY d.date_demande ASC
-    ''', (secteur_id,)).fetchall()
+    ''', (secteur_id, session['user_id'])).fetchall()
 
     # ── 5. Conges de l'equipe ──
     conges_equipe = conn.execute('''
@@ -265,11 +276,11 @@ def dashboard_responsable():
                COALESCE(u.cc_solde, 0) as cc_solde,
                (COALESCE(u.cp_a_prendre, 0) - COALESCE(u.cp_pris, 0) + COALESCE(u.cc_solde, 0)) as total_conges
         FROM users u
-        WHERE u.actif = 1 AND u.secteur_id = ?
+        WHERE u.actif = 1 AND (u.secteur_id = ? OR u.responsable_id = ?)
           AND u.profil NOT IN ('directeur', 'prestataire')
           AND u.id != ?
         ORDER BY total_conges DESC
-    ''', (secteur_id, session['user_id'])).fetchall()
+    ''', (secteur_id, session['user_id'], session['user_id'])).fetchall()
 
     # ── 6. Factures en attente du secteur ──
     factures_en_attente = conn.execute('''

--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -8,7 +8,7 @@ from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
                    calculer_heures_reelles_jour, slot_horaire,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
-                   total_hs_payees)
+                   total_hs_payees, est_dans_equipe_responsable)
 
 exports_bp = Blueprint('exports_bp', __name__)
 
@@ -30,18 +30,13 @@ def _peut_exporter_pdf_mensuel(conn, user_id_cible):
         ).fetchone() is not None
 
     if profil == 'responsable':
-        responsable = conn.execute(
-            'SELECT secteur_id FROM users WHERE id = ?',
-            (session['user_id'],)
-        ).fetchone()
-        secteur_id = responsable['secteur_id'] if responsable else None
-        if not secteur_id:
-            return False
-
-        return conn.execute('''
-            SELECT 1 FROM users
-            WHERE id = ? AND actif = 1 AND profil != 'prestataire' AND secteur_id = ?
-        ''', (user_id_cible, secteur_id)).fetchone() is not None
+        # Même périmètre que la vue mensuelle : secteur commun OU rattachement
+        # hiérarchique direct (est_dans_equipe_responsable), salarié actif.
+        actif = conn.execute(
+            "SELECT 1 FROM users WHERE id = ? AND actif = 1 AND profil != 'prestataire'",
+            (user_id_cible,)
+        ).fetchone() is not None
+        return actif and est_dans_equipe_responsable(conn, session['user_id'], user_id_cible)
 
     return False
 

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -166,25 +166,18 @@ def infos_salaries():
     if session.get('profil') == 'responsable':
         user = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
         secteur_id = user['secteur_id'] if user else None
-        if secteur_id:
-            salaries = conn.execute('''
-                SELECT u.id, u.nom, u.prenom, u.profil, u.email,
-                       COALESCE(s.nom, '') AS secteur_nom
-                FROM users u
-                LEFT JOIN secteurs s ON u.secteur_id = s.id
-                WHERE u.actif = 1 AND u.profil != 'prestataire'
-                  AND (u.secteur_id = ? OR u.id = ?)
-                ORDER BY u.nom, u.prenom
-            ''', (secteur_id, session['user_id'])).fetchall()
-        else:
-            salaries = conn.execute('''
-                SELECT u.id, u.nom, u.prenom, u.profil, u.email,
-                       COALESCE(s.nom, '') AS secteur_nom
-                FROM users u
-                LEFT JOIN secteurs s ON u.secteur_id = s.id
-                WHERE u.id = ? AND u.actif = 1 AND u.profil != 'prestataire'
-                ORDER BY u.nom, u.prenom
-            ''', (session['user_id'],)).fetchall()
+        # Équipe : secteur + rattachés directs (responsable_id) + lui-même —
+        # même périmètre que _est_salarie_visible (un secteur NULL ne matche
+        # jamais : seuls les rattachés et lui-même restent alors listés).
+        salaries = conn.execute('''
+            SELECT u.id, u.nom, u.prenom, u.profil, u.email,
+                   COALESCE(s.nom, '') AS secteur_nom
+            FROM users u
+            LEFT JOIN secteurs s ON u.secteur_id = s.id
+            WHERE u.actif = 1 AND u.profil != 'prestataire'
+              AND (u.secteur_id = ? OR u.responsable_id = ? OR u.id = ?)
+            ORDER BY u.nom, u.prenom
+        ''', (secteur_id, session['user_id'], session['user_id'])).fetchall()
     else:
         salaries = conn.execute('''
             SELECT u.id, u.nom, u.prenom, u.profil, u.email,

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -75,18 +75,17 @@ def _est_salarie_visible(conn, user_id):
     if profil != 'responsable':
         return False
 
+    # Équipe du responsable : son secteur + rattachés directs (responsable_id),
+    # même d'un autre secteur analytique — et lui-même.
     user = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
     secteur_id = user['secteur_id'] if user else None
 
-    if secteur_id:
-        row = conn.execute('''
-            SELECT 1 FROM users
-            WHERE id = ? AND actif = 1 AND profil != 'prestataire'
-              AND (secteur_id = ? OR id = ?)
-        ''', (user_id, secteur_id, session['user_id'])).fetchone()
-        return row is not None
-
-    return user_id == session['user_id']
+    row = conn.execute('''
+        SELECT 1 FROM users
+        WHERE id = ? AND actif = 1 AND profil != 'prestataire'
+          AND (secteur_id = ? OR responsable_id = ? OR id = ?)
+    ''', (user_id, secteur_id, session['user_id'], session['user_id'])).fetchone()
+    return row is not None
 
 
 def _nettoyer_nom(texte):

--- a/blueprints/mon_equipe.py
+++ b/blueprints/mon_equipe.py
@@ -278,7 +278,12 @@ def _doit_masquer_motifs_absence():
 
 def _get_equipe(conn, user_id):
     """Retourne les membres de l'equipe ayant un contrat en cours :
-    meme secteur + responsable du secteur."""
+    meme secteur + rattaches directs (responsable_id) + responsable du secteur.
+
+    Le lien direct couvre un salarie range dans un autre secteur analytique
+    (ex. entretien en logistique) mais encadre par ce responsable : il
+    apparait dans l'equipe de son responsable. Pour un non-responsable, la
+    condition responsable_id ne matche personne (aucun cout)."""
     today_str = datetime.now().strftime('%Y-%m-%d')
 
     user = conn.execute(
@@ -286,24 +291,28 @@ def _get_equipe(conn, user_id):
     ).fetchone()
 
     if not user or not user['secteur_id']:
-        # Pas de secteur : retourner juste l'utilisateur lui-meme
+        # Pas de secteur : l'utilisateur lui-meme + ses rattaches directs
         return conn.execute('''
             SELECT u.id, u.nom, u.prenom, u.profil,
                    COALESCE(s.nom, '') AS secteur_nom
             FROM users u
             LEFT JOIN secteurs s ON u.secteur_id = s.id
-            WHERE u.id = ? AND u.actif = 1
+            WHERE (u.id = ? OR u.responsable_id = ?) AND u.actif = 1
+              AND u.profil != 'prestataire'
               AND EXISTS (
                   SELECT 1 FROM contrats c
                   WHERE c.user_id = u.id
                     AND c.date_debut <= ?
                     AND (c.date_fin IS NULL OR c.date_fin >= ?)
               )
-        ''', (user_id, today_str, today_str)).fetchall()
+            ORDER BY
+                CASE u.profil WHEN 'responsable' THEN 0 ELSE 1 END,
+                u.nom, u.prenom
+        ''', (user_id, user_id, today_str, today_str)).fetchall()
 
     secteur_id = user['secteur_id']
 
-    # Salaries du meme secteur avec un contrat en cours
+    # Salaries du meme secteur (ou rattaches directs) avec un contrat en cours
     membres = conn.execute('''
         SELECT u.id, u.nom, u.prenom, u.profil,
                COALESCE(s.nom, '') AS secteur_nom
@@ -311,7 +320,7 @@ def _get_equipe(conn, user_id):
         LEFT JOIN secteurs s ON u.secteur_id = s.id
         WHERE u.actif = 1
         AND u.profil != 'prestataire'
-        AND u.secteur_id = ?
+        AND (u.secteur_id = ? OR u.responsable_id = ?)
         AND EXISTS (
             SELECT 1 FROM contrats c
             WHERE c.user_id = u.id
@@ -321,7 +330,7 @@ def _get_equipe(conn, user_id):
         ORDER BY
             CASE u.profil WHEN 'responsable' THEN 0 ELSE 1 END,
             u.nom, u.prenom
-    ''', (secteur_id, today_str, today_str)).fetchall()
+    ''', (secteur_id, user_id, today_str, today_str)).fetchall()
 
     # Ajouter le responsable du pole s'il n'est pas dans le meme secteur
     # (certains responsables sont dans un autre secteur mais gèrent celui-ci)

--- a/blueprints/notifications.py
+++ b/blueprints/notifications.py
@@ -153,15 +153,17 @@ def relance_validation():
     erreurs = []
 
     for resp in responsables:
-        # Compter les fiches non validees par ce responsable dans son secteur
+        # Compter les fiches non validees par ce responsable dans son equipe
+        # (secteur + rattaches directs, meme d'un autre secteur analytique)
         fiches_en_attente = conn.execute('''
             SELECT COUNT(*) as nb FROM users u
-            WHERE u.actif = 1 AND u.profil = 'salarie' AND u.secteur_id = ?
+            WHERE u.actif = 1 AND u.profil = 'salarie'
+            AND (u.secteur_id = ? OR u.responsable_id = ?)
             AND u.id NOT IN (
                 SELECT v.user_id FROM validations v
                 WHERE v.mois = ? AND v.annee = ? AND v.validation_responsable IS NOT NULL
             )
-        ''', (resp['secteur_id'], mois, annee)).fetchone()
+        ''', (resp['secteur_id'], resp['id'], mois, annee)).fetchone()
 
         nb_fiches = fiches_en_attente['nb'] if fiches_en_attente else 0
 
@@ -228,15 +230,16 @@ def relance_responsable_unique():
         conn.close()
         return jsonify({'error': f"{resp['prenom']} {resp['nom']} n'a pas d'adresse email configuree"}), 400
 
-    # Compter les fiches en attente
+    # Compter les fiches en attente (equipe : secteur + rattaches directs)
     fiches_en_attente = conn.execute('''
         SELECT COUNT(*) as nb FROM users u
-        WHERE u.actif = 1 AND u.profil = 'salarie' AND u.secteur_id = ?
+        WHERE u.actif = 1 AND u.profil = 'salarie'
+        AND (u.secteur_id = ? OR u.responsable_id = ?)
         AND u.id NOT IN (
             SELECT v.user_id FROM validations v
             WHERE v.mois = ? AND v.annee = ? AND v.validation_responsable IS NOT NULL
         )
-    ''', (resp['secteur_id'], mois, annee)).fetchone()
+    ''', (resp['secteur_id'], resp['id'], mois, annee)).fetchone()
 
     nb_fiches = fiches_en_attente['nb'] if fiches_en_attente else 0
 

--- a/blueprints/planning.py
+++ b/blueprints/planning.py
@@ -4,7 +4,7 @@ Blueprint planning_bp.
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash
 from datetime import datetime
 from database import get_db
-from utils import login_required, calculer_heures, get_semaine_alternance
+from utils import login_required, calculer_heures, get_semaine_alternance, est_dans_equipe_responsable
 
 planning_bp = Blueprint('planning_bp', __name__)
 
@@ -32,16 +32,12 @@ def _salarie_accessible(conn, user_id):
         ).fetchone() is not None
 
     if profil == 'responsable':
-        resp = conn.execute(
-            'SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)
-        ).fetchone()
-        secteur_id = resp['secteur_id'] if resp else None
-        if not secteur_id:
-            return False
-        return conn.execute('''
-            SELECT 1 FROM users
-            WHERE id = ? AND actif = 1 AND profil != 'prestataire' AND secteur_id = ?
-        ''', (user_id, secteur_id)).fetchone() is not None
+        # Équipe : secteur commun OU rattachement direct (responsable_id).
+        actif = conn.execute(
+            "SELECT 1 FROM users WHERE id = ? AND actif = 1 AND profil != 'prestataire'",
+            (user_id,)
+        ).fetchone() is not None
+        return actif and est_dans_equipe_responsable(conn, session['user_id'], user_id)
 
     return False
 
@@ -63,21 +59,16 @@ def _liste_salaries(conn):
             'SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)
         ).fetchone()
         secteur_id = resp['secteur_id'] if resp else None
-        if secteur_id:
-            return conn.execute('''
-                SELECT u.id, u.nom, u.prenom, COALESCE(s.nom, '') AS secteur_nom
-                FROM users u
-                LEFT JOIN secteurs s ON u.secteur_id = s.id
-                WHERE u.actif = 1 AND u.profil != 'prestataire'
-                  AND (u.secteur_id = ? OR u.id = ?)
-                ORDER BY u.nom, u.prenom
-            ''', (secteur_id, session['user_id'])).fetchall()
+        # Secteur + rattachés directs + lui-même (un secteur NULL ne matche
+        # jamais : seuls les rattachés et lui-même restent alors listés).
         return conn.execute('''
             SELECT u.id, u.nom, u.prenom, COALESCE(s.nom, '') AS secteur_nom
             FROM users u
             LEFT JOIN secteurs s ON u.secteur_id = s.id
-            WHERE u.id = ?
-        ''', (session['user_id'],)).fetchall()
+            WHERE u.actif = 1 AND u.profil != 'prestataire'
+              AND (u.secteur_id = ? OR u.responsable_id = ? OR u.id = ?)
+            ORDER BY u.nom, u.prenom
+        ''', (secteur_id, session['user_id'], session['user_id'])).fetchall()
 
     return []
 

--- a/blueprints/recup.py
+++ b/blueprints/recup.py
@@ -607,34 +607,33 @@ def validation_demandes_recup():
     conn = get_db()
     
     if session.get('profil') == 'responsable':
-        # Responsable : demandes de son secteur en attente_responsable
+        # Responsable : demandes en attente de son équipe — salariés de son
+        # secteur OU rattachés directs (responsable_id), même d'un autre
+        # secteur analytique (ex. entretien en logistique).
         responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-        
-        if responsable_secteur and responsable_secteur['secteur_id']:
-            sid = responsable_secteur['secteur_id']
-            demandes_recup = conn.execute('''
-                SELECT d.*, 'recup' as demande_type,
-                       u.nom || ' ' || u.prenom as demandeur_nom,
-                       s.nom as secteur_nom
-                FROM demandes_recup d
-                JOIN users u ON d.user_id = u.id
-                LEFT JOIN secteurs s ON u.secteur_id = s.id
-                WHERE u.secteur_id = ? AND d.statut = 'en_attente_responsable'
-                ORDER BY d.date_demande ASC
-            ''', (sid,)).fetchall()
-            demandes_conges = conn.execute('''
-                SELECT d.*, 'conge' as demande_type,
-                       u.nom || ' ' || u.prenom as demandeur_nom,
-                       s.nom as secteur_nom
-                FROM demandes_conges d
-                JOIN users u ON d.user_id = u.id
-                LEFT JOIN secteurs s ON u.secteur_id = s.id
-                WHERE u.secteur_id = ? AND d.statut = 'en_attente_responsable'
-                ORDER BY d.date_demande ASC
-            ''', (sid,)).fetchall()
-        else:
-            demandes_recup = []
-            demandes_conges = []
+        sid = responsable_secteur['secteur_id'] if responsable_secteur else None
+        demandes_recup = conn.execute('''
+            SELECT d.*, 'recup' as demande_type,
+                   u.nom || ' ' || u.prenom as demandeur_nom,
+                   s.nom as secteur_nom
+            FROM demandes_recup d
+            JOIN users u ON d.user_id = u.id
+            LEFT JOIN secteurs s ON u.secteur_id = s.id
+            WHERE (u.secteur_id = ? OR u.responsable_id = ?)
+              AND d.statut = 'en_attente_responsable'
+            ORDER BY d.date_demande ASC
+        ''', (sid, session['user_id'])).fetchall()
+        demandes_conges = conn.execute('''
+            SELECT d.*, 'conge' as demande_type,
+                   u.nom || ' ' || u.prenom as demandeur_nom,
+                   s.nom as secteur_nom
+            FROM demandes_conges d
+            JOIN users u ON d.user_id = u.id
+            LEFT JOIN secteurs s ON u.secteur_id = s.id
+            WHERE (u.secteur_id = ? OR u.responsable_id = ?)
+              AND d.statut = 'en_attente_responsable'
+            ORDER BY d.date_demande ASC
+        ''', (sid, session['user_id'])).fetchall()
     
     elif session.get('profil') in ['directeur', 'comptable']:
         # Direction : toutes les demandes en attente

--- a/blueprints/saisie.py
+++ b/blueprints/saisie.py
@@ -8,7 +8,7 @@ from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
                     calculer_heures_reelles_jour, slot_horaire,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date,
-                    calculer_solde_recup)
+                    calculer_solde_recup, est_dans_equipe_responsable)
 from app_options import get_option_bool
 
 saisie_bp = Blueprint('saisie_bp', __name__)
@@ -36,11 +36,9 @@ def saisie_heures():
         # Directeur peut modifier toutes les fiches
         peut_modifier = True
     elif session.get('profil') == 'responsable':
-        # Responsable peut modifier les fiches de son secteur
-        user_to_modify = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (user_id_cible,)).fetchone()
-        responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-        
-        if user_to_modify and responsable_secteur and user_to_modify['secteur_id'] == responsable_secteur['secteur_id']:
+        # Responsable : fiches de son secteur OU de ses rattachés directs
+        # (salarié d'un autre secteur analytique, ex. entretien en logistique).
+        if est_dans_equipe_responsable(conn, session['user_id'], user_id_cible):
             peut_modifier = True
     
     if not peut_modifier:

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -9,7 +9,7 @@ from blueprints.delegations import MISSION_SUIVI_VALIDATIONS_RELANCES, user_has_
 from utils import (login_required, get_user_info, calculer_heures,
                     calculer_heures_reelles_jour, slot_horaire,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
-                    total_hs_payees)
+                    total_hs_payees, est_dans_equipe_responsable)
 from app_options import get_option_bool
 from access_log import (journaliser_action, ACTION_VALIDATION_MOIS,
                         ACTION_DEVERROUILLAGE_MOIS)
@@ -66,31 +66,16 @@ def valider_mois():
             types_validation.append('salarie')
         else:
             # Validation responsable : le valideur est responsable du salarié.
-            # Deux façons d'être responsable d'un salarié :
+            # Deux façons d'être responsable d'un salarié (helper commun
+            # est_dans_equipe_responsable, utilisé par toutes les vues) :
             #  - être responsable de son secteur (même secteur_id) ;
             #  - être son responsable hiérarchique direct (responsable_id).
-            # Le second cas couvre notamment un directeur désigné comme
-            # responsable hiérarchique : le champ « Responsable hiérarchique »
-            # liste aussi les directeurs (cf. admin.py).
+            # Le second cas couvre un salarié rattaché hors de son secteur
+            # analytique (ex. entretien en logistique, encadré par la
+            # responsable crèche) et un directeur désigné comme responsable
+            # hiérarchique (le champ liste aussi les directeurs, cf. admin.py).
             if profil in ('responsable', 'directeur'):
-                user_to_validate = conn.execute(
-                    'SELECT secteur_id, responsable_id FROM users WHERE id = ?', (user_id,)
-                ).fetchone()
-                valideur_secteur = conn.execute(
-                    'SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)
-                ).fetchone()
-
-                meme_secteur = bool(
-                    user_to_validate and valideur_secteur
-                    and valideur_secteur['secteur_id'] is not None
-                    and user_to_validate['secteur_id'] == valideur_secteur['secteur_id']
-                )
-                est_responsable_hierarchique = bool(
-                    user_to_validate
-                    and user_to_validate['responsable_id'] == session['user_id']
-                )
-
-                if meme_secteur or est_responsable_hierarchique:
+                if est_dans_equipe_responsable(conn, session['user_id'], user_id):
                     types_validation.append('responsable')
 
             # Validation directeur : un directeur peut valider toute fiche.
@@ -270,11 +255,11 @@ def vue_ensemble_validation():
         # Récupérer les utilisateurs selon le profil connecté
         if profil == 'responsable' and not acces_delegation:
             responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
+            secteur_resp = responsable_secteur['secteur_id'] if responsable_secteur else None
 
-            if not responsable_secteur or not responsable_secteur['secteur_id']:
-                flash('Vous n\'êtes rattaché à aucun secteur', 'error')
-                return redirect(url_for('dashboard_bp.dashboard'))
-
+            # Équipe = salariés du secteur + rattachés directs (responsable_id),
+            # même d'un autre secteur (ex. entretien en secteur logistique
+            # encadré par la responsable crèche).
             users = conn.execute('''
                 SELECT u.id, u.nom, u.prenom, u.profil,
                        s.nom as secteur_nom,
@@ -282,9 +267,14 @@ def vue_ensemble_validation():
                 FROM users u
                 LEFT JOIN secteurs s ON u.secteur_id = s.id
                 LEFT JOIN users r ON u.responsable_id = r.id
-                WHERE u.actif = 1 AND u.profil = 'salarie' AND u.secteur_id = ?
+                WHERE u.actif = 1 AND u.profil = 'salarie'
+                  AND (u.secteur_id = ? OR u.responsable_id = ?)
                 ORDER BY u.nom, u.prenom
-            ''', (responsable_secteur['secteur_id'],)).fetchall()
+            ''', (secteur_resp, session['user_id'])).fetchall()
+
+            if not users and not secteur_resp:
+                flash('Vous n\'êtes rattaché à aucun secteur', 'error')
+                return redirect(url_for('dashboard_bp.dashboard'))
         else:
             users = conn.execute('''
                 SELECT u.id, u.nom, u.prenom, u.profil,
@@ -377,10 +367,9 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
         if session.get('profil') == 'directeur' or session.get('profil') == 'comptable':
             pass
         elif session.get('profil') == 'responsable':
-            user_to_view = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (user_id_a_afficher,)).fetchone()
-            responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-
-            if not user_to_view or not responsable_secteur or user_to_view['secteur_id'] != responsable_secteur['secteur_id']:
+            # Équipe du responsable : même secteur OU rattachement hiérarchique
+            # direct (salarié d'un autre secteur, ex. entretien en logistique).
+            if not est_dans_equipe_responsable(conn, session['user_id'], user_id_a_afficher):
                 flash('Accès non autorisé à cette fiche', 'error')
                 return None, redirect(url_for(redirect_route))
         else:
@@ -402,12 +391,14 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
         ''').fetchall()
     elif session.get('profil') == 'responsable':
         responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-        if responsable_secteur and responsable_secteur['secteur_id']:
-            users_accessibles = conn.execute('''
-                SELECT id, nom, prenom, profil FROM users
-                WHERE actif = 1 AND secteur_id = ?
-                ORDER BY nom, prenom
-            ''', (responsable_secteur['secteur_id'],)).fetchall()
+        secteur_resp = responsable_secteur['secteur_id'] if responsable_secteur else None
+        # Secteur + rattachés directs (un secteur NULL ne matche jamais : seuls
+        # les rattachés restent alors listés).
+        users_accessibles = conn.execute('''
+            SELECT id, nom, prenom, profil FROM users
+            WHERE actif = 1 AND (secteur_id = ? OR responsable_id = ? OR id = ?)
+            ORDER BY nom, prenom
+        ''', (secteur_resp, session['user_id'], session['user_id'])).fetchall()
 
     # Premier et dernier jour du mois
     premier_jour = datetime(annee, mois, 1)
@@ -640,10 +631,9 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
         elif session.get('profil') == 'directeur':
             peut_valider_mois = True
         elif session.get('profil') == 'responsable':
-            user_to_validate = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (user_id_a_afficher,)).fetchone()
-            responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-
-            if user_to_validate and responsable_secteur and user_to_validate['secteur_id'] == responsable_secteur['secteur_id']:
+            # Même règle que l'action de validation : secteur commun OU
+            # rattachement hiérarchique direct.
+            if est_dans_equipe_responsable(conn, session['user_id'], user_id_a_afficher):
                 peut_valider_mois = True
 
     peut_modifier = False
@@ -654,10 +644,7 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
         elif session.get('profil') == 'directeur':
             peut_modifier = True
         elif session.get('profil') == 'responsable':
-            user_to_view = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (user_id_a_afficher,)).fetchone()
-            responsable_secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?', (session['user_id'],)).fetchone()
-
-            if user_to_view and responsable_secteur and user_to_view['secteur_id'] == responsable_secteur['secteur_id']:
+            if est_dans_equipe_responsable(conn, session['user_id'], user_id_a_afficher):
                 peut_modifier = True
 
     if mois == 1:

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -94,9 +94,11 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
 
     # 1. Demandes de récupération / congé à valider.
     if profil == 'responsable':
+        # Équipe = secteur + rattachés directs (responsable_id), même d'un
+        # autre secteur analytique.
         statut_clause = "d.statut = 'en_attente_responsable'"
-        scope_clause = 'AND u.secteur_id = ?'
-        scope_params = (secteur_id,)
+        scope_clause = 'AND (u.secteur_id = ? OR u.responsable_id = ?)'
+        scope_params = (secteur_id, user_id)
     else:  # directeur / comptable
         statut_clause = "d.statut IN ('en_attente_responsable', 'en_attente_direction')"
         scope_clause = ''

--- a/tests/test_dashboard_responsable.py
+++ b/tests/test_dashboard_responsable.py
@@ -94,7 +94,13 @@ def test_dashboard_redirect_responsable(resp_client):
 
 
 def test_dashboard_responsable_sans_secteur_ne_boucle_pas(resp_client, app, db, sample_users):
-    """Un responsable sans secteur doit pouvoir rester sur /dashboard sans boucle de redirection."""
+    """Pas de boucle de redirection pour un responsable sans secteur.
+
+    - avec des rattachés directs : /dashboard renvoie vers le tableau
+      responsable, qui s'affiche (une seule redirection) ;
+    - sans secteur NI rattaché : /dashboard s'affiche directement (le tableau
+      responsable renverrait vers /dashboard : c'est le vrai risque de boucle).
+    """
     with app.app_context():
         db.execute(
             "UPDATE users SET secteur_id = NULL WHERE id = ?",
@@ -102,6 +108,17 @@ def test_dashboard_responsable_sans_secteur_ne_boucle_pas(resp_client, app, db, 
         )
         db.commit()
 
+    # Avec rattaché (Martin) : redirection unique vers le tableau responsable.
+    response = resp_client.get('/dashboard', follow_redirects=True)
+    assert response.status_code == 200
+    assert len(response.history) == 1
+    assert response.request.path == '/dashboard_responsable'
+
+    # Sans rattaché : /dashboard se rend directement, sans redirection.
+    with app.app_context():
+        db.execute("UPDATE users SET responsable_id = NULL WHERE responsable_id = ?",
+                   (sample_users['responsable_id'],))
+        db.commit()
     response = resp_client.get('/dashboard', follow_redirects=False)
     assert response.status_code == 200
 

--- a/tests/test_dashboard_responsable.py
+++ b/tests/test_dashboard_responsable.py
@@ -106,15 +106,28 @@ def test_dashboard_responsable_sans_secteur_ne_boucle_pas(resp_client, app, db, 
     assert response.status_code == 200
 
 
-def test_dashboard_responsable_sans_secteur_redirige_vers_dashboard(resp_client, app, db, sample_users):
-    """Le dashboard responsable redirige vers /dashboard quand le responsable n'a pas de secteur."""
+def test_dashboard_responsable_sans_secteur_ni_rattache_redirige(resp_client, app, db, sample_users):
+    """Sans secteur NI rattaché direct : redirection vers /dashboard."""
     with app.app_context():
-        db.execute(
-            "UPDATE users SET secteur_id = NULL WHERE id = ?",
-            (sample_users['responsable_id'],)
-        )
+        db.execute("UPDATE users SET secteur_id = NULL WHERE id = ?",
+                   (sample_users['responsable_id'],))
+        # Détacher aussi le salarié rattaché (responsable_id) du jeu de données.
+        db.execute("UPDATE users SET responsable_id = NULL WHERE responsable_id = ?",
+                   (sample_users['responsable_id'],))
         db.commit()
 
     response = resp_client.get('/dashboard_responsable', follow_redirects=False)
     assert response.status_code == 302
     assert response.headers.get('Location', '').endswith('/dashboard')
+
+
+def test_dashboard_responsable_sans_secteur_mais_avec_rattache(resp_client, app, db, sample_users):
+    """Sans secteur mais avec un rattaché direct (responsable_id), le tableau
+    reste accessible et montre l'équipe rattachée."""
+    with app.app_context():
+        db.execute("UPDATE users SET secteur_id = NULL WHERE id = ?",
+                   (sample_users['responsable_id'],))
+        db.commit()
+
+    html = resp_client.get('/dashboard_responsable').get_data(as_text=True)
+    assert 'Martin' in html    # le rattaché reste visible

--- a/tests/test_equipe_responsable.py
+++ b/tests/test_equipe_responsable.py
@@ -1,0 +1,171 @@
+"""
+Équipe d'un responsable = son secteur + ses rattachés directs.
+
+Un salarié peut être rangé dans un secteur pour l'analytique comptable (ex.
+entretien en « logistique ») tout en étant encadré par le responsable d'un
+autre secteur (la responsable de la crèche où il intervient). Le lien direct
+users.responsable_id doit ouvrir les mêmes suivis que l'appartenance au
+secteur : fiches d'heures (voir, saisir, valider, PDF), vue d'ensemble,
+demandes, tableaux de bord, fiche salarié, planning, mon équipe.
+"""
+from tests.conftest import _login
+from utils import est_dans_equipe_responsable
+
+
+def _creer_agent_transverse(db, sample_users, avec_contrat=False):
+    """Agent d'entretien en secteur Logistique, rattaché à la responsable
+    (resp_test) du Secteur Test. Retourne (agent_id, logistique_id)."""
+    from werkzeug.security import generate_password_hash
+    cur = db.cursor()
+    cur.execute("INSERT INTO secteurs (nom) VALUES ('Logistique')")
+    logistique_id = cur.lastrowid
+    cur.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil, secteur_id, responsable_id) "
+        "VALUES ('Agent', 'Paul', 'agent_test', ?, 'salarie', ?, ?)",
+        (generate_password_hash('agent123'), logistique_id, sample_users['responsable_id']))
+    agent_id = cur.lastrowid
+    if avec_contrat:
+        cur.execute(
+            "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+            "VALUES (?, 'CDI', '2025-01-01', NULL)", (agent_id,))
+    db.commit()
+    return agent_id, logistique_id
+
+
+def _creer_responsable_tiers(db):
+    """Responsable d'un troisième secteur, sans aucun lien avec l'agent."""
+    from werkzeug.security import generate_password_hash
+    cur = db.cursor()
+    cur.execute("INSERT INTO secteurs (nom) VALUES ('Animation')")
+    cur.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil, secteur_id) "
+        "VALUES ('Tiers', 'Anne', 'resp_tiers', ?, 'responsable', ?)",
+        (generate_password_hash('tiers123'), cur.lastrowid))
+    db.commit()
+
+
+# ── Helper ──
+
+def test_est_dans_equipe_meme_secteur(app, db, sample_users):
+    with app.app_context():
+        assert est_dans_equipe_responsable(
+            db, sample_users['responsable_id'], sample_users['salarie_id'])
+
+
+def test_est_dans_equipe_rattache_autre_secteur(app, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    with app.app_context():
+        assert est_dans_equipe_responsable(db, sample_users['responsable_id'], agent_id)
+
+
+def test_pas_dans_equipe_sans_lien(app, db, sample_users):
+    """Salarié d'un autre secteur SANS rattachement : hors équipe."""
+    from werkzeug.security import generate_password_hash
+    cur = db.cursor()
+    cur.execute("INSERT INTO secteurs (nom) VALUES ('Autre')")
+    cur.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil, secteur_id) "
+        "VALUES ('Sans', 'Lien', 'sans_lien', ?, 'salarie', ?)",
+        (generate_password_hash('x'), cur.lastrowid))
+    etranger_id = cur.lastrowid
+    db.commit()
+    with app.app_context():
+        assert not est_dans_equipe_responsable(db, sample_users['responsable_id'], etranger_id)
+
+
+# ── Fiches d'heures ──
+
+def test_vue_mensuelle_accessible_au_responsable(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    html = resp_client.get(f'/vue_mensuelle?user_id={agent_id}').get_data(as_text=True)
+    assert 'Agent' in html                       # fiche affichée, pas de redirection
+    assert f'value="{agent_id}"' in html         # présent dans le sélecteur
+
+
+def test_vue_mensuelle_refusee_sans_lien(client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    _creer_responsable_tiers(db)
+    _login(client, 'resp_tiers', 'tiers123')
+    r = client.get(f'/vue_mensuelle?user_id={agent_id}', follow_redirects=True)
+    assert 'Accès non autorisé' in r.get_data(as_text=True)
+
+
+def test_valider_mois_du_rattache(resp_client, db, sample_users):
+    """La responsable peut poser sa validation sur la fiche du rattaché."""
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    resp_client.post('/valider_mois', data={
+        'user_id': agent_id, 'mois': 5, 'annee': 2026}, follow_redirects=True)
+    v = db.execute("SELECT validation_responsable FROM validations "
+                   "WHERE user_id = ? AND mois = 5 AND annee = 2026", (agent_id,)).fetchone()
+    assert v is not None and v['validation_responsable']
+
+
+def test_vue_ensemble_liste_le_rattache(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    html = resp_client.get('/vue_ensemble_validation').get_data(as_text=True)
+    assert 'Agent' in html          # rattaché listé
+    assert 'Martin' in html         # salarié du secteur toujours là
+
+
+def test_export_pdf_du_rattache(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    db.execute('''INSERT INTO validations (user_id, mois, annee, validation_salarie,
+                  validation_responsable, validation_directeur, date_salarie,
+                  date_responsable, date_directeur, bloque)
+                  VALUES (?, 3, 2026, 'A', 'B', 'C', '2026-04-01', '2026-04-02',
+                          '2026-04-03', 1)''', (agent_id,))
+    db.commit()
+    r = resp_client.get(f'/export_pdf_mensuel?user_id={agent_id}&mois=3&annee=2026')
+    assert r.status_code == 200
+    assert r.data[:4] == b'%PDF'
+
+
+# ── Demandes ──
+
+def test_demande_recup_du_rattache_visible(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    db.execute('''INSERT INTO demandes_recup (user_id, date_debut, date_fin, nb_jours,
+                  nb_heures, statut) VALUES (?, '2026-08-03', '2026-08-03', 1, 7,
+                  'en_attente_responsable')''', (agent_id,))
+    db.commit()
+    html = resp_client.get('/validation_demandes_recup').get_data(as_text=True)
+    assert 'Agent' in html
+
+
+def test_dashboard_actions_inclut_le_rattache(app, db, sample_users):
+    from dashboard_actions import construire_actions
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    db.execute('''INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin,
+                  nb_jours, statut) VALUES (?, 'Congé payé', '2026-08-10', '2026-08-14',
+                  5, 'en_attente_responsable')''', (agent_id,))
+    db.commit()
+    with app.app_context():
+        actions = construire_actions(db, 'responsable', sample_users['responsable_id'],
+                                     secteur_id=sample_users['secteur_id'])
+    assert any('Agent' in a['titre'] for a in actions)
+
+
+# ── Dashboard, fiche salarié, planning, mon équipe ──
+
+def test_dashboard_responsable_inclut_le_rattache(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users, avec_contrat=True)
+    html = resp_client.get('/dashboard_responsable').get_data(as_text=True)
+    assert 'Agent' in html
+
+
+def test_fiche_salarie_du_rattache_visible(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    html = resp_client.get(f'/infos_salaries?user_id={agent_id}').get_data(as_text=True)
+    assert 'Agent' in html and 'Paul' in html
+
+
+def test_planning_selecteur_inclut_le_rattache(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    html = resp_client.get('/planning_theorique').get_data(as_text=True)
+    assert 'Agent' in html
+
+
+def test_mon_equipe_inclut_le_rattache(resp_client, db, sample_users):
+    agent_id, _ = _creer_agent_transverse(db, sample_users, avec_contrat=True)
+    html = resp_client.get('/mon_equipe').get_data(as_text=True)
+    assert 'Agent' in html

--- a/tests/test_equipe_responsable.py
+++ b/tests/test_equipe_responsable.py
@@ -169,3 +169,23 @@ def test_mon_equipe_inclut_le_rattache(resp_client, db, sample_users):
     agent_id, _ = _creer_agent_transverse(db, sample_users, avec_contrat=True)
     html = resp_client.get('/mon_equipe').get_data(as_text=True)
     assert 'Agent' in html
+
+
+def test_selecteur_infos_salaries_liste_le_rattache(resp_client, db, sample_users):
+    """Le rattaché apparaît dans le sélecteur de la page (pas seulement en
+    accès direct par URL) — revue Codex."""
+    agent_id, _ = _creer_agent_transverse(db, sample_users)
+    html = resp_client.get('/infos_salaries').get_data(as_text=True)
+    assert f'value="{agent_id}"' in html or 'Agent' in html
+
+
+def test_entree_dashboard_redirige_responsable_sans_secteur(resp_client, app, db, sample_users):
+    """/dashboard envoie vers le tableau responsable même sans secteur, dès
+    lors qu'il y a des rattachés directs — revue Codex."""
+    with app.app_context():
+        db.execute("UPDATE users SET secteur_id = NULL WHERE id = ?",
+                   (sample_users['responsable_id'],))
+        db.commit()
+    r = resp_client.get('/dashboard', follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers.get('Location', '').endswith('/dashboard_responsable')

--- a/utils.py
+++ b/utils.py
@@ -583,6 +583,27 @@ def calculer_stats_forfait_jour(user_id, annee):
     return stats
 
 
+def est_dans_equipe_responsable(conn, responsable_id, salarie_id):
+    """Vrai si le salarié fait partie de l'équipe suivie par ce responsable.
+
+    Deux liens équivalents (mêmes règles que la validation des fiches) :
+    - même secteur que le responsable ;
+    - rattachement hiérarchique direct (users.responsable_id), qui peut
+      traverser les secteurs : un agent d'entretien est rangé en secteur
+      « logistique » pour l'analytique comptable mais encadré par la
+      responsable de la crèche où il intervient.
+    """
+    row = conn.execute('''
+        SELECT 1
+        FROM users s
+        JOIN users r ON r.id = ?
+        WHERE s.id = ?
+          AND (s.responsable_id = r.id
+               OR (r.secteur_id IS NOT NULL AND s.secteur_id = r.secteur_id))
+    ''', (responsable_id, salarie_id)).fetchone()
+    return row is not None
+
+
 def total_hs_payees(conn, user_id, annee=None, mois=None, avant=False):
     """Total des heures supplémentaires payées ET marquées « déduites du
     compteur » (variables_paie.hs_deduites_compteur = 1) pour un salarié.


### PR DESCRIPTION
## Contexte

Un salarié peut être rangé dans un secteur pour l'**analytique comptable** tout en étant encadré par le responsable d'un **autre secteur** : un agent d'entretien est en « logistique » mais encadré par la responsable de la crèche où il intervient ; un autre par le responsable enfance, etc.

L'application assimilait presque partout « l'équipe d'un responsable » à « les salariés de son secteur ». Le rattachement hiérarchique direct (`users.responsable_id`, déjà saisi dans l'admin) n'ouvrait que **l'action** de valider une fiche — pas les vues : le responsable ne voyait ni la fiche d'heures du rattaché, ni ses demandes, ni sa fiche salarié.

## Principe

Nouveau helper commun `utils.est_dans_equipe_responsable(conn, responsable_id, salarie_id)` : l'équipe d'un responsable = **salariés de son secteur + salariés qui lui sont directement rattachés** (`responsable_id`), même d'un autre secteur. L'action `valider_mois` (qui implémentait déjà cette double règle en local) est rebranchée dessus — source de vérité unique.

## Vues étendues au périmètre équipe

- **Fiches d'heures** (la demande principale) : accès à la vue mensuelle, sélecteur de salariés, vue d'ensemble validation, `peut_valider`/`peut_modifier`, saisie des heures pour un membre de l'équipe, export PDF.
- **Demandes** : liste de validation récup/congés, file d'actions « À faire » du tableau de bord.
- **Tableau de bord responsable** : équipe/ETP, absences, validations mensuelles, demandes, congés de l'équipe. Un responsable **sans secteur mais avec des rattachés** garde son tableau. Les **factures restent scoppées au secteur** (c'est leur circuit d'approbation).
- **Fiche salarié** (`_est_salarie_visible`), **planning théorique** (garde + sélecteur), **Mon équipe** (les rattachés apparaissent chez leur responsable — l'inverse existait déjà), **relances de validation** (le comptage des fiches en attente inclut les rattachés).

## Tests

`tests/test_equipe_responsable.py` — 14 cas sur le scénario réel (agent « logistique » rattaché à la responsable du secteur test) : helper (même secteur / rattaché / sans lien), vue mensuelle accessible **et refusée à un responsable tiers sans lien**, validation posée sur la fiche du rattaché, vue d'ensemble, export PDF, demande récup visible, file d'actions, dashboard responsable, fiche salarié, planning, mon équipe.

Le test « dashboard sans secteur » est scindé en deux : sans secteur **ni** rattaché → redirection (comportement conservé) ; sans secteur **avec** rattaché → tableau accessible.

Suite complète verte (**921 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_