### PR TITLE
Salles : refonte visuelle de la vue semaine

### DIFF
--- a/blueprints/salles.py
+++ b/blueprints/salles.py
@@ -192,13 +192,19 @@ def salles():
             par_jour_salle = {}
             for r in resas_sem:
                 par_jour_salle.setdefault((r['date'], r['salle_id']), []).append(r)
+            # Même principe qu'en vue jour : les salles réservées cette
+            # semaine passent en tête (tri stable, alphabétique dans chaque
+            # groupe).
+            reservees_sem = {r['salle_id'] for r in resas_sem}
             semaine = {
                 'jours': [{'date': j.strftime('%Y-%m-%d'),
                            'libelle': JOURS_SEMAINE[j.weekday()],
                            'numero': j.day,
-                           'est_aujourdhui': j.date() == datetime.now().date()}
+                           'est_aujourdhui': j.date() == datetime.now().date(),
+                           'est_weekend': j.weekday() >= 5}
                           for j in jours],
                 'par_jour_salle': par_jour_salle,
+                'salles': sorted(salles_list, key=lambda s: s['id'] not in reservees_sem),
                 'date_prec': (date_obj - timedelta(days=7)).strftime('%Y-%m-%d'),
                 'date_suiv': (date_obj + timedelta(days=7)).strftime('%Y-%m-%d'),
             }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3137,6 +3137,40 @@ a.btn-icon:-webkit-any-link {
 /* ── Liste reservations ── */
 .salles-list { margin-top: 16px; }
 
+/* ── Vue semaine : grille salles x 7 jours ── */
+.salles-semaine-table {
+    width: 100%; table-layout: fixed; border-collapse: collapse;
+    background: var(--white, #fff); font-size: 0.8rem;
+}
+.salles-semaine-table col.salles-semaine-col-salle { width: 150px; }
+.salles-semaine-table th, .salles-semaine-table td {
+    border: 1px solid var(--gray-200); padding: 3px 4px; vertical-align: top;
+}
+.salles-semaine-table thead th {
+    background: var(--gray-100); text-align: center; padding: 7px 4px;
+    font-size: 0.82rem; color: var(--gray-700);
+}
+.salles-semaine-table thead th a { text-decoration: none; color: inherit; display: block; }
+.salles-semaine-table thead th a:hover { text-decoration: underline; }
+.salles-semaine-jour-actif { background: var(--primary) !important; }
+.salles-semaine-jour-actif, .salles-semaine-jour-actif a { color: #fff !important; }
+.salles-semaine-weekend { background: var(--gray-50); }
+.salles-semaine-salle {
+    font-weight: 600; color: var(--gray-700); white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis; vertical-align: middle !important;
+}
+.salles-semaine-salle a { color: var(--gray-700); text-decoration: none; }
+.salles-semaine-salle a:hover { color: var(--primary); text-decoration: underline; }
+.salles-semaine-table tbody tr:hover td { background: var(--gray-50); }
+.salles-semaine-table tbody tr:hover td.salles-semaine-weekend { background: var(--gray-100); }
+.salles-chip {
+    display: block; color: #fff; border-radius: 4px; padding: 2px 6px;
+    margin: 2px 0; font-size: 0.74rem; line-height: 1.35;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    opacity: 0.92; cursor: default;
+}
+.salles-chip:hover { opacity: 1; }
+
 /* ── Liens calendrier ── */
 .salles-calendrier-links {
     display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px;

--- a/templates/salles.html
+++ b/templates/salles.html
@@ -145,34 +145,38 @@
         </div>
 
         {% elif vue == 'semaine' %}
-        {# ── Vue semaine : salles x 7 jours ── #}
+        {# ── Vue semaine : grille salles x 7 jours (colonnes égales, salles
+             réservées en tête, week-end teinté) ── #}
         <div style="overflow-x:auto;">
-            <table class="salles-table" style="min-width:900px;">
+            <table class="salles-semaine-table" style="min-width:860px;">
+                <colgroup>
+                    <col class="salles-semaine-col-salle">
+                    {% for j in semaine.jours %}<col>{% endfor %}
+                </colgroup>
                 <thead>
                     <tr>
-                        <th style="min-width:130px;">Salle</th>
+                        <th style="text-align:left;">Salle</th>
                         {% for j in semaine.jours %}
-                        <th style="text-align:center;{% if j.est_aujourdhui %}background:var(--primary);color:#fff;{% endif %}">
+                        <th class="{% if j.est_aujourdhui %}salles-semaine-jour-actif{% elif j.est_weekend %}salles-semaine-weekend{% endif %}">
                             <a href="{{ url_for('salles_bp.salles', date=j.date, vue='jour') }}"
-                               style="text-decoration:none;{% if j.est_aujourdhui %}color:#fff;{% endif %}"
                                title="Voir la journee">{{ j.libelle[:3] }} {{ j.numero }}</a>
                         </th>
                         {% endfor %}
                     </tr>
                 </thead>
                 <tbody>
-                    {% for s in salles %}
+                    {% for s in semaine.salles %}
                     <tr>
-                        <td><span class="salles-color-dot" style="background:{{ s.couleur }};"></span>
-                            <a href="{{ url_for('salles_bp.calendrier_salle', salle_id=s.id) }}">{{ s.nom }}</a></td>
+                        <td class="salles-semaine-salle">
+                            <span class="salles-color-dot" style="background:{{ s.couleur }};"></span>
+                            <a href="{{ url_for('salles_bp.calendrier_salle', salle_id=s.id) }}">{{ s.nom }}</a>
+                        </td>
                         {% for j in semaine.jours %}
-                        <td style="vertical-align:top;font-size:0.78rem;">
+                        <td class="{% if j.est_weekend %}salles-semaine-weekend{% endif %}">
                             {% for r in semaine.par_jour_salle.get((j.date, s.id), []) %}
-                            <div style="background:{{ s.couleur }};color:#fff;border-radius:4px;
-                                        padding:1px 5px;margin:2px 0;white-space:nowrap;overflow:hidden;
-                                        text-overflow:ellipsis;max-width:140px;"
-                                 title="{{ r.titre }} ({{ r.heure_debut }}-{{ r.heure_fin }}) — {{ r.prenom }} {{ r.nom_user }}">
-                                {{ r.heure_debut }} {{ r.titre }}
+                            <div class="salles-chip" style="background:{{ s.couleur }};"
+                                 title="{{ r.titre }} ({{ r.heure_debut }}-{{ r.heure_fin }}) — {{ r.prenom }} {{ r.nom_user }}{% if r.description %}&#10;{{ r.description }}{% endif %}">
+                                <strong>{{ r.heure_debut }}</strong> {{ r.titre }}
                             </div>
                             {% endfor %}
                         </td>

--- a/tests/test_salles.py
+++ b/tests/test_salles.py
@@ -185,3 +185,14 @@ def test_date_ou_vue_invalide_retombe_proprement(auth_client, db, sample_users):
     for borne in ('0001-01-01', '9999-12-31', '1970-01-01'):
         r = auth_client.get(f'/salles?date={borne}&vue=semaine')
         assert r.status_code == 200, borne
+
+
+def test_vue_semaine_salles_reservees_en_tete(auth_client, db, sample_users):
+    """Même principe qu'en vue jour : la salle réservée dans la semaine passe
+    en tête du tableau hebdomadaire."""
+    _salle(db, 'Alpha')
+    zid = _salle(db, 'Zebre')
+    _resa(db, zid, '2026-07-14')
+    html = auth_client.get('/salles?date=2026-07-16&vue=semaine').get_data(as_text=True)
+    corps = html.split('salles-semaine-table')[1]
+    assert corps.index('Zebre') < corps.index('Alpha')


### PR DESCRIPTION
## Contexte

Retour utilisateur après fusion de #213 : avec un jeu de données réel (une douzaine de salles), la vue hebdomadaire était « bien moche » — colonnes de largeur inégale, aucune bordure de cellule (pastilles flottantes difficiles à rattacher à un jour), pastilles tronquées à 140 px, beaucoup de vide.

## Changements

- **Vraie grille** : `table-layout: fixed` (colonne salle 150 px + 7 colonnes de jours **égales**), **bordures de cellules**, en-têtes centrés, survol de ligne.
- **Week-end teinté** (samedi/dimanche) et **jour courant surligné** — classes dédiées `.salles-semaine-*` dans `style.css` (variables CSS compatibles thème sombre), suppression des styles en ligne.
- **Pastilles `.salles-chip`** pleine largeur de cellule : heure en gras + titre, ellipse propre, détail complet (horaires, auteur, description) en infobulle.
- **Salles réservées dans la semaine en tête** du tableau — même principe que la vue jour (tri stable, alphabétique dans chaque groupe) : les salles vides ne noient plus les réservations.

## Tests

- `test_vue_semaine_salles_reservees_en_tete` : la salle réservée passe devant dans le tableau hebdomadaire.
- Tests existants de la vue semaine inchangés et verts.
- Vérifié en navigateur (Playwright) sur un jeu dense de **13 salles** reproduisant la capture du retour : grille bordée, colonnes égales, salles réservées en tête, week-end teinté.

Suite complète verte (**932 tests**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGmZFtMgToSjcjJN58ARsp)_