### PR TITLE
Budget prévisionnel : ajout manuel d'un compte au budget (secteur et global)

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -817,7 +817,23 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
         monthly[compte][an][mois] = monthly[compte][an].get(mois, 0) + montant
 
     saisies_map = {}
-    if secteur_id:
+    if global_mode:
+        # Vue globale : consolidation des valeurs définitives saisies par les
+        # secteurs (même logique que la colonne « Initial » en actualisé). Le
+        # temporaire reste calculé depuis le FEC tous secteurs confondus.
+        saved = conn.execute('''
+            SELECT compte_num, SUM(valeur_def) AS total_def
+            FROM budget_prev_saisies
+            WHERE type_budget = ? AND annee = ?
+            GROUP BY compte_num
+        ''', (type_budget, annee)).fetchall()
+        for s in saved:
+            saisies_map[s['compte_num']] = {
+                'valeur_temp': None,
+                'valeur_def': float(s['total_def'] or 0),
+                'commentaire': ''
+            }
+    elif secteur_id:
         saved = conn.execute('''
             SELECT compte_num, valeur_temp, valeur_def, commentaire
             FROM budget_prev_saisies
@@ -923,7 +939,10 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
             'categorie': compte[:2],
             'nature': nature,
             'is_salary': is_salary,
-            'manuel': compte in comptes_manuels,
+            # « manuel » ne vaut True que si une ligne de saisie du type courant
+            # existe : en actualisé, un compte hérité du seul budget initial est
+            # affiché mais sans bouton de retrait (qui n'aurait rien à supprimer).
+            'manuel': compte in comptes_manuels and compte in saisies_map,
             'N-2': n2,
             'N-1': n1,
             'N': round(col_n, 2),

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -852,6 +852,35 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
             init_rows = []
         initial_map = {r['compte_num']: float(r['total_def'] or 0) for r in init_rows}
 
+    # Comptes ajoutés manuellement au budget : une ligne de saisie existe mais
+    # le compte n'a aucune écriture FEC sur N-2..N (ex. compte tout neuf), donc
+    # il n'entre jamais dans totals. On l'ajoute avec un historique à zéro.
+    # En actualisé, un compte budgété à l'initial de la même année reste visible.
+    if global_mode:
+        lignes_manuelles = conn.execute('''
+            SELECT DISTINCT compte_num FROM budget_prev_saisies
+            WHERE annee = ? AND type_budget IN ('initial', ?)
+        ''', (annee, type_budget)).fetchall()
+    elif secteur_id:
+        lignes_manuelles = conn.execute('''
+            SELECT DISTINCT compte_num FROM budget_prev_saisies
+            WHERE annee = ? AND secteur_id = ? AND type_budget IN ('initial', ?)
+        ''', (annee, secteur_id, type_budget)).fetchall()
+    else:
+        lignes_manuelles = []
+    comptes_manuels = set()
+    for r in lignes_manuelles:
+        compte = (r['compte_num'] or '').strip()
+        if not compte or compte in totals or not compte.startswith(('6', '7')):
+            continue
+        comptes_manuels.add(compte)
+        totals[compte] = {
+            'compte_num': compte,
+            'libelle': pcg.get(compte) or compte,
+            'N-2': 0.0, 'N-1': 0.0, 'N': 0.0
+        }
+        monthly[compte] = {}
+
     accounts = []
     for compte, vals in totals.items():
         n2 = round(vals['N-2'], 2)
@@ -894,6 +923,7 @@ def _compute_budget_previsionnel(conn, type_budget, annee, secteur_id=None, infl
             'categorie': compte[:2],
             'nature': nature,
             'is_salary': is_salary,
+            'manuel': compte in comptes_manuels,
             'N-2': n2,
             'N-1': n1,
             'N': round(col_n, 2),
@@ -1200,6 +1230,97 @@ def api_budget_previsionnel_save_line():
                 updated_by = excluded.updated_by,
                 updated_at = CURRENT_TIMESTAMP
         ''', (type_budget, int(annee), int(secteur_id), compte_num, valeur_temp, valeur_def, commentaire, user_id))
+        conn.commit()
+        return jsonify({'success': True})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/comptes-disponibles')
+@login_required
+def api_budget_prev_comptes_disponibles():
+    """Comptes 6x/7x proposables à l'ajout manuel : plan comptable général,
+    complété des comptes déjà vus dans les écritures FEC."""
+    profil = session.get('profil')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    conn = get_db()
+    try:
+        comptes = {}
+        for r in conn.execute('''
+            SELECT compte_num, libelle FROM plan_comptable_general
+            WHERE compte_num LIKE '6%' OR compte_num LIKE '7%'
+        ''').fetchall():
+            comptes[r['compte_num']] = r['libelle'] or r['compte_num']
+        for r in conn.execute('''
+            SELECT DISTINCT compte_num, libelle FROM bilan_fec_donnees
+            WHERE compte_num LIKE '6%' OR compte_num LIKE '7%'
+        ''').fetchall():
+            comptes.setdefault(r['compte_num'], r['libelle'] or r['compte_num'])
+        liste = [{'compte_num': num, 'libelle': lib} for num, lib in sorted(comptes.items())]
+        return jsonify({'comptes': liste})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/ajouter-compte', methods=['POST'])
+@login_required
+def api_budget_prev_ajouter_compte():
+    """Ajoute manuellement un compte au budget d'un secteur (ligne à zéro).
+
+    Crée la ligne de saisie qui fait apparaître le compte dans le tableau ;
+    une ligne déjà budgétée n'est pas écrasée (INSERT OR IGNORE)."""
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    data = request.get_json() or {}
+    type_budget = data.get('type_budget')
+    annee = data.get('annee')
+    secteur_id = data.get('secteur_id')
+    compte_num = (data.get('compte_num') or '').strip()
+    if type_budget not in ['initial', 'actualise']:
+        return jsonify({'error': 'Type de budget invalide'}), 400
+    if not annee or not secteur_id or not compte_num:
+        return jsonify({'error': 'Champs requis manquants'}), 400
+    if not compte_num.startswith(('6', '7')):
+        return jsonify({'error': 'Seuls les comptes de charges (6x) et de produits (7x) sont budgétables'}), 400
+    conn = get_db()
+    try:
+        cur = conn.execute('''
+            INSERT OR IGNORE INTO budget_prev_saisies
+            (type_budget, annee, secteur_id, compte_num, valeur_def, updated_by, updated_at)
+            VALUES (?, ?, ?, ?, 0, ?, CURRENT_TIMESTAMP)
+        ''', (type_budget, int(annee), int(secteur_id), compte_num, user_id))
+        conn.commit()
+        return jsonify({'success': True, 'deja_present': cur.rowcount == 0})
+    finally:
+        conn.close()
+
+
+@budget_bp.route('/api/budget-previsionnel/retirer-compte', methods=['POST'])
+@login_required
+def api_budget_prev_retirer_compte():
+    """Retire un compte ajouté manuellement : supprime sa ligne de saisie
+    (montants et commentaire compris) pour le type/année/secteur courants."""
+    profil = session.get('profil')
+    if profil not in ['directeur', 'comptable']:
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    data = request.get_json() or {}
+    type_budget = data.get('type_budget')
+    annee = data.get('annee')
+    secteur_id = data.get('secteur_id')
+    compte_num = (data.get('compte_num') or '').strip()
+    if type_budget not in ['initial', 'actualise']:
+        return jsonify({'error': 'Type de budget invalide'}), 400
+    if not annee or not secteur_id or not compte_num:
+        return jsonify({'error': 'Champs requis manquants'}), 400
+    conn = get_db()
+    try:
+        conn.execute('''
+            DELETE FROM budget_prev_saisies
+            WHERE type_budget = ? AND annee = ? AND secteur_id = ? AND compte_num = ?
+        ''', (type_budget, int(annee), int(secteur_id), compte_num))
         conn.commit()
         return jsonify({'success': True})
     finally:

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -239,6 +239,7 @@
     <h2>💶 Budget prévisionnel</h2>
     <div style="display:flex;gap:8px;flex-wrap:wrap;">
         {% if profil in ['directeur', 'comptable'] %}
+        <button class="btn btn-secondary" onclick="openAjoutCompte()">➕ Ajouter un compte au budget</button>
         <button class="btn btn-secondary" onclick="openPsConfig()">⚙️ Paramétrer les comptes PS</button>
         {% endif %}
         <button class="btn btn-secondary" onclick="exporterPdf(false)">📄 Export PDF secteur</button>
@@ -326,6 +327,31 @@
                     </select>
                 </div>
                 <button class="btn btn-primary" type="button" onclick="addPsCompte()">➕ Ajouter</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Ajout manuel d'un compte au budget (compte absent des écritures FEC) -->
+<div id="ajoutCompteModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeAjoutCompte()">
+    <div class="modal-content" style="max-width:560px;">
+        <div class="modal-header">
+            <h3>➕ Ajouter un compte au budget</h3>
+            <button class="modal-close" type="button" onclick="closeAjoutCompte()" aria-label="Fermer">&times;</button>
+        </div>
+        <div style="padding:0 1.5rem 1.5rem;">
+            <p class="help-text" style="margin-top:0;">
+                Pour budgéter un compte absent du tableau (ex. compte tout neuf, jamais
+                mouvementé), choisissez-le dans le plan comptable général — charges (6x)
+                ou produits (7x). Il sera ajouté au budget <strong id="ajoutCompteContexte"></strong>
+                avec un historique à zéro, et apparaîtra aussi dans le budget général.
+            </p>
+            <div style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap;">
+                <div class="form-group" style="margin:0;flex:1 1 280px;">
+                    <label>Compte (plan comptable général)</label>
+                    <select id="ajoutCompteSelect" class="form-select" style="width:100%;"></select>
+                </div>
+                <button class="btn btn-primary" type="button" onclick="ajouterCompteBudget()">➕ Ajouter</button>
             </div>
         </div>
     </div>
@@ -482,6 +508,11 @@ function bindBudgetInputHandlers(targetId){
             queueSave(this.dataset.bpCommentCompte || '', null, this.value);
         });
     });
+    root.querySelectorAll('button[data-retirer-compte]').forEach((btn) => {
+        btn.addEventListener('click', function(){
+            retirerCompteBudget(this.dataset.retirerCompte || '');
+        });
+    });
 }
 
 function buildTable(rows, labelTemp, labelDef, globalMode, ctx){
@@ -553,7 +584,10 @@ function buildTable(rows, labelTemp, labelDef, globalMode, ctx){
         const ficheBtn = (actualise && !globalMode && !psComptes[r.compte_num] && !r.is_salary)
             ? '<button type="button" class="btn btn-sm btn-secondary bp-ps-btn" data-fiche-compte="' + escapeHtml(r.compte_num) + '" title="Fiche de travail : réel + projection + ajustements" aria-label="Fiche de travail">📋</button>'
             : '';
-        const boutons = psBtn + paieBtn + ficheBtn;
+        const retirerBtn = (!globalMode && canEditPs && r.manuel)
+            ? '<button type="button" class="btn btn-sm btn-danger bp-ps-btn" data-retirer-compte="' + escapeHtml(r.compte_num) + '" title="Compte ajouté manuellement au budget — le retirer (supprime les montants saisis)" aria-label="Retirer ce compte du budget">🗑</button>'
+            : '';
+        const boutons = psBtn + paieBtn + ficheBtn + retirerBtn;
         html += '<tr' + rowStyle + '>' +
           '<td>' + escapeHtml(r.compte_num) + '</td>' +
           '<td><div class="bp-libelle-flex"><span>' + escapeHtml(r.libelle) + '</span>' +
@@ -843,6 +877,81 @@ function removePsCompte(compte){
             if (!data.success){ alert(data.error || 'Erreur'); return; }
             loadPsComptes().then(function(){ renderPsConfigList(); refreshBudgetButtons(); });
         });
+}
+
+// ---- Ajout manuel d'un compte au budget ----
+function openAjoutCompte(){
+    var modal = document.getElementById('ajoutCompteModal');
+    if (!modal) return;
+    var ctxEl = document.getElementById('ajoutCompteContexte');
+    if (ctxEl){
+        var sel = document.getElementById('secteurBudget');
+        var secteurNom = (sel && sel.selectedIndex >= 0) ? sel.options[sel.selectedIndex].text : '';
+        var type = document.getElementById('typeBudget').value === 'actualise' ? 'actualisé' : 'initial';
+        ctxEl.textContent = type + ' ' + document.getElementById('anneeBudget').value +
+            ' du secteur « ' + secteurNom + ' »';
+    }
+    modal.style.display = 'flex';
+    loadAjoutCompteOptions();
+}
+function closeAjoutCompte(){
+    var modal = document.getElementById('ajoutCompteModal');
+    if (modal) modal.style.display = 'none';
+}
+function loadAjoutCompteOptions(){
+    fetch('/api/budget-previsionnel/comptes-disponibles')
+        .then(r => r.json())
+        .then(data => {
+            var sel = document.getElementById('ajoutCompteSelect');
+            if (!sel) return;
+            // Ne proposer que les comptes absents du tableau affiché.
+            var deja = {};
+            currentRows.forEach(function(r){ deja[r.compte_num] = true; });
+            var list = ((data && data.comptes) || []).filter(function(c){ return !deja[c.compte_num]; });
+            if (!list.length){
+                sel.innerHTML = '<option value="">Aucun compte 6x/7x à ajouter (plan comptable vide ou comptes déjà affichés)</option>';
+                return;
+            }
+            sel.innerHTML = list.map(function(c){
+                return '<option value="' + escapeHtml(c.compte_num) + '">' +
+                    escapeHtml(c.compte_num + ' — ' + (c.libelle || '')) + '</option>';
+            }).join('');
+        });
+}
+function ajouterCompteBudget(){
+    var compte = (document.getElementById('ajoutCompteSelect') || {}).value || '';
+    if (!compte){ alert('Sélectionnez un compte.'); return; }
+    var context = getCurrentBudgetContext();
+    fetch('/api/budget-previsionnel/ajouter-compte', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({
+            type_budget: context.type_budget,
+            annee: context.annee,
+            secteur_id: context.secteur_id,
+            compte_num: compte
+        })
+    }).then(r => r.json()).then(data => {
+        if (!data.success){ alert(data.error || 'Erreur'); return; }
+        closeAjoutCompte();
+        chargerBudget();
+    });
+}
+function retirerCompteBudget(compte){
+    if (!confirm('Retirer le compte ' + compte + ' de ce budget ?\n' +
+                 'Les montants et le commentaire saisis sur cette ligne seront supprimés.')) return;
+    var context = getCurrentBudgetContext();
+    fetch('/api/budget-previsionnel/retirer-compte', {
+        method:'POST', headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({
+            type_budget: context.type_budget,
+            annee: context.annee,
+            secteur_id: context.secteur_id,
+            compte_num: compte
+        })
+    }).then(r => r.json()).then(data => {
+        if (!data.success){ alert(data.error || 'Erreur'); return; }
+        chargerBudget();
+    });
 }
 
 // ---- Étape 3 : simulateurs ----
@@ -2112,7 +2221,7 @@ function savePaieSimulator(){
 // Déplace les modales au niveau du <body> : le conteneur .container crée un
 // contexte d'empilement (animation) qui les confinerait sinon sous la barre
 // latérale de gauche (menu). Rattachées au body, elles s'affichent par-dessus.
-['psSimulatorModal', 'psConfigModal', 'paieSimulatorModal'].forEach(function(id){
+['psSimulatorModal', 'psConfigModal', 'paieSimulatorModal', 'ajoutCompteModal'].forEach(function(id){
     var el = document.getElementById(id);
     if (el && el.parentNode !== document.body) document.body.appendChild(el);
 });

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1458,12 +1458,14 @@ def test_compte_ajoute_sans_fec_apparait_dans_le_budget(app, db, admin_client, s
     ).get_json()
     assert any(r['compte_num'] == '606300' for r in data_glob['rows'])
 
-    # Budget actualisé de la même année : le compte budgété à l'initial reste visible
+    # Budget actualisé de la même année : le compte budgété à l'initial reste
+    # visible, mais sans bouton de retrait (aucune ligne « actualisé » à
+    # supprimer) : manuel vaut False (revue Codex).
     data_actu = admin_client.get(
         f'/api/budget-previsionnel/donnees?type_budget=actualise&annee={annee}&secteur_id={secteur_id}'
     ).get_json()
     row_actu = next(r for r in data_actu['rows'] if r['compte_num'] == '606300')
-    assert row_actu['manuel'] is True
+    assert row_actu['manuel'] is False
 
 
 def test_compte_avec_fec_n_est_pas_marque_manuel(app, db, admin_client, sample_users):
@@ -1541,3 +1543,51 @@ def test_budget_previsionnel_bouton_ajout_compte_absent_responsable(resp_client)
     html = resp_client.get('/budget-previsionnel').get_data(as_text=True)
     assert 'Ajouter un compte au budget' not in html
     assert 'id="ajoutCompteModal"' not in html
+
+
+def test_budget_global_consolide_les_valeurs_definitives(app, db, admin_client, sample_users):
+    """La vue globale additionne les valeurs définitives saisies par les
+    secteurs, y compris pour un compte ajouté manuellement (revue Codex)."""
+    secteur1 = sample_users['secteur_id']
+    annee = datetime.now().year
+    with app.app_context():
+        cur = db.execute("INSERT INTO secteurs (nom, description) VALUES ('Secteur Deux', 'Autre secteur')")
+        secteur2 = cur.lastrowid
+        db.commit()
+    for sid, montant in ((secteur1, 450), (secteur2, 100)):
+        admin_client.post('/api/budget-previsionnel/ajouter-compte', json={
+            'type_budget': 'initial', 'annee': annee, 'secteur_id': sid,
+            'compte_num': '606300',
+        })
+        admin_client.post('/api/budget-previsionnel/save-line', json={
+            'type_budget': 'initial', 'annee': annee, 'secteur_id': sid,
+            'compte_num': '606300', 'valeur_def': montant,
+        })
+
+    data = admin_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&global=1'
+    ).get_json()
+    row = next(r for r in data['rows'] if r['compte_num'] == '606300')
+    assert row['def'] == 550.0
+    assert data['totaux']['charges_def'] == 550.0
+
+
+def test_retrait_expose_uniquement_sur_le_type_courant(app, db, admin_client, sample_users):
+    """Un compte ajouté au budget actualisé y est retirable (manuel=True) ;
+    vu depuis l'initial de la même année, il n'apparaît pas."""
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    admin_client.post('/api/budget-previsionnel/ajouter-compte', json={
+        'type_budget': 'actualise', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '756000',
+    })
+    data_actu = admin_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=actualise&annee={annee}&secteur_id={secteur_id}'
+    ).get_json()
+    row = next(r for r in data_actu['rows'] if r['compte_num'] == '756000')
+    assert row['manuel'] is True
+
+    data_init = admin_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&secteur_id={secteur_id}'
+    ).get_json()
+    assert not any(r['compte_num'] == '756000' for r in data_init['rows'])

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1347,3 +1347,197 @@ def test_api_budget_previsionnel_actualise_inclut_budget_initial(app, db, admin_
     r2 = admin_client.get(f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&secteur_id={sid}')
     row2 = next(x for x in r2.get_json()['rows'] if x['compte_num'] == '606000')
     assert 'initial' not in row2
+
+
+# ============================================================
+# Ajout manuel d'un compte au budget (compte absent des écritures FEC)
+# ============================================================
+
+def test_api_comptes_disponibles_liste_6x_et_7x(app, db, admin_client):
+    """Le plan comptable alimente la liste : charges (6x) et produits (7x) seulement."""
+    with app.app_context():
+        db.execute("INSERT INTO plan_comptable_general (compte_num, libelle) VALUES ('606300', 'Fournitures entretien')")
+        db.execute("INSERT INTO plan_comptable_general (compte_num, libelle) VALUES ('756000', 'Cotisations')")
+        db.execute("INSERT INTO plan_comptable_general (compte_num, libelle) VALUES ('512000', 'Banque')")
+        db.commit()
+    resp = admin_client.get('/api/budget-previsionnel/comptes-disponibles')
+    assert resp.status_code == 200
+    comptes = {c['compte_num'] for c in resp.get_json()['comptes']}
+    assert '606300' in comptes
+    assert '756000' in comptes
+    assert '512000' not in comptes
+
+
+def test_api_comptes_disponibles_refuse_responsable(resp_client):
+    assert resp_client.get('/api/budget-previsionnel/comptes-disponibles').status_code == 403
+
+
+def test_api_ajouter_compte_cree_une_ligne_a_zero(app, db, admin_client, sample_users):
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    resp = admin_client.post('/api/budget-previsionnel/ajouter-compte', json={
+        'type_budget': 'initial', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '606300',
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+    with app.app_context():
+        row = db.execute('''
+            SELECT * FROM budget_prev_saisies
+            WHERE type_budget = 'initial' AND annee = ? AND secteur_id = ? AND compte_num = '606300'
+        ''', (annee, secteur_id)).fetchone()
+    assert row is not None
+    assert row['valeur_def'] == 0
+
+
+def test_api_ajouter_compte_ne_touche_pas_une_ligne_existante(app, db, admin_client, sample_users):
+    """Ré-ajouter un compte déjà budgété ne doit pas écraser les montants saisis."""
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    admin_client.post('/api/budget-previsionnel/save-line', json={
+        'type_budget': 'initial', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '606300', 'valeur_def': 850, 'commentaire': 'déjà budgété',
+    })
+    resp = admin_client.post('/api/budget-previsionnel/ajouter-compte', json={
+        'type_budget': 'initial', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '606300',
+    })
+    assert resp.get_json()['deja_present'] is True
+    with app.app_context():
+        row = db.execute('''
+            SELECT valeur_def, commentaire FROM budget_prev_saisies
+            WHERE type_budget = 'initial' AND annee = ? AND secteur_id = ? AND compte_num = '606300'
+        ''', (annee, secteur_id)).fetchone()
+    assert row['valeur_def'] == 850
+    assert row['commentaire'] == 'déjà budgété'
+
+
+def test_api_ajouter_compte_refuse_responsable(resp_client, sample_users):
+    resp = resp_client.post('/api/budget-previsionnel/ajouter-compte', json={
+        'type_budget': 'initial', 'annee': datetime.now().year,
+        'secteur_id': sample_users['secteur_id'], 'compte_num': '606300',
+    })
+    assert resp.status_code == 403
+
+
+def test_api_ajouter_compte_refuse_hors_classes_6_et_7(admin_client, sample_users):
+    resp = admin_client.post('/api/budget-previsionnel/ajouter-compte', json={
+        'type_budget': 'initial', 'annee': datetime.now().year,
+        'secteur_id': sample_users['secteur_id'], 'compte_num': '512000',
+    })
+    assert resp.status_code == 400
+
+
+def test_compte_ajoute_sans_fec_apparait_dans_le_budget(app, db, admin_client, sample_users):
+    """Un compte tout neuf (aucune écriture FEC) doit apparaître après ajout :
+    historique à zéro, libellé du plan comptable, drapeau manuel — dans le
+    budget du secteur, le budget global, et l'actualisé de la même année."""
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    with app.app_context():
+        db.execute("INSERT INTO plan_comptable_general (compte_num, libelle) VALUES ('606300', 'Fournitures entretien')")
+        db.commit()
+    admin_client.post('/api/budget-previsionnel/ajouter-compte', json={
+        'type_budget': 'initial', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '606300',
+    })
+
+    # Budget du secteur (initial)
+    data = admin_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&secteur_id={secteur_id}'
+    ).get_json()
+    row = next(r for r in data['rows'] if r['compte_num'] == '606300')
+    assert row['manuel'] is True
+    assert row['libelle'] == 'Fournitures entretien'
+    assert row['N-2'] == 0 and row['N-1'] == 0 and row['N'] == 0
+    assert row['nature'] == 'charges'
+
+    # Budget global
+    data_glob = admin_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&global=1'
+    ).get_json()
+    assert any(r['compte_num'] == '606300' for r in data_glob['rows'])
+
+    # Budget actualisé de la même année : le compte budgété à l'initial reste visible
+    data_actu = admin_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=actualise&annee={annee}&secteur_id={secteur_id}'
+    ).get_json()
+    row_actu = next(r for r in data_actu['rows'] if r['compte_num'] == '606300')
+    assert row_actu['manuel'] is True
+
+
+def test_compte_avec_fec_n_est_pas_marque_manuel(app, db, admin_client, sample_users):
+    """Une ligne budgétée qui a des écritures FEC reste une ligne normale."""
+    n = datetime.now().year
+    secteur_id = sample_users['secteur_id']
+    with app.app_context():
+        db.execute('INSERT INTO budget_prev_config_codes (code_analytique, secteur_id) VALUES (?, ?)',
+                   ('ANA-MAN', secteur_id))
+        db.execute("INSERT INTO bilan_fec_imports (fichier_nom, annee, nb_ecritures) VALUES ('bi.txt', ?, 1)", (n,))
+        imp = db.execute('SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1').fetchone()['id']
+        db.execute('INSERT INTO bilan_fec_donnees (compte_num, libelle, code_analytique, annee, mois, montant, import_id) '
+                   'VALUES (?, ?, ?, ?, ?, ?, ?)',
+                   ('601000', 'Charges test', 'ANA-MAN', n - 1, 1, 1000, imp))
+        db.commit()
+    admin_client.post('/api/budget-previsionnel/save-line', json={
+        'type_budget': 'initial', 'annee': n, 'secteur_id': secteur_id,
+        'compte_num': '601000', 'valeur_def': 1200,
+    })
+    data = admin_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=initial&annee={n}&secteur_id={secteur_id}'
+    ).get_json()
+    row = next(r for r in data['rows'] if r['compte_num'] == '601000')
+    assert row['manuel'] is False
+    assert row['N-1'] == 1000.0
+
+
+def test_api_retirer_compte_supprime_la_ligne(app, db, client, sample_users):
+    # admin_client / resp_client partagent le même client de test : on gère les
+    # connexions explicitement pour alterner directeur puis responsable.
+    secteur_id = sample_users['secteur_id']
+    annee = datetime.now().year
+    client.post('/login', data={'login': 'admin', 'password': 'Admin1234'}, follow_redirects=True)
+    client.post('/api/budget-previsionnel/ajouter-compte', json={
+        'type_budget': 'initial', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '606300',
+    })
+
+    # Le responsable ne peut pas retirer
+    client.get('/logout', follow_redirects=True)
+    client.post('/login', data={'login': 'resp_test', 'password': 'resp123'}, follow_redirects=True)
+    resp = client.post('/api/budget-previsionnel/retirer-compte', json={
+        'type_budget': 'initial', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '606300',
+    })
+    assert resp.status_code == 403
+
+    client.get('/logout', follow_redirects=True)
+    client.post('/login', data={'login': 'admin', 'password': 'Admin1234'}, follow_redirects=True)
+    resp = client.post('/api/budget-previsionnel/retirer-compte', json={
+        'type_budget': 'initial', 'annee': annee, 'secteur_id': secteur_id,
+        'compte_num': '606300',
+    })
+    assert resp.status_code == 200
+    with app.app_context():
+        row = db.execute('''
+            SELECT 1 FROM budget_prev_saisies
+            WHERE type_budget = 'initial' AND annee = ? AND secteur_id = ? AND compte_num = '606300'
+        ''', (annee, secteur_id)).fetchone()
+    assert row is None
+    data = client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&secteur_id={secteur_id}'
+    ).get_json()
+    assert not any(r['compte_num'] == '606300' for r in data['rows'])
+
+
+def test_budget_previsionnel_bouton_ajout_compte_directeur(admin_client):
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert 'Ajouter un compte au budget' in html
+    assert 'id="ajoutCompteModal"' in html
+    assert "'ajoutCompteModal'" in html   # modale rattachée au <body>
+
+
+def test_budget_previsionnel_bouton_ajout_compte_absent_responsable(resp_client):
+    html = resp_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert 'Ajouter un compte au budget' not in html
+    assert 'id="ajoutCompteModal"' not in html


### PR DESCRIPTION
## Résumé

Sur la page budget prévisionnel, la liste des comptes était construite uniquement à partir des écritures FEC (N-2..N) : un **compte tout neuf, jamais mouvementé, ne pouvait pas être budgété** — une ligne de saisie créée en base restait même invisible.

### Nouveautés

- Bouton **« ➕ Ajouter un compte au budget »** dans la barre d'outils (directeur/comptable uniquement, comme le paramétrage PS).
- **Modale simple** : liste déroulante alimentée par le **plan comptable général** — comptes **6x (charges)** et **7x (produits)** uniquement, complétés des comptes déjà vus au FEC — en excluant ceux déjà affichés dans le tableau. Le contexte (type de budget, année, secteur) est rappelé dans la modale.
- L'ajout crée une **ligne de saisie à zéro** (`INSERT OR IGNORE` : une ligne déjà budgétée n'est jamais écrasée). Le compte apparaît alors avec un historique N-2/N-1/N à zéro et son libellé du plan comptable :
  - dans le **budget du secteur** courant,
  - dans le **budget général** consolidé,
  - et dans le budget **actualisé** de la même année quand il a été budgété à l'initial.
- Les lignes ajoutées manuellement (drapeau `manuel` renvoyé par l'API) portent un bouton **🗑 retirer** (confirmation, supprime la ligne de saisie avec ses montants) — masqué en vue globale et pour le responsable.

### API

Trois nouvelles routes, réservées direction/comptabilité comme `save-line` :
- `GET /api/budget-previsionnel/comptes-disponibles` — comptes 6x/7x (plan comptable + FEC)
- `POST /api/budget-previsionnel/ajouter-compte` — validation classe 6/7, `INSERT OR IGNORE`
- `POST /api/budget-previsionnel/retirer-compte` — suppression de la ligne de saisie

Côté calcul, `_compute_budget_previsionnel` « seed » désormais les comptes présents dans `budget_prev_saisies` mais absents du FEC (correction au passage d'un défaut latent : une ligne budgétée dont l'historique FEC disparaissait devenait invisible en conservant ses montants en base).

Aucune migration nécessaire (réutilise la table `budget_prev_saisies` existante).

## Tests

- 11 nouveaux tests dans `tests/test_budget.py` : liste 6x/7x (classe 5 exclue), 403 responsable, création de ligne à zéro, non-écrasement d'une ligne existante, rejet hors classes 6/7, apparition dans les données secteur/global/actualisé avec libellé et drapeau `manuel`, non-marquage des comptes à historique FEC, retrait (droits + suppression + disparition), présence/absence du bouton selon le profil.
- **Suite complète : 965 tests OK.**
- Vérification navigateur (Playwright) : modale avec liste filtrée, ajout, saisie d'un montant, persistance après rechargement, consolidation en budget général, retrait avec confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_