### PR TITLE
Salles : navigation jour, vues semaine et mois, salles réservées en tête

### DIFF
--- a/blueprints/salles.py
+++ b/blueprints/salles.py
@@ -139,10 +139,14 @@ def salles():
         ).fetchall()
 
         # Date selectionnee (par defaut aujourd'hui) — une valeur mal formee
-        # retombe sur aujourd'hui plutot que de casser la navigation.
+        # OU hors de la fenetre applicative retombe sur aujourd'hui. La borne
+        # evite l'overflow de l'arithmetique de navigation aux limites de
+        # Python (0001-01-01 - 1 jour, 9999-12-31 + 1 jour) — revue Codex.
         date_sel = request.args.get('date', datetime.now().strftime('%Y-%m-%d'))
         try:
             date_obj = datetime.strptime(date_sel, '%Y-%m-%d')
+            if not (2000 <= date_obj.year <= 2100):
+                raise ValueError(date_sel)
         except ValueError:
             date_obj = datetime.now()
             date_sel = date_obj.strftime('%Y-%m-%d')

--- a/blueprints/salles.py
+++ b/blueprints/salles.py
@@ -6,7 +6,7 @@ from flask import (Blueprint, render_template, request, redirect,
                    url_for, session, flash, jsonify)
 from datetime import datetime, timedelta
 from database import get_db
-from utils import login_required, get_user_info
+from utils import login_required, get_user_info, NOMS_MOIS
 
 salles_bp = Blueprint('salles_bp', __name__)
 
@@ -131,15 +131,29 @@ def _verifier_conflit(conn, salle_id, date, heure_debut, heure_fin, exclure_id=N
 @salles_bp.route('/salles')
 @login_required
 def salles():
-    """Page principale : liste des salles et disponibilites."""
+    """Page principale : disponibilites en vue jour, semaine ou mois."""
     conn = get_db()
     try:
         salles_list = conn.execute(
             'SELECT * FROM salles WHERE active = 1 ORDER BY nom'
         ).fetchall()
 
-        # Date selectionnee (par defaut aujourd'hui)
+        # Date selectionnee (par defaut aujourd'hui) — une valeur mal formee
+        # retombe sur aujourd'hui plutot que de casser la navigation.
         date_sel = request.args.get('date', datetime.now().strftime('%Y-%m-%d'))
+        try:
+            date_obj = datetime.strptime(date_sel, '%Y-%m-%d')
+        except ValueError:
+            date_obj = datetime.now()
+            date_sel = date_obj.strftime('%Y-%m-%d')
+
+        vue = request.args.get('vue', 'jour')
+        if vue not in ('jour', 'semaine', 'mois'):
+            vue = 'jour'
+
+        # Navigation jour precedent / suivant (fleches de la vue quotidienne).
+        date_prec = (date_obj - timedelta(days=1)).strftime('%Y-%m-%d')
+        date_suiv = (date_obj + timedelta(days=1)).strftime('%Y-%m-%d')
 
         # Reservations du jour selectionne
         reservations = conn.execute('''
@@ -151,6 +165,73 @@ def salles():
             WHERE r.date = ?
             ORDER BY r.heure_debut, s.nom
         ''', (date_sel,)).fetchall()
+
+        # Vue jour : les salles ayant au moins une reservation passent en tete
+        # (tri stable : l'ordre alphabetique est conserve dans chaque groupe).
+        salles_reservees = {r['salle_id'] for r in reservations}
+        salles_jour = sorted(salles_list, key=lambda s: s['id'] not in salles_reservees)
+
+        # ── Vue semaine : reservations du lundi au dimanche contenant date_sel ──
+        semaine = None
+        if vue == 'semaine':
+            lundi = date_obj - timedelta(days=date_obj.weekday())
+            jours = [lundi + timedelta(days=i) for i in range(7)]
+            resas_sem = conn.execute('''
+                SELECT r.*, s.nom as salle_nom, s.couleur,
+                       u.prenom, u.nom as nom_user
+                FROM reservations_salles r
+                JOIN salles s ON r.salle_id = s.id
+                LEFT JOIN users u ON r.created_by = u.id
+                WHERE r.date BETWEEN ? AND ?
+                ORDER BY r.date, r.heure_debut, s.nom
+            ''', (jours[0].strftime('%Y-%m-%d'), jours[6].strftime('%Y-%m-%d'))).fetchall()
+            par_jour_salle = {}
+            for r in resas_sem:
+                par_jour_salle.setdefault((r['date'], r['salle_id']), []).append(r)
+            semaine = {
+                'jours': [{'date': j.strftime('%Y-%m-%d'),
+                           'libelle': JOURS_SEMAINE[j.weekday()],
+                           'numero': j.day,
+                           'est_aujourdhui': j.date() == datetime.now().date()}
+                          for j in jours],
+                'par_jour_salle': par_jour_salle,
+                'date_prec': (date_obj - timedelta(days=7)).strftime('%Y-%m-%d'),
+                'date_suiv': (date_obj + timedelta(days=7)).strftime('%Y-%m-%d'),
+            }
+
+        # ── Vue mois : un marqueur par jour ayant au moins une reservation ──
+        mois_cal = None
+        if vue == 'mois':
+            import calendar as _cal
+            annee_m, mois_m = date_obj.year, date_obj.month
+            dernier_jour = _cal.monthrange(annee_m, mois_m)[1]
+            rows = conn.execute('''
+                SELECT date, COUNT(*) AS nb FROM reservations_salles
+                WHERE date BETWEEN ? AND ?
+                GROUP BY date
+            ''', (f'{annee_m:04d}-{mois_m:02d}-01',
+                  f'{annee_m:04d}-{mois_m:02d}-{dernier_jour:02d}')).fetchall()
+            nb_par_jour = {r['date']: r['nb'] for r in rows}
+            semaines = []
+            for sem in _cal.monthcalendar(annee_m, mois_m):
+                ligne = []
+                for jour in sem:
+                    if jour == 0:
+                        ligne.append(None)   # case hors du mois
+                    else:
+                        d = f'{annee_m:04d}-{mois_m:02d}-{jour:02d}'
+                        ligne.append({'date': d, 'numero': jour,
+                                      'nb': nb_par_jour.get(d, 0),
+                                      'est_aujourdhui': d == datetime.now().strftime('%Y-%m-%d')})
+                semaines.append(ligne)
+            mois_prec = (date_obj.replace(day=1) - timedelta(days=1)).replace(day=1)
+            mois_suiv = (date_obj.replace(day=dernier_jour) + timedelta(days=1))
+            mois_cal = {
+                'semaines': semaines,
+                'libelle': f'{NOMS_MOIS[mois_m]} {annee_m}',
+                'date_prec': mois_prec.strftime('%Y-%m-%d'),
+                'date_suiv': mois_suiv.strftime('%Y-%m-%d'),
+            }
 
         # Recurrences actives
         recurrences = conn.execute('''
@@ -169,10 +250,16 @@ def salles():
 
         return render_template('salles.html',
                                salles=salles_list,
+                               salles_jour=salles_jour,
                                reservations=reservations,
                                recurrences=recurrences,
                                users=users,
                                date_sel=date_sel,
+                               vue=vue,
+                               date_prec=date_prec,
+                               date_suiv=date_suiv,
+                               semaine=semaine,
+                               mois_cal=mois_cal,
                                jours_semaine=JOURS_SEMAINE,
                                is_admin=_est_admin(),
                                can_create_recurrence=_peut_creer_recurrence(),

--- a/templates/salles.html
+++ b/templates/salles.html
@@ -63,19 +63,49 @@
     </div>
     {% endif %}
 
-    {# ══════ SECTION : Reservations du jour ══════ #}
+    {# ══════ SECTION : Reservations (vue jour / semaine / mois) ══════ #}
     <div class="salles-section">
-        <h2 class="salles-section-title">
-            Reservations du
+        {# Barre de navigation : onglets de vue + fleches + date #}
+        <div style="display:flex;align-items:center;gap:0.6rem;flex-wrap:wrap;margin-bottom:12px;">
+            <div style="display:inline-flex;border:1px solid var(--gray-300);border-radius:8px;overflow:hidden;">
+                {% for v, libelle in [('jour', 'Jour'), ('semaine', 'Semaine'), ('mois', 'Mois')] %}
+                <a href="{{ url_for('salles_bp.salles', date=date_sel, vue=v) }}"
+                   style="padding:6px 14px;text-decoration:none;font-weight:600;font-size:0.9rem;
+                          {% if vue == v %}background:var(--primary);color:#fff;{% else %}color:var(--gray-600);{% endif %}">
+                    {{ libelle }}</a>
+                {% endfor %}
+            </div>
+            {% if vue == 'jour' %}
+            <a href="{{ url_for('salles_bp.salles', date=date_prec, vue='jour') }}" class="btn btn-sm"
+               title="Jour precedent">&larr;</a>
             <input type="date" id="date-sel" value="{{ date_sel }}"
-                   onchange="window.location='{{ url_for('salles_bp.salles') }}?date='+this.value"
+                   onchange="window.location='{{ url_for('salles_bp.salles') }}?date='+this.value+'&vue=jour'"
                    style="font-size:16px;padding:4px 8px;border-radius:6px;border:1px solid var(--gray-300);">
-            {% set ds = date_sel.split('-') %}
-            {% set jj = ['Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi','Dimanche'] %}
-        </h2>
+            <a href="{{ url_for('salles_bp.salles', date=date_suiv, vue='jour') }}" class="btn btn-sm"
+               title="Jour suivant">&rarr;</a>
+            {% elif vue == 'semaine' %}
+            <a href="{{ url_for('salles_bp.salles', date=semaine.date_prec, vue='semaine') }}" class="btn btn-sm"
+               title="Semaine precedente">&larr;</a>
+            <strong>Semaine du {{ semaine.jours[0].numero }} au {{ semaine.jours[6].numero }}</strong>
+            <a href="{{ url_for('salles_bp.salles', date=semaine.date_suiv, vue='semaine') }}" class="btn btn-sm"
+               title="Semaine suivante">&rarr;</a>
+            {% elif vue == 'mois' %}
+            <a href="{{ url_for('salles_bp.salles', date=mois_cal.date_prec, vue='mois') }}" class="btn btn-sm"
+               title="Mois precedent">&larr;</a>
+            <strong>{{ mois_cal.libelle }}</strong>
+            <a href="{{ url_for('salles_bp.salles', date=mois_cal.date_suiv, vue='mois') }}" class="btn btn-sm"
+               title="Mois suivant">&rarr;</a>
+            {% endif %}
+            {% if date_sel != today or vue != 'jour' %}
+            <a href="{{ url_for('salles_bp.salles', date=today, vue=vue) }}" class="btn btn-sm btn-secondary">Aujourd'hui</a>
+            {% endif %}
+        </div>
 
-        {# Grille des creneaux par salle #}
-        {% if salles %}
+        {% if not salles %}
+        <p style="color:var(--gray-500);padding:20px;">Aucune salle configuree. {% if is_admin %}Ajoutez une salle ci-dessus.{% endif %}</p>
+
+        {% elif vue == 'jour' %}
+        {# ── Vue jour : grille des creneaux par salle (salles reservees en tete) ── #}
         <div class="salles-grid-wrapper">
             <div class="salles-timeline">
                 {% for h in range(7, 23) %}
@@ -83,7 +113,7 @@
                 {% endfor %}
             </div>
             <div class="salles-grid">
-                {% for s in salles %}
+                {% for s in salles_jour %}
                 <div class="salles-grid-row">
                     <div class="salles-grid-label">
                         <span class="salles-color-dot" style="background:{{ s.couleur }};"></span>
@@ -113,12 +143,84 @@
                 {% endfor %}
             </div>
         </div>
-        {% else %}
-        <p style="color:var(--gray-500);padding:20px;">Aucune salle configuree. {% if is_admin %}Ajoutez une salle ci-dessus.{% endif %}</p>
+
+        {% elif vue == 'semaine' %}
+        {# ── Vue semaine : salles x 7 jours ── #}
+        <div style="overflow-x:auto;">
+            <table class="salles-table" style="min-width:900px;">
+                <thead>
+                    <tr>
+                        <th style="min-width:130px;">Salle</th>
+                        {% for j in semaine.jours %}
+                        <th style="text-align:center;{% if j.est_aujourdhui %}background:var(--primary);color:#fff;{% endif %}">
+                            <a href="{{ url_for('salles_bp.salles', date=j.date, vue='jour') }}"
+                               style="text-decoration:none;{% if j.est_aujourdhui %}color:#fff;{% endif %}"
+                               title="Voir la journee">{{ j.libelle[:3] }} {{ j.numero }}</a>
+                        </th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for s in salles %}
+                    <tr>
+                        <td><span class="salles-color-dot" style="background:{{ s.couleur }};"></span>
+                            <a href="{{ url_for('salles_bp.calendrier_salle', salle_id=s.id) }}">{{ s.nom }}</a></td>
+                        {% for j in semaine.jours %}
+                        <td style="vertical-align:top;font-size:0.78rem;">
+                            {% for r in semaine.par_jour_salle.get((j.date, s.id), []) %}
+                            <div style="background:{{ s.couleur }};color:#fff;border-radius:4px;
+                                        padding:1px 5px;margin:2px 0;white-space:nowrap;overflow:hidden;
+                                        text-overflow:ellipsis;max-width:140px;"
+                                 title="{{ r.titre }} ({{ r.heure_debut }}-{{ r.heure_fin }}) — {{ r.prenom }} {{ r.nom_user }}">
+                                {{ r.heure_debut }} {{ r.titre }}
+                            </div>
+                            {% endfor %}
+                        </td>
+                        {% endfor %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% elif vue == 'mois' %}
+        {# ── Vue mois : un marqueur par jour ayant au moins une reservation ── #}
+        <table class="salles-table" style="table-layout:fixed;">
+            <thead>
+                <tr>
+                    {% for j in jours_semaine %}<th style="text-align:center;">{{ j[:3] }}</th>{% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for sem in mois_cal.semaines %}
+                <tr>
+                    {% for case in sem %}
+                    {% if case %}
+                    <td style="text-align:center;height:64px;vertical-align:top;
+                               {% if case.est_aujourdhui %}background:var(--gray-100);{% endif %}">
+                        <a href="{{ url_for('salles_bp.salles', date=case.date, vue='jour') }}"
+                           style="text-decoration:none;display:block;" title="Voir la journee">
+                            <div style="font-weight:600;">{{ case.numero }}</div>
+                            {% if case.nb > 0 %}
+                            <span class="badge badge-info salles-mois-marque"
+                                  title="{{ case.nb }} reservation(s)">&#9679; {{ case.nb }}</span>
+                            {% endif %}
+                        </a>
+                    </td>
+                    {% else %}
+                    <td style="background:var(--gray-50);"></td>
+                    {% endif %}
+                    {% endfor %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <p style="color:var(--gray-500);font-size:0.85rem;margin-top:6px;">
+            &#9679; = au moins une reservation ce jour. Cliquez sur un jour pour ouvrir la vue quotidienne.</p>
         {% endif %}
 
-        {# Liste detaillee #}
-        {% if reservations %}
+        {# Liste detaillee (vue jour uniquement) #}
+        {% if vue == 'jour' and reservations %}
         <div class="salles-list">
             <table class="salles-table">
                 <thead>
@@ -160,7 +262,7 @@
                 </tbody>
             </table>
         </div>
-        {% elif salles %}
+        {% elif vue == 'jour' and salles %}
         <p style="color:var(--gray-500);padding:10px 0;">Aucune reservation pour cette date.</p>
         {% endif %}
     </div>

--- a/tests/test_salles.py
+++ b/tests/test_salles.py
@@ -109,3 +109,73 @@ def test_responsable_peut_creer_recurrence(resp_client, db, sample_users):
     assert recurrence['titre'] == 'Formation equipe'
     assert recurrence['created_by'] == sample_users['responsable_id']
     assert reservations == 5
+
+
+# ── Vues jour / semaine / mois et navigation (retours utilisateurs) ──
+
+def _salle(db, nom, couleur='#2563eb'):
+    cur = db.execute("INSERT INTO salles (nom, couleur, active) VALUES (?, ?, 1)", (nom, couleur))
+    db.commit()
+    return cur.lastrowid
+
+
+def _resa(db, salle_id, date, debut='09:00', fin='10:00', titre='Reunion'):
+    db.execute("INSERT INTO reservations_salles (salle_id, titre, date, heure_debut, heure_fin) "
+               "VALUES (?, ?, ?, ?, ?)", (salle_id, titre, date, debut, fin))
+    db.commit()
+
+
+def test_navigation_jour_precedent_suivant(auth_client, db, sample_users):
+    _salle(db, 'Salle A')
+    html = auth_client.get('/salles?date=2026-07-15').get_data(as_text=True)
+    assert 'date=2026-07-14' in html    # flèche jour précédent
+    assert 'date=2026-07-16' in html    # flèche jour suivant
+    assert 'Semaine' in html and 'Mois' in html   # onglets de vue
+
+
+def test_vue_jour_salles_reservees_en_tete(auth_client, db, sample_users):
+    """La salle réservée passe devant dans la grille quotidienne, même si son
+    nom la classe en dernier alphabétiquement."""
+    _salle(db, 'Alpha')
+    zid = _salle(db, 'Zebre')
+    _resa(db, zid, '2026-07-15')
+    html = auth_client.get('/salles?date=2026-07-15').get_data(as_text=True)
+    assert html.index('Zebre') < html.index('Alpha')
+    # Sans réservation : ordre alphabétique conservé.
+    html = auth_client.get('/salles?date=2026-07-20').get_data(as_text=True)
+    assert html.index('Alpha') < html.index('Zebre')
+
+
+def test_vue_semaine_affiche_les_reservations(auth_client, db, sample_users):
+    sid = _salle(db, 'Salle A')
+    _resa(db, sid, '2026-07-14', titre='Atelier mardi')     # mardi
+    # N'importe quel jour de la même semaine (jeudi 16) montre la semaine du 13 au 19.
+    html = auth_client.get('/salles?date=2026-07-16&vue=semaine').get_data(as_text=True)
+    assert 'Atelier mardi' in html
+    assert 'Semaine du 13 au 19' in html
+    assert 'date=2026-07-09' in html    # semaine précédente
+    assert 'date=2026-07-23' in html    # semaine suivante
+    # Chaque jour est cliquable vers la vue quotidienne.
+    assert 'date=2026-07-14' in html and 'vue=jour' in html
+
+
+def test_vue_mois_marque_les_jours_reserves(auth_client, db, sample_users):
+    sid = _salle(db, 'Salle A')
+    _resa(db, sid, '2026-07-14')
+    _resa(db, sid, '2026-07-14', debut='14:00', fin='15:00')
+    html = auth_client.get('/salles?date=2026-07-01&vue=mois').get_data(as_text=True)
+    assert 'Juillet 2026' in html
+    assert html.count('salles-mois-marque') == 1        # un seul jour marqué
+    assert '2 reservation(s)' in html                    # avec le nombre
+    assert 'date=2026-06-01' in html                     # mois précédent
+    assert 'date=2026-08-01' in html                     # mois suivant
+    # Mois sans réservation : aucune marque.
+    html = auth_client.get('/salles?date=2026-09-01&vue=mois').get_data(as_text=True)
+    assert 'salles-mois-marque' not in html
+
+
+def test_date_ou_vue_invalide_retombe_proprement(auth_client, db, sample_users):
+    _salle(db, 'Salle A')
+    r = auth_client.get('/salles?date=zzz&vue=nimporte')
+    assert r.status_code == 200
+    assert 'salles-grid' in r.get_data(as_text=True)    # vue jour par défaut

--- a/tests/test_salles.py
+++ b/tests/test_salles.py
@@ -179,3 +179,9 @@ def test_date_ou_vue_invalide_retombe_proprement(auth_client, db, sample_users):
     r = auth_client.get('/salles?date=zzz&vue=nimporte')
     assert r.status_code == 200
     assert 'salles-grid' in r.get_data(as_text=True)    # vue jour par défaut
+    # Dates ISO valides mais aux bornes de Python : l'arithmétique de
+    # navigation (±1 jour, ±7 jours) déborderait → retombée sur aujourd'hui
+    # (revue Codex).
+    for borne in ('0001-01-01', '9999-12-31', '1970-01-01'):
+        r = auth_client.get(f'/salles?date={borne}&vue=semaine')
+        assert r.status_code == 200, borne


### PR DESCRIPTION
## Contexte

Trois retours utilisateurs sur la page Salles :
1. la vue quotidienne obligeait à sélectionner une date au calendrier — des flèches jour précédent/suivant seraient pratiques ;
2. une vue **hebdomadaire** est demandée, éventuellement une vue **mensuelle** avec une simple marque sur les jours ayant au moins une réservation ;
3. en vue quotidienne, afficher **en tête les salles réservées**, puis les autres.

## Changements

### Navigation (`blueprints/salles.py`, `templates/salles.html`)
- Onglets **Jour / Semaine / Mois** + flèches **← / →** (jour, semaine ou mois selon la vue) + bouton **« Aujourd'hui »**.
- La route parse désormais la date : une valeur mal formée retombe sur aujourd'hui, une vue inconnue retombe sur « jour ».

### Vue semaine
- Tableau **salles × 7 jours** (lundi → dimanche de la date choisie), réservations en pastilles colorées « HH:MM titre » (détail complet en infobulle), **jour courant surligné**, chaque en-tête de jour cliquable vers la vue quotidienne.

### Vue mois
- Calendrier du mois avec un **marqueur ● + nombre** sur chaque jour ayant au moins une réservation ; clic sur un jour → vue quotidienne ; légende sous le calendrier.

### Vue jour
- Les salles ayant au moins une réservation passent **en tête de la grille** (tri stable : ordre alphabétique conservé dans chaque groupe). Les sections d'administration et les formulaires gardent l'ordre alphabétique.
- La liste détaillée des réservations reste propre à la vue jour.

## Tests

`tests/test_salles.py` — 5 nouveaux cas : flèches et onglets présents ; salle réservée en tête (et retour à l'alphabétique un jour sans réservation) ; vue semaine (réservation du mardi visible depuis le jeudi de la même semaine, libellé « Semaine du 13 au 19 », navigation ±7 jours, jours cliquables) ; vue mois (un seul jour marqué avec compteur « 2 reservation(s) », mois vide sans marque, navigation ± mois) ; date/vue invalides → rendu propre en vue jour.

Vérifié en navigateur (Playwright) : captures des trois vues, navigation par flèche jour suivant, marqueurs mensuels corrects (4 jours marqués sur le jeu de données).

Suite complète verte (**931 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_