### PR TITLE
Congés : vrai rôle du valideur (comptable) + pause méridienne rémunérée dans la saisie des heures

### DIFF
--- a/blueprints/dashboard.py
+++ b/blueprints/dashboard.py
@@ -51,7 +51,7 @@ def dashboard():
             SELECT date, heure_debut_matin, heure_fin_matin,
                    heure_debut_aprem, heure_fin_aprem,
                    heure_debut_soir, heure_fin_soir,
-                   commentaire, type_saisie, declaration_conforme
+                   commentaire, type_saisie, declaration_conforme, pause_remuneree
             FROM heures_reelles
             WHERE user_id = ?
             ORDER BY date DESC

--- a/blueprints/dashboard_comptable.py
+++ b/blueprints/dashboard_comptable.py
@@ -39,7 +39,7 @@ def dashboard_comptable():
         SELECT date, heure_debut_matin, heure_fin_matin,
                heure_debut_aprem, heure_fin_aprem,
                heure_debut_soir, heure_fin_soir,
-               commentaire, type_saisie, declaration_conforme
+               commentaire, type_saisie, declaration_conforme, pause_remuneree
         FROM heures_reelles
         WHERE user_id = ?
         ORDER BY date DESC

--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
-                   calculer_heures_reelles_jour, slot_horaire,
+                   calculer_heures_reelles_jour, duree_pause_meridienne, slot_horaire,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
                    total_hs_payees, est_dans_equipe_responsable)
 
@@ -177,20 +177,22 @@ def export_pdf_mensuel():
                     horaires_reels_str = "✓ Conforme"
                     heures_reelles_jour = heures_theo_jour
                 else:
-                    # Horaires saisis manuellement
+                    # Horaires saisis manuellement. Total via le calcul commun,
+                    # qui inclut la pause méridienne rémunérée le cas échéant
+                    # (le PDF signé doit coller à la vue mensuelle).
+                    heures_reelles_jour = calculer_heures_reelles_jour(h)
                     horaires_parts_reelles = []
                     if h['heure_debut_matin'] and h['heure_fin_matin']:
                         horaires_parts_reelles.append(f"{h['heure_debut_matin']}-{h['heure_fin_matin']}")
-                        heures_reelles_jour += calculer_heures(h['heure_debut_matin'], h['heure_fin_matin'])
                     if h['heure_debut_aprem'] and h['heure_fin_aprem']:
                         horaires_parts_reelles.append(f"{h['heure_debut_aprem']}-{h['heure_fin_aprem']}")
-                        heures_reelles_jour += calculer_heures(h['heure_debut_aprem'], h['heure_fin_aprem'])
                     if slot_horaire(h, 'heure_debut_soir') and slot_horaire(h, 'heure_fin_soir'):
                         horaires_parts_reelles.append(f"{h['heure_debut_soir']}-{h['heure_fin_soir']}")
-                        heures_reelles_jour += calculer_heures(h['heure_debut_soir'], h['heure_fin_soir'])
 
                     if horaires_parts_reelles:
                         horaires_reels_str = " / ".join(horaires_parts_reelles)
+                        if h.get('pause_remuneree') and duree_pause_meridienne(h) > 0:
+                            horaires_reels_str += " (+ pause)"
                     else:
                         horaires_reels_str = "Non saisi"
             else:

--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -230,7 +230,8 @@ def export_pdf_mensuel():
     heures_anterieures = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin,
                heure_debut_aprem, heure_fin_aprem,
-               heure_debut_soir, heure_fin_soir, declaration_conforme, type_saisie
+               heure_debut_soir, heure_fin_soir, declaration_conforme, type_saisie,
+               pause_remuneree
         FROM heures_reelles
         WHERE user_id = ? AND date < ?
         ORDER BY date

--- a/blueprints/prevention_sante.py
+++ b/blueprints/prevention_sante.py
@@ -74,7 +74,7 @@ def compute_prevention_messages(conn, user_id: int, today=None) -> list[Preventi
     rows = conn.execute(
         """
         SELECT date, heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem,
-               heure_debut_soir, heure_fin_soir, declaration_conforme
+               heure_debut_soir, heure_fin_soir, declaration_conforme, pause_remuneree
         FROM heures_reelles
         WHERE user_id = ? AND date >= ? AND date <= ?
         ORDER BY date

--- a/blueprints/recup.py
+++ b/blueprints/recup.py
@@ -7,7 +7,7 @@ from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date,
                    calculer_jours_ouvres, calculer_solde_recup, calculer_recup_partielle,
-                   NOMS_MOIS)
+                   slot_horaire, NOMS_MOIS)
 from email_service import (
     is_email_configured, peut_envoyer_email, notifier_nouvelle_demande_recup,
     notifier_demande_recup_validee_responsable, notifier_demande_recup_decision,
@@ -514,9 +514,11 @@ def validation_demandes_recup():
                         UPDATE {table}
                         SET statut = 'validee',
                             validation_direction = ?,
-                            date_validation_direction = ?
+                            date_validation_direction = ?,
+                            profil_validation_direction = ?
                         WHERE id = ? AND statut IN ('en_attente_direction', 'en_attente_responsable')
-                    ''', (f"{user_info['prenom']} {user_info['nom']}", now, demande_id))
+                    ''', (f"{user_info['prenom']} {user_info['nom']}", now,
+                          session.get('profil'), demande_id))
 
                     # Ne créer les effets de bord que si la mise à jour a effectivement changé le statut
                     if cursor.rowcount > 0:
@@ -826,8 +828,9 @@ def demande_conge():
                                         (session['user_id'],)).fetchone()
                 nom_valideur = f"{valideur['prenom']} {valideur['nom']}" if valideur else ''
                 conn.execute(
-                    'UPDATE demandes_conges SET validation_direction = ?, date_validation_direction = ? WHERE id = ?',
-                    (nom_valideur, datetime.now().strftime('%Y-%m-%d %H:%M:%S'), demande_id))
+                    'UPDATE demandes_conges SET validation_direction = ?, date_validation_direction = ?, '
+                    'profil_validation_direction = ? WHERE id = ?',
+                    (nom_valideur, datetime.now().strftime('%Y-%m-%d %H:%M:%S'), 'directeur', demande_id))
                 demande = {
                     'user_id': session['user_id'], 'type_conge': type_conge,
                     'date_debut': date_debut, 'date_fin': date_fin, 'nb_jours': nb_jours,
@@ -986,12 +989,15 @@ def demande_conge_pdf(demande_id):
     elements.append(table)
     elements.append(Spacer(1, 1.2 * cm))
 
-    # Signatures : Direction (pré-remplie si validée) + Comité de présidence.
+    # Signatures : Direction ou Comptable selon le valideur (pré-rempli si
+    # validée) + Comité de présidence.
     elements.append(Paragraph('SIGNATURES', heading_style))
     elements.append(Spacer(1, 0.3 * cm))
     nom_direction = demande['validation_direction'] or ''
+    profil_valideur = slot_horaire(demande, 'profil_validation_direction')
+    libelle_valideur = 'Comptable' if profil_valideur == 'comptable' else 'Direction'
     data_sig = [
-        ['Direction', 'Comité de présidence', 'Date'],
+        [libelle_valideur, 'Comité de présidence', 'Date'],
         ['', '', ''],
         [nom_direction, '', ''],
     ]

--- a/blueprints/rh_statistiques.py
+++ b/blueprints/rh_statistiques.py
@@ -82,7 +82,7 @@ def rh_statistiques():
                hr.heure_debut_matin, hr.heure_fin_matin,
                hr.heure_debut_aprem, hr.heure_fin_aprem,
                hr.heure_debut_soir, hr.heure_fin_soir,
-               hr.declaration_conforme
+               hr.declaration_conforme, hr.pause_remuneree
         FROM heures_reelles hr
         JOIN users u ON hr.user_id = u.id
         WHERE hr.date >= ?

--- a/blueprints/saisie.py
+++ b/blueprints/saisie.py
@@ -106,6 +106,7 @@ def saisie_heures():
             if not commentaire:
                 commentaire = 'Déclaration conforme au planning'
             declaration_conforme_val = 1
+            pause_remuneree_val = 0
         # Si récupération journée complète, on met tout à vide
         elif recup_journee == '1':
             heure_debut_matin = None
@@ -118,6 +119,7 @@ def saisie_heures():
             if not commentaire:
                 commentaire = 'Récupération journée complète'
             declaration_conforme_val = 0
+            pause_remuneree_val = 0
         else:
             heure_debut_matin = request.form.get('heure_debut_matin') or None
             heure_fin_matin = request.form.get('heure_fin_matin') or None
@@ -128,6 +130,9 @@ def saisie_heures():
             heure_fin_soir = request.form.get('heure_fin_soir') or None
             type_saisie = 'heures_modifiees'
             declaration_conforme_val = 0
+            # Pause méridienne rémunérée : prise sur place en restant à
+            # disposition (temps de travail effectif, art. L3121-2).
+            pause_remuneree_val = 1 if request.form.get('pause_remuneree') == '1' else 0
         
         try:
             action = 'modification' if anciennes_donnees else 'creation'
@@ -142,7 +147,8 @@ def saisie_heures():
                     'heure_debut_soir': slot_horaire(anciennes_donnees, 'heure_debut_soir'),
                     'heure_fin_soir': slot_horaire(anciennes_donnees, 'heure_fin_soir'),
                     'commentaire': anciennes_donnees['commentaire'],
-                    'type_saisie': anciennes_donnees['type_saisie']
+                    'type_saisie': anciennes_donnees['type_saisie'],
+                    'pause_remuneree': slot_horaire(anciennes_donnees, 'pause_remuneree')
                 })
 
             nouvelles_valeurs = json.dumps({
@@ -153,7 +159,8 @@ def saisie_heures():
                 'heure_debut_soir': heure_debut_soir,
                 'heure_fin_soir': heure_fin_soir,
                 'commentaire': commentaire,
-                'type_saisie': type_saisie
+                'type_saisie': type_saisie,
+                'pause_remuneree': pause_remuneree_val
             })
             
             # DÉTECTION DES ANOMALIES
@@ -180,6 +187,7 @@ def saisie_heures():
                         'heure_debut_matin': heure_debut_matin, 'heure_fin_matin': heure_fin_matin,
                         'heure_debut_aprem': heure_debut_aprem, 'heure_fin_aprem': heure_fin_aprem,
                         'heure_debut_soir': heure_debut_soir, 'heure_fin_soir': heure_fin_soir,
+                        'pause_remuneree': pause_remuneree_val,
                     })
 
                     ecart = abs(heures_apres - heures_avant)
@@ -228,6 +236,7 @@ def saisie_heures():
                         'heure_debut_matin': heure_debut_matin, 'heure_fin_matin': heure_fin_matin,
                         'heure_debut_aprem': heure_debut_aprem, 'heure_fin_aprem': heure_fin_aprem,
                         'heure_debut_soir': heure_debut_soir, 'heure_fin_soir': heure_fin_soir,
+                        'pause_remuneree': pause_remuneree_val,
                     })
 
                     ecart = abs(heures_apres - total_theorique)
@@ -246,11 +255,11 @@ def saisie_heures():
                 INSERT OR REPLACE INTO heures_reelles
                 (user_id, date, heure_debut_matin, heure_fin_matin,
                  heure_debut_aprem, heure_fin_aprem, heure_debut_soir, heure_fin_soir,
-                 commentaire, type_saisie, declaration_conforme)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 commentaire, type_saisie, declaration_conforme, pause_remuneree)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''', (user_id_cible, date, heure_debut_matin, heure_fin_matin,
                   heure_debut_aprem, heure_fin_aprem, heure_debut_soir, heure_fin_soir,
-                  commentaire, type_saisie, declaration_conforme_val))
+                  commentaire, type_saisie, declaration_conforme_val, pause_remuneree_val))
             
             # Enregistrer dans l'historique
             conn.execute('''

--- a/blueprints/suivi.py
+++ b/blueprints/suivi.py
@@ -73,7 +73,7 @@ def _get_score_category(score):
 def _calculate_surcharge_alert(conn, user, today, feries_set, planning_cache, type_periode_cache):
     rows = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin, heure_debut_aprem, heure_fin_aprem,
-               heure_debut_soir, heure_fin_soir, declaration_conforme
+               heure_debut_soir, heure_fin_soir, declaration_conforme, pause_remuneree
         FROM heures_reelles
         WHERE user_id = ? AND date <= ?
         ORDER BY date

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -7,7 +7,7 @@ import json
 from database import get_db
 from blueprints.delegations import MISSION_SUIVI_VALIDATIONS_RELANCES, user_has_delegation
 from utils import (login_required, get_user_info, calculer_heures,
-                    calculer_heures_reelles_jour, slot_horaire,
+                    calculer_heures_reelles_jour, duree_pause_meridienne, slot_horaire,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
                     total_hs_payees, est_dans_equipe_responsable)
 from app_options import get_option_bool
@@ -475,6 +475,7 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
             type_saisie = None
             commentaire = None
             non_declare = False
+            pause_remuneree_jour = False
 
             if date_str in heures_reelles:
                 h = heures_reelles[date_str]
@@ -487,6 +488,7 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
                 else:
                     est_saisi = True
                     heures_reelles_jour = calculer_heures_reelles_jour(h)
+                    pause_remuneree_jour = bool(h.get('pause_remuneree')) and duree_pause_meridienne(h) > 0
                     horaires_reels = _formater_horaires(
                         h['heure_debut_matin'],
                         h['heure_fin_matin'],
@@ -559,6 +561,7 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
                 'type_periode': type_periode,
                 'est_ferie': est_ferie,
                 'libelle_ferie': libelle_ferie,
+                'pause_remuneree': pause_remuneree_jour,
             })
 
         jour_actuel += timedelta(days=1)
@@ -576,7 +579,8 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
     heures_anterieures = conn.execute('''
         SELECT date, heure_debut_matin, heure_fin_matin,
                heure_debut_aprem, heure_fin_aprem,
-               heure_debut_soir, heure_fin_soir, declaration_conforme
+               heure_debut_soir, heure_fin_soir, declaration_conforme,
+               pause_remuneree
         FROM heures_reelles
         WHERE user_id = ? AND date < ?
         ORDER BY date

--- a/blueprints/worktime_metrics.py
+++ b/blueprints/worktime_metrics.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from utils import slot_horaire
+from utils import duree_pause_meridienne, slot_horaire
 
 
 MIN_BREAK_MINUTES = 20
@@ -173,7 +173,7 @@ def day_segments_from_planning(planning, date_obj) -> list[tuple[str, str]]:
     return segments
 
 
-def compute_segments_metrics(date_obj, segments: list[tuple[str, str]]):
+def compute_segments_metrics(date_obj, segments: list[tuple[str, str]], pause_remuneree: bool = False):
     metrics = {
         "worked_hours": 0.0,
         "start_at": None,
@@ -199,13 +199,20 @@ def compute_segments_metrics(date_obj, segments: list[tuple[str, str]]):
     if len(dt_segments) >= 2:
         break_seconds = (dt_segments[1][0] - dt_segments[0][1]).total_seconds()
         metrics["break_minutes"] = round(max(0, break_seconds) / 60, 2)
+        if pause_remuneree and break_seconds > 0:
+            # Pause méridienne rémunérée : le salarié est resté à disposition,
+            # ce temps est du travail effectif et compte dans les heures.
+            metrics["worked_hours"] = round(metrics["worked_hours"] + break_seconds / 3600, 2)
 
     longest_seconds = (dt_segments[0][1] - dt_segments[0][0]).total_seconds()
     current_seconds = longest_seconds
     for index in range(1, len(dt_segments)):
         gap_seconds = (dt_segments[index][0] - dt_segments[index - 1][1]).total_seconds()
         segment_seconds = (dt_segments[index][1] - dt_segments[index][0]).total_seconds()
-        if gap_seconds < MIN_BREAK_MINUTES * 60:
+        # La pause méridienne rémunérée a bien été prise (sur place) : elle
+        # coupe le travail consécutif même si elle dure moins de 20 minutes.
+        pause_prise = pause_remuneree and index == 1 and gap_seconds > 0
+        if gap_seconds < MIN_BREAK_MINUTES * 60 and not pause_prise:
             current_seconds += max(gap_seconds, 0) + segment_seconds
         else:
             longest_seconds = max(longest_seconds, current_seconds)
@@ -222,14 +229,23 @@ def compute_day_metrics(conn, user_id: int, row, planning_cache: dict, type_peri
     planned_segments = day_segments_from_planning(planning, date_obj)
     actual_segments = planned_segments if row["declaration_conforme"] else day_segments_from_row(row)
 
+    # Pause méridienne rémunérée : uniquement sur une saisie réelle avec
+    # créneaux matin et après-midi complets séparés par un écart positif.
+    pause_remuneree = (
+        bool(slot_horaire(row, "pause_remuneree"))
+        and not row["declaration_conforme"]
+        and duree_pause_meridienne(row) > 0
+    )
+
     planned_metrics = compute_segments_metrics(date_obj, planned_segments)
-    actual_metrics = compute_segments_metrics(date_obj, actual_segments)
+    actual_metrics = compute_segments_metrics(date_obj, actual_segments, pause_remuneree=pause_remuneree)
 
     theoretical_hours = planned_metrics["worked_hours"] if date_obj.weekday() < BUSINESS_DAYS_PER_WEEK else 0.0
     actual_hours = theoretical_hours if row["declaration_conforme"] else actual_metrics["worked_hours"]
 
     pause_reduced = (
-        planned_metrics["break_minutes"] is not None
+        not pause_remuneree
+        and planned_metrics["break_minutes"] is not None
         and actual_metrics["break_minutes"] is not None
         and actual_metrics["break_minutes"] < planned_metrics["break_minutes"]
     )
@@ -245,6 +261,7 @@ def compute_day_metrics(conn, user_id: int, row, planning_cache: dict, type_peri
         "break_minutes": actual_metrics["break_minutes"],
         "planned_break_minutes": planned_metrics["break_minutes"],
         "pause_reduced": pause_reduced,
+        "pause_remuneree": pause_remuneree,
         "longest_consecutive_hours": actual_metrics["longest_consecutive_hours"],
     }
 

--- a/database.py
+++ b/database.py
@@ -341,6 +341,7 @@ def init_db():
             commentaire TEXT,
             type_saisie TEXT DEFAULT 'heures_sup',
             declaration_conforme INTEGER DEFAULT 0,
+            pause_remuneree INTEGER DEFAULT 0,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (user_id) REFERENCES users(id),
             UNIQUE(user_id, date)
@@ -484,6 +485,7 @@ def init_db():
             date_validation_responsable TEXT,
             validation_direction TEXT,
             date_validation_direction TEXT,
+            profil_validation_direction TEXT,
             motif_refus TEXT,
             refuse_par INTEGER,
             date_refus TEXT,
@@ -508,6 +510,7 @@ def init_db():
             date_validation_responsable TEXT,
             validation_direction TEXT,
             date_validation_direction TEXT,
+            profil_validation_direction TEXT,
             motif_refus TEXT,
             refuse_par INTEGER,
             date_refus TEXT,
@@ -1872,6 +1875,21 @@ def init_db():
                 cursor.execute(f"SELECT {col} FROM planning_theorique LIMIT 1")
             except sqlite3.OperationalError:
                 cursor.execute(f"ALTER TABLE planning_theorique ADD COLUMN {col} TEXT")
+
+    # Migration 0058 : profil du valideur « direction » (directeur ou comptable)
+    # pour afficher le bon libellé à côté du nom. NULL sur l'existant.
+    for _table in ('demandes_conges', 'demandes_recup'):
+        try:
+            cursor.execute(f"SELECT profil_validation_direction FROM {_table} LIMIT 1")
+        except sqlite3.OperationalError:
+            cursor.execute(f"ALTER TABLE {_table} ADD COLUMN profil_validation_direction TEXT")
+
+    # Migration 0059 : pause méridienne rémunérée (salarié resté à disposition,
+    # ex. accueil de loisirs) comptée dans les heures travaillées.
+    try:
+        cursor.execute("SELECT pause_remuneree FROM heures_reelles LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE heures_reelles ADD COLUMN pause_remuneree INTEGER DEFAULT 0")
 
     # Migration : ajouter temps_hebdo si n'existe pas dans contrats
     try:

--- a/migrations/0058_profil_validation_direction.py
+++ b/migrations/0058_profil_validation_direction.py
@@ -1,0 +1,57 @@
+"""
+Migration 0058 : profil du valideur « direction » des demandes de congés/récup.
+
+Jusqu'ici, seul le nom du valideur de second niveau était stocké
+(`validation_direction`) ; le libellé « (direction) » était écrit en dur à
+l'affichage. Quand un(e) comptable validait une demande (en l'absence de la
+direction), son nom apparaissait donc à tort suivi de « (direction) ».
+
+On ajoute `profil_validation_direction` à `demandes_conges` et
+`demandes_recup` : renseigné à la validation ('directeur' ou 'comptable'),
+il permet d'afficher le bon libellé. Les lignes déjà validées sont remplies
+au mieux en retrouvant l'utilisateur par « Prénom Nom » parmi les profils
+habilités ; sans correspondance la colonne reste NULL et l'affichage
+retombe sur « (direction) » comme avant.
+"""
+
+NOM = "Profil du valideur direction/comptable des demandes"
+DESCRIPTION = (
+    "Ajoute demandes_conges.profil_validation_direction et "
+    "demandes_recup.profil_validation_direction (TEXT, nullable) : profil du "
+    "valideur de second niveau ('directeur' ou 'comptable') pour afficher le "
+    "bon libellé à côté de son nom. Backfill au mieux par correspondance "
+    "Prénom Nom sur les demandes déjà validées."
+)
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    import sqlite3
+    cursor = conn.cursor()
+    for table in ('demandes_conges', 'demandes_recup'):
+        try:
+            cursor.execute(f"SELECT profil_validation_direction FROM {table} LIMIT 1")
+        except sqlite3.OperationalError:
+            cursor.execute(f"ALTER TABLE {table} ADD COLUMN profil_validation_direction TEXT")
+
+        # Backfill au mieux : retrouver le valideur par « Prénom Nom » parmi les
+        # profils habilités à valider ce niveau. Idempotent (ne touche que les
+        # lignes encore NULL) ; sans correspondance, NULL → libellé historique.
+        cursor.execute(f'''
+            UPDATE {table}
+            SET profil_validation_direction = (
+                SELECT u.profil FROM users u
+                WHERE (u.prenom || ' ' || u.nom) = {table}.validation_direction
+                  AND u.profil IN ('directeur', 'comptable')
+            )
+            WHERE validation_direction IS NOT NULL
+              AND validation_direction != ''
+              AND profil_validation_direction IS NULL
+        ''')
+    conn.commit()
+
+
+def downgrade(conn):
+    """SQLite ne supporte pas DROP COLUMN simplement : downgrade non destructif
+    (la colonne reste, inerte tant que le code ne la lit pas)."""
+    pass

--- a/migrations/0059_pause_remuneree.py
+++ b/migrations/0059_pause_remuneree.py
@@ -1,0 +1,38 @@
+"""
+Migration 0059 : pause méridienne rémunérée dans la saisie des heures.
+
+Certains salariés (accueil de loisirs, crèche…) prennent leur pause sur
+place en restant à la disposition de l'employeur : ce temps est du travail
+effectif rémunéré (art. L3121-2 du Code du travail).
+
+On ajoute `pause_remuneree` à `heures_reelles` : à 1, le temps entre la fin
+du matin et le début de l'après-midi est compté dans les heures travaillées
+et ne déclenche pas d'alerte « pause manquante » (la pause a bien eu lieu,
+simplement sans quitter le poste). À 0 (défaut, et sur tout l'existant),
+comportement inchangé.
+"""
+
+NOM = "Pause méridienne rémunérée (saisie des heures)"
+DESCRIPTION = (
+    "Ajoute heures_reelles.pause_remuneree (INTEGER, défaut 0). À 1, la pause "
+    "entre le matin et l'après-midi est comptée dans les heures travaillées "
+    "(salarié resté à disposition) et ne génère pas d'alerte pause. "
+    "L'existant reste à 0 : aucun changement rétroactif."
+)
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    import sqlite3
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SELECT pause_remuneree FROM heures_reelles LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE heures_reelles ADD COLUMN pause_remuneree INTEGER DEFAULT 0")
+    conn.commit()
+
+
+def downgrade(conn):
+    """SQLite ne supporte pas DROP COLUMN simplement : downgrade non destructif
+    (la colonne reste, inerte tant que le code ne la lit pas)."""
+    pass

--- a/templates/historique_demandes_recup.html
+++ b/templates/historique_demandes_recup.html
@@ -114,7 +114,7 @@
                         {% endif %}
                         
                         {% if d.validation_direction %}
-                        <div style="color: var(--success); margin-top: 0.25rem;">✓ {{ d.validation_direction }} <small>(direction)</small></div>
+                        <div style="color: var(--success); margin-top: 0.25rem;">✓ {{ d.validation_direction }} <small>({{ 'comptable' if d.profil_validation_direction == 'comptable' else 'direction' }})</small></div>
                         <div style="color: var(--gray-500); font-size: 0.8rem;">{{ d.date_validation_direction[:10] if d.date_validation_direction else '' }}</div>
                         {% endif %}
                         

--- a/templates/mes_demandes_conges.html
+++ b/templates/mes_demandes_conges.html
@@ -73,7 +73,7 @@
                         {% endif %}
                         
                         {% if d.validation_direction %}
-                        <div style="color: var(--success); margin-top: 0.25rem;">✓ {{ d.validation_direction }} <small>(direction)</small></div>
+                        <div style="color: var(--success); margin-top: 0.25rem;">✓ {{ d.validation_direction }} <small>({{ 'comptable' if d.profil_validation_direction == 'comptable' else 'direction' }})</small></div>
                         <div style="color: var(--gray-500); font-size: 0.8rem;">{{ d.date_validation_direction[:10] if d.date_validation_direction else '' }}</div>
                         {% elif d.statut not in ['en_attente_responsable', 'refusee'] %}
                         <div style="color: var(--gray-400); margin-top: 0.25rem;">⏳ Direction</div>

--- a/templates/saisie_heures.html
+++ b/templates/saisie_heures.html
@@ -106,8 +106,19 @@
                 </div>
                 {% endif %}
             </div>
+
+            <div class="form-group" style="margin-top: 0.75rem;">
+                <label style="display: flex; align-items: center; flex-wrap: wrap;">
+                    <input type="checkbox" id="pause_remuneree" name="pause_remuneree" value="1"
+                           onchange="togglePauseRemuneree()"
+                           {% if heures_existantes and heures_existantes.pause_remuneree %}checked{% endif %}
+                           {% if heures_existantes and heures_existantes.type_saisie == 'recup_journee' %}disabled{% endif %}>
+                    <strong>☕ Pause rémunérée (pause prise sur place, en restant à disposition)</strong>
+                    <span class="ctx-help ctx-help--below" onclick="toggleCtxHelp(event, this)">?<span class="ctx-help-bubble">Réservé aux salariés qui prennent leur pause sans pouvoir s'absenter du poste (accueil de loisirs, crèche…). Le temps entre la fin du matin et le début de l'après-midi est alors compté dans les heures travaillées (temps de travail effectif, art. L3121-2 du Code du travail) et ne déclenche pas d'alerte pause.</span></span>
+                </label>
+            </div>
         </div>
-        
+
         <div style="display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; background: var(--gray-50); border-radius: 8px; margin-bottom: 1rem;">
             <span style="font-size: 1.2rem;">⏱️</span>
             <span style="font-size: 0.85rem; color: var(--gray-500);">Solde de récupération</span>
@@ -159,6 +170,40 @@
         </ul>
     </div>
 
+    {# ── Modale d'avertissement « pause rémunérée » ── #}
+    <div id="pauseRemunereeModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)fermerAvertissementPause()">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>⚠️ Pause rémunérée — à lire attentivement</h3>
+                <button class="modal-close" type="button" onclick="fermerAvertissementPause()" aria-label="Fermer">&times;</button>
+            </div>
+            <div style="padding:0 1.5rem 1.5rem;">
+                <p style="line-height:1.6;color:var(--gray-700);margin:0 0 0.75rem;">
+                    En cochant cette case, vous déclarez que votre pause a <strong>réellement été
+                    prise</strong>, mais sur votre lieu de travail, en restant à la disposition de
+                    l'employeur (accueil de loisirs, crèche…). Ce temps est alors compté dans vos
+                    heures travaillées — temps de travail effectif, article L3121-2 du Code du travail.
+                </p>
+                <p style="line-height:1.6;color:#991b1b;margin:0 0 0.75rem;">
+                    <strong>Cette case ne doit jamais servir à enregistrer une pause fictive.</strong>
+                    Si le planning ne vous a pas permis de prendre votre pause, ne la cochez pas et
+                    signalez-le à votre responsable : au-delà de 6 h de travail, une pause d'au moins
+                    20 minutes consécutives est un droit (article L3121-16 du Code du travail).
+                </p>
+                <p style="line-height:1.6;color:var(--gray-700);margin:0;">
+                    Ne pas prendre de pause, même ponctuellement et plus encore de façon répétée,
+                    présente des <strong>risques réels pour la santé</strong> (source INRS) : baisse de
+                    vigilance et de concentration favorisant erreurs et accidents du travail, fatigue
+                    physique et mentale, troubles musculo-squelettiques (TMS), stress et, à la longue,
+                    épuisement professionnel (burn-out) et troubles cardiovasculaires.
+                </p>
+                <div class="actions" style="margin-top:1.25rem;">
+                    <button type="button" class="btn btn-primary" onclick="fermerAvertissementPause()">J'ai compris</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script>
     /* Aide contextuelle : toggle au clic, ferme au clic extérieur */
     function toggleCtxHelp(e, el) {
@@ -180,12 +225,13 @@
         const declarationCheckbox = document.getElementById('declaration_conforme');
         const recupCheckbox = document.getElementById('recup_journee');
         const detailHeures = document.getElementById('saisie-heures-detail');
+        const pauseCheckbox = document.getElementById('pause_remuneree');
         const inputs = detailHeures.querySelectorAll('input[type="time"], textarea');
 
         if (!declarationCheckbox) {
             return;
         }
-        
+
         if (declarationCheckbox.checked) {
             // Désactiver la récupération et les champs d'heures
             recupCheckbox.disabled = true;
@@ -195,6 +241,10 @@
                 input.disabled = true;
                 input.value = '';
             });
+            if (pauseCheckbox) {
+                pauseCheckbox.disabled = true;
+                pauseCheckbox.checked = false;
+            }
         } else {
             // Réactiver la récupération et les champs d'heures
             recupCheckbox.disabled = false;
@@ -202,15 +252,19 @@
             inputs.forEach(input => {
                 input.disabled = false;
             });
+            if (pauseCheckbox) {
+                pauseCheckbox.disabled = false;
+            }
         }
     }
-    
+
     function toggleRecupJournee() {
         const checkbox = document.getElementById('recup_journee');
         const declarationCheckbox = document.getElementById('declaration_conforme');
         const detailHeures = document.getElementById('saisie-heures-detail');
+        const pauseCheckbox = document.getElementById('pause_remuneree');
         const inputs = detailHeures.querySelectorAll('input[type="time"]');
-        
+
         if (checkbox.checked) {
             // Désactiver la déclaration conforme et les champs d'heures
             if (declarationCheckbox) {
@@ -222,6 +276,10 @@
                 input.disabled = true;
                 input.value = '';
             });
+            if (pauseCheckbox) {
+                pauseCheckbox.disabled = true;
+                pauseCheckbox.checked = false;
+            }
         } else {
             // Réactiver la déclaration conforme et les champs d'heures
             if (declarationCheckbox) {
@@ -231,8 +289,37 @@
             inputs.forEach(input => {
                 input.disabled = false;
             });
+            if (pauseCheckbox) {
+                pauseCheckbox.disabled = false;
+            }
         }
     }
+
+    // Pause rémunérée : avertissement à chaque coche — la pause doit avoir
+    // réellement eu lieu, jamais une pause fictive.
+    function togglePauseRemuneree() {
+        const checkbox = document.getElementById('pause_remuneree');
+        const modal = document.getElementById('pauseRemunereeModal');
+        if (checkbox && checkbox.checked && modal) {
+            modal.style.display = 'flex';
+        }
+    }
+
+    function fermerAvertissementPause() {
+        const modal = document.getElementById('pauseRemunereeModal');
+        if (modal) modal.style.display = 'none';
+    }
+
+    // La modale doit être enfant direct de <body> : ses conteneurs (.form-container)
+    // portent une animation dont le transform persistant piégerait le position:fixed.
+    (function () {
+        const modal = document.getElementById('pauseRemunereeModal');
+        if (modal) document.body.appendChild(modal);
+    })();
+
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') fermerAvertissementPause();
+    });
 
     // Affiche/masque le 3e créneau optionnel « soir » et active/désactive ses champs.
     function toggleSoir() {

--- a/templates/vue_mensuelle.html
+++ b/templates/vue_mensuelle.html
@@ -211,6 +211,7 @@
                                 {% else %}
                                 {{ "%.1f"|format(j.heures_reelles) }}h
                                 {% endif %}
+                                {% if j.pause_remuneree %}<span title="Pause méridienne rémunérée : prise sur place en restant à disposition, comptée dans les heures travaillées">☕</span>{% endif %}
                             </strong>
                             <span class="month-mobile-hours-gap {% if j.ecart > 0 %}is-positive{% elif j.ecart < 0 %}is-negative{% endif %}">
                                 {% if j.ecart > 0 %}
@@ -407,6 +408,9 @@
                             {{ j.horaires_reels }}
                             {% else %}
                             {{ "%.2f"|format(j.heures_reelles) }}h
+                            {% endif %}
+                            {% if j.pause_remuneree %}
+                            <span title="Pause méridienne rémunérée : prise sur place en restant à disposition, comptée dans les heures travaillées" style="cursor: help;">☕</span>
                             {% endif %}
                         </td>
                         <td data-label="Écart">

--- a/tests/test_pause_remuneree.py
+++ b/tests/test_pause_remuneree.py
@@ -159,3 +159,55 @@ class TestSaisiePauseRemuneree:
         html = auth_client.get('/vue_mensuelle?mois=6&annee=2025').get_data(as_text=True)
         assert 'Pause méridienne rémunérée' in html
         assert '☕' in html
+
+
+def _texte_pdf(data):
+    """Concatène les flux décompressés du PDF (le texte y est en clair).
+
+    ReportLab encode ses flux en ASCII85 puis Flate ; on tente les deux
+    décodages (a85 -> zlib, puis zlib direct) et on ignore le reste (polices…).
+    """
+    import base64
+    import re
+    import zlib
+    morceaux = []
+    for m in re.findall(rb'stream\r?\n(.*?)endstream', data, re.S):
+        m = m.strip()
+        for decode in (lambda b: zlib.decompress(base64.a85decode(b, adobe=True)),
+                       zlib.decompress):
+            try:
+                morceaux.append(decode(m))
+                break
+            except Exception:
+                continue
+    return b''.join(morceaux)
+
+
+class TestExportPdfPauseRemuneree:
+    """Le PDF mensuel signé doit inclure la pause rémunérée dans les totaux,
+    comme la vue mensuelle (revue Codex sur la PR #215)."""
+
+    DATE = '2025-06-16'
+
+    def test_pdf_mensuel_compte_la_pause_remuneree(self, auth_client, app, db, sample_users):
+        uid = sample_users['salarie_id']
+        with app.app_context():
+            db.execute(
+                "INSERT INTO heures_reelles (user_id, date, heure_debut_matin, heure_fin_matin, "
+                "heure_debut_aprem, heure_fin_aprem, type_saisie, declaration_conforme, pause_remuneree) "
+                "VALUES (?, ?, '09:00', '12:40', '13:00', '17:00', 'heures_modifiees', 0, 1)",
+                (uid, self.DATE))
+            # Le PDF n'est disponible que pour un mois validé/bloqué.
+            db.execute('''INSERT INTO validations (user_id, mois, annee, validation_salarie,
+                          validation_responsable, validation_directeur, bloque)
+                          VALUES (?, 6, 2025, 'Jean M.', 'Marie D.', 'Dir', 1)''', (uid,))
+            db.commit()
+
+        r = auth_client.get(f'/export_pdf_mensuel?user_id={uid}&mois=6&annee=2025')
+        assert r.status_code == 200
+        assert r.data[:4] == b'%PDF'
+        texte = _texte_pdf(r.data)
+        assert b'8.00h' in texte        # 3h40 + 4h + pause 20 min, comme la vue mensuelle
+        assert b'7.67' not in texte     # l'ancien total sans la pause ne doit plus apparaître
+        # Marqueur sur la ligne du jour (les parenthèses sont échappées dans le flux PDF).
+        assert b'+ pause' in texte

--- a/tests/test_pause_remuneree.py
+++ b/tests/test_pause_remuneree.py
@@ -1,0 +1,161 @@
+"""
+Tests de la pause méridienne rémunérée (case à cocher de la saisie des heures).
+
+Certains salariés (accueil de loisirs, crèche…) prennent leur pause sur place
+en restant à la disposition de l'employeur : ce temps est du travail effectif
+(art. L3121-2). Quand la case est cochée, l'écart entre la fin du matin et le
+début de l'après-midi est compté dans les heures travaillées et ne déclenche
+pas d'alerte « pause manquante » — la pause a bien eu lieu.
+"""
+from datetime import date
+
+from utils import calculer_heures_reelles_jour, duree_pause_meridienne
+from blueprints.prevention_sante import compute_prevention_messages
+from blueprints.worktime_metrics import compute_segments_metrics
+
+
+class TestCalculPauseRemuneree:
+    ROW = {
+        'heure_debut_matin': '09:00', 'heure_fin_matin': '12:40',   # 3h40
+        'heure_debut_aprem': '13:00', 'heure_fin_aprem': '17:00',   # 4h, pause 20 min
+    }
+
+    def test_duree_pause_meridienne(self):
+        assert duree_pause_meridienne(self.ROW) == 0.33
+
+    def test_total_sans_flag_exclut_la_pause(self):
+        assert calculer_heures_reelles_jour(self.ROW) == 7.67
+
+    def test_total_avec_flag_inclut_la_pause(self):
+        row = dict(self.ROW, pause_remuneree=1)
+        assert calculer_heures_reelles_jour(row) == 8.0
+
+    def test_flag_sans_apres_midi_sans_effet(self):
+        # Pas de créneau après-midi : aucune pause méridienne à rémunérer.
+        row = {'heure_debut_matin': '09:00', 'heure_fin_matin': '12:40',
+               'pause_remuneree': 1}
+        assert calculer_heures_reelles_jour(row) == 3.67
+
+    def test_horaires_incoherents_ignores(self):
+        # Début d'après-midi antérieur à la fin du matin : la « pause » négative
+        # ne doit ni compter ni basculer sur le lendemain (+24h).
+        row = {'heure_debut_matin': '09:00', 'heure_fin_matin': '13:00',
+               'heure_debut_aprem': '12:30', 'heure_fin_aprem': '17:00',
+               'pause_remuneree': 1}
+        assert duree_pause_meridienne(row) == 0
+        assert calculer_heures_reelles_jour(row) == 8.5  # 4h + 4h30, sans pause
+
+
+class TestMetriquesPauseRemuneree:
+    """La pause rémunérée compte dans les heures ET vaut pause prise
+    (pas d'alerte « plus de 6h consécutives »)."""
+
+    def test_flag_compte_la_pause_et_coupe_le_travail_consecutif(self):
+        segments = [('08:00', '12:00'), ('12:15', '16:45')]  # pause 15 min
+        sans = compute_segments_metrics(date(2025, 6, 16), segments)
+        assert sans['worked_hours'] == 8.5
+        assert sans['break_minutes'] == 15.0
+        # Pause < 20 min : le travail est considéré comme continu (8h45).
+        assert sans['longest_consecutive_hours'] == 8.75
+
+        avec = compute_segments_metrics(date(2025, 6, 16), segments, pause_remuneree=True)
+        assert avec['worked_hours'] == 8.75          # la pause est payée
+        assert avec['break_minutes'] == 15.0
+        assert avec['longest_consecutive_hours'] == 4.5  # la pause prise coupe
+
+    def test_flag_ne_paye_que_la_pause_meridienne(self):
+        # L'écart après-midi → soir reste exclu des heures travaillées.
+        segments = [('08:00', '12:00'), ('12:15', '16:00'), ('18:00', '20:00')]
+        m = compute_segments_metrics(date(2025, 6, 16), segments, pause_remuneree=True)
+        assert m['worked_hours'] == 10.0             # 4 + 3.75 + 2 + 0.25
+        assert m['longest_consecutive_hours'] == 4.0
+
+
+class TestPreventionPauseRemuneree:
+    """Journée > 6h avec pause courte : alerte sans le flag, silence avec."""
+
+    DATE = '2025-06-16'   # lundi
+    TODAY = date(2025, 6, 17)
+
+    def _inserer_jour(self, db, user_id, pause_remuneree):
+        db.execute(
+            "INSERT INTO heures_reelles (user_id, date, heure_debut_matin, heure_fin_matin, "
+            "heure_debut_aprem, heure_fin_aprem, type_saisie, declaration_conforme, pause_remuneree) "
+            "VALUES (?, ?, '08:00', '12:00', '12:15', '16:45', 'heures_modifiees', 0, ?)",
+            (user_id, self.DATE, pause_remuneree))
+        db.commit()
+
+    def test_pause_courte_alerte_sans_flag(self, app, db, sample_users):
+        with app.app_context():
+            self._inserer_jour(db, sample_users['salarie_id'], 0)
+            messages = compute_prevention_messages(db, sample_users['salarie_id'], today=self.TODAY)
+        assert any('s2_pause_courte' in m.key for m in messages)
+
+    def test_pause_remuneree_supprime_l_alerte(self, app, db, sample_users):
+        with app.app_context():
+            self._inserer_jour(db, sample_users['salarie_id'], 1)
+            messages = compute_prevention_messages(db, sample_users['salarie_id'], today=self.TODAY)
+        assert not any('s1_no_pause' in m.key or 's2_pause_courte' in m.key for m in messages)
+
+
+class TestSaisiePauseRemuneree:
+    DATE = '2025-06-16'
+
+    def test_saisie_enregistre_la_pause_remuneree(self, auth_client, app, db, sample_users):
+        with app.app_context():
+            auth_client.post('/saisie_heures', data={
+                'date': self.DATE,
+                'heure_debut_matin': '09:00', 'heure_fin_matin': '12:40',
+                'heure_debut_aprem': '13:00', 'heure_fin_aprem': '17:00',
+                'pause_remuneree': '1',
+            }, follow_redirects=True)
+            row = db.execute("SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?",
+                             (sample_users['salarie_id'], self.DATE)).fetchone()
+        assert row['pause_remuneree'] == 1
+        assert calculer_heures_reelles_jour(row) == 8.0
+
+    def test_saisie_sans_case_reste_a_zero(self, auth_client, app, db, sample_users):
+        with app.app_context():
+            auth_client.post('/saisie_heures', data={
+                'date': self.DATE,
+                'heure_debut_matin': '09:00', 'heure_fin_matin': '12:40',
+                'heure_debut_aprem': '13:00', 'heure_fin_aprem': '17:00',
+            }, follow_redirects=True)
+            row = db.execute("SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?",
+                             (sample_users['salarie_id'], self.DATE)).fetchone()
+        assert row['pause_remuneree'] == 0
+
+    def test_recup_journee_ignore_la_pause(self, auth_client, app, db, sample_users):
+        # Une récup journée n'a pas d'heures : le flag est remis à zéro même si envoyé.
+        with app.app_context():
+            auth_client.post('/saisie_heures', data={
+                'date': self.DATE,
+                'recup_journee': '1',
+                'pause_remuneree': '1',
+            }, follow_redirects=True)
+            row = db.execute("SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?",
+                             (sample_users['salarie_id'], self.DATE)).fetchone()
+        assert row['type_saisie'] == 'recup_journee'
+        assert row['pause_remuneree'] == 0
+
+    def test_formulaire_affiche_case_et_avertissement(self, auth_client):
+        html = auth_client.get(f'/saisie_heures?date={self.DATE}').get_data(as_text=True)
+        assert 'id="pause_remuneree"' in html
+        assert 'id="pauseRemunereeModal"' in html
+        # Le message d'avertissement : sincérité, cadre légal et risques santé.
+        assert 'pause fictive' in html
+        assert 'L3121-16' in html
+        assert 'L3121-2' in html
+        assert 'troubles musculo-squelettiques' in html
+
+    def test_vue_mensuelle_signale_la_pause_remuneree(self, auth_client, app, db, sample_users):
+        with app.app_context():
+            db.execute(
+                "INSERT INTO heures_reelles (user_id, date, heure_debut_matin, heure_fin_matin, "
+                "heure_debut_aprem, heure_fin_aprem, type_saisie, declaration_conforme, pause_remuneree) "
+                "VALUES (?, ?, '09:00', '12:40', '13:00', '17:00', 'heures_modifiees', 0, 1)",
+                (sample_users['salarie_id'], self.DATE))
+            db.commit()
+        html = auth_client.get('/vue_mensuelle?mois=6&annee=2025').get_data(as_text=True)
+        assert 'Pause méridienne rémunérée' in html
+        assert '☕' in html

--- a/tests/test_profil_valideur_conges.py
+++ b/tests/test_profil_valideur_conges.py
@@ -1,0 +1,156 @@
+"""
+Tests du libellé du valideur de second niveau des demandes (direction / comptable).
+
+Le nom du valideur était affiché avec un libellé « (direction) » codé en dur :
+quand un(e) comptable validait une demande (en l'absence de la direction), son
+nom apparaissait à tort comme « direction ». Le profil du valideur est
+désormais stocké à la validation (profil_validation_direction) et le libellé
+s'y adapte partout (pages, PDF).
+"""
+
+
+def _creer_demande_conge(db, user_id, statut='en_attente_direction'):
+    cur = db.execute('''
+        INSERT INTO demandes_conges
+        (user_id, type_conge, date_debut, date_fin, nb_jours, statut)
+        VALUES (?, 'Congé payé', '2025-08-04', '2025-08-08', 5, ?)
+    ''', (user_id, statut))
+    db.commit()
+    return cur.lastrowid
+
+
+def _valider(client, demande_id):
+    return client.post('/validation_demandes_recup', data={
+        'demande_id': demande_id,
+        'action': 'valider',
+        'demande_type': 'conge',
+    }, follow_redirects=True)
+
+
+def test_validation_par_comptable_stocke_son_profil(comptable_client, app, db,
+                                                    sample_users, sample_planning):
+    with app.app_context():
+        demande_id = _creer_demande_conge(db, sample_users['salarie_id'])
+    response = _valider(comptable_client, demande_id)
+    assert response.status_code == 200
+
+    with app.app_context():
+        dem = db.execute('SELECT * FROM demandes_conges WHERE id = ?', (demande_id,)).fetchone()
+    assert dem['statut'] == 'validee'
+    assert dem['validation_direction'] == 'Sophie Durand'
+    assert dem['profil_validation_direction'] == 'comptable'
+
+
+def test_validation_par_directeur_stocke_son_profil(admin_client, app, db,
+                                                    sample_users, sample_planning):
+    with app.app_context():
+        demande_id = _creer_demande_conge(db, sample_users['salarie_id'])
+    _valider(admin_client, demande_id)
+
+    with app.app_context():
+        dem = db.execute('SELECT * FROM demandes_conges WHERE id = ?', (demande_id,)).fetchone()
+    assert dem['statut'] == 'validee'
+    assert dem['profil_validation_direction'] == 'directeur'
+
+
+def test_auto_validation_directeur_stocke_son_profil(admin_client, app, db):
+    # Un directeur qui pose son propre congé est auto-validé « direction ».
+    admin_client.post('/demande_conge', data={
+        'type_conge': 'Congé payé', 'date_debut': '2026-06-02', 'date_fin': '2026-06-02',
+    }, follow_redirects=True)
+    with app.app_context():
+        dem = db.execute('SELECT * FROM demandes_conges ORDER BY id DESC LIMIT 1').fetchone()
+    assert dem['statut'] == 'validee'
+    assert dem['profil_validation_direction'] == 'directeur'
+
+
+def test_libelle_comptable_sur_mes_demandes_conges(client, app, db,
+                                                   sample_users, sample_planning):
+    """Le salarié doit voir « (comptable) » — pas « (direction) » — quand
+    c'est la comptabilité qui a validé sa demande."""
+    with app.app_context():
+        demande_id = _creer_demande_conge(db, sample_users['salarie_id'])
+
+    # La comptable valide la demande…
+    client.post('/login', data={'login': 'compta_test', 'password': 'compta123'},
+                follow_redirects=True)
+    _valider(client, demande_id)
+    client.get('/logout', follow_redirects=True)
+
+    # … puis le salarié consulte ses demandes.
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    html = client.get('/mes_demandes_conges').get_data(as_text=True)
+    assert 'Sophie Durand' in html
+    assert '(comptable)' in html
+    assert '(direction)' not in html
+
+
+def test_libelle_direction_conserve_pour_un_directeur(client, app, db,
+                                                      sample_users, sample_planning):
+    with app.app_context():
+        demande_id = _creer_demande_conge(db, sample_users['salarie_id'])
+
+    client.post('/login', data={'login': 'admin', 'password': 'Admin1234'},
+                follow_redirects=True)
+    _valider(client, demande_id)
+    client.get('/logout', follow_redirects=True)
+
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    html = client.get('/mes_demandes_conges').get_data(as_text=True)
+    assert '(direction)' in html
+    assert '(comptable)' not in html
+
+
+def test_pdf_conge_valide_par_comptable(comptable_client, app, db,
+                                        sample_users, sample_planning):
+    """Le PDF d'une demande validée par la comptabilité doit s'éditer sans
+    erreur (colonne de signature « Comptable »)."""
+    with app.app_context():
+        demande_id = _creer_demande_conge(db, sample_users['salarie_id'])
+    _valider(comptable_client, demande_id)
+
+    r = comptable_client.get(f'/demande_conge/{demande_id}/pdf')
+    assert r.status_code == 200
+    assert r.headers['Content-Type'] == 'application/pdf'
+    assert r.get_data()[:4] == b'%PDF'
+
+
+def test_backfill_migration_retrouve_le_profil(app, db, sample_users):
+    """La migration 0058 renseigne le profil des demandes déjà validées en
+    retrouvant le valideur par « Prénom Nom » (NULL si inconnu)."""
+    with app.app_context():
+        cur = db.execute('''
+            INSERT INTO demandes_conges
+            (user_id, type_conge, date_debut, date_fin, nb_jours, statut,
+             validation_direction, profil_validation_direction)
+            VALUES (?, 'Congé payé', '2025-03-03', '2025-03-04', 2, 'validee',
+                    'Sophie Durand', NULL)
+        ''', (sample_users['salarie_id'],))
+        connue_id = cur.lastrowid
+        cur = db.execute('''
+            INSERT INTO demandes_conges
+            (user_id, type_conge, date_debut, date_fin, nb_jours, statut,
+             validation_direction, profil_validation_direction)
+            VALUES (?, 'Congé payé', '2025-03-05', '2025-03-06', 2, 'validee',
+                    'Personne Partie', NULL)
+        ''', (sample_users['salarie_id'],))
+        inconnue_id = cur.lastrowid
+        db.commit()
+
+        import importlib.util
+        import os
+        chemin = os.path.join(os.path.dirname(__file__), '..', 'migrations',
+                              '0058_profil_validation_direction.py')
+        spec = importlib.util.spec_from_file_location('migration_0058_test', chemin)
+        migration = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(migration)
+        migration.upgrade(db)
+
+        connue = db.execute('SELECT profil_validation_direction FROM demandes_conges WHERE id = ?',
+                            (connue_id,)).fetchone()
+        inconnue = db.execute('SELECT profil_validation_direction FROM demandes_conges WHERE id = ?',
+                              (inconnue_id,)).fetchone()
+    assert connue['profil_validation_direction'] == 'comptable'
+    assert inconnue['profil_validation_direction'] is None

--- a/utils.py
+++ b/utils.py
@@ -193,17 +193,44 @@ def slot_horaire(row, key):
         return None
 
 
+def duree_pause_meridienne(row):
+    """Durée (heures) de la pause entre la fin du matin et le début de l'après-midi.
+
+    0 si l'un des deux créneaux est incomplet ou si les horaires sont
+    incohérents (début d'après-midi antérieur ou égal à la fin du matin).
+    """
+    fin_matin = slot_horaire(row, 'heure_fin_matin')
+    debut_aprem = slot_horaire(row, 'heure_debut_aprem')
+    if not (slot_horaire(row, 'heure_debut_matin') and fin_matin
+            and debut_aprem and slot_horaire(row, 'heure_fin_aprem')):
+        return 0
+    try:
+        fmt = '%H:%M'
+        pause = (datetime.strptime(debut_aprem, fmt)
+                 - datetime.strptime(fin_matin, fmt)).total_seconds() / 3600
+    except ValueError:
+        logger.warning("Format d'horaire invalide: %s - %s", fin_matin, debut_aprem)
+        return 0
+    return round(pause, 2) if pause > 0 else 0
+
+
 def calculer_heures_reelles_jour(row):
     """Total d'heures d'une saisie (heures_reelles) : matin + après-midi + soir.
 
     Le créneau « soir » (optionnel, personnel d'entretien en vacances) est
     additionné aux deux créneaux habituels ; absent/vide, il compte pour 0.
+    Si la pause méridienne est rémunérée (salarié resté à disposition sur
+    place, art. L3121-2 : temps de travail effectif), elle est comptée dans
+    le total.
     """
-    return (
+    total = (
         calculer_heures(slot_horaire(row, 'heure_debut_matin'), slot_horaire(row, 'heure_fin_matin'))
         + calculer_heures(slot_horaire(row, 'heure_debut_aprem'), slot_horaire(row, 'heure_fin_aprem'))
         + calculer_heures(slot_horaire(row, 'heure_debut_soir'), slot_horaire(row, 'heure_fin_soir'))
     )
+    if slot_horaire(row, 'pause_remuneree'):
+        total += duree_pause_meridienne(row)
+    return round(total, 2)
 
 
 def get_heures_theoriques_jour(planning, jour_semaine):
@@ -645,7 +672,8 @@ def calculer_solde_recup(user_id):
         heures = conn.execute('''
             SELECT date, heure_debut_matin, heure_fin_matin,
                    heure_debut_aprem, heure_fin_aprem,
-                   heure_debut_soir, heure_fin_soir, declaration_conforme
+                   heure_debut_soir, heure_fin_soir, declaration_conforme,
+                   pause_remuneree
             FROM heures_reelles
             WHERE user_id = ?
             ORDER BY date


### PR DESCRIPTION
## Résumé

Deux demandes traitées :

### 1. Libellé du valideur des demandes de congés/récup

Quand un(e) **comptable** validait une demande (en l'absence de la direction), son nom s'affichait bien mais suivi de « **(direction)** » codé en dur.

- Nouvelle colonne `profil_validation_direction` sur `demandes_conges` et `demandes_recup` (migration **0058**), renseignée à la validation (`directeur` ou `comptable`).
- **Backfill au mieux** des demandes déjà validées (correspondance « Prénom Nom » parmi les profils habilités ; sans correspondance → NULL → libellé « (direction) » comme avant).
- Affichage adapté : « (comptable) » ou « (direction) » sur *Mes demandes de congés*, l'*historique des demandes*, et dans le **PDF** (en-tête de la colonne de signature « Comptable » / « Direction »).

### 2. Pause méridienne rémunérée (saisie des heures)

Pour les salariés qui prennent leur pause **sur place en restant à disposition** (accueil de loisirs, crèche…) :

- Nouvelle case « ☕ Pause rémunérée » dans la saisie des heures (colonne `pause_remuneree`, migration **0059**).
- Cochée, la pause entre le matin et l'après-midi est **comptée dans les heures travaillées** (temps de travail effectif, art. L3121-2) : totaux journaliers, vue mensuelle, solde de récupération, exports, calculs d'anomalies.
- Les alertes « pause manquante / pause courte / pause réduite » (prévention santé salarié + score de surcharge direction) **ne se déclenchent plus** pour ces journées : la pause a bien eu lieu. Garde-fou conservé : un créneau unique de plus de 6 h sans aucune coupure continue d'alerter.
- À chaque coche, une **modale d'avertissement** rappelle que la pause doit avoir réellement été prise, que le dispositif ne doit jamais servir à enregistrer une **pause fictive** (pause de 20 min consécutives due au-delà de 6 h de travail, art. L3121-16), et cite les **risques santé** de l'absence de pause (source INRS) : baisse de vigilance et de concentration (erreurs, accidents du travail), fatigue, TMS, stress, burn-out, troubles cardiovasculaires.
- Badge ☕ en vue mensuelle (desktop + mobile) pour que la direction comprenne le total lors de la validation.
- La case est remise à zéro côté serveur pour une « déclaration conforme » ou une « récup journée », et désactivée côté client dans ces modes.

## Migrations

À appliquer via la page Administration : **0058** (profil valideur + backfill) et **0059** (pause rémunérée). `database.py` inclut aussi les garde-fous d'auto-mise à niveau au démarrage, comme pour les migrations précédentes.

## Tests

- `tests/test_profil_valideur_conges.py` : validation par comptable/directeur, auto-validation directeur, libellés rendus, PDF, backfill de la migration 0058.
- `tests/test_pause_remuneree.py` : calculs (avec/sans flag, horaires incohérents), métriques (pause payée comptée + coupure du travail consécutif), messages de prévention (alerte sans flag, silence avec), persistance POST, formulaire, badge vue mensuelle.
- **Suite complète : 953 tests OK.**
- Vérification navigateur (Playwright) : modale affichée à la coche avec le texte attendu, fermeture « J'ai compris », persistance de la case, total 8h00 et badge ☕ en vue mensuelle, interaction avec « récup journée ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_