### PR TITLE
Budget prévisionnel : PDF actualisé avec budget initial, actualisé et écart

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -1386,11 +1386,13 @@ def api_budget_previsionnel_export_pdf():
         from reportlab.platypus import SimpleDocTemplate, Table as RLTable, TableStyle, Paragraph, Spacer
         from reportlab.lib.styles import getSampleStyleSheet
 
-        titre = f"Budget {'global' if global_mode else 'secteur'} - {type_budget.capitalize()} - {annee}"
+        actualise = (type_budget == 'actualise')
+        libelle_type = 'Actualisé' if actualise else 'Initial'
+        titre = f"Budget {'global' if global_mode else 'secteur'} - {libelle_type} - {annee}"
         if secteur_id and not global_mode:
             secteur = conn.execute('SELECT nom FROM secteurs WHERE id = ?', (secteur_id,)).fetchone()
             if secteur:
-                titre = f"Budget {secteur['nom']} - {type_budget.capitalize()} - {annee}"
+                titre = f"Budget {secteur['nom']} - {libelle_type} - {annee}"
 
         buffer = io.BytesIO()
         doc = SimpleDocTemplate(buffer, pagesize=A4, leftMargin=1 * cm, rightMargin=1 * cm,
@@ -1398,15 +1400,43 @@ def api_budget_previsionnel_export_pdf():
         styles = getSampleStyleSheet()
         elements = [Paragraph(titre, styles['Title']), Spacer(1, 0.3 * cm)]
 
-        headers = ['Compte', 'Libellé', 'N-2', 'N-1', 'N', 'Temp.', 'Déf.']
+        # En budget actualisé, le document sert à comparer l'atterrissage au
+        # budget voté : la colonne « Temporaire » (aide à la saisie) laisse la
+        # place au budget initial et à l'écart.
+        if actualise:
+            # Les trois dernières colonnes portent des en-têtes plus larges :
+            # on puise dans la marge encore disponible sur la page A4 plutôt
+            # que de rogner le libellé du compte.
+            headers = ['Compte', 'Libellé', 'N-2', 'N-1', 'Initial N', 'Actualisé N', 'Écart']
+            largeurs = [2 * cm, 6.3 * cm, 2 * cm, 2 * cm, 2.2 * cm, 2.2 * cm, 2.2 * cm]
+        else:
+            headers = ['Compte', 'Libellé', 'N-2', 'N-1', 'N', 'Temp.', 'Déf.']
+            largeurs = [2 * cm, 6.4 * cm, 2 * cm, 2 * cm, 2 * cm, 2 * cm, 2 * cm]
         table_data = [headers]
+        initial_charges = initial_produits = 0.0
         for r in data['rows']:
-            table_data.append([
-                r['compte_num'], r['libelle'],
-                f"{r['N-2']:.2f}", f"{r['N-1']:.2f}", f"{r['N']:.2f}",
-                f"{r['temp']:.2f}", f"{r['def']:.2f}"
-            ])
-        t = RLTable(table_data, repeatRows=1, colWidths=[2 * cm, 6.4 * cm, 2 * cm, 2 * cm, 2 * cm, 2 * cm, 2 * cm])
+            if actualise:
+                # L'écart se lit directement entre les deux colonnes imprimées :
+                # il porte donc sur la valeur définitive. (À l'écran, où la
+                # colonne « Temporaire » reste visible, il retombe sur celle-ci
+                # tant que le définitif n'est pas saisi.)
+                initial = float(r.get('initial') or 0)
+                if r['nature'] == 'charges':
+                    initial_charges += initial
+                else:
+                    initial_produits += initial
+                table_data.append([
+                    r['compte_num'], r['libelle'],
+                    f"{r['N-2']:.2f}", f"{r['N-1']:.2f}", f"{initial:.2f}",
+                    f"{r['def']:.2f}", f"{r['def'] - initial:+.2f}"
+                ])
+            else:
+                table_data.append([
+                    r['compte_num'], r['libelle'],
+                    f"{r['N-2']:.2f}", f"{r['N-1']:.2f}", f"{r['N']:.2f}",
+                    f"{r['temp']:.2f}", f"{r['def']:.2f}"
+                ])
+        t = RLTable(table_data, repeatRows=1, colWidths=largeurs)
         t.setStyle(TableStyle([
             ('BACKGROUND', (0, 0), (-1, 0), colors.lightgrey),
             ('GRID', (0, 0), (-1, -1), 0.3, colors.grey),
@@ -1416,10 +1446,19 @@ def api_budget_previsionnel_export_pdf():
         elements.append(t)
         elements.append(Spacer(1, 0.4 * cm))
         tot = data['totaux']
-        elements.append(Paragraph(
-            f"Résultat Temp. : {tot['resultat_temp']:.2f} € | Résultat Déf. : {tot['resultat_def']:.2f} €",
-            styles['Heading3']
-        ))
+        if actualise:
+            resultat_initial = initial_produits - initial_charges
+            elements.append(Paragraph(
+                f"Résultat initial : {resultat_initial:.2f} € | "
+                f"Résultat actualisé : {tot['resultat_def']:.2f} € | "
+                f"Écart : {tot['resultat_def'] - resultat_initial:+.2f} €",
+                styles['Heading3']
+            ))
+        else:
+            elements.append(Paragraph(
+                f"Résultat Temp. : {tot['resultat_temp']:.2f} € | Résultat Déf. : {tot['resultat_def']:.2f} €",
+                styles['Heading3']
+            ))
         doc.build(elements)
         pdf = buffer.getvalue()
         buffer.close()

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1801,3 +1801,43 @@ def test_export_pdf_initial_conserve_ses_colonnes(app, db, admin_client):
     texte = _texte_pdf_budget(r.data)
     assert b'Temp.' in texte
     assert b'Initial N' not in texte
+
+
+def test_export_pdf_controle_acces_et_parametres(app, db, client, sample_users):
+    """Export d'un budget (données financières) : refus hors direction /
+    comptabilité et sur paramètres invalides. Les fixtures de clients
+    authentifiés partagent le même client de test : on gère les connexions
+    explicitement pour enchaîner plusieurs profils."""
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)
+    url = (f'/api/budget-previsionnel/export-pdf?type_budget=actualise'
+           f'&annee={annee}&secteur_id={sid}')
+
+    # Non connecté : redirigé vers la connexion, aucun PDF servi.
+    r = client.get(url, follow_redirects=False)
+    assert r.status_code in (301, 302)
+
+    # Salarié : accès refusé.
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'}, follow_redirects=True)
+    assert client.get(url).status_code == 403
+    client.get('/logout', follow_redirects=True)
+
+    # Responsable : la vue globale (tous secteurs) lui reste interdite, même
+    # si l'option lui ouvre la page de son secteur.
+    client.post('/login', data={'login': 'resp_test', 'password': 'resp123'}, follow_redirects=True)
+    assert client.get(
+        f'/api/budget-previsionnel/export-pdf?type_budget=actualise&annee={annee}&global=1'
+    ).status_code == 403
+    client.get('/logout', follow_redirects=True)
+
+    # Directeur : paramètres invalides refusés (type de budget, année manquante).
+    client.post('/login', data={'login': 'admin', 'password': 'Admin1234'}, follow_redirects=True)
+    assert client.get(
+        f'/api/budget-previsionnel/export-pdf?type_budget=inconnu&annee={annee}&secteur_id={sid}'
+    ).status_code == 400
+    assert client.get(
+        f'/api/budget-previsionnel/export-pdf?type_budget=actualise&secteur_id={sid}'
+    ).status_code == 400
+    # Et l'export légitime reste servi.
+    assert client.get(url).status_code == 200

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1743,3 +1743,61 @@ def test_paie_context_agrege_les_periodes_de_contrats_successifs(app, db, admin_
     # Caractéristiques affichées : celles du contrat en cours (le plus récent).
     assert emp['type_contrat'] == 'CDI'
     assert emp['temps_hebdo'] == 28
+
+
+def _texte_pdf_budget(data):
+    """Concatène les flux décompressés d'un PDF (le texte y est en clair).
+
+    ReportLab encode ses flux en ASCII85 puis Flate ; on tente les deux
+    décodages et on ignore le reste (polices…).
+    """
+    import base64
+    import re
+    import zlib
+    morceaux = []
+    for m in re.findall(rb'stream\r?\n(.*?)endstream', data, re.S):
+        m = m.strip()
+        for decode in (lambda b: zlib.decompress(base64.a85decode(b, adobe=True)),
+                       zlib.decompress):
+            try:
+                morceaux.append(decode(m))
+                break
+            except Exception:
+                continue
+    return b''.join(morceaux)
+
+
+def test_export_pdf_actualise_colonnes_initial_actualise_ecart(app, db, admin_client):
+    """PDF d'un budget actualisé : N-2, N-1, budget initial, actualisé
+    (définitif) et l'écart entre les deux — la colonne « Temporaire » laisse la
+    place à la comparaison initial / actualisé."""
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)   # initial définitif = 1 500 €
+        db.execute("INSERT INTO budget_prev_saisies (type_budget, annee, secteur_id, compte_num, valeur_def) "
+                   "VALUES ('actualise', ?, ?, '606000', 1800)", (annee, sid))
+        db.commit()
+
+    r = admin_client.get(
+        f'/api/budget-previsionnel/export-pdf?type_budget=actualise&annee={annee}&secteur_id={sid}')
+    assert r.status_code == 200
+    assert r.data[:4] == b'%PDF'
+    texte = _texte_pdf_budget(r.data)
+    # Les accents sont échappés en latin-1 dans les flux PDF (« Écart » →
+    # « \311cart ») : on cherche les fragments non accentués.
+    for attendu in (b'Initial N', b'Actualis', b'cart', b'1500.00', b'1800.00', b'+300.00'):
+        assert attendu in texte, f"{attendu!r} absent du PDF actualisé"
+    assert b'Temp.' not in texte, "la colonne Temporaire ne doit plus figurer en actualisé"
+
+
+def test_export_pdf_initial_conserve_ses_colonnes(app, db, admin_client):
+    """PDF d'un budget initial : présentation inchangée (N, Temp., Déf.)."""
+    annee = datetime.now().year
+    with app.app_context():
+        sid = _setup_fiche_secteur(db, annee)
+    r = admin_client.get(
+        f'/api/budget-previsionnel/export-pdf?type_budget=initial&annee={annee}&secteur_id={sid}')
+    assert r.status_code == 200
+    texte = _texte_pdf_budget(r.data)
+    assert b'Temp.' in texte
+    assert b'Initial N' not in texte


### PR DESCRIPTION
## Résumé

En **budget actualisé**, le PDF reprenait les colonnes du budget initial (N, Temporaire, Définitif) sans faire figurer le budget voté : impossible de mesurer l'atterrissage sur le document imprimé.

### Nouvelle présentation (budget actualisé uniquement)

| Compte | Libellé | N-2 | N-1 | **Initial N** | **Actualisé N** | **Écart** |
|---|---|---|---|---|---|---|

- **Initial N** : valeur définitive du budget initial de la même année.
- **Actualisé N** : valeur définitive de l'actualisé.
- **Écart** : différence entre les deux, signée (`+192.00`).
- Pied de page adapté : `Résultat initial | Résultat actualisé | Écart` (au lieu de `Résultat Temp. | Résultat Déf.`).
- Le titre affiche « Actualisé » avec son accent (au lieu de « Actualise »).

**Choix assumé sur l'écart** : sur le PDF, il se lit directement entre les deux colonnes imprimées, il porte donc sur la **valeur définitive**. À l'écran, où la colonne « Temporaire » reste visible, l'écart retombe sur celle-ci tant que le définitif n'est pas saisi — comportement inchangé. Documenté en commentaire dans le code.

Le PDF du **budget initial est inchangé**.

### Mise en page

Les trois dernières colonnes portent des en-têtes plus larges : elles passent de 2 à 2,2 cm en puisant dans la marge encore disponible sur la page A4, sans rogner le libellé du compte (6,3 cm au lieu de 6,4 cm).

## Vérifications

- 2 nouveaux tests (méthode correctif d'AGENTS.md : test écrit d'abord, échec constaté) : le PDF actualisé contient les nouveaux en-têtes, l'initial (1 500 €), l'actualisé (1 800 €) et l'écart (+300.00) et ne contient plus « Temp. » ; le PDF initial conserve ses colonnes.
- **Suite complète : 1011 tests OK.**
- Contrôle de mise en page sur un PDF réel (5 comptes, libellés longs, charges et produits) extrait avec pdfplumber : en-têtes conformes, aucun chevauchement entre le libellé et les colonnes de chiffres, tableau contenu dans les marges de la page.

Extrait obtenu :

```
Budget Accueil de loisirs - Actualisé - 2026
Compte Libellé                                    N-2       N-1    Initial N  Actualisé N   Écart
606300 Fournitures d'entretien et petit équipement 4200.00   4800.00  4896.00     5088.00  +192.00
641100 Rémunérations du personnel non cadre      142000.00 151000.00 154020.00   160060.00 +6040.00
Résultat initial : -8466.00 € | Résultat actualisé : -8798.00 € | Écart : -332.00 €
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_