### PR TITLE
Planificateur : la priorité devient le critère maître, l'échéance un ajustement intelligent

### DIFF
--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -460,7 +460,10 @@ def _taches_non_placees(conn, user_id):
                  SELECT 1 FROM planif_blocs b
                  WHERE b.tache_id = t.id AND b.date >= ?
              )
-           ORDER BY t.deadline IS NULL, t.deadline''',
+           ORDER BY COALESCE(t.priorite_num,
+                             CASE t.priorite WHEN 'haute' THEN 1
+                                             WHEN 'basse' THEN -1 ELSE 0 END) DESC,
+                    t.duree_min, t.id DESC''',
         (user_id, today)
     ).fetchall()
     return [dict(r) for r in rows]

--- a/planificateur_engine.py
+++ b/planificateur_engine.py
@@ -11,10 +11,14 @@ Principe general (heuristique de placement glouton + equilibrage de charge) :
 1. On reconstruit, pour chaque jour de l'horizon, les creneaux libres a partir
    des horaires de travail du salarie, desquels on retire les evenements fixes
    (rendez-vous, reunions) et les blocs deja realises ou verrouilles.
-2. On traite les taches par ordre d'urgence : echeance la plus proche d'abord,
-   puis priorite (numerique relative, plus grand = plus urgent), puis duree
-   croissante (la plus rapide d'abord), puis la plus recente. Les taches
-   recurrentes sont placees en dernier, « la ou il reste de la place ».
+2. On traite les taches par priorite (numerique relative, plus grand = plus
+   urgent), puis duree croissante (la plus rapide d'abord), puis la plus
+   recente. L'echeance ne participe pas au tri : elle sert d'« ajustement
+   intelligent » — si une tache se retrouve hors delai, sa priorite est
+   rehaussee (le temps du calcul seulement) juste au-dessus de la moins
+   urgente des taches planifiees d'ici son echeance, et on replanifie.
+   Les taches recurrentes sont placees en dernier, « la ou il reste de la
+   place ».
 3. Pour chaque tache, on choisit a chaque etape le jour le moins charge de sa
    fenetre (equilibrage), en respectant la preference matin / apres-midi.
 4. Les longues missions secables sont reparties sur plusieurs jours, avec des
@@ -252,31 +256,35 @@ def niveau_urgence(deadline, jour_ref, statut='a_faire'):
     return 'a_venir'
 
 
-def _cle_tri_tache(tache, horizon_fin):
-    """Cle de tri d'une tache : echeance, puis (a echeance egale) les gros blocs
-    contigus d'abord, puis priorite, puis duree croissante (la plus rapide
-    d'abord), puis la plus recente (une tache ancienne jamais traitee peut
-    attendre).
+def _deadline_date(tache):
+    """Echeance d'une tache sous forme de date, ou None (absente / invalide)."""
+    deadline = tache.get('deadline')
+    if isinstance(deadline, str):
+        try:
+            return date.fromisoformat(deadline)
+        except ValueError:
+            return None
+    return deadline
+
+
+def _cle_tri_tache(tache, prios_effectives=None):
+    """Cle de tri d'une tache : priorite (plus grand = plus urgent), puis — a
+    priorite egale — les gros blocs contigus d'abord, puis duree croissante (la
+    plus rapide d'abord), puis la plus recente (une tache ancienne jamais
+    traitee peut attendre). L'echeance ne participe pas au tri : elle est
+    traitee par le rehaussement des taches hors delai (voir planifier).
 
     Une grosse tache NON secable exige un long creneau contigu : c'est la plus
     difficile a caser. Si on la traitait apres de petites taches flexibles du
     meme jour, celles-ci fragmenteraient les demi-journees et la rendraient
-    improuvable (elle devrait alors etre reportee). On la place donc en premier,
-    quitte a bousculer un peu l'ordre de priorite entre taches de meme echeance.
+    improuvable (elle devrait alors etre reportee). A priorite egale, on la
+    place donc en premier.
     """
-    deadline = tache.get('deadline') or horizon_fin
-    if isinstance(deadline, str):
-        try:
-            deadline = date.fromisoformat(deadline)
-        except ValueError:
-            deadline = horizon_fin
-    # Les taches sans echeance passent apres celles qui en ont une.
-    sans_echeance = 0 if tache.get('deadline') else 1
     duree = int(tache.get('duree_min', 0))
     secable = bool(tache.get('secable', True))
     gros_bloc_contigu = 0 if (not secable and duree > CIBLE_PAR_JOUR) else 1
-    return (sans_echeance, deadline, gros_bloc_contigu, -_priorite_valeur(tache),
-            duree, -int(tache.get('id') or 0))
+    prio = (prios_effectives or {}).get(tache.get('id'), _priorite_valeur(tache))
+    return (-prio, gros_bloc_contigu, duree, -int(tache.get('id') or 0))
 
 
 def _taille_chunk(duree, min_bloc, nb_jours_dispo, secable):
@@ -332,28 +340,33 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
     jours_feries = jours_feries or set()
     occupes_par_date = occupes_par_date or {}
 
-    # 1. Construire les journees et leurs creneaux libres.
-    jours = {}
-    d = date_debut
-    while d <= date_fin:
-        date_str = d.isoformat()
-        if date_str not in jours_feries:
-            work = horaires.get(date_str, [])
-            if work:
-                occ = list(occupes_par_date.get(date_str, []))
-                # Le premier jour, on ne planifie pas avant l'heure courante.
-                if d == date_debut and minute_courante > 0:
-                    occ.append((0, minute_courante))
-                libres = _soustraire(work, occ)
-                if libres:
-                    jours[date_str] = _PlanJour(d, libres)
-        d += timedelta(days=1)
+    def _construire_jours():
+        """Journees de l'horizon et leurs creneaux libres (etat d'une passe)."""
+        construits = {}
+        d = date_debut
+        while d <= date_fin:
+            date_str = d.isoformat()
+            if date_str not in jours_feries:
+                work = horaires.get(date_str, [])
+                if work:
+                    occ = list(occupes_par_date.get(date_str, []))
+                    # Le premier jour, on ne planifie pas avant l'heure courante.
+                    if d == date_debut and minute_courante > 0:
+                        occ.append((0, minute_courante))
+                    libres = _soustraire(work, occ)
+                    if libres:
+                        construits[date_str] = _PlanJour(d, libres)
+            d += timedelta(days=1)
+        return construits
 
-    # 2. Trier les taches : prioritaires (par urgence) puis recurrentes.
+    # 2. Separer prioritaires et recurrentes. Le tri, dependant des priorites
+    #    effectives (rehaussements compris), est refait a chaque passe.
     prioritaires = [t for t in taches if not t.get('est_recurrente')]
     recurrentes = [t for t in taches if t.get('est_recurrente')]
-    prioritaires.sort(key=lambda t: _cle_tri_tache(t, date_fin))
 
+    # Etat d'une passe de placement : reinitialise EN PLACE a chaque passe
+    # (les fonctions internes y accedent par fermeture).
+    jours = {}
     blocs_resultat = []
     non_planifie = []
 
@@ -493,10 +506,73 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
                 'raison': 'capacite insuffisante sur l\'horizon',
             })
 
-    for tache in prioritaires:
-        _placer_tache(tache)
-    # Les taches recurrentes remplissent l'espace restant.
-    for tache in recurrentes:
-        _placer_tache(tache)
+    def _prochain_rehaussement(prios_effectives):
+        """Tache hors delai a rehausser : (tache_id, nouvelle_priorite) ou None.
+
+        Hors delai = tache a echeance non entierement placee, ou dont un bloc
+        depasse l'echeance. Traitees par echeance la plus proche. Cible :
+        [moins urgente des taches planifiees d'ici l'echeance] + 2 ; si la
+        tache est deja au-dessus de cette cible et reste en retard, on grimpe
+        juste au-dessus de son plus faible bloqueur. Aucune tache a deplacer
+        dans la fenetre : surcapacite reelle, on n'insiste pas.
+        """
+        blocs_par_tache = {}
+        for b in blocs_resultat:
+            blocs_par_tache.setdefault(b['tache_id'], []).append(b['date'])
+        manquantes = {n['tache_id'] for n in non_planifie
+                      if n.get('minutes_restantes', 0) > 0}
+
+        retardataires = []
+        for t in prioritaires:
+            dl = _deadline_date(t)
+            if not dl:
+                continue
+            dates_t = blocs_par_tache.get(t['id'], [])
+            if t['id'] in manquantes or (dates_t and max(dates_t) > dl.isoformat()):
+                retardataires.append((dl, t))
+        retardataires.sort(key=lambda x: x[0])
+
+        for dl, tache in retardataires:
+            dl_str = dl.isoformat()
+            prios_fenetre = [
+                prios_effectives.get(autre['id'], _priorite_valeur(autre))
+                for autre in prioritaires
+                if autre['id'] != tache['id']
+                and any(dj <= dl_str for dj in blocs_par_tache.get(autre['id'], []))
+            ]
+            if not prios_fenetre:
+                continue
+            courante = prios_effectives.get(tache['id'], _priorite_valeur(tache))
+            cible = min(prios_fenetre) + 2
+            if cible <= courante:
+                bloqueurs = [p for p in prios_fenetre if p >= courante]
+                if not bloqueurs:
+                    continue
+                cible = min(bloqueurs) + 1
+            return tache['id'], cible
+        return None
+
+    # 3. Placement par passes : priorite pure d'abord ; tant qu'une tache a
+    #    echeance ressort hors delai, sa priorite est rehaussee — le temps du
+    #    calcul seulement, la priorite stockee n'est jamais modifiee — puis on
+    #    replanifie. Chaque rehaussement fait strictement monter une tache
+    #    au-dessus d'un bloqueur : la borne de passes reste large.
+    prios_effectives = {}
+    for _passe in range(3 * len(prioritaires) + 3):
+        jours.clear()
+        jours.update(_construire_jours())
+        del blocs_resultat[:]
+        del non_planifie[:]
+        charge_demi['matin'] = 0
+        charge_demi['apres_midi'] = 0
+        for tache in sorted(prioritaires, key=lambda t: _cle_tri_tache(t, prios_effectives)):
+            _placer_tache(tache)
+        # Les taches recurrentes remplissent l'espace restant.
+        for tache in recurrentes:
+            _placer_tache(tache)
+        rehaussement = _prochain_rehaussement(prios_effectives)
+        if rehaussement is None:
+            break
+        prios_effectives[rehaussement[0]] = rehaussement[1]
 
     return {'blocs': blocs_resultat, 'non_planifie': non_planifie}

--- a/planificateur_engine.py
+++ b/planificateur_engine.py
@@ -555,10 +555,12 @@ def planifier(taches, occupes_par_date, horaires, date_debut, date_fin,
     # 3. Placement par passes : priorite pure d'abord ; tant qu'une tache a
     #    echeance ressort hors delai, sa priorite est rehaussee — le temps du
     #    calcul seulement, la priorite stockee n'est jamais modifiee — puis on
-    #    replanifie. Chaque rehaussement fait strictement monter une tache
-    #    au-dessus d'un bloqueur : la borne de passes reste large.
+    #    replanifie. L'arret normal vient de _prochain_rehaussement (None) ;
+    #    la borne, quadratique, couvre le cas de plusieurs taches en retard sur
+    #    une meme echeance (chacune peut devoir depasser ses semblables avant
+    #    ses vrais bloqueurs) et ne joue vraiment qu'en surcapacite reelle.
     prios_effectives = {}
-    for _passe in range(3 * len(prioritaires) + 3):
+    for _passe in range(len(prioritaires) * len(prioritaires) + 3):
         jours.clear()
         jours.update(_construire_jours())
         del blocs_resultat[:]

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -975,3 +975,33 @@ def test_engine_surcapacite_reelle_reste_signalee():
     assert res['blocs'] == []
     assert len(res['non_planifie']) == 1
     assert res['non_planifie'][0]['tache_id'] == 1
+
+
+def test_engine_rehaussements_multiples_toutes_echeances_tenues():
+    """Plusieurs taches en retard sur la MEME echeance : chacune peut devoir
+    etre rehaussee plusieurs fois (elle depasse d'abord ses semblables avant
+    ses vrais bloqueurs). Toutes les echeances tenables doivent etre tenues
+    (revue Codex : la borne de passes ne doit pas s'epuiser avant)."""
+    lundi = _lundi_prochain()
+    taches = [
+        # 6 taches tres prioritaires sans echeance : elles saturent lundi en
+        # partie et peuvent glisser a mardi sans dommage.
+        *[{'id': 10 + i, 'titre': f'Prioritaire {i}', 'duree_min': 60,
+           'deadline': None, 'priorite_num': 5,
+           'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30}
+          for i in range(1, 7)],
+        # 4 taches modestes a echeance lundi : elles doivent toutes y tenir.
+        *[{'id': i, 'titre': f'Echeance lundi {i}', 'duree_min': 60,
+           'deadline': lundi.isoformat(), 'priorite_num': 0,
+           'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30}
+          for i in range(1, 5)],
+    ]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=1))
+
+    assert res['non_planifie'] == []
+    for b in res['blocs']:
+        if b['tache_id'] <= 4:
+            assert b['date'] == lundi.isoformat(), \
+                f"echeance manquee pour la tache {b['tache_id']} : {b['date']}"
+    # Les priorites stockees n'ont pas bouge (rehaussement ephemere).
+    assert all(t['priorite_num'] in (0, 5) for t in taches)

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -277,11 +277,12 @@ def test_engine_repartit_matin_et_apres_midi():
 
 
 def test_engine_utilise_apres_midi_meme_etale_sur_plusieurs_jours():
-    """Des taches etalees a raison d'une par jour (echeances a quelques jours) ne
-    doivent pas atterrir toutes le matin : l'equilibrage matin/apres-midi est
-    global a l'horizon, pas seulement interne a une journee."""
+    """Des taches etalees sur plusieurs jours ne doivent pas atterrir toutes le
+    matin : l'equilibrage matin/apres-midi est global a l'horizon, pas
+    seulement interne a une journee. (Depuis le tri par priorite pure, les
+    echeances ne forcent plus « une tache par jour » : on verifie l'etalement
+    ET le respect des echeances.)"""
     lundi = _lundi_prochain()
-    # 4 taches d'1h, echeances a 1..4 jours -> le moteur les etale (1 par jour).
     taches = [{'id': i, 'titre': f'T{i}', 'duree_min': 60,
                'deadline': (lundi + timedelta(days=i)).isoformat(),
                'priorite': 'normale', 'preference': 'aucune', 'secable': False,
@@ -291,7 +292,11 @@ def test_engine_utilise_apres_midi_meme_etale_sur_plusieurs_jours():
     par_jour = {}
     for b in res['blocs']:
         par_jour.setdefault(b['date'], []).append(b)
-    assert len(par_jour) == 4, "les taches doivent s'etaler sur plusieurs jours"
+    assert len(par_jour) >= 3, "les taches doivent s'etaler sur plusieurs jours"
+    # Chaque tache reste dans les delais.
+    deadlines = {t['id']: t['deadline'] for t in taches}
+    for b in res['blocs']:
+        assert b['date'] <= deadlines[b['tache_id']]
     heures = [moteur._to_min(b['heure_debut']) for b in res['blocs']]
     assert any(h < 720 for h in heures), "au moins une tache le matin"
     assert any(h >= 720 for h in heures), \
@@ -903,3 +908,70 @@ def test_menu_lien_visible_comptable(comptable_client):
 def test_menu_lien_visible_salarie(auth_client):
     html = auth_client.get('/dashboard').get_data(as_text=True)
     assert '/planificateur' in html
+
+
+def test_engine_priorite_prime_sur_une_echeance_lointaine():
+    """Une tache plus prioritaire SANS echeance passe avant une tache moins
+    prioritaire dont l'echeance est lointaine (il reste le temps de la faire)."""
+    lundi = _lundi_prochain()
+    taches = [
+        {'id': 1, 'titre': 'Echeance J+8', 'duree_min': 60,
+         'deadline': (lundi + timedelta(days=8)).isoformat(), 'priorite_num': 0,
+         'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30},
+        {'id': 2, 'titre': 'Prioritaire sans echeance', 'duree_min': 60,
+         'deadline': None, 'priorite_num': 1,
+         'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30},
+    ]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=8))
+
+    premiers = {}
+    for b in res['blocs']:
+        cle = (b['date'], b['heure_debut'])
+        if b['tache_id'] not in premiers or cle < premiers[b['tache_id']]:
+            premiers[b['tache_id']] = cle
+    assert premiers[2] < premiers[1], "la tache prioritaire doit etre placee avant"
+    # Et l'echeance de la moins prioritaire reste respectee.
+    deadline_1 = (lundi + timedelta(days=8)).isoformat()
+    assert all(b['date'] <= deadline_1 for b in res['blocs'] if b['tache_id'] == 1)
+
+
+def test_engine_echeance_rehausse_une_tache_hors_delai():
+    """L'echeance sert d'ajustement : une tache moins prioritaire qui sortirait
+    de son delai est rehaussee au-dessus de la moins urgente planifiee d'ici
+    son echeance, puis replanifiee — et tient alors son echeance."""
+    lundi = _lundi_prochain()
+    # Horizon de 2 jours (450 min/jour, micro-pauses comprises). Le remplissage
+    # prioritaire (720 min) sature lundi : sans rehaussement, la tache
+    # d'echeance lundi partirait a mardi, hors delai.
+    taches = [
+        {'id': 1, 'titre': 'Remplissage prioritaire', 'duree_min': 720,
+         'deadline': None, 'priorite_num': 5,
+         'preference': 'aucune', 'secable': True, 'duree_min_bloc': 30},
+        {'id': 2, 'titre': 'Echeance lundi', 'duree_min': 60,
+         'deadline': lundi.isoformat(), 'priorite_num': 0,
+         'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30},
+    ]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=1))
+
+    blocs_2 = [b for b in res['blocs'] if b['tache_id'] == 2]
+    assert blocs_2, "la tache a echeance doit etre placee"
+    assert all(b['date'] == lundi.isoformat() for b in blocs_2), \
+        "le rehaussement doit la ramener dans sa fenetre d'echeance"
+    # Tout le reste tient aussi sur les deux jours.
+    assert res['non_planifie'] == []
+    # Le rehaussement est ephemere : les priorites stockees n'ont pas bouge.
+    assert taches[0]['priorite_num'] == 5
+    assert taches[1]['priorite_num'] == 0
+
+
+def test_engine_surcapacite_reelle_reste_signalee():
+    """Sans tache a deplacer dans la fenetre, le rehaussement n'insiste pas :
+    la tache impossible reste signalee non planifiable (pas de boucle)."""
+    lundi = _lundi_prochain()
+    taches = [{'id': 1, 'titre': 'Impossible', 'duree_min': 600,
+               'deadline': lundi.isoformat(), 'priorite_num': 0,
+               'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30}]
+    res = moteur.planifier(taches, {}, _horaires_standard(), lundi, lundi + timedelta(days=1))
+    assert res['blocs'] == []
+    assert len(res['non_planifie']) == 1
+    assert res['non_planifie'][0]['tache_id'] == 1

--- a/tests/test_planificateur_priorite.py
+++ b/tests/test_planificateur_priorite.py
@@ -217,8 +217,7 @@ class TestMoteurPriorite:
             'preference': 'aucune', 'secable': False, 'duree_min_bloc': 30}
 
     def _ordre(self, taches):
-        horizon = date(2025, 6, 20)
-        return [t['id'] for t in sorted(taches, key=lambda t: moteur._cle_tri_tache(t, horizon))]
+        return [t['id'] for t in sorted(taches, key=moteur._cle_tri_tache)]
 
     def test_priorite_numerique_avant_duree(self):
         t1 = dict(self.BASE, id=1, titre='A', priorite_num=5, duree_min=120)


### PR DESCRIPTION
## Résumé

Suite du retour d'usage sur la PR #218 : une tâche **sans échéance mais jugée plus prioritaire** passait après une tâche d'échéance lointaine (J+8), car l'échéance dominait le tri.

### Nouveau classement (moteur + liste « à planifier »)

**Priorité** (relative, issue des comparaisons) → à priorité égale : gros blocs contigus d'abord (inchangé, faisabilité de placement) → **durée croissante** (la plus rapide avant) → **la plus récente** (une tâche ancienne jamais traitée peut attendre). L'échéance ne participe plus au tri.

### L'échéance devient un garde-fou (« ajustement intelligent »)

Le placement se fait par passes :
1. Placement par priorité pure.
2. Si une tâche à échéance ressort **hors délai** (non placée, ou débordant au-delà de son échéance), sa priorité est **rehaussée** à `[moins urgente des tâches planifiées d'ici son échéance] + 2` — ou juste au-dessus de son plus faible bloqueur si elle est déjà au-dessus de cette cible — puis on replanifie. Itéré (échéance la plus proche d'abord) jusqu'à stabilité, avec une borne de passes.
3. **Rehaussement éphémère** : recalculé à chaque planification, jamais écrit dans `priorite_num` — l'échelle construite par les comparaisons de l'utilisateur reste intacte.
4. S'il n'y a **aucune tâche à déplacer** dans la fenêtre (surcapacité réelle), la tâche reste signalée « non planifiable dans les délais » comme avant — pas de boucle.

### Comportements obtenus

- Le scénario rapporté : tâche prioritaire sans échéance placée **avant** la tâche d'échéance J+8, dont l'échéance reste tenue.
- Une tâche modeste d'échéance imminente n'est plus écrasée par des tâches plus prioritaires : elle remonte juste ce qu'il faut pour tenir son délai.
- La liste « à planifier » de l'interface suit le même ordre que le moteur.

## Tests

- 3 nouveaux tests moteur : priorité prime sur échéance lointaine (scénario rapporté), rehaussement d'une tâche hors délai (avec vérification que le scénario sature réellement la journée sans le mécanisme, et que les priorités stockées ne bougent pas), surcapacité réelle signalée sans boucle.
- 2 tests adaptés à la nouvelle sémantique (étalement, signature du tri).
- **Suite complète : 995 tests OK.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_