### PR TITLE
Simulateur de paie : le prorata du temps partiel ne s'applique qu'au socle et à la pesée

### DIFF
--- a/blueprints/bilan_action.py
+++ b/blueprints/bilan_action.py
@@ -103,8 +103,10 @@ def _calc_salarie(s, params):
     """Calcule la paie d'un salarié pour l'action à partir de ses paramètres.
 
     Brut mensuel (même formule que le simulateur de paie) :
-        (socle + (pesée + ancienneté + compétence) * point) / 12 * ratio_temps
-        + maintien
+        [(socle + pesée * point) * ratio_temps
+         + (ancienneté + compétence) * point] / 12 + maintien
+    Le prorata ne s'applique qu'au socle et à la pesée : les points
+    d'ancienneté et de compétences sont dus à temps plein.
     Coût brut sur l'action (taux horaire annuel) :
         coût brut = (brut mensuel * 12) / (temps hebdo * 52) * heures sur l'action
     Charges sociales = coût brut * taux chargé (ex. 27 %).
@@ -126,7 +128,8 @@ def _calc_salarie(s, params):
     taux_taxe = _num(s.get('taux_taxe'), TAUX_TAXE_DEFAUT)
 
     ratio = (temps_hebdo / temps_plein) if temps_plein else 1.0
-    brut_mensuel = (socle + (pesee + anciennete + competence) * point) / 12.0 * ratio + maintien
+    brut_mensuel = ((socle + pesee * point) * ratio
+                    + (anciennete + competence) * point) / 12.0 + maintien
     heures_annuelles = temps_hebdo * 52.0
     taux_horaire = (brut_mensuel * 12.0 / heures_annuelles) if heures_annuelles else 0.0
     cout_brut = taux_horaire * heures

--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -2504,9 +2504,11 @@ def _paie_reel_641(conn, secteur_id, compte_num, annee):
 def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_reel):
     """Calcule le brut par salarié et par mois, le coût CEE et le total annuel.
 
-    Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12,
-    proratisé selon le temps de travail (temps_hebdo / temps plein de référence)
-    pour les salariés à temps partiel, puis + maintien (montant fixe non proratisé).
+    Brut mensuel = [(socle + pesée × valeur du point) × prorata
+                    + (ancienneté + compétences) × valeur du point] / 12,
+    puis + maintien (montant fixe non proratisé). Le prorata
+    (temps_hebdo / temps plein de référence) ne s'applique qu'au socle et à la
+    pesée : les points d'ancienneté et de compétences sont dus à temps plein.
     En budget actualisé, seuls les mois > last_real_month sont simulés ; le total
     intègre le réel (FEC) déjà constaté.
     """
@@ -2522,8 +2524,11 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
 
     start_month = (last_real_month or 0) + 1
 
-    def brut_mensuel(pesee, anciennete, competence):
-        return (socle + (pesee + anciennete + competence) * point) / 12.0
+    def brut_mensuel(pesee, anciennete, competence, ratio):
+        # Prorata sur le socle et la pesée uniquement ; les points
+        # d'ancienneté et de compétences restent dus à temps plein.
+        return ((socle + pesee * point) * ratio
+                + (anciennete + competence) * point) / 12.0
 
     def ratio_temps(temps_hebdo):
         # Temps inconnu ou non renseigné => temps plein (ratio 1).
@@ -2555,7 +2560,7 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         ratio = ratio_temps(override_num(ov, 'temps_hebdo', e.get('temps_hebdo')))
         mois_vals, total_e = {}, 0.0
         for m in range(max(start_month, e['mois_debut']), e['mois_fin'] + 1):
-            val = brut_mensuel(pesee_eff, anciennete, competence) * ratio + maintien
+            val = brut_mensuel(pesee_eff, anciennete, competence, ratio) + maintien
             mois_vals[m] = round(val, 2)
             monthly_totals[m] += val
             total_e += val
@@ -2586,7 +2591,7 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         mf = min(max(mf, 1), 12)
         mois_vals, total_a = {}, 0.0
         for m in range(max(start_month, mb), mf + 1):
-            val = brut_mensuel(pesee_eff, anciennete, competence) * ratio + maintien
+            val = brut_mensuel(pesee_eff, anciennete, competence, ratio) + maintien
             mois_vals[m] = round(val, 2)
             monthly_totals[m] += val
             total_a += val

--- a/templates/bilan_action.html
+++ b/templates/bilan_action.html
@@ -146,7 +146,9 @@ function calcSalarie(s, params){
     var tc = num(s.taux_charge, CTX.defaults.taux_charge);
     var tt = num(s.taux_taxe, CTX.defaults.taux_taxe);
     var ratio = tp ? th / tp : 1;
-    var brutm = (socle + (pesee + anc + comp) * point) / 12 * ratio + maint;
+    // Prorata sur le socle et la pesée uniquement ; ancienneté et compétences
+    // restent dues à temps plein (même règle que le simulateur de paie).
+    var brutm = ((socle + pesee * point) * ratio + (anc + comp) * point) / 12 + maint;
     var ha = th * 52;
     var txh = ha ? brutm * 12 / ha : 0;
     var coutb = txh * heures;

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -2020,7 +2020,9 @@ function computePaieJS(st, ctx, typeBudget){
     var lastReal = (typeBudget === 'actualise') ? (ctx.last_real_month || 0) : 0;
     var reel = (typeBudget === 'actualise') ? (ctx.montant_reel || 0) : 0;
     var start = lastReal + 1;
-    function brut(p,a,c){ return (socle + (p+a+c)*point) / 12; }
+    // Prorata sur le socle et la pesée uniquement ; ancienneté et compétences
+    // restent dues à temps plein.
+    function brut(p,a,c,ratio){ return ((socle + p*point)*ratio + (a+c)*point) / 12; }
     // Temps inconnu/0 => temps plein (ratio 1).
     function ratioTemps(th){ return (th && th > 0 && tplein) ? th/tplein : 1; }
     // Champ surchargé présent (même vide) => saisie (vide = 0) ; absent => fiche.
@@ -2039,7 +2041,7 @@ function computePaieJS(st, ctx, typeBudget){
         var maint = ovNum(ov, 'maintien', e.maintien);
         var ratio = ratioTemps(ovNum(ov, 'temps_hebdo', e.temps_hebdo));
         var mvals = {}, tot = 0;
-        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp)*ratio+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
+        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp,ratio)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
         lignes[e.id] = {mois: mvals, total: tot, pesee_eff: pEff};
     });
     var ajouts = {};
@@ -2051,7 +2053,7 @@ function computePaieJS(st, ctx, typeBudget){
         var mf = (typ==='cdd') ? (parseInt(a.mois_fin,10)||12) : 12;
         mb=Math.min(Math.max(mb,1),12); mf=Math.min(Math.max(mf,1),12);
         var mvals = {}, tot = 0;
-        for (var m=Math.max(start,mb); m<=mf; m++){ var v=brut(pEff,anc,comp)*ratioA+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
+        for (var m=Math.max(start,mb); m<=mf; m++){ var v=brut(pEff,anc,comp,ratioA)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
         ajouts[i] = {mois: mvals, total: tot};
     });
     var ceeJours = paieCeeParMois(ctx, st), ceeCout = {};
@@ -2075,7 +2077,7 @@ function renderPaieSimulator(){
         '<div class="ps-field"><label>Valeur du point</label>' + paieInput('data-paie-top="valeur_point"', st.valeur_point, '0.01') + '</div>' +
         '<div class="ps-field"><label>Temps plein (h/sem.)</label>' + paieInput('data-paie-top="temps_plein"', st.temps_plein, '0.5') + '</div>' +
         '</div>';
-    html += '<div class="ps-legend">Brut mensuel = (socle + (pesée + ancienneté + compétence) × valeur du point) / 12, au prorata du temps de travail (h.hebdo / temps plein). Colonnes <span class="bp-ps-calc">surlignées</span> = calculées. Les colonnes « Nv » (nouvelle pesée, ancienneté, compétences) simulent une évolution : renseignées, elles prennent le pas sur la valeur actuelle sans modifier la fiche du salarié. Survolez les en-têtes pour les libellés complets.';
+    html += '<div class="ps-legend">Brut mensuel = [(socle + pesée × valeur du point) × prorata + (ancienneté + compétences) × valeur du point] / 12. Le prorata (h.hebdo / temps plein) ne s\'applique qu\'au socle et à la pesée : ancienneté et compétences sont dues à temps plein. Colonnes <span class="bp-ps-calc">surlignées</span> = calculées. Les colonnes « Nv » (nouvelle pesée, ancienneté, compétences) simulent une évolution : renseignées, elles prennent le pas sur la valeur actuelle sans modifier la fiche du salarié. Survolez les en-têtes pour les libellés complets.';
     if (actualise){
         html += ' Budget actualisé : seuls les mois après <strong>' + (ctx.last_real_month ? MOIS_COURT[ctx.last_real_month-1] : '—') +
             '</strong> sont simulés ; réel déjà constaté : <strong>' + fmt(ctx.montant_reel || 0) + ' €</strong>.';

--- a/tests/test_bilan_action.py
+++ b/tests/test_bilan_action.py
@@ -178,3 +178,16 @@ def test_export_pdf(admin_client, app):
     assert r.status_code == 200
     assert r.headers['Content-Type'] == 'application/pdf'
     assert r.get_data()[:4] == b'%PDF'
+
+
+def test_calc_salarie_prorata_seulement_socle_et_pesee():
+    """Mi-temps : le prorata s'applique au socle et à la pesée ; les points
+    d'ancienneté et de compétences restent dus à temps plein (même règle que
+    le simulateur de paie du budget prévisionnel)."""
+    from blueprints.bilan_action import _calc_salarie
+    res = _calc_salarie(
+        {'temps_hebdo': 17.5, 'pesee': 100, 'anciennete': 10, 'competence': 20,
+         'maintien': 0, 'heures_action': 0},
+        {'socle': 23000, 'point': 55, 'temps_plein': 35})
+    # [(23000 + 100×55) × 0,5 + (10 + 20) × 55] / 12 = 15 900 / 12 = 1 325 €/mois
+    assert abs(res['brut_mensuel'] - 1325.0) < 0.01

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1648,3 +1648,25 @@ def test_budget_previsionnel_simulateur_paie_colonnes_nouvelles(admin_client):
     assert 'Nv comp.' in html
     assert 'nouvelle_anciennete' in html
     assert 'nouvelle_competence' in html
+
+
+def test_paie_simulation_prorata_seulement_socle_et_pesee(app, db, admin_client):
+    """Temps partiel : le prorata s'applique au socle et à la pesée, mais les
+    points d'ancienneté et de compétences restent calculés à temps plein.
+
+    Mi-temps (17,5/35), pesée 100, ancienneté 10, compétences 20 :
+    (23000 + 100×55) × 0,5 + (10 + 20) × 55 = 14 250 + 1 650 = 15 900 €.
+    """
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55, 'temps_plein': 35,
+               'employes': {str(uid): {'pesee': 100, 'nouvelle_pesee': '',
+                                       'anciennete': 10, 'competence': 20,
+                                       'temps_hebdo': 17.5}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial',
+        'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    assert abs(r.get_json()['total'] - 15900.0) < 0.01


### PR DESCRIPTION
## Résumé

Correction d'une erreur de calcul du simulateur de paie (budget prévisionnel), signalée à l'usage : le brut mensuel proratisait **tout** au temps de travail, y compris les points d'ancienneté et de compétences.

### Nouvelle règle

```
Brut mensuel = [ (socle + pesée × valeur du point) × prorata
                 + (ancienneté + compétences) × valeur du point ] / 12
               + maintien
```

Le prorata (h.hebdo / temps plein) ne s'applique qu'au **socle et à la pesée** ; les points d'**ancienneté** et de **compétences** sont dus **à temps plein**. Le maintien reste un montant fixe non proratisé (inchangé).

- Corrigé à l'identique **côté serveur** (`_compute_paie` — salariés du secteur et ajouts) et **côté client** (`computePaieJS`, recalcul instantané).
- La **légende** du simulateur énonce désormais la règle.
- **Sans effet pour les salariés à temps plein** (ratio 1 : les deux formules coïncident) — seuls les temps partiels changent.

### Exemple (mi-temps 17,5/35, socle 23 000, point 55, pesée 100, ancienneté 10, compétences 20)

- Avant : (23 000 + 130 × 55) × 0,5 = **15 075 €**
- Après : (23 000 + 100 × 55) × 0,5 + (10 + 20) × 55 = 14 250 + 1 650 = **15 900 €**

## Vérifications

- Méthode correctif d'AGENTS.md : test écrit d'abord (échec constaté à 15 075 €), puis correction (15 900 € ✓).
- Tests existants inchangés et verts (ils sont tous à temps plein, où la règle ne change rien). **Suite complète : 1005 tests OK.**
- Vérification navigateur (Playwright) : à temps plein le total est inchangé et « Nv anc. » ajoute bien 4 × point ; au passage à mi-temps, le total affiché correspond exactement à la nouvelle règle ; la légende mentionne « à temps plein ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_