### PR TITLE
Délégations : le comptable peut définir les réservations de salle récurrentes

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -62,11 +62,9 @@ def delegations():
     conn = get_db()
     try:
         if request.method == 'POST':
-            if session.get('profil') != 'directeur':
-                flash('Seule la direction peut modifier les délégations.', 'error')
-                return redirect(url_for('admin_bp.delegations'))
-
             # Délégation des réservations de salle récurrentes (multi-salariés).
+            # Modifiable par la direction ET le comptable (gestion des salles) ;
+            # les autres missions restent réservées à la direction.
             if request.form.get('form_type') == 'salle_recurrence':
                 selected = [int(x) for x in request.form.getlist('salle_recurrence_users') if x.isdigit()]
                 valides = []
@@ -81,6 +79,10 @@ def delegations():
                     valides = [r['id'] for r in rows]
                 save_salle_recurrence_delegations(valides, session['user_id'])
                 flash('Les autorisations de réservation récurrente ont été enregistrées.', 'success')
+                return redirect(url_for('admin_bp.delegations'))
+
+            if session.get('profil') != 'directeur':
+                flash('Seule la direction peut modifier les délégations.', 'error')
                 return redirect(url_for('admin_bp.delegations'))
 
             mission_key = request.form.get('mission_key')
@@ -150,6 +152,9 @@ def delegations():
         salaries=salaries,
         salle_recurrence_user_ids=get_salle_recurrence_user_ids(),
         peut_modifier=session.get('profil') == 'directeur',
+        # Les réservations de salle récurrentes relèvent de la gestion des
+        # salles : le comptable peut aussi définir qui y a droit.
+        peut_modifier_salles=session.get('profil') in ('directeur', 'comptable'),
     )
 
 @admin_bp.route('/creer_user', methods=['GET', 'POST'])

--- a/templates/delegations.html
+++ b/templates/delegations.html
@@ -93,7 +93,7 @@
                         <label class="recurrence-user">
                             <input type="checkbox" name="salle_recurrence_users" value="{{ user.id }}"
                                    {% if user.id in salle_recurrence_user_ids %}checked{% endif %}
-                                   {% if not peut_modifier %}disabled{% endif %}>
+                                   {% if not peut_modifier_salles %}disabled{% endif %}>
                             {{ user.prenom }} {{ user.nom }}{% if user.profil == 'responsable' %} — Responsable{% endif %}
                         </label>
                         {% endfor %}
@@ -105,7 +105,7 @@
 
                 <div class="form-actions">
                     <a href="{{ url_for('dashboard_bp.dashboard') }}" class="btn btn-secondary">Retour</a>
-                    {% if peut_modifier %}
+                    {% if peut_modifier_salles %}
                     <button type="submit" class="btn btn-primary">Enregistrer les autorisations</button>
                     {% endif %}
                 </div>

--- a/tests/test_delegation_recurrence_salles.py
+++ b/tests/test_delegation_recurrence_salles.py
@@ -102,19 +102,78 @@ def test_retrait_delegation(app, sample_users):
     assert _count_recurrences(app) == 0
 
 
-def test_comptable_ne_peut_pas_deleguer(app, sample_users):
-    admin = app.test_client()
+def test_comptable_peut_deleguer_les_salles(app, sample_users):
+    """Le comptable (gestion des salles) peut définir les salariés autorisés
+    aux réservations récurrentes — et le salarié peut ensuite en créer une."""
+    salle_id = _make_salle(app)
     compta = app.test_client()
     _login(compta, 'compta_test', 'compta123')
-    compta.post('/delegations', data={
+    r = compta.post('/delegations', data={
         'form_type': 'salle_recurrence',
         'salle_recurrence_users': [sample_users['salarie_id']],
     }, follow_redirects=True)
+    assert 'ont été enregistrées' in r.get_data(as_text=True)
+    with app.app_context():
+        conn = get_db()
+        n = conn.execute('SELECT COUNT(*) AS n FROM delegations_salles_recurrence').fetchone()['n']
+        conn.close()
+    assert n == 1
+    # Bout en bout : le salarié délégué crée une récurrence.
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    sal.post('/salles/recurrence', data=_recurrence_form(salle_id), follow_redirects=True)
+    assert _count_recurrences(app) == 1
+
+
+def test_comptable_peut_retirer_les_delegations_salles(app, sample_users):
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    admin.post('/delegations', data={
+        'form_type': 'salle_recurrence',
+        'salle_recurrence_users': [sample_users['salarie_id']],
+    }, follow_redirects=True)
+    compta = app.test_client()
+    _login(compta, 'compta_test', 'compta123')
+    compta.post('/delegations', data={'form_type': 'salle_recurrence'},
+                follow_redirects=True)
     with app.app_context():
         conn = get_db()
         n = conn.execute('SELECT COUNT(*) AS n FROM delegations_salles_recurrence').fetchone()['n']
         conn.close()
     assert n == 0
+
+
+def test_comptable_ne_peut_pas_deleguer_les_missions(app, sample_users):
+    """Les missions (fournitures, suivi validations…) restent réservées à la
+    direction : seul le formulaire des salles est ouvert au comptable."""
+    compta = app.test_client()
+    _login(compta, 'compta_test', 'compta123')
+    r = compta.post('/delegations', data={
+        'mission_key': 'suivi_commandes_fournitures',
+        'delegated_user_id': sample_users['salarie_id'],
+    }, follow_redirects=True)
+    assert 'Seule la direction peut modifier les délégations' in r.get_data(as_text=True)
+    with app.app_context():
+        conn = get_db()
+        n = conn.execute('SELECT COUNT(*) AS n FROM delegations_missions').fetchone()['n']
+        conn.close()
+    assert n == 0
+
+
+def test_page_comptable_formulaire_salles_actif(app, sample_users):
+    """Côté page : cases cochables et bouton visible pour le comptable sur la
+    section salles, missions toujours désactivées."""
+    compta = app.test_client()
+    _login(compta, 'compta_test', 'compta123')
+    html = compta.get('/delegations').get_data(as_text=True)
+    # La section salles est active : au moins une case non désactivée.
+    section_salles = html.split('Réservation de salle récurrente')[1]
+    assert 'Enregistrer les autorisations' in section_salles
+    assert 'name="salle_recurrence_users"' in section_salles
+    assert 'disabled' not in section_salles.split('form-actions')[0]
+    # Les missions restent en lecture seule (selects désactivés).
+    section_missions = html.split('Réservation de salle récurrente')[0]
+    assert 'disabled' in section_missions
 
 
 def test_page_delegations_affiche_section_recurrence(app, sample_users):


### PR DESCRIPTION
## Contexte

La page Délégations permet de cocher les salariés autorisés à créer des **réservations de salle récurrentes**, mais seule la **direction** pouvait modifier cette liste — le comptable, qui gère les salles au quotidien, ne pouvait que consulter la page (formulaire désactivé, POST refusé).

## Changements

- **`blueprints/admin.py`** : le formulaire `salle_recurrence` accepte désormais le **comptable** en plus du directeur. Les **missions** (suivi des fournitures, suivi des validations/relances…) restent réservées à la direction — le contrôle est simplement déplacé après la branche salles.
- **`templates/delegations.html`** : nouveau drapeau `peut_modifier_salles` (directeur **ou** comptable) pour la section salles — cases cochables et bouton « Enregistrer » actifs pour le comptable ; les sélecteurs des missions restent désactivés pour lui.

## Tests

`tests/test_delegation_recurrence_salles.py` :
- le comptable **enregistre** les autorisations, et le salarié délégué crée ensuite une récurrence (bout en bout) ;
- le comptable **retire** les autorisations ;
- les **missions lui restent refusées** (message + rien d'enregistré) ;
- côté page : section salles active pour le comptable, missions toujours en lecture seule.

(Remplace l'ancien test `test_comptable_ne_peut_pas_deleguer`, qui verrouillait le comportement désormais assoupli.)

Suite complète verte (**926 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_