### PR TITLE
Simulateur de paie : colonnes « nouvelle ancienneté » et « nouvelles compétences », en-têtes abrégés

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -2543,8 +2543,14 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         pesee_act = override_num(ov, 'pesee', e['pesee'])
         nouv = ov.get('nouvelle_pesee')
         pesee_eff = _ps_num(nouv) if nouv not in (None, '') else pesee_act
-        anciennete = override_num(ov, 'anciennete', e['anciennete'])
-        competence = override_num(ov, 'competence', e['competence'])
+        # Ancienneté et compétences : même mécanique « nouvelle valeur » que la
+        # pesée — la valeur simulée prend le pas sans toucher à la fiche.
+        anciennete_act = override_num(ov, 'anciennete', e['anciennete'])
+        nouv_anc = ov.get('nouvelle_anciennete')
+        anciennete = _ps_num(nouv_anc) if nouv_anc not in (None, '') else anciennete_act
+        competence_act = override_num(ov, 'competence', e['competence'])
+        nouv_comp = ov.get('nouvelle_competence')
+        competence = _ps_num(nouv_comp) if nouv_comp not in (None, '') else competence_act
         maintien = override_num(ov, 'maintien', e.get('maintien'))
         ratio = ratio_temps(override_num(ov, 'temps_hebdo', e.get('temps_hebdo')))
         mois_vals, total_e = {}, 0.0

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -1981,7 +1981,9 @@ function defaultPaieState(ctx){
             pesee: e.pesee != null ? e.pesee : '',
             nouvelle_pesee: '',
             anciennete: e.anciennete != null ? e.anciennete : 0,
+            nouvelle_anciennete: '',
             competence: e.competence != null ? e.competence : '',
+            nouvelle_competence: '',
             maintien: e.maintien != null ? e.maintien : 0,
             temps_hebdo: e.temps_hebdo != null ? e.temps_hebdo : ''
         };
@@ -2029,7 +2031,11 @@ function computePaieJS(st, ctx, typeBudget){
         var ov = st.employes[e.id] || {};
         var pAct = ovNum(ov, 'pesee', e.pesee);
         var pEff = (ov.nouvelle_pesee !== '' && ov.nouvelle_pesee != null) ? psNum(ov.nouvelle_pesee) : pAct;
-        var anc = ovNum(ov, 'anciennete', e.anciennete), comp = ovNum(ov, 'competence', e.competence);
+        // Ancienneté / compétences : la « nouvelle » valeur prend le pas, comme la pesée.
+        var anc = (ov.nouvelle_anciennete !== '' && ov.nouvelle_anciennete != null)
+            ? psNum(ov.nouvelle_anciennete) : ovNum(ov, 'anciennete', e.anciennete);
+        var comp = (ov.nouvelle_competence !== '' && ov.nouvelle_competence != null)
+            ? psNum(ov.nouvelle_competence) : ovNum(ov, 'competence', e.competence);
         var maint = ovNum(ov, 'maintien', e.maintien);
         var ratio = ratioTemps(ovNum(ov, 'temps_hebdo', e.temps_hebdo));
         var mvals = {}, tot = 0;
@@ -2069,7 +2075,7 @@ function renderPaieSimulator(){
         '<div class="ps-field"><label>Valeur du point</label>' + paieInput('data-paie-top="valeur_point"', st.valeur_point, '0.01') + '</div>' +
         '<div class="ps-field"><label>Temps plein (h/sem.)</label>' + paieInput('data-paie-top="temps_plein"', st.temps_plein, '0.5') + '</div>' +
         '</div>';
-    html += '<div class="ps-legend">Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12, au prorata du temps de travail (temps hebdo / temps plein). Colonnes <span class="bp-ps-calc">surlignées</span> = calculées.';
+    html += '<div class="ps-legend">Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12, au prorata du temps de travail (h.hebdo / temps plein). Colonnes <span class="bp-ps-calc">surlignées</span> = calculées. Les colonnes « Nv » (nouvelle pesée, ancienneté, compétences) simulent une évolution : renseignées, elles prennent le pas sur la valeur actuelle sans modifier la fiche du salarié. Survolez les en-têtes pour les libellés complets.';
     if (actualise){
         html += ' Budget actualisé : seuls les mois après <strong>' + (ctx.last_real_month ? MOIS_COURT[ctx.last_real_month-1] : '—') +
             '</strong> sont simulés ; réel déjà constaté : <strong>' + fmt(ctx.montant_reel || 0) + ' €</strong>.';
@@ -2082,7 +2088,15 @@ function renderPaieSimulator(){
         html += '<p class="ps-legend">Aucun salarié actif en CDI/CDD rattaché à ce secteur sur l\'année.</p>';
     } else {
         html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
-            '<th>Salarié</th><th>Type</th><th>Temps hebdo</th><th>Pesée actuelle</th><th>Nouvelle pesée</th><th>Ancienneté</th><th>Compétence</th><th>Maintien €/mois</th>' +
+            '<th>Salarié</th><th>Type</th>' +
+            '<th title="Temps hebdomadaire (h/semaine)">h.hebdo</th>' +
+            '<th title="Pesée actuelle (fiche salarié)">Pesée</th>' +
+            '<th title="Nouvelle pesée simulée — prend le pas sur l\'actuelle, sans modifier la fiche">Nv pesée</th>' +
+            '<th title="Points d\'ancienneté actuels">Anc.</th>' +
+            '<th title="Nouvelle ancienneté simulée — prend le pas sur l\'actuelle, sans modifier la fiche">Nv anc.</th>' +
+            '<th title="Points de compétences actuels (fiche salarié)">Comp.</th>' +
+            '<th title="Nouvelles compétences simulées — prennent le pas sur les actuelles, sans modifier la fiche">Nv comp.</th>' +
+            '<th title="Maintien de salaire (€/mois)">Maint. €</th>' +
             monthTh + '<th class="bp-ps-calc">Total</th></tr></thead><tbody>';
         (ctx.employes || []).forEach(function(e){
             var ov = st.employes[e.id] || {};
@@ -2092,7 +2106,9 @@ function renderPaieSimulator(){
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="pesee"', ov.pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="nouvelle_pesee"', ov.nouvelle_pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="anciennete"', ov.anciennete, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="nouvelle_anciennete"', ov.nouvelle_anciennete, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="competence"', ov.competence, '0.01') + '</td>' +
+                '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="nouvelle_competence"', ov.nouvelle_competence, '0.01') + '</td>' +
                 '<td>' + paieInput('data-paie-emp="' + e.id + '" data-paie-key="maintien"', ov.maintien, '0.01') + '</td>' +
                 months.map(function(m){ return '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-' + m + '"></td>'; }).join('') +
                 '<td class="bp-ps-calc" id="paie-emp-' + e.id + '-tot"></td></tr>';
@@ -2106,7 +2122,14 @@ function renderPaieSimulator(){
         '<button class="btn btn-sm btn-secondary" type="button" onclick="paieAddAjout(\'cdd\')">+ CDD</button></div>';
     if ((st.ajouts || []).length){
         html += '<div class="ps-table-scroll"><table class="ps-table"><thead><tr>' +
-            '<th>Type</th><th>Temps hebdo</th><th>Pesée</th><th>Ancienneté</th><th>Maintien €/mois</th><th>Mois début / embauche</th><th>Mois fin (CDD)</th>' +
+            '<th>Type</th>' +
+            '<th title="Temps hebdomadaire (h/semaine)">h.hebdo</th>' +
+            '<th title="Pesée">Pesée</th>' +
+            '<th title="Points d\'ancienneté">Anc.</th>' +
+            '<th title="Points de compétences">Comp.</th>' +
+            '<th title="Maintien de salaire (€/mois)">Maint. €</th>' +
+            '<th title="Mois de début (CDD) ou d\'embauche (CDI)">Début</th>' +
+            '<th title="Mois de fin (CDD)">Fin</th>' +
             monthTh + '<th class="bp-ps-calc">Total</th><th></th></tr></thead><tbody>';
         st.ajouts.forEach(function(a, i){
             var isCdd = (a.type === 'cdd');
@@ -2114,6 +2137,7 @@ function renderPaieSimulator(){
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="temps_hebdo"', a.temps_hebdo, '0.5') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="pesee"', a.pesee, '1') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="anciennete"', a.anciennete, '1') + '</td>' +
+                '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="competence"', a.competence, '0.01') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="maintien"', a.maintien, '0.01') + '</td>' +
                 '<td>' + paieInput('data-paie-aj="' + i + '" data-paie-key="' + (isCdd ? 'mois_debut' : 'mois_embauche') + '"', isCdd ? a.mois_debut : a.mois_embauche, '1') + '</td>' +
                 '<td>' + (isCdd ? paieInput('data-paie-aj="' + i + '" data-paie-key="mois_fin"', a.mois_fin, '1') : '—') + '</td>' +

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1591,3 +1591,60 @@ def test_retrait_expose_uniquement_sur_le_type_courant(app, db, admin_client, sa
         f'/api/budget-previsionnel/donnees?type_budget=initial&annee={annee}&secteur_id={secteur_id}'
     ).get_json()
     assert not any(r['compte_num'] == '756000' for r in data_init['rows'])
+
+
+def test_paie_simulation_nouvelle_anciennete_et_competences(app, db, admin_client):
+    """Les colonnes « Nv anc. » et « Nv comp. » prennent le pas sur les valeurs
+    actuelles, comme la nouvelle pesée — sans modifier la fiche du salarié."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 100, 'nouvelle_pesee': '',
+                                       'anciennete': 3, 'nouvelle_anciennete': 10,
+                                       'competence': 5, 'nouvelle_competence': 20}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial',
+        'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    data = r.get_json()
+    # 23000 + (100 + 10 + 20) × 55 = 30150 € (annuel, temps plein)
+    assert abs(data['total'] - 30150.0) < 0.01
+    ligne = next(l for l in data['computed']['lignes'] if l['id'] == uid)
+    assert ligne['anciennete'] == 10
+    assert ligne['competence'] == 20
+    # La fiche du salarié garde les valeurs ACTUELLES (les « Nv » sont pure simulation).
+    with app.app_context():
+        u = db.execute("SELECT pesee, competence FROM users WHERE id=?", (uid,)).fetchone()
+    assert u['pesee'] == 100
+    assert u['competence'] == 5
+
+
+def test_paie_simulation_nouvelle_valeur_vide_sans_effet(app, db, admin_client):
+    """Champ « nouvelle » laissé vide : la valeur actuelle reste utilisée."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 100, 'nouvelle_pesee': '',
+                                       'anciennete': 3, 'nouvelle_anciennete': '',
+                                       'competence': 5, 'nouvelle_competence': ''}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial',
+        'compte_num': '641000', 'donnees': donnees})
+    # 23000 + (100 + 3 + 5) × 55 = 28940 €
+    assert abs(r.get_json()['total'] - 28940.0) < 0.01
+
+
+def test_budget_previsionnel_simulateur_paie_colonnes_nouvelles(admin_client):
+    """Le tableau du simulateur expose les colonnes abrégées et les « nouvelles »
+    valeurs pour l'ancienneté et les compétences."""
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert 'h.hebdo' in html
+    assert 'Nv pesée' in html
+    assert 'Nv anc.' in html
+    assert 'Nv comp.' in html
+    assert 'nouvelle_anciennete' in html
+    assert 'nouvelle_competence' in html


### PR DESCRIPTION
## Résumé

Sur la page budget prévisionnel, le simulateur de paie disposait d'une colonne « Nouvelle pesée » mais pas d'équivalent pour l'ancienneté et les compétences.

### Nouvelles colonnes « Nv anc. » et « Nv comp. »

Même mécanique que la nouvelle pesée, côté serveur (`_compute_paie`) comme côté client (`computePaieJS`) :
- renseignée, la « nouvelle » valeur **prend le pas** sur la valeur actuelle dans le calcul du brut ;
- laissée vide, la valeur actuelle reste utilisée ;
- **la fiche du salarié n'est jamais modifiée** par une « nouvelle » valeur — seules les valeurs actuelles saisies continuent d'être reportées sur la fiche à l'enregistrement (comportement existant inchangé) ;
- compatibilité assurée avec les simulations déjà enregistrées (clés absentes → comportement identique à avant).

### En-têtes abrégés (le tableau reste contenu)

`Salarié | Type | h.hebdo | Pesée | Nv pesée | Anc. | Nv anc. | Comp. | Nv comp. | Maint. € | [mois…] | Total` — les libellés complets sont disponibles en **info-bulle** sur chaque en-tête et rappelés dans la légende (« Les colonnes “Nv” simulent une évolution : renseignées, elles prennent le pas sur la valeur actuelle sans modifier la fiche »).

### Au passage

Le tableau « Autres salariés (ajouts) » gagne la colonne **Comp.** qui manquait alors que le calcul utilisait déjà cette valeur (elle restait toujours à 0 faute d'input), et ses en-têtes sont abrégés de la même façon.

## Vérifications

- 3 nouveaux tests : nouvelles valeurs effectives dans le total (23000 + (100+10+20)×55 = 30 150 €) avec fiche préservée ; champ « nouvelle » vide sans effet ; présence des colonnes abrégées sur la page. **Suite complète : 1004 tests OK.**
- Vérification navigateur (Playwright) : ouverture du simulateur depuis la ligne 641000, en-têtes abrégés (aucun « Temps hebdo » restant), saisie « Nv anc. » = +4 points → total +4 × valeur du point, « Nv comp. » = +2 → +2 × point, champ vidé → retour à la valeur actuelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_