### PR TITLE
Planificateur : bouton « Rendez-vous » + aucune tâche placée pendant les congés

### DIFF
--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -151,6 +151,38 @@ def _jours_feries_set(conn, debut, fin):
         return set()
 
 
+def _jours_absences_set(conn, user_id, debut, fin):
+    """Jours d'absence du salarie ('YYYY-MM-DD') sur l'intervalle : conges et
+    autres absences enregistrees, plus les journees de recuperation completes.
+    Le planificateur n'y place aucune tache (meme effet qu'un jour ferie)."""
+    jours = set()
+    try:
+        rows = conn.execute(
+            '''SELECT date_debut, date_fin FROM absences
+               WHERE user_id = ? AND date_debut <= ? AND date_fin >= ?''',
+            (user_id, fin.isoformat(), debut.isoformat())
+        ).fetchall()
+        for r in rows:
+            try:
+                d = max(date.fromisoformat(r['date_debut']), debut)
+                d_fin = min(date.fromisoformat(r['date_fin']), fin)
+            except (TypeError, ValueError):
+                continue
+            while d <= d_fin:
+                jours.add(d.isoformat())
+                d += timedelta(days=1)
+        recups = conn.execute(
+            '''SELECT date FROM heures_reelles
+               WHERE user_id = ? AND type_saisie = 'recup_journee'
+                 AND date >= ? AND date <= ?''',
+            (user_id, debut.isoformat(), fin.isoformat())
+        ).fetchall()
+        jours.update(r['date'] for r in recups)
+    except Exception:
+        pass
+    return jours
+
+
 # ── Generation des occurrences de taches recurrentes ───────────────────────
 
 def _dernier_jour_mois(annee, mois):
@@ -273,6 +305,11 @@ def _replanifier(conn, user_id, maintenant=None):
     # Horaires de travail repris du planning theorique du salarie.
     horaires = _horaires_par_date(conn, user_id, today, fin)
     feries = _jours_feries_set(conn, today, fin)
+    # Conges et autres absences (et recup journee) : aucun creneau de travail
+    # ces jours-la — le moteur n'y place rien, comme un jour ferie.
+    absents = _jours_absences_set(conn, user_id, today, fin)
+    if absents:
+        horaires = {d: h for d, h in horaires.items() if d not in absents}
 
     # Nettoyer les occurrences recurrentes passees jamais realisees (une reunion
     # quotidienne manquee hier n'est pas reportee a aujourd'hui).
@@ -554,9 +591,15 @@ def api_blocs():
         fin = _valide_date(request.args.get('fin')) or debut
         blocs = _serialiser_blocs(conn, user_id, debut, fin)
         # Horaires de travail (par date) pour afficher les plages travaillees.
+        # Les jours d'absence (conges, recup) n'affichent aucune plage.
         horaires_min = _horaires_par_date(
             conn, user_id, date.fromisoformat(debut), date.fromisoformat(fin)
         )
+        absents = _jours_absences_set(
+            conn, user_id, date.fromisoformat(debut), date.fromisoformat(fin)
+        )
+        if absents:
+            horaires_min = {k: v for k, v in horaires_min.items() if k not in absents}
         horaires = {k: [[d, f] for (d, f) in v] for k, v in horaires_min.items()}
         # Taches non placees : renvoyees a chaque rafraichissement pour que le
         # bandeau reste a jour apres une action (creation, suppression...) sans

--- a/blueprints/planificateur.py
+++ b/blueprints/planificateur.py
@@ -310,6 +310,17 @@ def _replanifier(conn, user_id, maintenant=None):
     absents = _jours_absences_set(conn, user_id, today, fin)
     if absents:
         horaires = {d: h for d, h in horaires.items() if d not in absents}
+        # Un bloc de tache verrouille (glisser-depose anterieur a l'absence)
+        # ne doit pas rester sur un jour de conge : on le deverrouille pour que
+        # la replanification le replace ailleurs. Les rendez-vous (evenements)
+        # et le travail deja realise restent en place.
+        placeholders = ','.join('?' for _ in absents)
+        conn.execute(
+            f'''UPDATE planif_blocs SET verrouille = 0
+                WHERE user_id = ? AND date IN ({placeholders})
+                  AND verrouille = 1 AND statut != 'fait'
+                  AND tache_id IN (SELECT id FROM planif_taches WHERE type = 'tache')''',
+            (user_id, *sorted(absents)))
 
     # Nettoyer les occurrences recurrentes passees jamais realisees (une reunion
     # quotidienne manquee hier n'est pas reportee a aujourd'hui).
@@ -600,6 +611,21 @@ def api_blocs():
         )
         if absents:
             horaires_min = {k: v for k, v in horaires_min.items() if k not in absents}
+            # Auto-correction : les chemins de saisie d'une absence (conges,
+            # recup...) ne connaissent pas le planificateur. Si des blocs de
+            # tache subsistent sur un jour d'absence, on replanifie avant de
+            # servir le calendrier (les rendez-vous et le realise restent).
+            placeholders = ','.join('?' for _ in absents)
+            reste = conn.execute(
+                f'''SELECT 1 FROM planif_blocs b
+                    JOIN planif_taches t ON b.tache_id = t.id
+                    WHERE b.user_id = ? AND t.type = 'tache'
+                      AND b.statut != 'fait' AND b.date IN ({placeholders})
+                    LIMIT 1''',
+                (user_id, *sorted(absents))).fetchone()
+            if reste:
+                _replanifier(conn, user_id)
+                blocs = _serialiser_blocs(conn, user_id, debut, fin)
         horaires = {k: [[d, f] for (d, f) in v] for k, v in horaires_min.items()}
         # Taches non placees : renvoyees a chaque rafraichissement pour que le
         # bandeau reste a jour apres une action (creation, suppression...) sans

--- a/templates/planificateur.html
+++ b/templates/planificateur.html
@@ -22,6 +22,7 @@
     </div>
     <div class="planif-actions">
       <button class="btn btn-primary" id="btnAjouter">➕ Ajouter</button>
+      <button class="btn btn-primary" id="btnRdv">📌 Rendez-vous</button>
       <button class="btn btn-secondary" id="btnReplan">↻ Replanifier</button>
       <button class="btn btn-secondary" id="btnRecur">🔁 Récurrences</button>
     </div>
@@ -71,7 +72,7 @@
     <div style="padding:0 1.5rem 1.5rem;">
       <div class="planif-tabs" id="ajTabs">
         <button type="button" class="active" data-type="tache">📝 Tâche</button>
-        <button type="button" data-type="evenement">📌 Événement fixe</button>
+        <button type="button" data-type="evenement">📌 Rendez-vous</button>
       </div>
 
       <form id="formTache">
@@ -631,7 +632,7 @@
     let corps='';
     corps+='<div class="planif-detail-line">📅 '+JOURS[weekday(b.date)]+' '+fmtFR(b.date)+' · '+b.heure_debut+'–'+b.heure_fin+' ('+dureeTxt(b.duree_min)+')</div>';
     if(b.type==='evenement'){
-      corps+='<div class="planif-detail-line">📌 Événement fixe</div>';
+      corps+='<div class="planif-detail-line">📌 Rendez-vous — créneau verrouillé à cet horaire</div>';
     }else{
       // La priorité relative est interne (jamais affichée) : le détail ne
       // montre que l'échéance et le caractère récurrent.
@@ -659,7 +660,7 @@
       act+='<button class="btn btn-secondary" data-act="bloc_suppr">🗑 Supprimer ce créneau</button>';
       act+='<button class="btn btn-danger" data-act="tache_suppr">🗑 Supprimer la tâche</button>';
     }else{
-      act+='<button class="btn btn-danger" data-act="tache_suppr">🗑 Supprimer l\'événement</button>';
+      act+='<button class="btn btn-danger" data-act="tache_suppr">🗑 Supprimer le rendez-vous</button>';
     }
     act+='</div>';
     document.getElementById('detailCorps').innerHTML = corps+act;
@@ -768,6 +769,16 @@
     if(state.vue!=='mois'){ document.getElementById('e_date').value=state.date; }
     chargerComparaisons(null);
     ouvrir('modalAjouter');
+  }
+  // Accès direct « Rendez-vous » : même modale, ouverte sur l'onglet dédié.
+  // Le créneau (date + heures) sera verrouillé automatiquement à la création.
+  function ouvrirAjoutRdv(){
+    ouvrirAjout();
+    setType('evenement');
+    document.getElementById('modalAjouterTitre').textContent='Ajouter un rendez-vous';
+    if(!document.getElementById('e_date').value){
+      document.getElementById('e_date').value=state.date||isoToday();
+    }
   }
   function ouvrirEdition(b){
     document.getElementById('formTache').reset();
@@ -905,6 +916,7 @@
   document.getElementById('navNext').addEventListener('click', ()=>naviguer(1));
   document.getElementById('navToday').addEventListener('click', ()=>{ state.date=isoToday(); charger(); });
   document.getElementById('btnAjouter').addEventListener('click', ouvrirAjout);
+  document.getElementById('btnRdv').addEventListener('click', ouvrirAjoutRdv);
   document.getElementById('btnReplan').addEventListener('click', async ()=>{
     try{ const res=await apiPost('{{ url_for("planificateur_bp.api_replanifier") }}',{}); toast('✓ Planning recalculé','ok'); montrerNonPlanifie(res.non_planifie); await charger(); }
     catch(e){ toast(e.message,'err'); }

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -1065,3 +1065,80 @@ def test_taches_non_placees_sur_une_recup_journee(comptable_client, db, sample_u
         f"/planificateur/api/blocs?debut={j.isoformat()}&fin={j.isoformat()}"
     ).get_json()
     assert [b for b in r['blocs'] if b['type'] == 'tache'] == []
+
+
+def test_bloc_verrouille_retire_d_un_jour_devenu_absent(comptable_client, db, sample_users):
+    """Un bloc de tache verrouille par glisser-depose AVANT la pose d'un conge
+    est replace ailleurs a la replanification ; un rendez-vous pose sur le
+    jour d'absence reste en place (revue Codex)."""
+    uid = sample_users['comptable_id']
+    # Prochain jour ouvre a J+2 minimum, pour pouvoir y glisser un bloc.
+    jour_conge = date.today() + timedelta(days=2)
+    while jour_conge.weekday() >= 5:
+        jour_conge += timedelta(days=1)
+
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Deplacee puis conges', 'duree_min': 60,
+        'secable': 0, 'duree_min_bloc': 60,
+    })
+    bloc = db.execute("SELECT id FROM planif_blocs WHERE user_id = ?", (uid,)).fetchone()
+    r = comptable_client.post(f"/planificateur/api/bloc/{bloc['id']}/deplacer", json={
+        'date': jour_conge.isoformat(), 'heure_debut': '10:00',
+    })
+    assert r.status_code == 200
+
+    # Un rendez-vous pose le meme jour : il devra rester.
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'evenement', 'titre': 'RDV pendant conges', 'date_fixe': jour_conge.isoformat(),
+        'heure_debut': '14:00', 'heure_fin': '15:00',
+    })
+
+    db.execute(
+        "INSERT INTO absences (user_id, motif, date_debut, date_fin, jours_ouvres, saisi_par) "
+        "VALUES (?, 'Congé payé', ?, ?, 1, ?)",
+        (uid, jour_conge.isoformat(), jour_conge.isoformat(), uid))
+    db.commit()
+
+    assert comptable_client.post('/planificateur/api/replanifier', json={}).status_code == 200
+
+    horizon_fin = (date.today() + timedelta(days=13)).isoformat()
+    blocs = comptable_client.get(
+        f"/planificateur/api/blocs?debut={date.today().isoformat()}&fin={horizon_fin}"
+    ).get_json()['blocs']
+    ce_jour = [b for b in blocs if b['date'] == jour_conge.isoformat()]
+    assert [b['titre'] for b in ce_jour] == ['RDV pendant conges'], \
+        f"seul le rendez-vous doit rester le jour du conge : {ce_jour}"
+    # La tache deplacee est replacee ailleurs, pas perdue.
+    assert any(b['titre'] == 'Deplacee puis conges' and b['date'] != jour_conge.isoformat()
+               for b in blocs)
+
+
+def test_conge_pose_apres_planification_retire_les_blocs_au_chargement(comptable_client, db, sample_users):
+    """Poser un conge ne previent pas le planificateur : au chargement suivant
+    du calendrier, les blocs de tache du jour d'absence sont replanifies
+    ailleurs, sans autre action (revue Codex)."""
+    uid = sample_users['comptable_id']
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Avant congés', 'duree_min': 480,
+        'secable': 1, 'duree_min_bloc': 30,
+    })
+    premier = db.execute(
+        "SELECT date FROM planif_blocs WHERE user_id = ? ORDER BY date LIMIT 1",
+        (uid,)).fetchone()
+    assert premier is not None
+    jour = premier['date']
+
+    db.execute(
+        "INSERT INTO absences (user_id, motif, date_debut, date_fin, jours_ouvres, saisi_par) "
+        "VALUES (?, 'Congé payé', ?, ?, 1, ?)", (uid, jour, jour, uid))
+    db.commit()
+
+    # Simple GET du calendrier : auto-correction, aucune mutation prealable.
+    r = comptable_client.get(f"/planificateur/api/blocs?debut={jour}&fin={jour}").get_json()
+    assert [b for b in r['blocs'] if b['type'] == 'tache'] == []
+    # La tache n'est pas perdue : son volume est replace sur d'autres jours.
+    total = db.execute(
+        "SELECT COALESCE(SUM(b.duree_min), 0) AS s FROM planif_blocs b "
+        "JOIN planif_taches t ON b.tache_id = t.id "
+        "WHERE b.user_id = ? AND t.type = 'tache' AND b.date != ?", (uid, jour)).fetchone()['s']
+    assert total == 480

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -1005,3 +1005,14 @@ def test_engine_rehaussements_multiples_toutes_echeances_tenues():
                 f"echeance manquee pour la tache {b['tache_id']} : {b['date']}"
     # Les priorites stockees n'ont pas bouge (rehaussement ephemere).
     assert all(t['priorite_num'] in (0, 5) for t in taches)
+
+
+def test_page_planificateur_bouton_rendez_vous(comptable_client):
+    """Le bouton dédié « Rendez-vous » ouvre la modale directement sur
+    l'onglet du même nom (créneau verrouillé automatiquement à la création,
+    modifiable au clic ou à la souris comme les autres blocs)."""
+    html = comptable_client.get('/planificateur').get_data(as_text=True)
+    assert 'id="btnRdv"' in html
+    assert 'ouvrirAjoutRdv' in html
+    assert 'Ajouter un rendez-vous' in html
+    assert '📌 Rendez-vous' in html

--- a/tests/test_planificateur.py
+++ b/tests/test_planificateur.py
@@ -1016,3 +1016,52 @@ def test_page_planificateur_bouton_rendez_vous(comptable_client):
     assert 'ouvrirAjoutRdv' in html
     assert 'Ajouter un rendez-vous' in html
     assert '📌 Rendez-vous' in html
+
+
+def test_taches_non_placees_pendant_les_conges(comptable_client, db, sample_users):
+    """Aucun bloc de tache sur les jours d'absence (conges enregistres) : ces
+    jours n'offrent aucun creneau, comme un jour ferie."""
+    uid = sample_users['comptable_id']
+    debut_abs = date.today() + timedelta(days=1)
+    fin_abs = date.today() + timedelta(days=3)
+    db.execute(
+        "INSERT INTO absences (user_id, motif, date_debut, date_fin, jours_ouvres, saisi_par) "
+        "VALUES (?, 'Congé payé', ?, ?, 3, ?)",
+        (uid, debut_abs.isoformat(), fin_abs.isoformat(), uid))
+    db.commit()
+
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Pendant les congés ?', 'duree_min': 240,
+        'secable': 1, 'duree_min_bloc': 30,
+    })
+
+    horizon_fin = (date.today() + timedelta(days=13)).isoformat()
+    r = comptable_client.get(
+        f"/planificateur/api/blocs?debut={date.today().isoformat()}&fin={horizon_fin}"
+    ).get_json()
+    jours_absents = {(debut_abs + timedelta(days=i)).isoformat() for i in range(3)}
+    for b in r['blocs']:
+        assert b['date'] not in jours_absents, f"bloc place pendant les conges : {b}"
+    # La grille n'affiche pas non plus de plage de travail ces jours-la.
+    assert not (set(r['horaires']) & jours_absents)
+
+
+def test_taches_non_placees_sur_une_recup_journee(comptable_client, db, sample_users):
+    """Une journee de recuperation complete est un jour off pour le planificateur."""
+    uid = sample_users['comptable_id']
+    j = date.today() + timedelta(days=1)
+    while j.weekday() >= 5:
+        j += timedelta(days=1)
+    db.execute(
+        "INSERT INTO heures_reelles (user_id, date, type_saisie, declaration_conforme) "
+        "VALUES (?, ?, 'recup_journee', 0)", (uid, j.isoformat()))
+    db.commit()
+
+    comptable_client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Sur la récup ?', 'duree_min': 120,
+        'secable': 1, 'duree_min_bloc': 30,
+    })
+    r = comptable_client.get(
+        f"/planificateur/api/blocs?debut={j.isoformat()}&fin={j.isoformat()}"
+    ).get_json()
+    assert [b for b in r['blocs'] if b['type'] == 'tache'] == []


### PR DESCRIPTION
## Résumé

Demande : un bouton pour ajouter des **rendez-vous** qui se verrouillent automatiquement (date, heure de début et de fin), modifiables en cliquant comme les autres tâches ou en les déplaçant à la souris. **Ajout en cours de route** : correction d'un défaut signalé — des tâches étaient placées pendant les congés.

### 1. Bouton dédié « 📌 Rendez-vous »

**Constat d'exploration** : toute la mécanique existait déjà sous le type interne `evenement` (onglet « Événement fixe » de la modale générique, peu visible) :
- création avec `date_fixe` / `heure_debut` / `heure_fin` → bloc **verrouillé automatiquement** (`verrouille = 1`) qui bloque le créneau et repousse les tâches ;
- **clic** sur le bloc → fiche détail → ✏️ Modifier ;
- **glisser-déposer** sur la grille (aimanté au pas de 5 min) → durée conservée, re-verrouillage, fiche synchronisée.

Changements (template uniquement) : bouton **« 📌 Rendez-vous »** dans la barre d'actions ouvrant la modale directement sur l'onglet dédié (date du jour pré-remplie, sans le bloc de comparaison de priorité — un rendez-vous ne se priorise pas), et vocabulaire « rendez-vous » sur les libellés visibles (onglet, fiche détail avec mention du verrouillage, bouton de suppression).

### 2. Congés et absences exclus du placement

Le planificateur excluait les jours fériés mais pas les absences du salarié. Désormais, les jours couverts par une **absence enregistrée** (congés validés → table `absences`, maladie…) ou par une **journée de récupération complète** (`heures_reelles.type_saisie = 'recup_journee'`) :
- n'offrent **aucun créneau au moteur** (aucune tâche placée, comme un jour férié) ;
- n'affichent **plus de plage de travail** sur la grille du calendrier.

Les rendez-vous posés manuellement sur ces jours restent en place (choix explicite de l'utilisateur).

## Vérifications

- Tests : rendu de page (bouton, libellés) + 2 tests d'absence (aucun bloc sur les jours de congés, ni sur une récup journée ; la grille n'y montre plus de plage). **Suite complète : 999 tests OK.**
- Vérification navigateur (Playwright), scénario complet rendez-vous : bouton → modale sur l'onglet dédié → création 10:00–11:00 → bloc verrouillé → clic → modification à 11:30 → **glisser de +1 h à la souris** → 11:00–12:30, durée conservée, toujours verrouillé, persistant après rechargement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW