### PR TITLE
Planificateur : priorité relative par comparaisons de tâches

### DIFF
--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -627,6 +627,19 @@ def _candidats_comparaison(conn, user_id, exclude_id=None):
     return [plus_urgente, moins_urgente]
 
 
+def _parser_reponses(comparaisons):
+    """Extrait les reponses de comparaison valides : {tache_id: reponse}."""
+    reponses = {}
+    for c in comparaisons or []:
+        try:
+            tid = int(c.get('tache_id'))
+        except (TypeError, ValueError, AttributeError):
+            continue
+        if c.get('reponse') in ('superieur', 'egal', 'inferieur'):
+            reponses[tid] = c['reponse']
+    return reponses
+
+
 def _calculer_priorite_num(conn, user_id, comparaisons, exclude_id=None):
     """Calcule la priorite relative d'une tache a partir des reponses de
     comparaison. Retourne (priorite_num, id_tache_reevaluee_ou_None).
@@ -642,14 +655,7 @@ def _calculer_priorite_num(conn, user_id, comparaisons, exclude_id=None):
       jugement du moment — la nouvelle passe a H+1 et B, sans doute mal
       estimee au depart, est reevaluee a H+2.
     """
-    reponses = {}
-    for c in comparaisons or []:
-        try:
-            tid = int(c.get('tache_id'))
-        except (TypeError, ValueError, AttributeError):
-            continue
-        if c.get('reponse') in ('superieur', 'egal', 'inferieur'):
-            reponses[tid] = c['reponse']
+    reponses = _parser_reponses(comparaisons)
     if not reponses:
         return 0, None
 
@@ -757,6 +763,15 @@ def api_creer_tache():
             preference = data.get('preference') if data.get('preference') in PREFERENCES_VALIDES else 'aucune'
             secable = 1 if str(data.get('secable')) in ('1', 'true', 'on', 'True') else 0
             duree_min_bloc = _parse_int(data.get('duree_min_bloc'), 30, mini=5, maxi=duree_min)
+            # Les comparaisons sont obligatoires des qu'il existe des taches de
+            # reference : sans cela, une soumission avant la fin du chargement
+            # (ou un client d'API) creerait des priorites neutres silencieuses.
+            if (not _parser_reponses(data.get('comparaisons'))
+                    and _candidats_comparaison(conn, user_id)):
+                return jsonify({
+                    'ok': False,
+                    'erreur': 'Situez la priorité de la tâche par rapport aux tâches présentées.'
+                }), 400
             priorite_num, _reevaluee = _calculer_priorite_num(
                 conn, user_id, data.get('comparaisons'))
             conn.execute(

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -13,6 +13,8 @@ Acces (phase 1) : reserve au profil comptable, pour la phase de test.
 """
 import calendar
 import logging
+import math
+import random
 from datetime import date, timedelta
 from functools import wraps
 
@@ -191,12 +193,12 @@ def _ensure_occurrence(conn, rec, anchor, fenetre_debut, fenetre_fin, today):
     conn.execute(
         '''INSERT INTO planif_taches
            (user_id, type, titre, description, duree_min, deadline, date_min,
-            priorite, preference, secable, duree_min_bloc, statut,
+            priorite, priorite_num, preference, secable, duree_min_bloc, statut,
             recurrence_id, occurrence_jour)
-           VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire', ?, ?)''',
+           VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire', ?, ?)''',
         (rec['user_id'], rec['titre'], rec['description'], rec['duree_min'],
          fenetre_fin.isoformat(), fenetre_debut.isoformat(), rec['priorite'],
-         rec['preference'], rec['secable'], rec['duree_min_bloc'],
+         rec['priorite_num'], rec['preference'], rec['secable'], rec['duree_min_bloc'],
          rec['id'], anchor)
     )
 
@@ -354,6 +356,7 @@ def _replanifier(conn, user_id, maintenant=None):
         taches.append({
             'id': t['id'], 'titre': t['titre'], 'duree_min': restant,
             'deadline': t['deadline'], 'priorite': t['priorite'],
+            'priorite_num': t['priorite_num'],
             'preference': t['preference'], 'secable': bool(t['secable']),
             'duree_min_bloc': t['duree_min_bloc'],
             'est_recurrente': t['recurrence_id'] is not None,
@@ -571,6 +574,148 @@ def _lire_payload():
     return request.form
 
 
+# ── Priorite relative par comparaisons ─────────────────────────────────────
+#
+# L'echelle fixe haute/normale/basse s'ecrase a l'usage (tout finit en
+# « haute »). A la place, une priorite numerique relative — jamais affichee —
+# est construite en situant chaque nouvelle tache par rapport aux taches en
+# cours : la premiere vaut 0, les suivantes sont comparees (superieur / egal /
+# inferieur) a la plus urgente et a la moins urgente d'ici J+3, presentees en
+# aveugle dans un ordre aleatoire pour eviter tout ancrage.
+
+FENETRE_COMPARAISON_JOURS = 3
+
+
+def _priorite_de(row):
+    """Priorite numerique d'une ligne de tache (repli sur l'ancien texte)."""
+    if row['priorite_num'] is not None:
+        return int(row['priorite_num'])
+    return {'haute': 1, 'basse': -1}.get(row['priorite'], 0)
+
+
+def _arrondi(x):
+    """Arrondi a l'entier le plus proche (0,5 vers le haut, negatifs compris)."""
+    return math.floor(x + 0.5)
+
+
+def _candidats_comparaison(conn, user_id, exclude_id=None):
+    """Les taches de reference pour situer une (nouvelle) tache : la plus
+    urgente et la moins urgente d'ici J+3 ; s'il n'y a pas deux taches dans
+    cette fenetre, on elargit a l'ensemble des taches en cours.
+
+    Retourne 0, 1 ou 2 lignes (2 taches distinctes si possible)."""
+    params = [user_id]
+    exclusion = ''
+    if exclude_id:
+        exclusion = ' AND id != ?'
+        params.append(exclude_id)
+    en_cours = conn.execute(
+        f'''SELECT id, titre, deadline, priorite, priorite_num FROM planif_taches
+            WHERE user_id = ? AND type = 'tache' AND statut = 'a_faire'{exclusion}''',
+        params).fetchall()
+    if not en_cours:
+        return []
+    limite = (aujourd_hui() + timedelta(days=FENETRE_COMPARAISON_JOURS)).isoformat()
+    fenetre = [t for t in en_cours if t['deadline'] and t['deadline'] <= limite]
+    if len(fenetre) < 2:
+        fenetre = en_cours
+    plus_urgente = max(fenetre, key=_priorite_de)
+    autres = [t for t in fenetre if t['id'] != plus_urgente['id']]
+    if not autres:
+        return [plus_urgente]
+    moins_urgente = min(autres, key=_priorite_de)
+    return [plus_urgente, moins_urgente]
+
+
+def _calculer_priorite_num(conn, user_id, comparaisons, exclude_id=None):
+    """Calcule la priorite relative d'une tache a partir des reponses de
+    comparaison. Retourne (priorite_num, id_tache_reevaluee_ou_None).
+
+    Regles :
+    - aucune reference : 0 (premiere tache) ;
+    - une reference P : superieur -> P+1, egal -> P, inferieur -> P-1 ;
+    - deux references H (plus urgente) et B (moins urgente) :
+      inferieur aux deux -> B-2 ; superieur aux deux -> H+2 ;
+      entre les deux -> arrondi de ((H-1) x 1 + (B+1) x 2) / 3 ;
+      egal a l'une -> sa valeur (egal aux deux -> arrondi de (H+B)/2) ;
+      incoherent (superieur a H ET inferieur a B) : on fait confiance au
+      jugement du moment — la nouvelle passe a H+1 et B, sans doute mal
+      estimee au depart, est reevaluee a H+2.
+    """
+    reponses = {}
+    for c in comparaisons or []:
+        try:
+            tid = int(c.get('tache_id'))
+        except (TypeError, ValueError, AttributeError):
+            continue
+        if c.get('reponse') in ('superieur', 'egal', 'inferieur'):
+            reponses[tid] = c['reponse']
+    if not reponses:
+        return 0, None
+
+    marqueurs = ','.join('?' * len(reponses))
+    rows = conn.execute(
+        f'''SELECT id, priorite, priorite_num FROM planif_taches
+            WHERE user_id = ? AND id IN ({marqueurs})''',
+        [user_id, *reponses.keys()]).fetchall()
+    if exclude_id:
+        rows = [r for r in rows if r['id'] != exclude_id]
+    if not rows:
+        return 0, None
+
+    if len(rows) == 1:
+        p = _priorite_de(rows[0])
+        rep = reponses[rows[0]['id']]
+        if rep == 'superieur':
+            return p + 1, None
+        if rep == 'inferieur':
+            return p - 1, None
+        return p, None
+
+    rows = sorted(rows, key=_priorite_de, reverse=True)[:2]
+    haute, basse = rows[0], rows[1]
+    h, b = _priorite_de(haute), _priorite_de(basse)
+    rep_h, rep_b = reponses[haute['id']], reponses[basse['id']]
+
+    if rep_h == 'egal' and rep_b == 'egal':
+        return _arrondi((h + b) / 2), None
+    if rep_h == 'egal':
+        return h, None
+    if rep_b == 'egal':
+        return b, None
+    if rep_h == 'superieur' and rep_b == 'superieur':
+        return h + 2, None
+    if rep_h == 'inferieur' and rep_b == 'inferieur':
+        return b - 2, None
+    if rep_h == 'inferieur' and rep_b == 'superieur':
+        # Entre les deux : moyenne ponderee, coefficient 2 cote « superieur ».
+        return _arrondi(((h - 1) * 1 + (b + 1) * 2) / 3), None
+
+    # Incoherent : superieur a la plus urgente ET inferieur a la moins urgente.
+    conn.execute(
+        'UPDATE planif_taches SET priorite_num = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
+        (h + 2, basse['id']))
+    return h + 1, basse['id']
+
+
+@planificateur_bp.route('/planificateur/api/priorite/comparaison')
+@planif_required
+def api_priorite_comparaison():
+    """Taches de reference a presenter pour situer une (nouvelle) tache.
+
+    L'ordre est aleatoire et rien n'indique laquelle est la plus urgente :
+    le jugement se fait en aveugle, sans ancrage."""
+    conn = get_db()
+    try:
+        exclude_id = request.args.get('exclude_id', type=int)
+        candidats = _candidats_comparaison(conn, _uid(), exclude_id)
+        candidats = [{'id': t['id'], 'titre': t['titre']} for t in candidats]
+        random.shuffle(candidats)
+        return jsonify({'comparaisons': candidats})
+    finally:
+        conn.close()
+
+
 @planificateur_bp.route('/planificateur/api/tache', methods=['POST'])
 @planif_required
 def api_creer_tache():
@@ -612,13 +757,15 @@ def api_creer_tache():
             preference = data.get('preference') if data.get('preference') in PREFERENCES_VALIDES else 'aucune'
             secable = 1 if str(data.get('secable')) in ('1', 'true', 'on', 'True') else 0
             duree_min_bloc = _parse_int(data.get('duree_min_bloc'), 30, mini=5, maxi=duree_min)
+            priorite_num, _reevaluee = _calculer_priorite_num(
+                conn, user_id, data.get('comparaisons'))
             conn.execute(
                 '''INSERT INTO planif_taches
                    (user_id, type, titre, description, duree_min, deadline,
-                    priorite, preference, secable, duree_min_bloc, statut)
-                   VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire')''',
+                    priorite, priorite_num, preference, secable, duree_min_bloc, statut)
+                   VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire')''',
                 (user_id, titre, description, duree_min, deadline, priorite,
-                 preference, secable, duree_min_bloc)
+                 priorite_num, preference, secable, duree_min_bloc)
             )
             conn.commit()
 
@@ -673,13 +820,20 @@ def api_modifier_tache(tache_id):
             preference = data.get('preference') if data.get('preference') in PREFERENCES_VALIDES else tache['preference']
             secable = 1 if str(data.get('secable')) in ('1', 'true', 'on', 'True') else 0
             duree_min_bloc = _parse_int(data.get('duree_min_bloc'), tache['duree_min_bloc'], mini=5, maxi=duree_min)
+            # Reevaluation manuelle : de nouvelles comparaisons recalculent la
+            # priorite relative ; sinon elle est conservee telle quelle.
+            if data.get('comparaisons'):
+                priorite_num, _reevaluee = _calculer_priorite_num(
+                    conn, user_id, data.get('comparaisons'), exclude_id=tache_id)
+            else:
+                priorite_num = tache['priorite_num']
             conn.execute(
                 '''UPDATE planif_taches SET titre = ?, description = ?, duree_min = ?,
-                   deadline = ?, priorite = ?, preference = ?, secable = ?,
+                   deadline = ?, priorite = ?, priorite_num = ?, preference = ?, secable = ?,
                    duree_min_bloc = ?, updated_at = CURRENT_TIMESTAMP
                    WHERE id = ?''',
-                (titre, description, duree_min, deadline, priorite, preference,
-                 secable, duree_min_bloc, tache_id)
+                (titre, description, duree_min, deadline, priorite, priorite_num,
+                 preference, secable, duree_min_bloc, tache_id)
             )
             conn.commit()
 
@@ -802,11 +956,11 @@ def api_terminer_partiel(tache_id):
             conn.execute(
                 '''INSERT INTO planif_taches
                    (user_id, type, titre, description, duree_min, deadline,
-                    priorite, preference, secable, duree_min_bloc, statut)
-                   VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire')''',
+                    priorite, priorite_num, preference, secable, duree_min_bloc, statut)
+                   VALUES (?, 'tache', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'a_faire')''',
                 (user_id, (tache['titre'] + ' (suite)')[:200], tache['description'],
-                 restant, tache['deadline'], tache['priorite'], tache['preference'],
-                 tache['secable'], tache['duree_min_bloc'])
+                 restant, tache['deadline'], tache['priorite'], tache['priorite_num'],
+                 tache['preference'], tache['secable'], tache['duree_min_bloc'])
             )
         conn.commit()
         non_planifie = _replanifier(conn, user_id)
@@ -1011,9 +1165,10 @@ def api_creer_recurrence():
 
         conn.execute(
             '''INSERT INTO planif_recurrences
-               (user_id, titre, description, duree_min, priorite, preference, secable,
-                duree_min_bloc, frequence, jour_semaine, jour_mois, date_debut, date_fin, active)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)''',
+               (user_id, titre, description, duree_min, priorite, priorite_num, preference,
+                secable, duree_min_bloc, frequence, jour_semaine, jour_mois, date_debut,
+                date_fin, active)
+               VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, 1)''',
             (user_id, titre, (data.get('description') or '').strip(), duree_min, priorite,
              preference, secable, duree_min_bloc, frequence, jour_semaine, jour_mois,
              date_debut, date_fin)

--- a/database.py
+++ b/database.py
@@ -1638,6 +1638,7 @@ def init_db():
             description TEXT DEFAULT '',
             duree_min INTEGER DEFAULT 30,
             priorite TEXT DEFAULT 'normale',
+            priorite_num INTEGER,
             preference TEXT DEFAULT 'aucune',
             secable INTEGER DEFAULT 0,
             duree_min_bloc INTEGER DEFAULT 30,
@@ -1665,6 +1666,7 @@ def init_db():
             deadline TEXT,
             date_min TEXT,
             priorite TEXT DEFAULT 'normale',
+            priorite_num INTEGER,
             preference TEXT DEFAULT 'aucune',
             secable INTEGER DEFAULT 1,
             duree_min_bloc INTEGER DEFAULT 30,
@@ -1890,6 +1892,14 @@ def init_db():
         cursor.execute("SELECT pause_remuneree FROM heures_reelles LIMIT 1")
     except sqlite3.OperationalError:
         cursor.execute("ALTER TABLE heures_reelles ADD COLUMN pause_remuneree INTEGER DEFAULT 0")
+
+    # Migration 0060 : priorité numérique relative du planificateur (par
+    # comparaisons). NULL sur l'existant : le moteur retombe sur le texte.
+    for _table in ('planif_taches', 'planif_recurrences'):
+        try:
+            cursor.execute(f"SELECT priorite_num FROM {_table} LIMIT 1")
+        except sqlite3.OperationalError:
+            cursor.execute(f"ALTER TABLE {_table} ADD COLUMN priorite_num INTEGER")
 
     # Migration : ajouter temps_hebdo si n'existe pas dans contrats
     try:

--- a/migrations/0060_priorite_numerique_planificateur.py
+++ b/migrations/0060_priorite_numerique_planificateur.py
@@ -1,0 +1,51 @@
+"""
+Migration 0060 : priorité numérique relative du planificateur de tâches.
+
+L'échelle fixe haute/normale/basse s'écrase à l'usage (tout finit en
+« haute »). Elle est remplacée par une priorité numérique relative, jamais
+affichée, construite par comparaisons par paires à la saisie : la première
+tâche vaut 0, chaque nouvelle tâche est située par rapport à la plus urgente
+et la moins urgente des tâches en cours (supérieur / égal / inférieur).
+
+On ajoute `priorite_num` (INTEGER, nullable) à `planif_taches` et
+`planif_recurrences`. L'existant est repris en préservant l'ordre relatif de
+l'ancienne échelle : haute → 1, normale → 0, basse → -1. L'ancienne colonne
+`priorite` reste en place (SQLite ne supprime pas les colonnes) et sert de
+secours au moteur quand `priorite_num` est NULL.
+"""
+
+NOM = "Priorité numérique relative du planificateur"
+DESCRIPTION = (
+    "Ajoute planif_taches.priorite_num et planif_recurrences.priorite_num "
+    "(INTEGER, nullable) : priorité relative construite par comparaisons par "
+    "paires. Reprise de l'existant : haute → 1, normale → 0, basse → -1."
+)
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    import sqlite3
+    cursor = conn.cursor()
+    for table in ('planif_taches', 'planif_recurrences'):
+        try:
+            cursor.execute(f"SELECT priorite_num FROM {table} LIMIT 1")
+        except sqlite3.OperationalError:
+            cursor.execute(f"ALTER TABLE {table} ADD COLUMN priorite_num INTEGER")
+
+        # Reprise de l'existant en conservant l'ordre relatif des trois niveaux.
+        cursor.execute(f'''
+            UPDATE {table}
+            SET priorite_num = CASE priorite
+                WHEN 'haute' THEN 1
+                WHEN 'basse' THEN -1
+                ELSE 0
+            END
+            WHERE priorite_num IS NULL
+        ''')
+    conn.commit()
+
+
+def downgrade(conn):
+    """SQLite ne supporte pas DROP COLUMN simplement : downgrade non destructif
+    (la colonne reste, inerte tant que le code ne la lit pas)."""
+    pass

--- a/planificateur_engine.py
+++ b/planificateur_engine.py
@@ -12,8 +12,9 @@ Principe general (heuristique de placement glouton + equilibrage de charge) :
    des horaires de travail du salarie, desquels on retire les evenements fixes
    (rendez-vous, reunions) et les blocs deja realises ou verrouilles.
 2. On traite les taches par ordre d'urgence : echeance la plus proche d'abord,
-   puis priorite, puis duree. Les taches recurrentes sont placees en dernier,
-   « la ou il reste de la place ».
+   puis priorite (numerique relative, plus grand = plus urgent), puis duree
+   croissante (la plus rapide d'abord), puis la plus recente. Les taches
+   recurrentes sont placees en dernier, « la ou il reste de la place ».
 3. Pour chaque tache, on choisit a chaque etape le jour le moins charge de sa
    fenetre (equilibrage), en respectant la preference matin / apres-midi.
 4. Les longues missions secables sont reparties sur plusieurs jours, avec des
@@ -25,8 +26,25 @@ Principe general (heuristique de placement glouton + equilibrage de charge) :
 from datetime import date, timedelta
 import math
 
-# Poids de tri des priorites (plus petit = traite en premier).
-PRIORITE_POIDS = {'haute': 0, 'normale': 1, 'basse': 2}
+# Conversion de l'ancienne priorite texte vers l'echelle numerique relative
+# (plus grand = plus urgent), utilisee quand priorite_num est absent.
+PRIORITE_TEXTE_NUM = {'haute': 1, 'normale': 0, 'basse': -1}
+
+
+def _priorite_valeur(tache):
+    """Priorite numerique d'une tache (plus grand = plus urgent).
+
+    `priorite_num` — l'echelle relative construite par comparaisons a la
+    saisie — prime ; a defaut (anciennes taches), la priorite texte est
+    convertie via PRIORITE_TEXTE_NUM.
+    """
+    num = tache.get('priorite_num')
+    if num is not None:
+        try:
+            return int(num)
+        except (TypeError, ValueError):
+            pass
+    return PRIORITE_TEXTE_NUM.get(tache.get('priorite', 'normale'), 0)
 
 # Seuil (minutes de travail disponibles dans la journee) au-dela duquel la
 # journee est consideree « chargee » et beneficie de micro-pauses rapprochees.
@@ -236,7 +254,9 @@ def niveau_urgence(deadline, jour_ref, statut='a_faire'):
 
 def _cle_tri_tache(tache, horizon_fin):
     """Cle de tri d'une tache : echeance, puis (a echeance egale) les gros blocs
-    contigus d'abord, puis priorite, puis duree.
+    contigus d'abord, puis priorite, puis duree croissante (la plus rapide
+    d'abord), puis la plus recente (une tache ancienne jamais traitee peut
+    attendre).
 
     Une grosse tache NON secable exige un long creneau contigu : c'est la plus
     difficile a caser. Si on la traitait apres de petites taches flexibles du
@@ -255,8 +275,8 @@ def _cle_tri_tache(tache, horizon_fin):
     duree = int(tache.get('duree_min', 0))
     secable = bool(tache.get('secable', True))
     gros_bloc_contigu = 0 if (not secable and duree > CIBLE_PAR_JOUR) else 1
-    priorite = PRIORITE_POIDS.get(tache.get('priorite', 'normale'), 1)
-    return (sans_echeance, deadline, gros_bloc_contigu, priorite, -duree)
+    return (sans_echeance, deadline, gros_bloc_contigu, -_priorite_valeur(tache),
+            duree, -int(tache.get('id') or 0))
 
 
 def _taille_chunk(duree, min_bloc, nb_jours_dispo, secable):
@@ -284,7 +304,8 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
     Args:
         taches: liste de dicts, chacun contenant :
             id, titre, duree_min (int), deadline (date|str|None),
-            priorite ('haute'|'normale'|'basse'),
+            priorite_num (int, optionnel : echelle relative, plus grand = plus
+            urgent ; a defaut priorite texte 'haute'|'normale'|'basse'),
             preference ('matin'|'apres_midi'|'aucune'),
             secable (bool), duree_min_bloc (int),
             est_recurrente (bool, optionnel),

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -727,8 +727,14 @@
       const d=await r.json();
       rendreComparaisons(d.comparaisons||[]);
     }catch(e){
+      // Sans comparaisons, le serveur refusera l'enregistrement dès qu'il
+      // existe des tâches de référence : proposer de réessayer.
       comparaisonsAffichees=[];
-      conteneur.innerHTML='<p class="planif-help" style="margin:0;">Comparaison indisponible (priorité neutre).</p>';
+      conteneur.innerHTML='<p class="planif-help" style="margin:0 0 .35rem;">Comparaisons indisponibles pour le moment.</p>'
+        +'<button type="button" class="btn btn-secondary" id="btnRetryComparaisons">↻ Réessayer</button>';
+      document.getElementById('btnRetryComparaisons').addEventListener('click', function(){
+        chargerComparaisons(excludeId);
+      });
     }
   }
   function lireComparaisons(){

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -98,14 +98,6 @@
           </div>
           <div class="planif-row">
             <div class="form-group">
-              <label for="t_priorite">Priorité</label>
-              <select id="t_priorite">
-                <option value="basse">Basse</option>
-                <option value="normale" selected>Normale</option>
-                <option value="haute">Haute</option>
-              </select>
-            </div>
-            <div class="form-group">
               <label for="t_preference">Préférence</label>
               <select id="t_preference">
                 <option value="aucune" selected>Aucune</option>
@@ -113,6 +105,13 @@
                 <option value="apres_midi">Après-midi</option>
               </select>
             </div>
+          </div>
+          {# Espace priorité : jamais saisie sur une échelle — déduite de
+             comparaisons en aveugle avec les tâches en cours (JS chargerComparaisons). #}
+          <div class="form-group" id="blocPriorite"
+               style="background:var(--gray-50);border:1px solid var(--gray-200);border-left:4px solid #3b82f6;border-radius:8px;padding:.75rem 1rem;">
+            <label style="font-weight:700;">🎯 Priorité</label>
+            <div id="prioriteContenu"></div>
           </div>
           <div class="planif-row">
             <div class="form-group" style="flex:0 0 auto;">
@@ -206,14 +205,6 @@
               <input type="number" id="r_heures" min="0" max="23" value="0"> h
               <input type="number" id="r_minutes" min="0" max="59" step="5" value="30"> min
             </div>
-          </div>
-          <div class="form-group">
-            <label for="r_priorite">Priorité</label>
-            <select id="r_priorite">
-              <option value="basse">Basse</option>
-              <option value="normale" selected>Normale</option>
-              <option value="haute">Haute</option>
-            </select>
           </div>
           <div class="form-group">
             <label for="r_preference">Préférence</label>
@@ -637,13 +628,14 @@
   function ouvrirDetail(b){
     document.getElementById('detailTitre').textContent = b.titre;
     const ech = b.deadline ? ('Échéance : '+fmtFR(b.deadline)) : 'Sans échéance';
-    const prio = {basse:'Basse',normale:'Normale',haute:'Haute'}[b.priorite]||b.priorite;
     let corps='';
     corps+='<div class="planif-detail-line">📅 '+JOURS[weekday(b.date)]+' '+fmtFR(b.date)+' · '+b.heure_debut+'–'+b.heure_fin+' ('+dureeTxt(b.duree_min)+')</div>';
     if(b.type==='evenement'){
       corps+='<div class="planif-detail-line">📌 Événement fixe</div>';
     }else{
-      corps+='<div class="planif-detail-line">⏳ '+esc(ech)+' · 🚩 Priorité '+prio+(b.recurrente?' · 🔁 récurrente':'')+'</div>';
+      // La priorité relative est interne (jamais affichée) : le détail ne
+      // montre que l'échéance et le caractère récurrent.
+      corps+='<div class="planif-detail-line">⏳ '+esc(ech)+(b.recurrente?' · 🔁 récurrente':'')+'</div>';
     }
     if(b.description) corps+='<div class="planif-detail-line">📝 '+esc(b.description)+'</div>';
     if(b.statut==='fait') corps+='<div class="planif-detail-line">✅ Marqué comme effectué</div>';
@@ -696,6 +688,61 @@
     }catch(e){ toast(e.message,'err'); }
   }
 
+  // ── Priorité relative : comparaisons par paires ──
+  // La priorité n'est jamais saisie sur une échelle : la tâche est située par
+  // rapport à la plus urgente et la moins urgente des tâches en cours (d'ici
+  // J+3, sinon toutes), présentées en aveugle dans un ordre aléatoire.
+  let comparaisonsAffichees=[];
+  function rendreComparaisons(liste){
+    const conteneur=document.getElementById('prioriteContenu');
+    comparaisonsAffichees=liste||[];
+    if(!comparaisonsAffichees.length){
+      conteneur.innerHTML='<p class="planif-help" style="margin:0;">Première tâche : elle servira de référence pour situer les suivantes (priorité 0).</p>';
+      return;
+    }
+    let html='<p class="planif-help" style="margin:0 0 .5rem;">Par rapport à '
+      +(comparaisonsAffichees.length>1?'chacune de ces tâches':'cette tâche')
+      +', la nouvelle tâche est :</p>';
+    html+=comparaisonsAffichees.map(function(c){
+      const nom='p_cmp_'+c.id;
+      return '<div style="margin:.35rem 0;padding:.45rem .6rem;background:var(--white);border:1px solid var(--gray-200);border-radius:6px;">'
+        +'<div style="font-weight:600;margin-bottom:.3rem;">« '+esc(c.titre)+' »</div>'
+        +'<div style="display:flex;gap:.9rem;flex-wrap:wrap;">'
+        +'<label class="planif-check"><input type="radio" name="'+nom+'" value="inferieur"> Moins urgente</label>'
+        +'<label class="planif-check"><input type="radio" name="'+nom+'" value="egal"> Aussi urgente</label>'
+        +'<label class="planif-check"><input type="radio" name="'+nom+'" value="superieur"> Plus urgente</label>'
+        +'</div></div>';
+    }).join('');
+    if(comparaisonsAffichees.length>1){
+      html+='<p class="planif-help" style="margin:.5rem 0 0;">Les deux tâches présentées sont susceptibles d\'ajustement de priorité selon vos réponses.</p>';
+    }
+    conteneur.innerHTML=html;
+  }
+  async function chargerComparaisons(excludeId){
+    const conteneur=document.getElementById('prioriteContenu');
+    conteneur.innerHTML='<p class="planif-help" style="margin:0;">Chargement…</p>';
+    try{
+      const url='/planificateur/api/priorite/comparaison'+(excludeId?('?exclude_id='+excludeId):'');
+      const r=await fetch(url,{headers:{'X-Requested-With':'fetch'}});
+      const d=await r.json();
+      rendreComparaisons(d.comparaisons||[]);
+    }catch(e){
+      comparaisonsAffichees=[];
+      conteneur.innerHTML='<p class="planif-help" style="margin:0;">Comparaison indisponible (priorité neutre).</p>';
+    }
+  }
+  function lireComparaisons(){
+    // null = réponses incomplètes ; [] = rien à comparer (première tâche, ou
+    // réévaluation non ouverte en édition : la priorité actuelle est gardée).
+    const reponses=[];
+    for(const c of comparaisonsAffichees){
+      const coche=document.querySelector('input[name="p_cmp_'+c.id+'"]:checked');
+      if(!coche) return null;
+      reponses.push({tache_id:c.id, reponse:coche.value});
+    }
+    return reponses;
+  }
+
   // ── Modale ajouter / modifier ──
   let typeCourant='tache';
   function setType(t){
@@ -713,6 +760,7 @@
     document.getElementById('grpMinBloc').style.display='';
     setType('tache');
     if(state.vue!=='mois'){ document.getElementById('e_date').value=state.date; }
+    chargerComparaisons(null);
     ouvrir('modalAjouter');
   }
   function ouvrirEdition(b){
@@ -733,11 +781,18 @@
       document.getElementById('t_heures').value=Math.floor(duree/60);
       document.getElementById('t_minutes').value=duree%60;
       document.getElementById('t_deadline').value=b.deadline||'';
-      document.getElementById('t_priorite').value=b.priorite||'normale';
       document.getElementById('t_preference').value=b.preference||'aucune';
       document.getElementById('t_secable').checked=!!b.secable;
       document.getElementById('t_min_bloc').value=b.duree_min_bloc||30;
       document.getElementById('grpMinBloc').style.display=b.secable?'':'none';
+      // En édition, la priorité actuelle est conservée sauf réévaluation.
+      comparaisonsAffichees=[];
+      document.getElementById('prioriteContenu').innerHTML=
+        '<p class="planif-help" style="margin:0 0 .35rem;">La priorité actuelle est conservée.</p>'
+        +'<button type="button" class="btn btn-secondary" id="btnReevaluer">🔁 Réévaluer la priorité</button>';
+      document.getElementById('btnReevaluer').addEventListener('click', function(){
+        chargerComparaisons(b.tache_id);
+      });
     }
     ouvrir('modalAjouter');
   }
@@ -755,12 +810,14 @@
     }else{
       const duree=(parseInt(document.getElementById('t_heures').value,10)||0)*60+(parseInt(document.getElementById('t_minutes').value,10)||0);
       if(duree<5){ toast('La durée doit être d\'au moins 5 minutes','err'); return; }
+      const comparaisons=lireComparaisons();
+      if(comparaisons===null){ toast('Merci de situer la priorité par rapport à chaque tâche présentée','err'); return; }
       payload={ type:'tache', titre, description:document.getElementById('t_description').value,
         duree_min:duree, deadline:document.getElementById('t_deadline').value,
-        priorite:document.getElementById('t_priorite').value,
         preference:document.getElementById('t_preference').value,
         secable:document.getElementById('t_secable').checked?1:0,
         duree_min_bloc:parseInt(document.getElementById('t_min_bloc').value,10)||30 };
+      if(comparaisons.length) payload.comparaisons=comparaisons;
     }
     url = id ? ('/planificateur/api/tache/'+id) : '{{ url_for("planificateur_bp.api_creer_tache") }}';
     try{
@@ -799,7 +856,7 @@
     if(duree<5){ toast('La durée doit être d\'au moins 5 minutes','err'); return; }
     const payload={ titre:document.getElementById('r_titre').value.trim(),
       frequence:document.getElementById('r_frequence').value, duree_min:duree,
-      priorite:document.getElementById('r_priorite').value, preference:document.getElementById('r_preference').value,
+      preference:document.getElementById('r_preference').value,
       jour_semaine:document.getElementById('r_jour_sem').value, jour_mois:document.getElementById('r_jour_mois').value,
       date_debut:document.getElementById('r_debut').value, date_fin:document.getElementById('r_fin').value };
     if(!payload.titre){ toast('Le titre est obligatoire','err'); return; }
@@ -859,7 +916,7 @@
   // sans ce panneau, elle serait invisible et impossible à corriger/supprimer.
   function npToBloc(t){
     return { tache_id:t.id, titre:t.titre, description:t.description||'', type:'tache',
-      deadline:t.deadline||'', priorite:t.priorite||'normale', preference:t.preference||'aucune',
+      deadline:t.deadline||'', preference:t.preference||'aucune',
       secable:!!t.secable, duree_min_bloc:t.duree_min_bloc||30, tache_duree_min:t.duree_min };
   }
   async function actionNonPlacee(act, t){

--- a/tests/test_planificateur_priorite.py
+++ b/tests/test_planificateur_priorite.py
@@ -1,0 +1,260 @@
+"""
+Tests de la priorité relative du planificateur (comparaisons par paires).
+
+La priorité n'est plus saisie sur une échelle haute/normale/basse : la
+première tâche vaut 0, puis chaque nouvelle tâche est située (supérieur /
+égal / inférieur) par rapport à la plus urgente et à la moins urgente des
+tâches en cours d'ici J+3 (repli : toutes les tâches), présentées en
+aveugle. Des réponses incohérentes réévaluent la tâche mal estimée.
+"""
+from datetime import date, timedelta
+
+import planificateur_engine as moteur
+
+
+def _inserer(db, uid, titre, prio_num=None, deadline=None, statut='a_faire'):
+    cur = db.execute(
+        "INSERT INTO planif_taches (user_id, type, titre, duree_min, deadline, priorite_num, statut) "
+        "VALUES (?, 'tache', ?, 30, ?, ?, ?)",
+        (uid, titre, deadline, prio_num, statut))
+    db.commit()
+    return cur.lastrowid
+
+
+def _prio(db, tache_id):
+    return db.execute('SELECT priorite_num FROM planif_taches WHERE id = ?',
+                      (tache_id,)).fetchone()['priorite_num']
+
+
+def _creer(client, titre, comparaisons=None):
+    payload = {'type': 'tache', 'titre': titre, 'duree_min': 30}
+    if comparaisons:
+        payload['comparaisons'] = comparaisons
+    r = client.post('/planificateur/api/tache', json=payload)
+    assert r.status_code == 200
+    assert r.get_json()['ok'] is True
+
+
+def _derniere(db, uid):
+    return db.execute("SELECT * FROM planif_taches WHERE user_id = ? ORDER BY id DESC LIMIT 1",
+                      (uid,)).fetchone()
+
+
+class TestCalculPriorite:
+    def test_premiere_tache_a_zero(self, comptable_client, db, sample_users):
+        _creer(comptable_client, 'Première tâche')
+        assert _derniere(db, sample_users['comptable_id'])['priorite_num'] == 0
+
+    def test_deuxieme_tache_superieure(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        ref = _inserer(db, uid, 'Référence', 0)
+        _creer(comptable_client, 'Nouvelle', [{'tache_id': ref, 'reponse': 'superieur'}])
+        assert _derniere(db, uid)['priorite_num'] == 1
+
+    def test_deuxieme_tache_egale(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        ref = _inserer(db, uid, 'Référence', 0)
+        _creer(comptable_client, 'Nouvelle', [{'tache_id': ref, 'reponse': 'egal'}])
+        assert _derniere(db, uid)['priorite_num'] == 0
+
+    def test_deuxieme_tache_inferieure(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        ref = _inserer(db, uid, 'Référence', 0)
+        _creer(comptable_client, 'Nouvelle', [{'tache_id': ref, 'reponse': 'inferieur'}])
+        assert _derniere(db, uid)['priorite_num'] == -1
+
+    def test_entre_les_deux_moyenne_ponderee(self, comptable_client, db, sample_users):
+        # Exemple validé avec l'utilisateur : haute à 5 (réponse inférieur),
+        # basse à 2 (réponse supérieur) → (4×1 + 3×2) / 3 = 3,33 → 3.
+        uid = sample_users['comptable_id']
+        h = _inserer(db, uid, 'Haute', 5)
+        b = _inserer(db, uid, 'Basse', 2)
+        _creer(comptable_client, 'Nouvelle', [
+            {'tache_id': h, 'reponse': 'inferieur'},
+            {'tache_id': b, 'reponse': 'superieur'},
+        ])
+        assert _derniere(db, uid)['priorite_num'] == 3
+
+    def test_superieure_aux_deux(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        h = _inserer(db, uid, 'Haute', 5)
+        b = _inserer(db, uid, 'Basse', 2)
+        _creer(comptable_client, 'Nouvelle', [
+            {'tache_id': h, 'reponse': 'superieur'},
+            {'tache_id': b, 'reponse': 'superieur'},
+        ])
+        assert _derniere(db, uid)['priorite_num'] == 7   # la plus haute + 2
+
+    def test_inferieure_aux_deux(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        h = _inserer(db, uid, 'Haute', 5)
+        b = _inserer(db, uid, 'Basse', 2)
+        _creer(comptable_client, 'Nouvelle', [
+            {'tache_id': h, 'reponse': 'inferieur'},
+            {'tache_id': b, 'reponse': 'inferieur'},
+        ])
+        assert _derniere(db, uid)['priorite_num'] == 0   # la plus basse − 2
+
+    def test_egale_a_une_reference(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        h = _inserer(db, uid, 'Haute', 5)
+        b = _inserer(db, uid, 'Basse', 2)
+        _creer(comptable_client, 'Nouvelle', [
+            {'tache_id': h, 'reponse': 'egal'},
+            {'tache_id': b, 'reponse': 'superieur'},
+        ])
+        assert _derniere(db, uid)['priorite_num'] == 5
+
+    def test_incoherence_reevalue_la_tache_mal_estimee(self, comptable_client, db, sample_users):
+        # Exemple validé : supérieur à la tâche à 5, inférieur à celle à 2 →
+        # la nouvelle passe à 6, la 5 ne bouge pas, la 2 remonte à 7.
+        uid = sample_users['comptable_id']
+        h = _inserer(db, uid, 'Haute', 5)
+        b = _inserer(db, uid, 'Basse', 2)
+        _creer(comptable_client, 'Nouvelle', [
+            {'tache_id': h, 'reponse': 'superieur'},
+            {'tache_id': b, 'reponse': 'inferieur'},
+        ])
+        assert _derniere(db, uid)['priorite_num'] == 6
+        assert _prio(db, h) == 5
+        assert _prio(db, b) == 7
+
+
+class TestEndpointComparaison:
+    URL = '/planificateur/api/priorite/comparaison'
+
+    def test_sans_tache_liste_vide(self, comptable_client):
+        assert comptable_client.get(self.URL).get_json()['comparaisons'] == []
+
+    def test_une_tache_une_seule_reference(self, comptable_client, db, sample_users):
+        _inserer(db, sample_users['comptable_id'], 'Seule', 0)
+        comparaisons = comptable_client.get(self.URL).get_json()['comparaisons']
+        assert len(comparaisons) == 1
+        assert comparaisons[0]['titre'] == 'Seule'
+
+    def test_references_plus_et_moins_urgentes(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        a = _inserer(db, uid, 'P5', 5)
+        _inserer(db, uid, 'P2', 2)
+        c = _inserer(db, uid, 'P0', 0)
+        comparaisons = comptable_client.get(self.URL).get_json()['comparaisons']
+        assert {x['id'] for x in comparaisons} == {a, c}
+
+    def test_fenetre_j3_prime_sur_les_taches_lointaines(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        today = date.today()
+        proche_haute = _inserer(db, uid, 'Proche haute', 4, deadline=today.isoformat())
+        proche_basse = _inserer(db, uid, 'Proche basse', 1,
+                                deadline=(today + timedelta(days=2)).isoformat())
+        _inserer(db, uid, 'Lointaine', 9, deadline=(today + timedelta(days=30)).isoformat())
+        comparaisons = comptable_client.get(self.URL).get_json()['comparaisons']
+        assert {x['id'] for x in comparaisons} == {proche_haute, proche_basse}
+
+    def test_repli_sur_toutes_les_taches(self, comptable_client, db, sample_users):
+        # Une seule tâche d'ici J+3 : pas assez → on élargit à l'ensemble.
+        uid = sample_users['comptable_id']
+        today = date.today()
+        proche = _inserer(db, uid, 'Proche', 1, deadline=today.isoformat())
+        lointaine = _inserer(db, uid, 'Lointaine', 9,
+                             deadline=(today + timedelta(days=30)).isoformat())
+        comparaisons = comptable_client.get(self.URL).get_json()['comparaisons']
+        assert {x['id'] for x in comparaisons} == {proche, lointaine}
+
+    def test_exclusion_pour_reevaluation(self, comptable_client, db, sample_users):
+        seule = _inserer(db, sample_users['comptable_id'], 'Seule', 0)
+        data = comptable_client.get(f'{self.URL}?exclude_id={seule}').get_json()
+        assert data['comparaisons'] == []
+
+    def test_taches_faites_ignorees(self, comptable_client, db, sample_users):
+        _inserer(db, sample_users['comptable_id'], 'Terminée', 5, statut='fait')
+        assert comptable_client.get(self.URL).get_json()['comparaisons'] == []
+
+
+class TestEditionPriorite:
+    def test_edition_sans_comparaisons_conserve(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        t = _inserer(db, uid, 'À modifier', 4)
+        r = comptable_client.post(f'/planificateur/api/tache/{t}',
+                                  json={'titre': 'Modifiée', 'duree_min': 45})
+        assert r.status_code == 200
+        assert _prio(db, t) == 4
+
+    def test_edition_reevalue_avec_comparaisons(self, comptable_client, db, sample_users):
+        uid = sample_users['comptable_id']
+        ref = _inserer(db, uid, 'Référence', 2)
+        t = _inserer(db, uid, 'À réévaluer', 0)
+        r = comptable_client.post(f'/planificateur/api/tache/{t}', json={
+            'titre': 'À réévaluer', 'duree_min': 30,
+            'comparaisons': [{'tache_id': ref, 'reponse': 'superieur'}],
+        })
+        assert r.status_code == 200
+        assert _prio(db, t) == 3
+
+
+class TestMoteurPriorite:
+    BASE = {'duree_min': 60, 'deadline': '2025-06-16', 'priorite': 'normale',
+            'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30}
+
+    def _ordre(self, taches):
+        horizon = date(2025, 6, 20)
+        return [t['id'] for t in sorted(taches, key=lambda t: moteur._cle_tri_tache(t, horizon))]
+
+    def test_priorite_numerique_avant_duree(self):
+        t1 = dict(self.BASE, id=1, titre='A', priorite_num=5, duree_min=120)
+        t2 = dict(self.BASE, id=2, titre='B', priorite_num=2, duree_min=30)
+        assert self._ordre([t2, t1]) == [1, 2]
+
+    def test_duree_croissante_puis_recence(self):
+        t1 = dict(self.BASE, id=1, titre='Longue', priorite_num=0, duree_min=120)
+        t2 = dict(self.BASE, id=2, titre='Rapide', priorite_num=0, duree_min=30)
+        assert self._ordre([t1, t2]) == [2, 1]
+        # Tout égal : la plus récente (id le plus grand) d'abord.
+        t3 = dict(self.BASE, id=3, titre='Ancienne', priorite_num=0)
+        t4 = dict(self.BASE, id=4, titre='Récente', priorite_num=0)
+        assert self._ordre([t3, t4]) == [4, 3]
+
+    def test_repli_sur_l_ancienne_echelle_texte(self):
+        t1 = dict(self.BASE, id=1, titre='Haute', priorite='haute', priorite_num=None)
+        t2 = dict(self.BASE, id=2, titre='Basse', priorite='basse', priorite_num=None)
+        assert self._ordre([t2, t1]) == [1, 2]
+
+
+def test_recurrence_creee_avec_priorite_neutre(comptable_client, db, sample_users):
+    r = comptable_client.post('/planificateur/api/recurrence', json={
+        'titre': 'Relevé hebdo', 'frequence': 'hebdomadaire', 'duree_min': 30,
+        'jour_semaine': 1,
+    })
+    assert r.status_code == 200
+    rec = db.execute("SELECT * FROM planif_recurrences ORDER BY id DESC LIMIT 1").fetchone()
+    assert rec['priorite_num'] == 0
+
+
+def test_fenetre_contient_l_espace_priorite(comptable_client):
+    html = comptable_client.get('/planificateur').get_data(as_text=True)
+    assert 'id="blocPriorite"' in html
+    assert 'ajustement de priorité selon vos réponses' in html
+    assert 'Réévaluer la priorité' in html
+    assert 'id="t_priorite"' not in html   # l'ancien sélecteur a disparu
+    assert 'id="r_priorite"' not in html
+
+
+def test_migration_0060_reprend_l_ancienne_echelle(app, db, sample_users):
+    uid = sample_users['salarie_id']
+    for titre, prio in (('H', 'haute'), ('N', 'normale'), ('B', 'basse')):
+        db.execute(
+            "INSERT INTO planif_taches (user_id, type, titre, duree_min, priorite, priorite_num, statut) "
+            "VALUES (?, 'tache', ?, 30, ?, NULL, 'a_faire')", (uid, titre, prio))
+    db.commit()
+
+    import importlib.util
+    import os
+    chemin = os.path.join(os.path.dirname(__file__), '..', 'migrations',
+                          '0060_priorite_numerique_planificateur.py')
+    spec = importlib.util.spec_from_file_location('migration_0060_test', chemin)
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    migration.upgrade(db)
+
+    rows = {r['titre']: r['priorite_num'] for r in db.execute(
+        "SELECT titre, priorite_num FROM planif_taches WHERE user_id = ?", (uid,))}
+    assert rows == {'H': 1, 'N': 0, 'B': -1}

--- a/tests/test_planificateur_priorite.py
+++ b/tests/test_planificateur_priorite.py
@@ -105,6 +105,27 @@ class TestCalculPriorite:
         ])
         assert _derniere(db, uid)['priorite_num'] == 5
 
+    def test_creation_refusee_sans_comparaisons_quand_references_existent(self, comptable_client, db, sample_users):
+        """Garde-fou serveur (revue Codex) : dès qu'il existe des tâches de
+        référence, une création sans réponses de comparaison est refusée —
+        sinon une soumission trop rapide créerait des priorités neutres."""
+        uid = sample_users['comptable_id']
+        _inserer(db, uid, 'Référence', 0)
+
+        r = comptable_client.post('/planificateur/api/tache',
+                                  json={'type': 'tache', 'titre': 'Sans comparaison', 'duree_min': 30})
+        assert r.status_code == 400
+
+        # Des réponses invalides ne comptent pas non plus.
+        r = comptable_client.post('/planificateur/api/tache', json={
+            'type': 'tache', 'titre': 'Comparaison invalide', 'duree_min': 30,
+            'comparaisons': [{'tache_id': 'abc', 'reponse': 'peut-être'}],
+        })
+        assert r.status_code == 400
+
+        nb = db.execute("SELECT COUNT(*) FROM planif_taches WHERE user_id = ?", (uid,)).fetchone()[0]
+        assert nb == 1   # seule la référence existe
+
     def test_incoherence_reevalue_la_tache_mal_estimee(self, comptable_client, db, sample_users):
         # Exemple validé : supérieur à la tâche à 5, inférieur à celle à 2 →
         # la nouvelle passe à 6, la 5 ne bouge pas, la 2 remonte à 7.


### PR DESCRIPTION
## Résumé

Remplacement du système de priorité du planificateur de tâches. L'échelle fixe haute/normale/basse s'écrase à l'usage (tout finit en « haute ») : place à une **priorité numérique relative, jamais affichée**, construite par **comparaisons par paires** dans un **espace dédié de la fenêtre d'ajout**.

### Fonctionnement (validé avec l'utilisateur)

- **Première tâche** → priorité 0 (message : « elle servira de référence »).
- Ensuite, la nouvelle tâche est comparée (**moins / aussi / plus urgente**) à la **plus urgente** et à la **moins urgente** des tâches en cours d'ici **J+3** — repli sur l'ensemble des tâches s'il y en a moins de deux dans la fenêtre — présentées **en aveugle dans un ordre aléatoire** (anti-ancrage). Un message prévient que « les deux tâches présentées sont susceptibles d'ajustement de priorité selon vos réponses ».
- **Calcul** : inférieure aux deux → plus basse − 2 ; supérieure aux deux → plus haute + 2 ; entre les deux → arrondi de ((H−1)×1 + (B+1)×2) ÷ 3 (coefficient 2 côté « supérieur ») ; égale à une référence → sa valeur.
- **Réponses incohérentes** (supérieure à la plus urgente ET inférieure à la moins urgente) : le jugement du moment fait foi — la nouvelle passe au-dessus de la plus haute et la tâche mal estimée est réévaluée au-dessus (ex. validé : 5 et 2 → nouvelle à 6, la 2 remonte à 7).
- La réponse est **obligatoire** pour enregistrer (blocage avec message sinon).

### Ordre de planification (moteur)

**Échéance d'abord, puis priorité** (numérique, repli sur l'ancien texte pour l'existant), puis **durée croissante** (la plus rapide d'abord), puis **la plus récente** (une tâche ancienne jamais traitée peut attendre) — départages validés avec l'utilisateur.

### Interface

- Espace « 🎯 Priorité » clairement délimité dans la fenêtre d'ajout (remplace le sélecteur) ; masqué pour les événements fixes.
- La valeur numérique n'apparaît **nulle part** (détail d'un bloc : plus de mention de priorité).
- **Édition** : la priorité actuelle est conservée par défaut ; bouton « 🔁 Réévaluer la priorité » qui rejoue les comparaisons (en excluant la tâche elle-même) — c'est aussi le moyen de « remonter » manuellement une tâche mal classée.
- Récurrences : créées neutres (priorité 0, sélecteur retiré) ; occurrences et tâches « (suite) » héritent de la priorité.

### Données

- Migration **0060** : `priorite_num` (nullable) sur `planif_taches` et `planif_recurrences`, reprise de l'existant en préservant l'ordre relatif (haute → 1, normale → 0, basse → −1) ; l'ancienne colonne texte reste en secours pour le moteur.
- Nouvelle route `GET /planificateur/api/priorite/comparaison` (+ `exclude_id` pour la réévaluation) ; le calcul est entièrement côté serveur dans `_calculer_priorite_num`.

## Tests

- 24 nouveaux tests (`tests/test_planificateur_priorite.py`) : première tâche à 0, ±1/égal à une référence, formule pondérée (exemple validé 5/2 → 3), bornes ±2, égalité, **incohérence → réévaluation (6/5→5/2→7)**, fenêtre J+3 et repli, exclusion en réévaluation, tâches faites ignorées, édition avec/sans réévaluation, tri moteur (priorité > durée croissante > récence, repli texte), récurrence neutre, présence de l'espace dans la page, backfill de la migration 0060.
- **Suite complète : 991 tests OK** (les 52 tests existants du moteur passent inchangés).
- Vérification navigateur (Playwright) : première tâche (message référence), blocage sans réponse, une puis deux comparaisons en aveugle avec message préventif, priorités résultantes vérifiées en base (0 / 1 / −2), détail sans mention de priorité, bouton « Réévaluer » fonctionnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW