### PR TITLE
Contrôles d'accès : cloisonnement subventions/factures, limite d'envoi et couverture des tests négatifs (+257 tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Le fichier `.env` est genere automatiquement au premier demarrage dans le meme d
 |---|---|---|
 | `SECRET_KEY` | Cle secrete Flask pour les sessions (generee automatiquement) | — |
 | `BEHIND_PROXY` | Mettre `true` si l'application est derriere un proxy/tunnel (ngrok, Cloudflare…) | `false` |
+| `MAX_UPLOAD_MO` | Taille maximale d'un envoi de fichier, **en megaoctets** (justificatifs d'absence, contrats, modeles DOCX, imports comptables, lots de factures). Au-dela, la requete est refusee avec un message « Envoi trop volumineux ». Une valeur absente, non numerique ou inferieure ou egale a 0 est ignoree : l'application journalise l'anomalie et reprend la valeur par defaut. | `256` |
 
 ## Configuration des notifications email (Gmail)
 

--- a/app.py
+++ b/app.py
@@ -534,10 +534,14 @@ def _attend_du_json():
 
 
 def _url_retour_sure():
-    """Retourne une URL locale sûre où renvoyer l'utilisateur après une erreur."""
-    referrer = request.referrer or ''
-    if referrer.startswith(request.host_url):
-        return referrer
+    """Retourne l'URL où renvoyer l'utilisateur après un envoi trop volumineux.
+
+    On ne réutilise JAMAIS l'URL fournie par le navigateur (en-tête Referer) :
+    une valeur contrôlée par le client ne doit pas devenir une cible de
+    redirection (redirection ouverte). Le tableau de bord est la destination de
+    repli utilisée partout ailleurs dans l'application ; le message flash
+    explique ce qui s'est passé.
+    """
     return url_for('dashboard_bp.dashboard')
 
 

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import os
 import sys
 import secrets
 from dotenv import load_dotenv
-from flask import Flask, session, render_template, flash, redirect, url_for, request
+from flask import Flask, session, render_template, flash, redirect, url_for, request, jsonify
 from flask_wtf.csrf import CSRFError
 from werkzeug.middleware.proxy_fix import ProxyFix
 import logging
@@ -190,6 +190,51 @@ if _behind_proxy:
 else:
     app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
     app.config['SESSION_COOKIE_SECURE'] = False
+
+# ==================== Taille maximale des envois de fichiers ====================
+# L'application expose de nombreux points d'envoi (justificatifs d'absence,
+# contrats et documents salariés, modèles DOCX de génération de contrats,
+# imports comptables FEC/TXT, plan comptable, lots de factures PDF...). Sans
+# borne, une requête de taille arbitraire peut saturer la mémoire ou le disque
+# du serveur.
+#
+# La limite est volontairement TRÈS LARGE pour ne bloquer aucun usage réel :
+# le flux le plus volumineux est l'import de factures, qui accepte plusieurs
+# PDF dans une seule requête. La restauration d'une sauvegarde ne transite pas
+# par un formulaire d'envoi (le fichier est déjà présent sur le serveur, seul
+# son nom est transmis), elle n'est donc pas concernée par cette limite.
+#
+# Surchargeable par la variable d'environnement MAX_UPLOAD_MO (en méga-octets).
+MAX_UPLOAD_MO_DEFAUT = 256
+
+
+def lire_max_upload_mo():
+    """Retourne la taille maximale d'un envoi HTTP, en méga-octets.
+
+    Lit MAX_UPLOAD_MO dans l'environnement et retombe sur la valeur par défaut
+    si elle est absente, non numérique ou nulle/négative.
+    """
+    valeur = os.environ.get('MAX_UPLOAD_MO', '').strip()
+    if not valeur:
+        return MAX_UPLOAD_MO_DEFAUT
+    try:
+        mo = int(valeur)
+    except ValueError:
+        logger.warning(
+            "MAX_UPLOAD_MO invalide (%r) : limite par défaut de %s Mo appliquée.",
+            valeur, MAX_UPLOAD_MO_DEFAUT,
+        )
+        return MAX_UPLOAD_MO_DEFAUT
+    if mo <= 0:
+        logger.warning(
+            "MAX_UPLOAD_MO doit être un entier positif (%r) : limite par défaut "
+            "de %s Mo appliquée.", valeur, MAX_UPLOAD_MO_DEFAUT,
+        )
+        return MAX_UPLOAD_MO_DEFAUT
+    return mo
+
+
+app.config['MAX_CONTENT_LENGTH'] = lire_max_upload_mo() * 1024 * 1024
 
 # ==================== Initialisation des extensions ====================
 # Le jeton CSRF reste valide tant que la session l'est (pas d'expiration au
@@ -465,6 +510,59 @@ def ratelimit_handler(e):
     """Affiche un message clair quand la limite de tentatives est atteinte."""
     flash('Trop de tentatives. Veuillez patienter avant de réessayer.', 'error')
     return render_template('login.html'), 429
+
+
+def _taille_max_lisible():
+    """Retourne la taille maximale d'envoi formatée pour un message utilisateur."""
+    limite = app.config.get('MAX_CONTENT_LENGTH') or 0
+    mo = limite / (1024 * 1024)
+    if mo >= 1:
+        return f"{mo:.0f} Mo" if mo == int(mo) else f"{mo:.1f} Mo"
+    return f"{limite / 1024:.0f} Ko"
+
+
+def _attend_du_json():
+    """Vrai si le client attend une réponse JSON (route d'API ou appel fetch).
+
+    N'inspecte que le chemin et les en-têtes : lire le corps de la requête
+    relancerait immédiatement l'erreur de dépassement de taille.
+    """
+    return ('/api/' in request.path
+            or request.accept_mimetypes.best == 'application/json'
+            or request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+            or request.is_json)
+
+
+def _url_retour_sure():
+    """Retourne une URL locale sûre où renvoyer l'utilisateur après une erreur."""
+    referrer = request.referrer or ''
+    if referrer.startswith(request.host_url):
+        return referrer
+    return url_for('dashboard_bp.dashboard')
+
+
+@app.errorhandler(413)
+def handle_request_entity_too_large(e):
+    """Répond proprement quand l'envoi dépasse la taille maximale autorisée.
+
+    Les routes d'API (ou les appels fetch) reçoivent un JSON en 413 ; les
+    formulaires classiques reçoivent un message flash puis une redirection,
+    conformément au schéma Post/Redirect/Get utilisé dans l'application.
+    """
+    taille_max = _taille_max_lisible()
+    message = (
+        f"Envoi trop volumineux : la taille totale des fichiers ne doit pas "
+        f"dépasser {taille_max}. Compressez le document ou envoyez-le en "
+        f"plusieurs fois."
+    )
+    logger.warning(
+        "Envoi refusé (413) : path=%s method=%s user_id=%s taille_max=%s",
+        request.path, request.method, session.get('user_id'), taille_max,
+    )
+    if _attend_du_json():
+        return jsonify({'ok': False, 'error': message}), 413
+    flash(message, 'error')
+    return redirect(_url_retour_sure())
 
 
 @app.errorhandler(CSRFError)

--- a/blueprints/factures.py
+++ b/blueprints/factures.py
@@ -264,6 +264,14 @@ def assigner_facture(facture_id):
         direction = request.form.get('direction') == '1'
 
     conn = get_db()
+    facture = conn.execute('SELECT id FROM factures WHERE id=?', (facture_id,)).fetchone()
+    if not facture:
+        conn.close()
+        if request.is_json:
+            return jsonify({'error': 'Facture introuvable'}), 404
+        flash('Facture introuvable.', 'error')
+        return redirect(url_for('factures_bp.liste_factures'))
+
     if direction:
         conn.execute(
             'UPDATE factures SET assigned_direction=1, secteur_id=NULL, updated_at=CURRENT_TIMESTAMP WHERE id=?',
@@ -348,12 +356,27 @@ def commenter_facture(facture_id):
         flash('Accès non autorisé', 'error')
         return redirect(url_for('dashboard_bp.dashboard'))
 
+    conn = get_db()
+    facture = conn.execute('SELECT secteur_id FROM factures WHERE id=?', (facture_id,)).fetchone()
+    if not facture:
+        conn.close()
+        flash('Facture introuvable.', 'error')
+        return redirect(url_for('factures_bp.approbation_factures'))
+
+    # Responsable : vérifier que la facture est de son secteur
+    if session.get('profil') == 'responsable':
+        user = conn.execute('SELECT secteur_id FROM users WHERE id=?', (session['user_id'],)).fetchone()
+        if not user or user['secteur_id'] != facture['secteur_id']:
+            conn.close()
+            flash('Accès non autorisé à cette facture.', 'error')
+            return redirect(url_for('factures_bp.approbation_factures'))
+
     commentaire = request.form.get('commentaire', '').strip()
     if not commentaire:
+        conn.close()
         flash('Le commentaire ne peut pas être vide.', 'error')
         return redirect(url_for('factures_bp.detail_facture', facture_id=facture_id))
 
-    conn = get_db()
     conn.execute(
         'INSERT INTO facture_commentaires (facture_id, user_id, commentaire) VALUES (?, ?, ?)',
         (facture_id, session['user_id'], commentaire)

--- a/blueprints/subventions.py
+++ b/blueprints/subventions.py
@@ -88,6 +88,59 @@ def _peut_gerer_types():
     return session.get('profil') in ('directeur', 'comptable')
 
 
+def _refus_acces_subvention(conn, sub_id):
+    """Controle le perimetre d'une action portant sur la subvention `sub_id`.
+
+    Retourne None quand l'action est autorisee, sinon la reponse JSON a renvoyer
+    telle quelle : 404 si la subvention n'existe pas, 403 si le profil n'a pas le
+    droit d'agir dessus.
+
+    La direction et la comptabilite agissent sur toutes les subventions. Un
+    responsable n'agit que sur celles qui lui sont assignees — exactement le
+    perimetre de la page de consultation : assigne principal ou secondaire de la
+    subvention, ou assigne de l'un de ses sous-elements. Sans ce controle, un
+    responsable pourrait modifier ou supprimer par ID les subventions d'un autre
+    secteur. Les autres profils sont refuses.
+    """
+    profil = session.get('profil')
+    if profil not in ('directeur', 'comptable', 'responsable'):
+        return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
+
+    existe = conn.execute('SELECT 1 FROM subventions WHERE id = ?', (sub_id,)).fetchone()
+    if not existe:
+        return jsonify({'ok': False, 'error': 'Subvention introuvable'}), 404
+
+    if profil in ('directeur', 'comptable'):
+        return None
+
+    user_id = session.get('user_id')
+    assignee = conn.execute(
+        '''SELECT 1 FROM subventions
+           WHERE id = ?
+             AND (assignee_1_id = ? OR assignee_2_id = ?
+                  OR id IN (
+                      SELECT subvention_id FROM subventions_sous_elements
+                      WHERE assignee_id = ?
+                  ))''',
+        (sub_id, user_id, user_id, user_id)
+    ).fetchone()
+    if not assignee:
+        return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
+    return None
+
+
+def _refus_acces_sous_element(conn, se_id):
+    """Meme controle que `_refus_acces_subvention`, a partir d'un sous-element :
+    le droit s'evalue toujours sur la subvention parente. Retourne None si
+    l'action est autorisee, 404 si le sous-element est introuvable."""
+    se = conn.execute(
+        'SELECT subvention_id FROM subventions_sous_elements WHERE id = ?', (se_id,)
+    ).fetchone()
+    if not se:
+        return jsonify({'ok': False, 'error': 'Sous-élément introuvable'}), 404
+    return _refus_acces_subvention(conn, se['subvention_id'])
+
+
 def _get_initiales(prenom, nom):
     p = (prenom or '').strip()
     n = (nom or '').strip()
@@ -406,6 +459,10 @@ def api_modifier_subvention(sub_id):
 
     conn = get_db()
     try:
+        refus = _refus_acces_subvention(conn, sub_id)
+        if refus:
+            return refus
+
         # Coherence avec la creation : refuser un type inexistant plutot que de
         # laisser une reference orpheline (les FK ne sont pas activees).
         if field == 'type_id' and value is not None:
@@ -443,6 +500,10 @@ def api_supprimer_subvention(sub_id):
 
     conn = get_db()
     try:
+        refus = _refus_acces_subvention(conn, sub_id)
+        if refus:
+            return refus
+
         conn.execute('DELETE FROM subventions_sous_elements WHERE subvention_id = ?', (sub_id,))
         sub = conn.execute('SELECT justificatif_path FROM subventions WHERE id = ?', (sub_id,)).fetchone()
         if sub and sub['justificatif_path']:
@@ -577,6 +638,10 @@ def api_ajouter_sous_element(sub_id):
 
     conn = get_db()
     try:
+        refus = _refus_acces_subvention(conn, sub_id)
+        if refus:
+            return refus
+
         max_ordre = conn.execute(
             'SELECT COALESCE(MAX(ordre), -1) as m FROM subventions_sous_elements WHERE subvention_id = ?',
             (sub_id,)
@@ -613,6 +678,10 @@ def api_modifier_sous_element(se_id):
 
     conn = get_db()
     try:
+        refus = _refus_acces_sous_element(conn, se_id)
+        if refus:
+            return refus
+
         infos_notif = None
         if field == 'assignee_id' and value:
             avant = conn.execute(
@@ -645,6 +714,10 @@ def api_supprimer_sous_element(se_id):
 
     conn = get_db()
     try:
+        refus = _refus_acces_sous_element(conn, se_id)
+        if refus:
+            return refus
+
         se = conn.execute('SELECT document_path FROM subventions_sous_elements WHERE id = ?', (se_id,)).fetchone()
         if se and se['document_path']:
             chemin = os.path.join(DOCUMENTS_DIR, se['document_path'])
@@ -664,7 +737,12 @@ def api_supprimer_sous_element(se_id):
 @subventions_bp.route('/api/subventions/analytiques/ajouter', methods=['POST'])
 @login_required
 def api_ajouter_analytique():
-    if not _peut_modifier():
+    # Le plan analytique est un referentiel GLOBAL, partage par toutes les
+    # subventions et tous les secteurs : sa creation suit la meme regle que la
+    # gestion des types (direction / comptabilite). L'interface ne l'expose a
+    # aucun responsable — la page subventions n'appelle pas cet endpoint —, la
+    # restriction ne casse donc aucun parcours utilisateur.
+    if not _peut_gerer_types():
         return jsonify({'ok': False, 'error': 'Non autorisé'}), 403
 
     data = request.get_json(silent=True) or {}
@@ -726,6 +804,10 @@ def api_upload_se_document(se_id):
 
     conn = get_db()
     try:
+        refus = _refus_acces_sous_element(conn, se_id)
+        if refus:
+            return refus
+
         se = conn.execute(
             'SELECT se.*, s.nom as sub_nom, s.annee_action '
             'FROM subventions_sous_elements se '
@@ -823,6 +905,10 @@ def api_upload_justificatif(sub_id):
 
     conn = get_db()
     try:
+        refus = _refus_acces_subvention(conn, sub_id)
+        if refus:
+            return refus
+
         sub = conn.execute(
             'SELECT nom, justificatif_path FROM subventions WHERE id = ?', (sub_id,)
         ).fetchone()

--- a/blueprints/subventions.py
+++ b/blueprints/subventions.py
@@ -141,6 +141,23 @@ def _refus_acces_sous_element(conn, se_id):
     return _refus_acces_subvention(conn, se['subvention_id'])
 
 
+def _peut_telecharger_piece_subvention(conn, sub_id):
+    """Vrai si le profil courant peut telecharger une piece de la subvention.
+
+    Applique exactement le meme perimetre que les routes de modification (en
+    reutilisant `_refus_acces_subvention`, pour que les deux ne divergent
+    jamais). Sans ce controle, un responsable non assigne pourrait recuperer,
+    en devinant l'identifiant, le justificatif d'une subvention d'un autre
+    secteur — alors que la page de consultation ne la lui montre pas.
+    """
+    return _refus_acces_subvention(conn, sub_id) is None
+
+
+def _peut_telecharger_piece_sous_element(conn, se_id):
+    """Meme controle que ci-dessus, a partir d'un sous-element."""
+    return _refus_acces_sous_element(conn, se_id) is None
+
+
 def _get_initiales(prenom, nom):
     p = (prenom or '').strip()
     n = (nom or '').strip()
@@ -860,6 +877,9 @@ def telecharger_se_document(se_id):
 
     conn = get_db()
     try:
+        if not _peut_telecharger_piece_sous_element(conn, se_id):
+            flash("Accès non autorisé.", "error")
+            return redirect(url_for('subventions_bp.gestion_subventions'))
         se = conn.execute(
             'SELECT document_path, document_nom FROM subventions_sous_elements WHERE id = ?',
             (se_id,)
@@ -957,6 +977,9 @@ def telecharger_justificatif(sub_id):
 
     conn = get_db()
     try:
+        if not _peut_telecharger_piece_subvention(conn, sub_id):
+            flash("Accès non autorisé.", "error")
+            return redirect(url_for('subventions_bp.gestion_subventions'))
         sub = conn.execute(
             'SELECT justificatif_path, justificatif_nom FROM subventions WHERE id = ?',
             (sub_id,)

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -109,6 +109,14 @@ BEHIND_PROXY=true
 
 > En développement local, `BEHIND_PROXY` n'est pas nécessaire.
 
+**Option taille des fichiers envoyés** — les envois (justificatifs d'absence, contrats, modèles DOCX, imports comptables, lots de factures) sont limités à **256 Mo** par défaut. Pour changer cette borne, indiquez la valeur **en mégaoctets** :
+
+```
+MAX_UPLOAD_MO=512
+```
+
+> Une valeur absente, non numérique ou inférieure ou égale à 0 est ignorée : l'application le signale dans la console et repart sur 256 Mo. Au-delà de la limite, l'utilisateur reçoit un message « Envoi trop volumineux » au lieu d'une erreur technique.
+
 ---
 
 ## 4. Lancer l'application

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,28 @@ def comptable_client(client, sample_users):
 
 
 @pytest.fixture
+def prestataire_client(app, db, client, sample_users):
+    """Client authentifie en tant que prestataire paie (cabinet externe).
+
+    Profil dedie a la preparation de paie : il accede aux justificatifs
+    d'absence et aux contrats, dont il a besoin pour saisir la paie, mais pas
+    au reste de l'application. L'utilisateur est cree a la demande (et non
+    dans `sample_users`) pour ne pas modifier les effectifs attendus par les
+    tests existants.
+    """
+    from werkzeug.security import generate_password_hash
+
+    with app.app_context():
+        db.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?, ?, ?, ?, ?)",
+            ('Cabinet', 'Paie', 'presta_test', generate_password_hash('presta123'), 'prestataire')
+        )
+        db.commit()
+    _login(client, 'presta_test', 'presta123')
+    return client
+
+
+@pytest.fixture
 def sample_planning(app, db, sample_users):
     """Crée un planning théorique standard (8h/jour, lun-ven) pour le salarié de test.
 

--- a/tests/test_acces_routes_sensibles.py
+++ b/tests/test_acces_routes_sensibles.py
@@ -1,0 +1,471 @@
+"""
+Filet de sécurité sur le contrôle d'accès des routes sensibles.
+
+POURQUOI CE FICHIER
+-------------------
+Chaque route de CS PILOT est protégée « à la main » (un test de profil au début
+de la vue). Rien ne garantit qu'une route ajoutée plus tard soit protégée : un
+oubli ne déclenche aucune alerte. Ce fichier centralise donc une table de
+référence des routes qui exposent des données ou des actions sensibles, et
+vérifie automatiquement, pour chacune, que :
+
+1. un visiteur NON CONNECTÉ est renvoyé vers `/login` ;
+2. un profil NON AUTORISÉ est refusé (403 pour les routes d'API, redirection
+   pour les pages HTML) ;
+3. le chemin et la méthode déclarés existent réellement dans l'application
+   (sans quoi le test passerait à vide sur une route fantôme).
+
+MODE D'EMPLOI — AJOUTER UNE ROUTE
+---------------------------------
+Quand vous ajoutez une fonctionnalité qui touche à l'argent, à la paie, aux
+données nominatives, à l'administration, aux clés API ou à une suppression,
+ajoutez une ligne dans `ROUTES_SENSIBLES` :
+
+    RouteSensible(
+        'mon_identifiant',        # identifiant unique, sert d'id pytest lisible
+        '/ma/route',              # chemin ; jetons acceptés : {secteur_id},
+                                  # {salarie_id}, {id_inexistant}
+        'POST',                   # méthode HTTP
+        ('directeur', 'comptable'),  # profils réellement autorisés
+        '/dashboard',             # forme du refus : chemin de redirection
+                                  # attendu, ou REFUS_403 pour une API JSON
+        corps={'cle': 'valeur'},  # optionnel : corps JSON envoyé à la route
+    )
+
+Les profils déclarés doivent correspondre au code, pas à l'intention : une
+ligne fausse rend le filet inutile. En cas d'échec, ne relâchez jamais
+l'assertion — vérifiez d'abord si la vue protège vraiment ce qu'elle prétend.
+
+PIÈGE : les fixtures de clients authentifiés (`auth_client`, `resp_client`…)
+partagent le même objet client. On utilise donc `client` et on gère les
+connexions/déconnexions explicitement.
+"""
+from collections import namedtuple
+from urllib.parse import urlsplit
+
+import pytest
+
+
+# ── Profils et identifiants de test (voir tests/conftest.py) ─────────────────
+
+PROFILS = {
+    'salarie': ('salarie_test', 'sal123'),
+    'responsable': ('resp_test', 'resp123'),
+    'comptable': ('compta_test', 'compta123'),
+    'directeur': ('admin', 'Admin1234'),
+    'prestataire': ('presta_test', 'presta123'),
+}
+
+TOUS_LES_PROFILS = ('salarie', 'responsable', 'comptable', 'directeur', 'prestataire')
+
+# Marqueur de refus pour les routes d'API, qui répondent en JSON au lieu de
+# rediriger. Les autres routes déclarent le chemin de redirection attendu.
+REFUS_403 = 403
+
+# Identifiant volontairement absent de la base de test.
+#
+# LIMITE ASSUMÉE : pour les routes à paramètre (<int:id>) qui ne portent pas
+# sur une ressource créée par les fixtures, on appelle la route avec cet
+# identifiant. Ce n'est PAS une assertion complaisante : dans toutes les vues
+# concernées, le contrôle de profil s'exécute AVANT la lecture de la ressource
+# en base. Le refus attendu (403 ou redirection) est donc bien le refus
+# d'autorisation, jamais un 404 accidentel — et l'assertion vérifie le statut
+# exact, pas un simple « différent de 200 ». Si une vue venait à inverser cet
+# ordre (lecture puis contrôle), le test échouerait, ce qui est le
+# comportement voulu.
+ID_INEXISTANT = 999999
+
+# Année figée : les tests ne doivent pas dépendre de l'heure réelle. Le refus
+# étudié intervient de toute façon avant tout calcul lié à l'année.
+ANNEE_REFERENCE = 2026
+
+
+RouteSensible = namedtuple(
+    'RouteSensible',
+    'identifiant chemin methode autorises refus corps',
+    defaults=(None,),
+)
+
+
+# ── Table de référence des routes sensibles ─────────────────────────────────
+#
+# Colonnes : identifiant | chemin | méthode | profils autorisés | refus attendu
+#
+# « refus attendu » = REFUS_403 pour une route d'API (réponse JSON), sinon le
+# chemin vers lequel la vue redirige un profil non autorisé.
+
+ROUTES_SENSIBLES = [
+    # ── Administration système et opérations destructives ────────────────────
+    RouteSensible('administration', '/administration', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('administration_options', '/administration/options', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('administration_migrations', '/administration/appliquer_toutes', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('administration_reinitialiser_bdd', '/administration/reinitialiser_bdd', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('sauvegardes_liste', '/sauvegardes', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('sauvegardes_creer', '/sauvegardes/creer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('sauvegardes_restaurer', '/sauvegardes/restaurer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('sauvegardes_supprimer', '/sauvegardes/supprimer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('sauvegardes_telecharger', '/sauvegardes/telecharger/cs_pilot.db', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('mise_a_jour_page', '/mise-a-jour', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('mise_a_jour_lancer', '/api/mise-a-jour/lancer', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+
+    # ── Comptes utilisateurs et délégations ──────────────────────────────────
+    RouteSensible('gestion_users', '/gestion_users', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('creer_user', '/creer_user', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('modifier_user', '/modifier_user/{salarie_id}', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('toggle_user', '/toggle_user/{salarie_id}', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('gestion_secteurs', '/gestion_secteurs', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('delegations', '/delegations', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+
+    # ── Clés API (secrets) ───────────────────────────────────────────────────
+    RouteSensible('cles_api_page', '/gestion_cles_api', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('cles_api_enregistrer', '/api/api_keys/save', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('cles_api_supprimer', '/api/api_keys/delete', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('cles_api_statut', '/api/api_keys/status', 'GET',
+                  ('directeur', 'comptable'), REFUS_403),
+
+    # ── Journaux de sécurité et traçabilité ──────────────────────────────────
+    RouteSensible('journal_acces', '/securite/journal-acces', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('journal_acces_export', '/securite/journal-acces/export', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('journal_actions', '/securite/journal-actions', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('journal_recherches', '/securite/journal-recherches', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('historique_modifications', '/historique_modifications', 'GET',
+                  ('directeur',), '/dashboard'),
+
+    # ── Trésorerie ───────────────────────────────────────────────────────────
+    RouteSensible('tresorerie', '/tresorerie', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('tresorerie_comptes', '/tresorerie/comptes', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('tresorerie_reinitialiser', '/api/tresorerie/reinitialiser', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('tresorerie_supprimer_comptes', '/api/tresorerie/comptes/supprimer_tous', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('tresorerie_import_fec', '/api/tresorerie/import_fec', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+
+    # ── Comptabilité et états financiers ─────────────────────────────────────
+    RouteSensible('compte_resultat', '/compte-resultat', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('compte_resultat_export_pdf', '/api/cr/export-pdf', 'GET',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('indicateurs_financiers', '/indicateurs-financiers', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('indicateurs_export_pdf', '/api/indicateurs/export-pdf', 'GET',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('plan_comptable_general', '/plan-comptable-general', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('plan_general_supprimer_compte', '/api/plan-general/comptes/{id_inexistant}',
+                  'DELETE', ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('plan_comptable_analytique', '/plan-comptable-analytique', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('analytique_supprimer_compte', '/api/comptabilite/comptes/{id_inexistant}',
+                  'DELETE', ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('ecritures', '/ecritures', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('ecritures_generer', '/ecritures/generer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('exportation', '/exportation', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('exportation_exporter', '/exportation/exporter', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('exportation_archive_supprimer',
+                  '/exportation/archives/{id_inexistant}/supprimer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('regles_comptables_supprimer', '/regles-comptables/{id_inexistant}/supprimer',
+                  'POST', ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('fournisseurs_supprimer', '/fournisseurs/{id_inexistant}/supprimer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('import_bi', '/import-bi', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('bilan_supprimer_annee', f'/api/bilan/annee/{ANNEE_REFERENCE}', 'DELETE',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('bilan_secteurs', '/bilan-secteurs', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('bilan_action', '/bilan-action', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('analyse_alsh', '/analyse-alsh', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+
+    # ── Budget (l'option « responsable autorisé » est activée par défaut) ────
+    RouteSensible('gestion_budgets', '/gestion_budgets', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('budget_secteur', '/budget_secteur/{secteur_id}', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('budget_previsionnel', '/budget-previsionnel', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('budget_previsionnel_export_pdf',
+                  '/api/budget-previsionnel/export-pdf'
+                  f'?type_budget=initial&annee={ANNEE_REFERENCE}' + '&secteur_id={secteur_id}',
+                  'GET', ('directeur', 'comptable', 'responsable'), REFUS_403),
+    # Le contrôle de profil de cette route s'exécute après la validation des
+    # paramètres : on envoie donc un corps complet et un secteur réel.
+    RouteSensible('budget_enregistrer', '/api/budget/save', 'POST',
+                  ('directeur', 'comptable', 'responsable'), REFUS_403,
+                  corps={'secteur_id': '{secteur_id}', 'annee': ANNEE_REFERENCE,
+                         'montant_global': 0, 'lignes': []}),
+
+    # ── Subventions et factures (cloisonnement par secteur) ─────────────────
+    RouteSensible('subventions', '/subventions', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('subventions_ajouter', '/api/subventions/ajouter', 'POST',
+                  ('directeur', 'comptable', 'responsable'), REFUS_403),
+    RouteSensible('subventions_supprimer', '/api/subventions/{id_inexistant}/supprimer', 'POST',
+                  ('directeur', 'comptable', 'responsable'), REFUS_403),
+    RouteSensible('subventions_supprimer_type', '/api/subventions/types/{id_inexistant}/supprimer',
+                  'POST', ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('subventions_justificatif', '/subventions/justificatif/{id_inexistant}', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/subventions'),
+    RouteSensible('factures', '/factures', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('factures_importer', '/factures/importer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('factures_supprimer', '/factures/{id_inexistant}/supprimer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('factures_relancer', '/factures/relancer', 'POST',
+                  ('directeur', 'comptable'), '/factures'),
+    RouteSensible('factures_approbation', '/factures/approbation', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('factures_telecharger', '/factures/{id_inexistant}/telecharger', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+
+    # ── Données RH et paie nominatives ───────────────────────────────────────
+    RouteSensible('infos_salaries', '/infos_salaries', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('infos_salaries_document', '/infos_salaries/telecharger_document/{id_inexistant}',
+                  'GET', ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('infos_salaries_supprimer_document',
+                  '/infos_salaries/supprimer_document/{id_inexistant}', 'POST',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('infos_salaries_contrat', '/infos_salaries/telecharger_contrat/{id_inexistant}',
+                  'GET', ('directeur', 'comptable', 'responsable', 'prestataire'), '/dashboard'),
+    RouteSensible('soldes_conges', '/soldes_conges', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('prepa_paie', '/prepa_paie', 'GET',
+                  ('directeur', 'comptable', 'prestataire'), '/dashboard'),
+    RouteSensible('prepa_paie_export_excel', '/prepa_paie/export_excel', 'GET',
+                  ('directeur', 'comptable', 'prestataire'), '/dashboard'),
+    RouteSensible('prepa_paie_traiter', '/prepa_paie/traiter', 'POST',
+                  ('directeur', 'comptable', 'prestataire'), '/dashboard'),
+    RouteSensible('variables_paie', '/variables_paie', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('variables_paie_enregistrer', '/variables_paie/enregistrer', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('variables_paie_cloturer', '/variables_paie/cloturer_conges', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('rh_statistiques', '/rh/statistiques', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('contrats', '/contrats', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('generation_contrats', '/generation_contrats', 'GET',
+                  ('directeur', 'comptable', 'responsable'), '/dashboard'),
+    RouteSensible('presence_effectif', '/presence-effectif', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('pesee_alisfa', '/pesee_alisfa', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('pesee_alisfa_supprimer_poste', '/api/pesee_alisfa/poste/{id_inexistant}',
+                  'DELETE', ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('absences_justificatif', '/absences/justificatif/{id_inexistant}', 'GET',
+                  ('directeur', 'comptable', 'prestataire'), '/dashboard'),
+    RouteSensible('absences_supprimer', '/absences/supprimer/{id_inexistant}', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('dashboard_direction', '/dashboard_direction', 'GET',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('dashboard_direction_seuils', '/api/dashboard-direction/seuils', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('deverrouiller_mois', '/deverrouiller_mois', 'POST',
+                  ('directeur',), '/dashboard'),
+    RouteSensible('rapport_forfait_jour_pdf', f'/rapport_forfait_jour_pdf/1/{ANNEE_REFERENCE}',
+                  'GET', ('directeur',), '/dashboard'),
+
+    # ── Configuration email et recherche transverse ──────────────────────────
+    RouteSensible('configuration_email', '/configuration_email', 'POST',
+                  ('directeur', 'comptable'), '/dashboard'),
+    RouteSensible('email_test', '/api/email/test', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+    RouteSensible('recherche_globale', '/api/search', 'POST',
+                  ('directeur', 'comptable'), REFUS_403),
+]
+
+IDS_ROUTES = [route.identifiant for route in ROUTES_SENSIBLES]
+
+
+# ── Utilitaires ─────────────────────────────────────────────────────────────
+
+def _resoudre(gabarit, sample_users):
+    """Remplace les jetons du gabarit par les identifiants réels du jeu d'essai."""
+    return gabarit.format(
+        secteur_id=sample_users['secteur_id'],
+        salarie_id=sample_users['salarie_id'],
+        id_inexistant=ID_INEXISTANT,
+    )
+
+
+def _resoudre_corps(corps, sample_users):
+    """Résout les jetons présents dans les valeurs du corps JSON."""
+    if corps is None:
+        return None
+    return {
+        cle: (_resoudre(valeur, sample_users) if isinstance(valeur, str) else valeur)
+        for cle, valeur in corps.items()
+    }
+
+
+def _appeler(client, route, sample_users):
+    """Appelle la route sans suivre les redirections (le refus doit rester visible)."""
+    chemin = _resoudre(route.chemin, sample_users)
+    corps = _resoudre_corps(route.corps, sample_users)
+    if corps is None:
+        return client.open(chemin, method=route.methode, follow_redirects=False)
+    return client.open(chemin, method=route.methode, json=corps, follow_redirects=False)
+
+
+def _chemin_redirection(reponse):
+    """Chemin visé par une redirection (sans schéma ni hôte)."""
+    return urlsplit(reponse.headers.get('Location', '')).path
+
+
+def _diagnostic(route, profil, reponse):
+    """Message d'échec nommant la route fautive et le profil concerné."""
+    destination = _chemin_redirection(reponse) or 'aucune redirection'
+    return (
+        f"Contrôle d'accès insuffisant sur {route.methode} {route.chemin} "
+        f"(entrée « {route.identifiant} ») : le profil « {profil} » a obtenu "
+        f"le statut {reponse.status_code} (destination : {destination}) "
+        f"alors que seuls {', '.join(route.autorises)} sont autorisés."
+    )
+
+
+def _verifier_refus(route, profil, reponse):
+    """Vérifie que la réponse est bien le refus déclaré dans la table."""
+    if route.refus == REFUS_403:
+        assert reponse.status_code == 403, _diagnostic(route, profil, reponse)
+        return
+    assert reponse.status_code in (301, 302), _diagnostic(route, profil, reponse)
+    assert _chemin_redirection(reponse) == route.refus, _diagnostic(route, profil, reponse)
+
+
+def _connexion(client, profil):
+    """Connecte le client de test avec les identifiants du profil demandé."""
+    identifiant, mot_de_passe = PROFILS[profil]
+    return client.post(
+        '/login',
+        data={'login': identifiant, 'password': mot_de_passe},
+        follow_redirects=True,
+    )
+
+
+@pytest.fixture
+def client_anonyme(client, sample_users, prestataire_client):
+    """Client de test déconnecté, les cinq profils étant présents en base.
+
+    `prestataire_client` sert uniquement à créer le compte prestataire ; comme
+    cette fixture connecte au passage le client partagé, on referme la session
+    pour repartir d'un visiteur réellement anonyme.
+    """
+    client.get('/logout', follow_redirects=True)
+    return client
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+def test_table_de_reference_est_coherente(app, sample_users):
+    """La table doit décrire des routes réelles : identifiants uniques, chemins
+    et méthodes existants, profils connus. Sans ce garde-fou, une faute de
+    frappe rendrait les tests suivants vides de sens."""
+    assert len(IDS_ROUTES) == len(set(IDS_ROUTES)), \
+        'Deux entrées de ROUTES_SENSIBLES partagent le même identifiant.'
+
+    adaptateur = app.url_map.bind('localhost')
+    for route in ROUTES_SENSIBLES:
+        chemin = _resoudre(route.chemin, sample_users).split('?')[0]
+        try:
+            adaptateur.match(chemin, method=route.methode)
+        except Exception as erreur:
+            pytest.fail(
+                f"Entrée « {route.identifiant} » : {route.methode} {chemin} "
+                f"ne correspond à aucune route de l'application ({erreur})."
+            )
+
+        assert route.autorises, \
+            f"Entrée « {route.identifiant} » : aucun profil autorisé déclaré."
+        inconnus = set(route.autorises) - set(TOUS_LES_PROFILS)
+        assert not inconnus, \
+            f"Entrée « {route.identifiant} » : profils inconnus {sorted(inconnus)}."
+        assert set(route.autorises) != set(TOUS_LES_PROFILS), \
+            (f"Entrée « {route.identifiant} » : tous les profils sont autorisés, "
+             f"la route n'a rien de sensible à vérifier.")
+
+
+@pytest.mark.parametrize('route', ROUTES_SENSIBLES, ids=IDS_ROUTES)
+def test_route_sensible_refuse_anonymes_et_profils_non_autorises(
+    route, app, sample_users, client_anonyme
+):
+    """Chaque route sensible refuse le visiteur anonyme et tout profil non
+    autorisé. Les fixtures de clients authentifiés partagent le même client :
+    on enchaîne donc les profils par connexion/déconnexion explicites."""
+    client = client_anonyme
+
+    # 1. Visiteur non connecté : renvoyé vers la page de connexion.
+    reponse = _appeler(client, route, sample_users)
+    assert reponse.status_code in (301, 302), _diagnostic(route, 'anonyme', reponse)
+    assert _chemin_redirection(reponse) == '/login', _diagnostic(route, 'anonyme', reponse)
+
+    # 2. Profils non autorisés : refus explicite (403) ou redirection.
+    for profil in TOUS_LES_PROFILS:
+        if profil in route.autorises:
+            continue
+        _connexion(client, profil)
+        reponse = _appeler(client, route, sample_users)
+        _verifier_refus(route, profil, reponse)
+        client.get('/logout', follow_redirects=True)
+
+
+def test_setup_ne_recree_pas_un_administrateur_quand_des_comptes_existent(
+    app, db, client, sample_users
+):
+    """La page d'installation initiale crée le premier administrateur : elle
+    doit être fermée dès qu'un compte existe, sinon un visiteur anonyme
+    obtiendrait les pleins pouvoirs."""
+    reponse = client.get('/setup', follow_redirects=False)
+    assert reponse.status_code in (301, 302)
+    assert _chemin_redirection(reponse) == '/login'
+
+    reponse = client.post('/setup', data={
+        'nom': 'Pirate',
+        'prenom': 'Anonyme',
+        'login': 'pirate_test',
+        'password': 'Pirate1234!',
+        'password_confirm': 'Pirate1234!',
+    }, follow_redirects=False)
+    assert reponse.status_code in (301, 302)
+    assert _chemin_redirection(reponse) == '/login'
+
+    with app.app_context():
+        cree = db.execute(
+            "SELECT 1 FROM users WHERE login = 'pirate_test'"
+        ).fetchone()
+    assert cree is None, "La page /setup a créé un compte alors que la base n'est pas vierge."

--- a/tests/test_administration_acces.py
+++ b/tests/test_administration_acces.py
@@ -1,0 +1,562 @@
+"""
+Tests de contrôle d'accès des écrans d'administration système.
+
+Enjeu : ces routes sont les plus destructrices de l'application (application de
+migrations, réinitialisation complète de la base, activation/désactivation de
+comptes, secrets des fournisseurs IA). Une entrée de menu masquée ne constitue
+pas un contrôle d'accès : on vérifie ici que le serveur refuse réellement, et
+surtout qu'un refus est **sans effet** sur les données.
+
+Règles observées dans le code testé :
+- `blueprints/administration.py` : `_check_admin()` n'autorise que `directeur`
+  et `comptable`. Tout autre profil est redirigé vers le tableau de bord.
+- `blueprints/admin.py` : mêmes profils autorisés (`directeur`, `comptable`) ;
+  le `responsable` n'est jamais autorisé sur ces écrans.
+- `blueprints/api_keys.py` : `PROFILS_AUTORISES` = `directeur`, `comptable` ;
+  les routes JSON répondent 403 au lieu d'une redirection.
+
+Les fixtures de clients authentifiés partagent le MÊME client de test : les
+tests qui enchaînent plusieurs profils utilisent `client` et gèrent les
+connexions explicitement.
+"""
+import os
+
+import pytest
+
+
+# Profils qui ne doivent JAMAIS accéder à l'administration système.
+PROFILS_REFUSES = [
+    ('salarie_test', 'sal123'),
+    ('resp_test', 'resp123'),
+]
+
+
+def _connexion(client, login, mot_de_passe):
+    """Connecte le client de test avec le profil demandé."""
+    return client.post(
+        '/login',
+        data={'login': login, 'password': mot_de_passe},
+        follow_redirects=True,
+    )
+
+
+def _deconnexion(client):
+    """Ferme la session courante du client de test."""
+    return client.get('/logout', follow_redirects=True)
+
+
+def _etat_base(db):
+    """Photographie l'état sensible de la base (tables, comptes, migrations).
+
+    Sert de témoin : après une tentative refusée, l'état doit être identique.
+    """
+    tables = [
+        row['name'] for row in db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+    ]
+    users = [
+        tuple(row) for row in db.execute(
+            "SELECT id, login, profil, actif, password FROM users ORDER BY id"
+        ).fetchall()
+    ]
+    migrations = [
+        tuple(row) for row in db.execute(
+            "SELECT version, statut, appliquee_par FROM schema_migrations "
+            "ORDER BY version"
+        ).fetchall()
+    ]
+    return {'tables': tables, 'users': users, 'migrations': migrations}
+
+
+def _est_redirection_connexion(reponse):
+    """Vrai si la réponse renvoie l'anonyme vers le formulaire de connexion."""
+    return reponse.status_code in (301, 302) and '/login' in reponse.headers.get('Location', '')
+
+
+def _est_redirection_tableau_de_bord(reponse):
+    """Vrai si la réponse renvoie un profil authentifié mais non autorisé."""
+    return reponse.status_code in (301, 302) and '/dashboard' in reponse.headers.get('Location', '')
+
+
+class TestAdministrationSysteme:
+    """Page d'administration et opérations de migration (`_check_admin()`).
+
+    Enjeu : la consultation expose le nom du fichier de base, sa taille et le
+    volume de chaque table ; les POST modifient le schéma. Réservé à la
+    direction et à la comptabilité.
+    """
+
+    def test_page_administration_refusee_hors_direction(self, client, sample_users):
+        """Anonyme, salarié et responsable ne doivent pas voir l'inventaire des tables."""
+        reponse = client.get('/administration', follow_redirects=False)
+        assert _est_redirection_connexion(reponse)
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.get('/administration', follow_redirects=False)
+            assert _est_redirection_tableau_de_bord(reponse), (
+                f"Le profil {login} ne doit pas accéder à /administration"
+            )
+            _deconnexion(client)
+
+    def test_page_administration_refusee_prestataire(self, prestataire_client):
+        """Le prestataire paie (cabinet externe) n'a rien à faire côté système."""
+        reponse = prestataire_client.get('/administration', follow_redirects=False)
+        assert _est_redirection_tableau_de_bord(reponse)
+
+    def test_page_administration_ouverte_direction_et_comptabilite(self, client, sample_users):
+        """Cas légitime : directeur et comptable consultent bien la page."""
+        for login, mot_de_passe in (('admin', 'Admin1234'), ('compta_test', 'compta123')):
+            _connexion(client, login, mot_de_passe)
+            reponse = client.get('/administration')
+            assert reponse.status_code == 200, f"{login} doit accéder à /administration"
+            _deconnexion(client)
+
+    @pytest.mark.parametrize('url, donnees', [
+        ('/administration/appliquer_migration', {'version': '0001'}),
+        ('/administration/appliquer_toutes', {}),
+        ('/administration/initialiser_baseline', {}),
+    ])
+    def test_operations_migration_refusees_et_sans_effet(
+        self, url, donnees, app, db, client, sample_users
+    ):
+        """Aucun profil non autorisé ne peut toucher au schéma de la base.
+
+        On compare l'historique `schema_migrations` avant/après : un refus doit
+        laisser la base strictement identique.
+        """
+        avant = _etat_base(db)
+
+        # Non connecté : renvoyé vers la connexion.
+        reponse = client.post(url, data=donnees, follow_redirects=False)
+        assert _est_redirection_connexion(reponse)
+
+        # Salarié et responsable : renvoyés vers leur tableau de bord.
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.post(url, data=donnees, follow_redirects=False)
+            assert _est_redirection_tableau_de_bord(reponse), (
+                f"Le profil {login} ne doit pas déclencher {url}"
+            )
+            _deconnexion(client)
+
+        assert _etat_base(db) == avant, (
+            f"Une tentative refusée sur {url} a modifié la base"
+        )
+
+    def test_appliquer_migration_sans_version_refuse_cote_direction(self, db, admin_client):
+        """Entrée invalide : une version manquante est rejetée, sans effet en base."""
+        avant = _etat_base(db)
+
+        reponse = admin_client.post(
+            '/administration/appliquer_migration', data={}, follow_redirects=False
+        )
+        assert reponse.status_code in (301, 302)
+        assert '/administration' in reponse.headers.get('Location', '')
+
+        assert _etat_base(db) == avant
+
+
+class TestReinitialisationBaseDeDonnees:
+    """POST /administration/reinitialiser_bdd — route la plus dangereuse.
+
+    Elle supprime le fichier SQLite et recrée un schéma vide : toutes les
+    données RH, paie et comptables sont perdues. On ne déclenche JAMAIS le cas
+    positif dans un test ; on prouve uniquement que le refus protège les
+    données, et qu'aucune sauvegarde `.avant_reinit` n'est même amorcée.
+    """
+
+    def test_reinitialisation_refusee_hors_direction_et_base_intacte(
+        self, app, db, client, sample_users
+    ):
+        """Anonyme, salarié et responsable : refus et base strictement intacte."""
+        import database
+
+        avant = _etat_base(db)
+        assert avant['users'], 'Le jeu de données de test doit contenir des comptes'
+        chemin_base = database.DATABASE
+        chemin_sauvegarde = chemin_base + '.avant_reinit'
+
+        donnees = {'confirmation': 'REINITIALISER'}
+
+        reponse = client.post(
+            '/administration/reinitialiser_bdd', data=donnees, follow_redirects=False
+        )
+        assert _est_redirection_connexion(reponse)
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.post(
+                '/administration/reinitialiser_bdd', data=donnees, follow_redirects=False
+            )
+            assert _est_redirection_tableau_de_bord(reponse), (
+                f"Le profil {login} ne doit pas réinitialiser la base"
+            )
+            _deconnexion(client)
+
+        assert os.path.exists(chemin_base), 'Le fichier de base a été supprimé'
+        assert not os.path.exists(chemin_sauvegarde), (
+            'La branche destructrice a été atteinte malgré le refus'
+        )
+        assert _etat_base(db) == avant, 'Les données ont été altérées malgré le refus'
+
+    def test_reinitialisation_refusee_prestataire(self, app, db, prestataire_client):
+        """Le prestataire paie ne peut pas non plus effacer la base."""
+        import database
+
+        avant = _etat_base(db)
+        reponse = prestataire_client.post(
+            '/administration/reinitialiser_bdd',
+            data={'confirmation': 'REINITIALISER'},
+            follow_redirects=False,
+        )
+        assert _est_redirection_tableau_de_bord(reponse)
+        assert os.path.exists(database.DATABASE)
+        assert not os.path.exists(database.DATABASE + '.avant_reinit')
+        assert _etat_base(db) == avant
+
+    @pytest.mark.parametrize('donnees', [
+        {},
+        {'confirmation': ''},
+        {'confirmation': 'reinitialiser'},
+        {'confirmation': 'OUI'},
+    ])
+    def test_jeton_de_confirmation_invalide_annule_la_reinitialisation(
+        self, donnees, app, db, admin_client
+    ):
+        """Même pour un directeur, un jeton de confirmation incorrect annule tout.
+
+        Le jeton attendu est exactement « REINITIALISER » (sensible à la casse).
+        """
+        import database
+
+        avant = _etat_base(db)
+
+        reponse = admin_client.post(
+            '/administration/reinitialiser_bdd', data=donnees, follow_redirects=False
+        )
+        assert reponse.status_code in (301, 302)
+        assert '/administration' in reponse.headers.get('Location', '')
+
+        assert os.path.exists(database.DATABASE)
+        assert not os.path.exists(database.DATABASE + '.avant_reinit')
+        assert _etat_base(db) == avant
+
+
+class TestAdministrationUtilisateurs:
+    """Écrans de gestion des comptes et référentiels (`blueprints/admin.py`).
+
+    Enjeu : activer/désactiver un compte, changer un profil ou un mot de passe
+    revient à donner ou retirer l'accès à toute l'application.
+    """
+
+    def test_toggle_user_refuse_et_statut_inchange(self, db, client, sample_users):
+        """Personne hors direction/comptabilité ne peut désactiver un compte."""
+        cible = sample_users['salarie_id']
+        url = f'/toggle_user/{cible}'
+        statut_initial = db.execute(
+            'SELECT actif FROM users WHERE id = ?', (cible,)
+        ).fetchone()['actif']
+
+        reponse = client.post(url, follow_redirects=False)
+        assert _est_redirection_connexion(reponse)
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.post(url, follow_redirects=False)
+            assert _est_redirection_tableau_de_bord(reponse), (
+                f"Le profil {login} ne doit pas basculer le statut d'un compte"
+            )
+            _deconnexion(client)
+
+        statut_final = db.execute(
+            'SELECT actif FROM users WHERE id = ?', (cible,)
+        ).fetchone()['actif']
+        assert statut_final == statut_initial
+
+    def test_toggle_user_refuse_prestataire(self, db, prestataire_client, sample_users):
+        """Le prestataire paie ne peut pas désactiver un salarié."""
+        cible = sample_users['salarie_id']
+        statut_initial = db.execute(
+            'SELECT actif FROM users WHERE id = ?', (cible,)
+        ).fetchone()['actif']
+
+        reponse = prestataire_client.post(f'/toggle_user/{cible}', follow_redirects=False)
+        assert _est_redirection_tableau_de_bord(reponse)
+        assert db.execute(
+            'SELECT actif FROM users WHERE id = ?', (cible,)
+        ).fetchone()['actif'] == statut_initial
+
+    def test_modifier_user_refuse_et_compte_inchange(self, db, client, sample_users):
+        """Ni consultation ni modification d'une fiche utilisateur hors habilitation.
+
+        La tentative vise une élévation de privilège classique : un salarié qui
+        se promeut « directeur » et se choisit un nouveau mot de passe.
+        """
+        cible = sample_users['salarie_id']
+        url = f'/modifier_user/{cible}'
+        avant = tuple(db.execute(
+            'SELECT nom, prenom, login, profil, password FROM users WHERE id = ?',
+            (cible,)
+        ).fetchone())
+
+        donnees = {
+            'nom': 'Pirate',
+            'prenom': 'Jean',
+            'login': 'salarie_test',
+            'profil': 'directeur',
+            'nouveau_password': 'Pirate1234',
+        }
+
+        reponse = client.post(url, data=donnees, follow_redirects=False)
+        assert _est_redirection_connexion(reponse)
+        assert _est_redirection_connexion(client.get(url, follow_redirects=False))
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            assert _est_redirection_tableau_de_bord(
+                client.get(url, follow_redirects=False)
+            ), f"Le profil {login} ne doit pas consulter la fiche d'un autre compte"
+            assert _est_redirection_tableau_de_bord(
+                client.post(url, data=donnees, follow_redirects=False)
+            ), f"Le profil {login} ne doit pas modifier un compte"
+            _deconnexion(client)
+
+        apres = tuple(db.execute(
+            'SELECT nom, prenom, login, profil, password FROM users WHERE id = ?',
+            (cible,)
+        ).fetchone())
+        assert apres == avant, 'Le compte a été modifié malgré le refus'
+
+    def test_gestion_secteurs_refusee_et_referentiel_inchange(self, db, client, sample_users):
+        """Le référentiel des secteurs structure budgets et plannings : lecture
+        et écriture réservées à la direction et à la comptabilité."""
+        nb_avant = db.execute('SELECT COUNT(*) AS nb FROM secteurs').fetchone()['nb']
+        donnees = {
+            'action': 'ajouter',
+            'nom': 'Secteur Intrus',
+            'description': 'Créé par une tentative non autorisée',
+        }
+
+        assert _est_redirection_connexion(
+            client.get('/gestion_secteurs', follow_redirects=False)
+        )
+        assert _est_redirection_connexion(
+            client.post('/gestion_secteurs', data=donnees, follow_redirects=False)
+        )
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            assert _est_redirection_tableau_de_bord(
+                client.get('/gestion_secteurs', follow_redirects=False)
+            )
+            assert _est_redirection_tableau_de_bord(
+                client.post('/gestion_secteurs', data=donnees, follow_redirects=False)
+            )
+            # Tentative de suppression du secteur de rattachement.
+            assert _est_redirection_tableau_de_bord(client.post(
+                '/gestion_secteurs',
+                data={'action': 'supprimer', 'secteur_id': sample_users['secteur_id']},
+                follow_redirects=False,
+            ))
+            _deconnexion(client)
+
+        assert db.execute('SELECT COUNT(*) AS nb FROM secteurs').fetchone()['nb'] == nb_avant
+        assert db.execute(
+            'SELECT COUNT(*) AS nb FROM secteurs WHERE nom = ?', ('Secteur Intrus',)
+        ).fetchone()['nb'] == 0
+        assert db.execute(
+            'SELECT COUNT(*) AS nb FROM secteurs WHERE id = ?', (sample_users['secteur_id'],)
+        ).fetchone()['nb'] == 1
+
+    def test_gestion_jours_feries_refusee_et_calendrier_inchange(self, db, client, sample_users):
+        """Les jours fériés pilotent les compteurs de temps : un ajout sauvage
+        fausserait les heures théoriques de toute l'association."""
+        nb_avant = db.execute('SELECT COUNT(*) AS nb FROM jours_feries').fetchone()['nb']
+        donnees = {
+            'action': 'ajouter',
+            'date': '2026-03-17',
+            'libelle': 'Jour férié frauduleux',
+        }
+
+        assert _est_redirection_connexion(
+            client.get('/gestion_jours_feries', follow_redirects=False)
+        )
+        assert _est_redirection_connexion(
+            client.post('/gestion_jours_feries', data=donnees, follow_redirects=False)
+        )
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            assert _est_redirection_tableau_de_bord(
+                client.get('/gestion_jours_feries', follow_redirects=False)
+            )
+            assert _est_redirection_tableau_de_bord(
+                client.post('/gestion_jours_feries', data=donnees, follow_redirects=False)
+            )
+            _deconnexion(client)
+
+        assert db.execute('SELECT COUNT(*) AS nb FROM jours_feries').fetchone()['nb'] == nb_avant
+        assert db.execute(
+            'SELECT COUNT(*) AS nb FROM jours_feries WHERE date = ?', ('2026-03-17',)
+        ).fetchone()['nb'] == 0
+
+
+class TestClesApiFournisseursIA:
+    """Écrans et API des clés des fournisseurs IA (`blueprints/api_keys.py`).
+
+    Enjeu : ces clés sont des secrets facturables. Un profil non autorisé ne
+    doit ni les lire, ni les remplacer, ni les supprimer — et aucune réponse ne
+    doit contenir la clé en clair.
+    """
+
+    CLE_FACTICE = 'sk-CLE-DE-TEST-NE-PAS-UTILISER-0123456789'
+
+    @pytest.fixture
+    def cle_enregistree(self, app):
+        """Enregistre une clé OpenAI factice dans les réglages chiffrés."""
+        from utils import save_setting
+
+        with app.app_context():
+            save_setting('openai_api_key', self.CLE_FACTICE)
+        return self.CLE_FACTICE
+
+    @staticmethod
+    def _interdire_appel_reseau(monkeypatch):
+        """Fait échouer tout appel HTTP sortant : un refus ne doit rien appeler."""
+        import blueprints.api_keys as api_keys
+
+        def _refuser(*args, **kwargs):
+            raise AssertionError('Aucun appel au fournisseur IA ne doit être émis')
+
+        monkeypatch.setattr(api_keys.http_requests, 'post', _refuser)
+
+    def test_page_cles_api_refusee_et_aucune_fuite(self, client, sample_users, cle_enregistree):
+        """La page de gestion des clés reste inaccessible et ne fuit rien."""
+        assert _est_redirection_connexion(
+            client.get('/gestion_cles_api', follow_redirects=False)
+        )
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.get('/gestion_cles_api', follow_redirects=False)
+            assert _est_redirection_tableau_de_bord(reponse), (
+                f"Le profil {login} ne doit pas accéder à /gestion_cles_api"
+            )
+            # Même en suivant la redirection, la clé ne doit apparaître nulle part.
+            suivie = client.get('/gestion_cles_api', follow_redirects=True)
+            assert cle_enregistree not in suivie.get_data(as_text=True)
+            _deconnexion(client)
+
+    def test_statut_cles_refuse_en_403_sans_divulgation(
+        self, client, sample_users, cle_enregistree
+    ):
+        """L'API de statut répond 403 (JSON) et ne renvoie aucun secret."""
+        assert _est_redirection_connexion(
+            client.get('/api/api_keys/status', follow_redirects=False)
+        )
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.get('/api/api_keys/status')
+            assert reponse.status_code == 403
+            corps = reponse.get_data(as_text=True)
+            assert cle_enregistree not in corps
+            assert 'configured' not in corps
+            _deconnexion(client)
+
+    def test_enregistrement_cle_refuse_sans_ecriture_ni_appel_reseau(
+        self, app, monkeypatch, client, sample_users, cle_enregistree
+    ):
+        """Un profil non autorisé ne peut pas écraser la clé configurée.
+
+        On vérifie aussi qu'aucune requête n'est envoyée au fournisseur : le
+        contrôle d'accès doit précéder toute validation coûteuse de la clé.
+        """
+        from utils import get_setting
+
+        self._interdire_appel_reseau(monkeypatch)
+        charge = {'provider': 'openai', 'api_key': 'sk-CLE-INTRUSE-9999'}
+
+        assert _est_redirection_connexion(
+            client.post('/api/api_keys/save', json=charge, follow_redirects=False)
+        )
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.post('/api/api_keys/save', json=charge)
+            assert reponse.status_code == 403
+            assert 'Accès non autorisé' in reponse.get_json()['error']
+            _deconnexion(client)
+
+        with app.app_context():
+            assert get_setting('openai_api_key') == cle_enregistree
+
+    def test_suppression_cle_refusee_et_cle_conservee(
+        self, app, client, sample_users, cle_enregistree
+    ):
+        """La suppression d'une clé (perte de service IA) est refusée et sans effet."""
+        from utils import get_setting
+
+        charge = {'provider': 'openai'}
+
+        assert _est_redirection_connexion(
+            client.post('/api/api_keys/delete', json=charge, follow_redirects=False)
+        )
+
+        for login, mot_de_passe in PROFILS_REFUSES:
+            _connexion(client, login, mot_de_passe)
+            reponse = client.post('/api/api_keys/delete', json=charge)
+            assert reponse.status_code == 403
+            _deconnexion(client)
+
+        with app.app_context():
+            assert get_setting('openai_api_key') == cle_enregistree
+
+    def test_prestataire_refuse_sur_toutes_les_routes_cles_api(
+        self, app, monkeypatch, prestataire_client, cle_enregistree
+    ):
+        """Le prestataire paie est exclu de la gestion des secrets IA."""
+        from utils import get_setting
+
+        self._interdire_appel_reseau(monkeypatch)
+
+        assert _est_redirection_tableau_de_bord(
+            prestataire_client.get('/gestion_cles_api', follow_redirects=False)
+        )
+        assert prestataire_client.get('/api/api_keys/status').status_code == 403
+        assert prestataire_client.post(
+            '/api/api_keys/save', json={'provider': 'openai', 'api_key': 'sk-intrus'}
+        ).status_code == 403
+        assert prestataire_client.post(
+            '/api/api_keys/delete', json={'provider': 'openai'}
+        ).status_code == 403
+
+        with app.app_context():
+            assert get_setting('openai_api_key') == cle_enregistree
+
+    def test_profil_autorise_ne_recoit_jamais_la_cle_en_clair(
+        self, admin_client, cle_enregistree
+    ):
+        """Même le directeur ne récupère qu'un indicateur de configuration.
+
+        La page n'expose que `has_key` (« Configuree » / « Non configuree ») et
+        l'API de statut ne renvoie que des booléens : la valeur du secret ne
+        transite jamais vers le navigateur.
+        """
+        page = admin_client.get('/gestion_cles_api')
+        assert page.status_code == 200
+        html = page.get_data(as_text=True)
+        assert cle_enregistree not in html
+        # Aucun fragment significatif de la clé ne doit apparaître.
+        assert 'CLE-DE-TEST' not in html
+        assert 'Configuree' in html
+
+        statut = admin_client.get('/api/api_keys/status')
+        assert statut.status_code == 200
+        assert cle_enregistree not in statut.get_data(as_text=True)
+        donnees = statut.get_json()
+        assert donnees['configured']['openai'] is True
+        assert donnees['configured']['anthropic'] is False

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,4 +1,9 @@
+import os
+import sqlite3
 import zipfile
+
+import pytest
+from markupsafe import escape
 
 
 def _configurer_documents_test(tmp_path, monkeypatch):
@@ -104,3 +109,458 @@ def test_suppression_archive_documents_affiche_message_specifique(
     assert response.status_code == 200
     assert 'Archive des documents supprimée' in contenu
     assert not archive_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Outils communs aux tests negatifs
+# ---------------------------------------------------------------------------
+
+# Nom de sauvegarde temoin : conforme a la whitelist backup_*.db, il permet de
+# verifier qu'un acces refuse ne supprime, ne sert et ne restaure rien.
+SAUVEGARDE_TEMOIN = 'backup_20260101_000000_temoin.db'
+MARQUEUR_TEMOIN = 'contenu de la sauvegarde temoin'
+
+# Les cinq routes du blueprint backup_bp, avec un formulaire plausible.
+ROUTES_SAUVEGARDES = [
+    ('get', '/sauvegardes', None),
+    ('post', '/sauvegardes/creer', {'label': 'intrusion'}),
+    ('get', f'/sauvegardes/telecharger/{SAUVEGARDE_TEMOIN}', None),
+    ('post', '/sauvegardes/restaurer', {'filename': SAUVEGARDE_TEMOIN}),
+    ('post', '/sauvegardes/supprimer', {'filename': SAUVEGARDE_TEMOIN}),
+]
+
+
+def _dossier_sauvegardes(tmp_path):
+    """Retourne le dossier de sauvegardes utilise par les tests."""
+    return tmp_path / 'backups'
+
+
+def _fichiers_sauvegardes(tmp_path):
+    """Retourne l'ensemble des noms de fichiers presents dans le dossier de sauvegardes."""
+    backup_dir = _dossier_sauvegardes(tmp_path)
+    if not backup_dir.exists():
+        return set()
+    return {fichier.name for fichier in backup_dir.iterdir()}
+
+
+def _creer_sauvegarde_temoin(tmp_path, nom=SAUVEGARDE_TEMOIN):
+    """Depose une base SQLite valide mais reconnaissable dans le dossier de sauvegardes."""
+    backup_dir = _dossier_sauvegardes(tmp_path)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    chemin = backup_dir / nom
+    conn = sqlite3.connect(str(chemin))
+    conn.execute('CREATE TABLE marqueur (valeur TEXT)')
+    conn.execute('INSERT INTO marqueur (valeur) VALUES (?)', (MARQUEUR_TEMOIN,))
+    conn.commit()
+    conn.close()
+    return chemin
+
+
+def _nb_utilisateurs():
+    """Compte les utilisateurs de la base en place.
+
+    La sauvegarde temoin ne contient pas de table `users` : ce compteur detecte
+    donc toute restauration qui aurait ete executee a tort.
+    """
+    import database
+
+    conn = sqlite3.connect(database.DATABASE)
+    nombre = conn.execute('SELECT COUNT(*) FROM users').fetchone()[0]
+    conn.close()
+    return nombre
+
+
+def _connexion(client, login, mot_de_passe):
+    """Connecte explicitement le client de test (les fixtures partagent le meme client)."""
+    return client.post(
+        '/login',
+        data={'login': login, 'password': mot_de_passe},
+        follow_redirects=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Controle d'acces : les cinq routes exigent une session directeur/comptable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('methode, url, donnees', ROUTES_SAUVEGARDES)
+def test_routes_sauvegardes_refusees_sans_connexion(
+    app, client, sample_users, monkeypatch, tmp_path, methode, url, donnees
+):
+    """Un visiteur anonyme est redirige vers /login, sans aucun effet sur les sauvegardes."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    temoin = _creer_sauvegarde_temoin(tmp_path)
+    fichiers_avant = _fichiers_sauvegardes(tmp_path)
+    utilisateurs_avant = _nb_utilisateurs()
+
+    response = getattr(client, methode)(url, data=donnees)
+
+    assert response.status_code == 302
+    assert '/login' in response.headers['Location']
+    assert 'Content-Disposition' not in response.headers
+    assert MARQUEUR_TEMOIN.encode() not in response.data
+    assert _fichiers_sauvegardes(tmp_path) == fichiers_avant
+    assert temoin.exists()
+    assert _nb_utilisateurs() == utilisateurs_avant
+
+
+@pytest.mark.parametrize('login, mot_de_passe', [
+    ('salarie_test', 'sal123'),
+    ('resp_test', 'resp123'),
+])
+@pytest.mark.parametrize('methode, url, donnees', ROUTES_SAUVEGARDES)
+def test_routes_sauvegardes_refusees_profils_non_autorises(
+    app, client, sample_users, monkeypatch, tmp_path, methode, url, donnees, login, mot_de_passe
+):
+    """Un salarie ou un responsable est renvoye vers son tableau de bord, sans effet."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    temoin = _creer_sauvegarde_temoin(tmp_path)
+    fichiers_avant = _fichiers_sauvegardes(tmp_path)
+    utilisateurs_avant = _nb_utilisateurs()
+
+    _connexion(client, login, mot_de_passe)
+    response = getattr(client, methode)(url, data=donnees)
+
+    assert response.status_code == 302
+    assert '/dashboard' in response.headers['Location']
+    assert '/login' not in response.headers['Location']
+    assert 'Content-Disposition' not in response.headers
+    assert MARQUEUR_TEMOIN.encode() not in response.data
+
+    suivi = getattr(client, methode)(url, data=donnees, follow_redirects=True)
+    assert 'Acces non autorise' in suivi.get_data(as_text=True)
+
+    assert _fichiers_sauvegardes(tmp_path) == fichiers_avant
+    assert temoin.exists()
+    assert _nb_utilisateurs() == utilisateurs_avant
+
+    client.get('/logout', follow_redirects=True)
+
+
+@pytest.mark.parametrize('methode, url, donnees', ROUTES_SAUVEGARDES)
+def test_routes_sauvegardes_refusees_au_prestataire_paie(
+    app, prestataire_client, monkeypatch, tmp_path, methode, url, donnees
+):
+    """Le prestataire paie n'accede pas aux sauvegardes de la base complete."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    temoin = _creer_sauvegarde_temoin(tmp_path)
+    fichiers_avant = _fichiers_sauvegardes(tmp_path)
+    utilisateurs_avant = _nb_utilisateurs()
+
+    response = getattr(prestataire_client, methode)(url, data=donnees)
+
+    assert response.status_code == 302
+    assert '/dashboard' in response.headers['Location']
+    assert 'Content-Disposition' not in response.headers
+    assert MARQUEUR_TEMOIN.encode() not in response.data
+    assert _fichiers_sauvegardes(tmp_path) == fichiers_avant
+    assert temoin.exists()
+    assert _nb_utilisateurs() == utilisateurs_avant
+
+
+def test_comptable_accede_aux_sauvegardes(app, comptable_client, monkeypatch, tmp_path):
+    """Temoin positif : le comptable fait bien partie des profils autorises."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+
+    response = comptable_client.get('/sauvegardes')
+
+    assert response.status_code == 200
+    assert 'Archives des documents (0)' in response.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# Path traversal : telechargement
+# ---------------------------------------------------------------------------
+
+NOMS_HOSTILES_URL = [
+    '../backup_20260101_000000_cible.db',
+    '../../etc/passwd',
+    '/etc/passwd',
+    'backup_../backup_20260101_000000_cible.db',
+    '..%2f..%2fetc%2fpasswd',
+    '%2e%2e%2fbackup_20260101_000000_cible.db',
+]
+
+
+@pytest.mark.parametrize('nom_hostile', NOMS_HOSTILES_URL)
+def test_telechargement_refuse_path_traversal(
+    app, admin_client, monkeypatch, tmp_path, nom_hostile
+):
+    """Aucun fichier situe hors du dossier de sauvegardes n'est servi."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    _dossier_sauvegardes(tmp_path).mkdir(parents=True, exist_ok=True)
+    hors_perimetre = tmp_path / 'backup_20260101_000000_cible.db'
+    hors_perimetre.write_text('contenu confidentiel hors perimetre', encoding='utf-8')
+
+    response = admin_client.get(f'/sauvegardes/telecharger/{nom_hostile}')
+
+    assert response.status_code != 200
+    assert 'Content-Disposition' not in response.headers
+    assert b'contenu confidentiel hors perimetre' not in response.data
+    assert hors_perimetre.exists()
+
+
+def test_telechargement_refuse_lien_symbolique_vers_l_exterieur(
+    app, admin_client, monkeypatch, tmp_path
+):
+    """Un nom conforme a la whitelist ne suffit pas : le chemin reel doit rester dans backups."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    backup_dir = _dossier_sauvegardes(tmp_path)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    secret = tmp_path / 'hors_backups.db'
+    secret.write_text('contenu confidentiel hors perimetre', encoding='utf-8')
+    (backup_dir / 'backup_20260101_000000_lien.db').symlink_to(secret)
+
+    response = admin_client.get(
+        '/sauvegardes/telecharger/backup_20260101_000000_lien.db',
+        follow_redirects=True,
+    )
+    contenu = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'Fichier introuvable ou nom invalide' in contenu
+    assert 'contenu confidentiel hors perimetre' not in contenu
+    assert secret.exists()
+
+
+def test_telechargement_refuse_fichier_inexistant(app, admin_client, monkeypatch, tmp_path):
+    """Un nom valide mais inconnu renvoie un message francais, sans 404 technique."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    _dossier_sauvegardes(tmp_path).mkdir(parents=True, exist_ok=True)
+
+    response = admin_client.get(
+        '/sauvegardes/telecharger/backup_20260101_000000_absent.db',
+        follow_redirects=True,
+    )
+    contenu = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'Fichier introuvable ou nom invalide' in contenu
+    assert str(tmp_path) not in contenu
+
+
+# ---------------------------------------------------------------------------
+# Path traversal et whitelist : suppression
+# ---------------------------------------------------------------------------
+
+NOMS_HOSTILES_SUPPRESSION = [
+    '../hors_backups/backup_cible.db',
+    '../../etc/passwd',
+    '/etc/passwd',
+    '..\\backup_cible.db',
+    'backup_cible.db/../../hors_backups/backup_cible.db',
+    'backup cible.db',
+]
+
+
+@pytest.mark.parametrize('nom_hostile', NOMS_HOSTILES_SUPPRESSION)
+def test_suppression_refuse_path_traversal(
+    app, admin_client, monkeypatch, tmp_path, nom_hostile
+):
+    """Aucun fichier hors du dossier de sauvegardes ne peut etre supprime."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    temoin = _creer_sauvegarde_temoin(tmp_path)
+    hors_perimetre = tmp_path / 'hors_backups'
+    hors_perimetre.mkdir()
+    cible = hors_perimetre / 'backup_cible.db'
+    cible.write_text('fichier hors perimetre', encoding='utf-8')
+
+    response = admin_client.post(
+        '/sauvegardes/supprimer',
+        data={'filename': nom_hostile},
+        follow_redirects=True,
+    )
+    contenu = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'Erreur : Operation non autorisee' in contenu
+    assert str(tmp_path) not in contenu
+    assert cible.exists()
+    assert temoin.exists()
+
+
+@pytest.mark.parametrize('nom_refuse', [
+    'cspilot.db',
+    'backup_20260101_000000_temoin.txt',
+    'documents_20260101_000000.db',
+    'notes.zip',
+])
+def test_suppression_refuse_hors_whitelist(
+    app, admin_client, monkeypatch, tmp_path, nom_refuse
+):
+    """Seuls les fichiers backup_*.db et documents_*.zip sont supprimables."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    backup_dir = _dossier_sauvegardes(tmp_path)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    fichier = backup_dir / nom_refuse
+    fichier.write_text('fichier non supprimable', encoding='utf-8')
+
+    response = admin_client.post(
+        '/sauvegardes/supprimer',
+        data={'filename': nom_refuse},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert 'Erreur : Operation non autorisee' in response.get_data(as_text=True)
+    assert fichier.exists()
+
+
+def test_suppression_refuse_lien_symbolique_vers_l_exterieur(
+    app, admin_client, monkeypatch, tmp_path
+):
+    """Un lien symbolique nomme backup_*.db ne permet pas de supprimer hors du dossier."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    backup_dir = _dossier_sauvegardes(tmp_path)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    cible = tmp_path / 'hors_backups.db'
+    cible.write_text('fichier hors perimetre', encoding='utf-8')
+    lien = backup_dir / 'backup_20260101_000000_lien.db'
+    lien.symlink_to(cible)
+
+    response = admin_client.post(
+        '/sauvegardes/supprimer',
+        data={'filename': lien.name},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert 'Erreur : Operation non autorisee' in response.get_data(as_text=True)
+    assert cible.exists()
+
+
+def test_suppression_sans_nom_de_fichier(app, admin_client, monkeypatch, tmp_path):
+    """Un formulaire vide est refuse avec un message francais."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    temoin = _creer_sauvegarde_temoin(tmp_path)
+
+    response = admin_client.post('/sauvegardes/supprimer', data={'filename': ''}, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert 'Aucun fichier specifie' in response.get_data(as_text=True)
+    assert temoin.exists()
+
+
+# ---------------------------------------------------------------------------
+# Restauration : la route qui ecrase toute la base
+# ---------------------------------------------------------------------------
+
+def test_restauration_sans_nom_de_fichier(app, admin_client, monkeypatch, tmp_path):
+    """Sans nom de fichier, aucune restauration ni sauvegarde de securite."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    _dossier_sauvegardes(tmp_path).mkdir(parents=True, exist_ok=True)
+    utilisateurs_avant = _nb_utilisateurs()
+
+    response = admin_client.post('/sauvegardes/restaurer', data={'filename': ''}, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert 'Aucun fichier specifie' in response.get_data(as_text=True)
+    assert _fichiers_sauvegardes(tmp_path) == set()
+    assert _nb_utilisateurs() == utilisateurs_avant
+
+
+@pytest.mark.parametrize('nom_invalide', NOMS_HOSTILES_SUPPRESSION)
+def test_restauration_refuse_nom_invalide(
+    app, admin_client, monkeypatch, tmp_path, nom_invalide
+):
+    """Un nom hors whitelist est rejete avant toute lecture de fichier."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    _dossier_sauvegardes(tmp_path).mkdir(parents=True, exist_ok=True)
+    utilisateurs_avant = _nb_utilisateurs()
+
+    response = admin_client.post(
+        '/sauvegardes/restaurer',
+        data={'filename': nom_invalide},
+        follow_redirects=True,
+    )
+    contenu = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'Erreur lors de la restauration : Nom de fichier invalide' in contenu
+    assert str(tmp_path) not in contenu
+    # Aucune sauvegarde de securite : le refus intervient avant toute ecriture.
+    assert _fichiers_sauvegardes(tmp_path) == set()
+    assert _nb_utilisateurs() == utilisateurs_avant
+
+
+def test_restauration_refuse_fichier_inexistant(app, admin_client, monkeypatch, tmp_path):
+    """Un nom valide mais absent du dossier ne declenche aucune restauration."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    _dossier_sauvegardes(tmp_path).mkdir(parents=True, exist_ok=True)
+    utilisateurs_avant = _nb_utilisateurs()
+
+    response = admin_client.post(
+        '/sauvegardes/restaurer',
+        data={'filename': 'backup_20260101_000000_absent.db'},
+        follow_redirects=True,
+    )
+    contenu = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'Erreur lors de la restauration : Fichier de sauvegarde introuvable' in contenu
+    assert str(tmp_path) not in contenu
+    assert _fichiers_sauvegardes(tmp_path) == set()
+    assert _nb_utilisateurs() == utilisateurs_avant
+
+
+def test_restauration_refuse_fichier_non_sqlite(app, admin_client, monkeypatch, tmp_path):
+    """Un fichier qui n'est pas une base SQLite est refuse proprement, base intacte."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+    backup_dir = _dossier_sauvegardes(tmp_path)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    faux = backup_dir / 'backup_20260101_000000_corrompu.db'
+    faux.write_bytes(b'ceci n\'est pas une base de donnees SQLite' * 32)
+    utilisateurs_avant = _nb_utilisateurs()
+
+    response = admin_client.post(
+        '/sauvegardes/restaurer',
+        data={'filename': faux.name},
+        follow_redirects=True,
+    )
+    contenu = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    # Jinja echappe l'apostrophe du message : on compare avec le texte echappe.
+    assert str(escape(
+        "Erreur lors de la restauration : Le fichier n'est pas une base de donnees SQLite valide"
+    )) in contenu
+    # Pas de fuite technique : ni trace d'exception, ni chemin local.
+    assert 'Traceback' not in contenu
+    assert 'sqlite3' not in contenu
+    assert str(tmp_path) not in contenu
+    # Base inchangee et aucune sauvegarde de securite creee.
+    assert _nb_utilisateurs() == utilisateurs_avant
+    assert _fichiers_sauvegardes(tmp_path) == {faux.name}
+
+
+def test_restauration_sauvegarde_valide_par_directeur(
+    app, db, admin_client, sample_users, monkeypatch, tmp_path
+):
+    """Cas legitime : un directeur restaure une sauvegarde valide et la base revient a son etat."""
+    _configurer_documents_test(tmp_path, monkeypatch)
+
+    admin_client.post('/sauvegardes/creer', data={'label': 'avantmodif'})
+    sauvegarde = next(_dossier_sauvegardes(tmp_path).glob('backup_*_avantmodif.db'))
+    utilisateurs_avant = _nb_utilisateurs()
+
+    # Modification volontaire de la base apres la sauvegarde
+    with app.app_context():
+        db.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?, ?, ?, ?, ?)",
+            ('Intrus', 'Test', 'intrus_test', 'x', 'salarie')
+        )
+        db.commit()
+    assert _nb_utilisateurs() == utilisateurs_avant + 1
+
+    response = admin_client.post(
+        '/sauvegardes/restaurer',
+        data={'filename': sauvegarde.name},
+        follow_redirects=True,
+    )
+    contenu = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'Restauration reussie' in contenu
+    assert _nb_utilisateurs() == utilisateurs_avant
+    # Une sauvegarde de securite a bien ete creee avant l'ecrasement.
+    assert list(_dossier_sauvegardes(tmp_path).glob('backup_*_avant_restauration.db'))

--- a/tests/test_exports_acces.py
+++ b/tests/test_exports_acces.py
@@ -1,0 +1,550 @@
+"""
+Contrôle d'accès des routes d'EXPORT (fichiers téléchargeables).
+
+Les tests de refus existants portent sur les routes de DONNÉES (pages et API
+JSON) ; leurs exports servent pourtant les mêmes informations financières et
+nominatives, mais dans un fichier qui sort de l'application. Un découplage
+futur entre la page et son export ne serait détecté par aucun test : ce
+fichier verrouille donc, pour chaque export, le cas non connecté, le cas d'un
+profil non autorisé, l'absence de document dans la réponse de refus, et
+l'absence d'effet en base pour les exports qui écrivent.
+
+Rappel de la mécanique de test : les fixtures de clients authentifiés
+partagent le même client. Dès qu'un test enchaîne plusieurs profils, il part
+de la fixture `client` et gère les connexions explicitement.
+"""
+from io import BytesIO
+
+
+# Signature d'un classeur Excel (xlsx = archive ZIP) et d'un PDF.
+SIGNATURE_XLSX = b'PK\x03\x04'
+SIGNATURE_PDF = b'%PDF'
+
+TYPE_XLSX = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+
+def _connexion(client, login, password):
+    """Connecte le client de test avec le compte demandé."""
+    return client.post('/login', data={'login': login, 'password': password},
+                       follow_redirects=True)
+
+
+def _deconnexion(client):
+    return client.get('/logout', follow_redirects=True)
+
+
+def _assert_aucun_document(response):
+    """Vérifie qu'une réponse de refus ne transporte aucun fichier exporté."""
+    assert response.headers.get('Content-Type') != 'application/pdf'
+    assert response.headers.get('Content-Type') != TYPE_XLSX
+    assert not response.data.startswith(SIGNATURE_PDF)
+    assert not response.data.startswith(SIGNATURE_XLSX)
+
+
+def _assert_redirige_vers_login(response):
+    """Utilisateur non connecté : renvoyé vers la page de connexion."""
+    assert response.status_code in (301, 302)
+    assert '/login' in response.headers['Location']
+    _assert_aucun_document(response)
+
+
+# ── Jeux de données minimaux ─────────────────────────────────────────────────
+
+def _seed_bilan_secteur(db, annee, secteur_id, compte_num, montant, libelle):
+    """Rattache un compte à un secteur et lui associe un montant importé."""
+    db.execute(
+        "INSERT INTO comptabilite_comptes (compte_num, libelle, secteur_id) VALUES (?, ?, ?)",
+        (compte_num, libelle, secteur_id)
+    )
+    cur = db.execute(
+        "INSERT INTO bilan_fec_imports (fichier_nom, annee, nb_ecritures) VALUES (?, ?, ?)",
+        (f'fec_{annee}_{compte_num}.txt', annee, 1)
+    )
+    db.execute(
+        "INSERT INTO bilan_fec_donnees (compte_num, libelle, code_analytique, annee, "
+        "mois, montant, import_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (compte_num, libelle, '', annee, 1, montant, cur.lastrowid)
+    )
+    db.commit()
+
+
+def _seed_ecriture_validee(db, montant=120.0):
+    """Crée une écriture comptable validée, prête à être exportée."""
+    cur = db.execute(
+        "INSERT INTO fournisseurs (nom) VALUES (?)", ('Fournisseur Test',)
+    )
+    cur = db.execute(
+        "INSERT INTO factures (fournisseur_id, numero_facture, date_facture, "
+        "montant_ttc, description, statut) VALUES (?, ?, ?, ?, ?, ?)",
+        (cur.lastrowid, 'INV-EXPORT-001', '2026-01-15', montant, 'Fournitures', 'traitee')
+    )
+    cur = db.execute(
+        "INSERT INTO ecritures_comptables (facture_id, date_ecriture, compte, libelle, "
+        "numero_facture, debit, credit, statut) VALUES (?, ?, ?, ?, ?, ?, ?, 'validee')",
+        (cur.lastrowid, '2026-01-15', '606100', 'Fournitures', 'INV-EXPORT-001', montant, 0)
+    )
+    db.commit()
+    return cur.lastrowid
+
+
+def _seed_archive(db, tmp_path, created_by):
+    """Crée une archive d'export réellement présente sur le disque."""
+    fichier = tmp_path / 'export_ecritures_20260115_120000.txt'
+    fichier.write_text('AC\t15012026\t606100\tFOURNITURES\n', encoding='utf-8')
+    cur = db.execute(
+        "INSERT INTO archives_export (nom_fichier, fichier_path, nb_ecritures, created_by) "
+        "VALUES (?, ?, ?, ?)",
+        (fichier.name, str(fichier), 1, created_by)
+    )
+    db.commit()
+    return cur.lastrowid, fichier
+
+
+def _verrouiller_fiche(db, user_id, mois, annee):
+    """Verrouille la fiche mensuelle : condition préalable à l'export PDF."""
+    db.execute('''
+        INSERT INTO validations (
+            user_id, mois, annee, bloque,
+            validation_salarie, validation_responsable, validation_directeur,
+            date_salarie, date_responsable, date_directeur
+        ) VALUES (?, ?, ?, 1, 'Salarié', 'Responsable', 'Directeur',
+                  '2026-01-31', '2026-01-31', '2026-01-31')
+    ''', (user_id, mois, annee))
+    db.commit()
+
+
+# ── Prépa paie : export Excel de toute la paie nominative du mois ────────────
+
+def test_prepa_paie_export_excel_controle_acces(client, sample_users, app, db):
+    """L'export Excel de la prépa paie contient la paie nominative de tout
+    l'effectif : seuls comptable, directeur et prestataire y ont droit."""
+    url = '/prepa_paie/export_excel?mois=6&annee=2026'
+
+    # Non connecté : renvoyé vers la connexion, aucun classeur servi.
+    _assert_redirige_vers_login(client.get(url, follow_redirects=False))
+
+    # Salarié : refusé vers le tableau de bord.
+    _connexion(client, 'salarie_test', 'sal123')
+    reponse = client.get(url, follow_redirects=False)
+    assert reponse.status_code == 302
+    assert reponse.headers['Location'].endswith('/dashboard')
+    _assert_aucun_document(reponse)
+    _deconnexion(client)
+
+    # Responsable : refusé lui aussi, la paie ne relève pas de son périmètre.
+    _connexion(client, 'resp_test', 'resp123')
+    reponse = client.get(url, follow_redirects=False)
+    assert reponse.status_code == 302
+    assert reponse.headers['Location'].endswith('/dashboard')
+    _assert_aucun_document(reponse)
+    _deconnexion(client)
+
+    # Comptable : export légitime.
+    _connexion(client, 'compta_test', 'compta123')
+    reponse = client.get(url)
+    assert reponse.status_code == 200
+    assert reponse.headers['Content-Type'] == TYPE_XLSX
+    _deconnexion(client)
+
+
+def test_prepa_paie_export_excel_autorise_le_prestataire(prestataire_client):
+    """Élargissement VOULU (confirmé par l'utilisateur) : le cabinet de paie
+    externe télécharge bien le classeur, c'est sa matière de travail."""
+    reponse = prestataire_client.get('/prepa_paie/export_excel?mois=6&annee=2026')
+
+    assert reponse.status_code == 200
+    assert reponse.headers['Content-Type'] == TYPE_XLSX
+    assert reponse.data.startswith(SIGNATURE_XLSX)
+
+
+# ── Compte de résultat / indicateurs financiers ─────────────────────────────
+
+def test_cr_export_pdf_controle_acces(client, sample_users, app, db):
+    """Le PDF du compte de résultat suit les droits de la page : direction et
+    comptabilité uniquement."""
+    annee = 2026
+    with app.app_context():
+        _seed_bilan_secteur(db, annee, sample_users['secteur_id'],
+                            '606100', 1500.0, 'Fournitures')
+    url = f'/api/cr/export-pdf?annee={annee}'
+
+    _assert_redirige_vers_login(client.get(url, follow_redirects=False))
+
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+        _connexion(client, login, mot_de_passe)
+        reponse = client.get(url)
+        assert reponse.status_code == 403, login
+        _assert_aucun_document(reponse)
+        _deconnexion(client)
+
+    _connexion(client, 'compta_test', 'compta123')
+    reponse = client.get(url)
+    assert reponse.status_code == 200
+    assert reponse.headers['Content-Type'] == 'application/pdf'
+    assert reponse.data.startswith(SIGNATURE_PDF)
+    _deconnexion(client)
+
+
+def test_indicateurs_export_pdf_controle_acces(client, sample_users, app, db):
+    """Le PDF des indicateurs financiers agrège tous les exercices : refusé au
+    salarié et au responsable."""
+    with app.app_context():
+        _seed_bilan_secteur(db, 2026, sample_users['secteur_id'],
+                            '706100', 9000.0, 'Prestations')
+    url = '/api/indicateurs/export-pdf'
+
+    _assert_redirige_vers_login(client.get(url, follow_redirects=False))
+
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+        _connexion(client, login, mot_de_passe)
+        reponse = client.get(url)
+        assert reponse.status_code == 403, login
+        _assert_aucun_document(reponse)
+        _deconnexion(client)
+
+    _connexion(client, 'admin', 'Admin1234')
+    reponse = client.get(url)
+    assert reponse.status_code == 200
+    assert reponse.headers['Content-Type'] == 'application/pdf'
+    assert reponse.data.startswith(SIGNATURE_PDF)
+    _deconnexion(client)
+
+
+# ── Bilan secteurs : cloisonnement du responsable ───────────────────────────
+
+def test_bilan_export_pdf_refuse_hors_perimetre(client, sample_users, app, db):
+    """Le PDF du bilan secteurs est fermé au salarié comme au prestataire de
+    paie : ni l'un ni l'autre n'a affaire aux comptes de l'association.
+    (Le prestataire est créé ici plutôt que via sa fixture, qui monopolise le
+    client de test partagé.)"""
+    from werkzeug.security import generate_password_hash
+
+    with app.app_context():
+        db.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?, ?, ?, ?, ?)",
+            ('Cabinet', 'Paie', 'presta_bilan', generate_password_hash('presta123'),
+             'prestataire')
+        )
+        db.commit()
+
+    url = '/api/bilan/export-pdf?annee=2026'
+
+    _assert_redirige_vers_login(client.get(url, follow_redirects=False))
+
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('presta_bilan', 'presta123')):
+        _connexion(client, login, mot_de_passe)
+        reponse = client.get(url, follow_redirects=False)
+        assert reponse.status_code == 302, login
+        assert reponse.headers['Location'].endswith('/dashboard'), login
+        _assert_aucun_document(reponse)
+        _deconnexion(client)
+
+
+def test_bilan_export_pdf_cloisonne_le_secteur_du_responsable(
+        client, sample_users, app, db):
+    """Test central du lot : le responsable est autorisé sur cet export, mais
+    le serveur FORCE son secteur assigné. Même en réclamant explicitement le
+    secteur d'un collègue dans l'URL, il reçoit le PDF de son propre secteur,
+    sans le moindre montant du secteur voisin."""
+    annee = 2026
+    with app.app_context():
+        cur = db.execute(
+            "INSERT INTO secteurs (nom, description) VALUES (?, ?)",
+            ('Secteur Confidentiel', 'Secteur hors périmètre du responsable')
+        )
+        secteur_autre_id = cur.lastrowid
+        db.commit()
+
+        # Un montant distinctif par secteur pour les repérer dans le PDF.
+        _seed_bilan_secteur(db, annee, sample_users['secteur_id'],
+                            '606100', 1111.0, 'Achats Secteur Test')
+        _seed_bilan_secteur(db, annee, secteur_autre_id,
+                            '606200', 8888.0, 'Achats Secteur Confidentiel')
+
+    _connexion(client, 'resp_test', 'resp123')
+    reponse = client.get(
+        f'/api/bilan/export-pdf?annee={annee}&secteur_id={secteur_autre_id}')
+
+    # L'export lui est bien servi (accès légitime, périmètre restreint).
+    assert reponse.status_code == 200
+    assert reponse.headers['Content-Type'] == 'application/pdf'
+    # Le nom de fichier est construit à partir du secteur RÉELLEMENT interrogé.
+    assert f'secteur{sample_users["secteur_id"]}.pdf' in \
+        reponse.headers['Content-Disposition']
+    assert f'secteur{secteur_autre_id}.pdf' not in \
+        reponse.headers['Content-Disposition']
+
+    import pdfplumber
+    with pdfplumber.open(BytesIO(reponse.data)) as pdf:
+        texte = '\n'.join(page.extract_text() or '' for page in pdf.pages)
+    # Les montants sont formatés avec une espace insécable : on normalise pour
+    # que l'assertion ne dépende pas de l'extraction de texte.
+    texte = texte.replace('\xa0', ' ')
+
+    assert 'Secteur Test' in texte
+    assert 'Secteur Confidentiel' not in texte
+    # Le montant du secteur voisin (8 888,00) ne doit apparaître nulle part ;
+    # celui du secteur du responsable, si.
+    assert '1 111,00' in texte
+    assert '8 888,00' not in texte
+    assert '606200' not in texte
+
+
+def test_bilan_export_pdf_responsable_sans_secteur_est_refuse(client, app, db):
+    """Un responsable sans secteur assigné ne doit pas récupérer le bilan
+    global par défaut : le forçage de secteur le renvoie vers la page."""
+    from werkzeug.security import generate_password_hash
+
+    with app.app_context():
+        db.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil) VALUES (?, ?, ?, ?, ?)",
+            ('Sansecteur', 'Paul', 'resp_orphelin', generate_password_hash('resp123'),
+             'responsable')
+        )
+        db.commit()
+
+    _connexion(client, 'resp_orphelin', 'resp123')
+    reponse = client.get('/api/bilan/export-pdf?annee=2026&secteur_id=1',
+                         follow_redirects=False)
+
+    assert reponse.status_code == 302
+    assert '/bilan-secteurs' in reponse.headers['Location']
+    _assert_aucun_document(reponse)
+
+
+# ── Bilan action ────────────────────────────────────────────────────────────
+
+def test_bilan_action_export_pdf_controle_acces(client, sample_users, app, db):
+    """Le PDF du budget d'une action est réservé à la direction et à la
+    comptabilité ; le responsable en est exclu."""
+    with app.app_context():
+        cur = db.execute("INSERT INTO comptabilite_actions (nom) VALUES (?)",
+                         ('Action Export',))
+        action_id = cur.lastrowid
+        db.commit()
+    url = f'/api/bilan-action/export-pdf?annee=2026&action_id={action_id}'
+
+    _assert_redirige_vers_login(client.get(url, follow_redirects=False))
+
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+        _connexion(client, login, mot_de_passe)
+        reponse = client.get(url, follow_redirects=False)
+        assert reponse.status_code == 302, login
+        assert '/bilan-action' in reponse.headers['Location'], login
+        _assert_aucun_document(reponse)
+        _deconnexion(client)
+
+    _connexion(client, 'admin', 'Admin1234')
+    reponse = client.get(url)
+    assert reponse.status_code == 200
+    assert reponse.headers['Content-Type'] == 'application/pdf'
+    assert reponse.data.startswith(SIGNATURE_PDF)
+    _deconnexion(client)
+
+
+# ── Journal d'audit ─────────────────────────────────────────────────────────
+
+def test_journal_actions_export_controle_acces(client, sample_users):
+    """Le CSV du journal des actions trace qui a fait quoi (avec l'adresse
+    IP) : hors direction et comptabilité, aucun export."""
+    url = '/securite/journal-actions/export'
+
+    _assert_redirige_vers_login(client.get(url, follow_redirects=False))
+
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+        _connexion(client, login, mot_de_passe)
+        reponse = client.get(url, follow_redirects=False)
+        assert reponse.status_code == 302, login
+        assert reponse.headers['Location'].endswith('/dashboard'), login
+        assert 'text/csv' not in (reponse.headers.get('Content-Type') or ''), login
+        _assert_aucun_document(reponse)
+        _deconnexion(client)
+
+    _connexion(client, 'compta_test', 'compta123')
+    reponse = client.get(url)
+    assert reponse.status_code == 200
+    assert 'text/csv' in reponse.content_type
+    _deconnexion(client)
+
+
+# ── Exportation des écritures comptables ────────────────────────────────────
+
+def test_exportation_page_et_archive_refusees(client, sample_users, app, db, tmp_path):
+    """Page d'exportation et téléchargement d'archive : réservés au directeur
+    et au comptable."""
+    with app.app_context():
+        archive_id, fichier = _seed_archive(db, tmp_path, sample_users['directeur_id'])
+
+    urls = ('/exportation', f'/exportation/archives/{archive_id}/telecharger')
+
+    for url in urls:
+        _assert_redirige_vers_login(client.get(url, follow_redirects=False))
+
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+        _connexion(client, login, mot_de_passe)
+        for url in urls:
+            reponse = client.get(url, follow_redirects=False)
+            assert reponse.status_code == 302, (login, url)
+            assert reponse.headers['Location'].endswith('/dashboard'), (login, url)
+            # Le contenu de l'archive n'est jamais servi.
+            assert b'FOURNITURES' not in reponse.data, (login, url)
+        _deconnexion(client)
+
+    # L'archive reste intacte et téléchargeable pour un profil habilité.
+    _connexion(client, 'compta_test', 'compta123')
+    reponse = client.get(f'/exportation/archives/{archive_id}/telecharger')
+    assert reponse.status_code == 200
+    assert b'FOURNITURES' in reponse.data
+    _deconnexion(client)
+    assert fichier.exists()
+
+
+def test_exportation_exporter_refuse_sans_effet_en_base(client, sample_users, app, db,
+                                                        monkeypatch, tmp_path):
+    """POST /exportation/exporter change le statut des écritures en base :
+    un refus ne doit ni générer le fichier, ni marquer quoi que ce soit
+    « exportée », ni créer d'archive."""
+    from blueprints import exportation as exportation_module
+    archives_dir = tmp_path / 'exports'
+    archives_dir.mkdir()
+    monkeypatch.setattr(exportation_module, 'ARCHIVES_DIR', str(archives_dir))
+
+    with app.app_context():
+        ecriture_id = _seed_ecriture_validee(db)
+
+    def _statut():
+        with app.app_context():
+            return db.execute(
+                "SELECT statut FROM ecritures_comptables WHERE id = ?", (ecriture_id,)
+            ).fetchone()['statut']
+
+    def _nb_archives():
+        with app.app_context():
+            return db.execute(
+                "SELECT COUNT(*) AS n FROM archives_export").fetchone()['n']
+
+    donnees = {'ecriture_ids': [str(ecriture_id)]}
+
+    # Non connecté.
+    reponse = client.post('/exportation/exporter', data=donnees, follow_redirects=False)
+    assert reponse.status_code in (301, 302)
+    assert '/login' in reponse.headers['Location']
+    assert _statut() == 'validee'
+    assert _nb_archives() == 0
+
+    # Salarié puis responsable : refus et aucune écriture consommée.
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+        _connexion(client, login, mot_de_passe)
+        reponse = client.post('/exportation/exporter', data=donnees,
+                              follow_redirects=False)
+        assert reponse.status_code == 302, login
+        assert reponse.headers['Location'].endswith('/dashboard'), login
+        assert b'606100' not in reponse.data, login
+        assert _statut() == 'validee', login
+        assert _nb_archives() == 0, login
+        _deconnexion(client)
+
+    # Le comptable, lui, obtient le fichier et l'écriture bascule en « exportee ».
+    _connexion(client, 'compta_test', 'compta123')
+    reponse = client.post('/exportation/exporter', data=donnees)
+    assert reponse.status_code == 200
+    assert b'606100' in reponse.data
+    assert _statut() == 'exportee'
+    assert _nb_archives() == 1
+    # L'archive a bien été écrite dans le répertoire d'archives (isolé ici).
+    assert list(archives_dir.iterdir())
+    _deconnexion(client)
+
+
+def test_exportation_supprimer_archive_refuse_sans_effet(client, sample_users,
+                                                         app, db, tmp_path):
+    """La suppression d'archive efface un fichier et une ligne en base : sur
+    refus, l'archive et son fichier doivent être intacts."""
+    with app.app_context():
+        archive_id, fichier = _seed_archive(db, tmp_path, sample_users['directeur_id'])
+
+    url = f'/exportation/archives/{archive_id}/supprimer'
+
+    def _archive_existe():
+        with app.app_context():
+            return db.execute(
+                "SELECT COUNT(*) AS n FROM archives_export WHERE id = ?", (archive_id,)
+            ).fetchone()['n'] == 1
+
+    # Non connecté.
+    reponse = client.post(url, follow_redirects=False)
+    assert reponse.status_code in (301, 302)
+    assert '/login' in reponse.headers['Location']
+    assert _archive_existe()
+    assert fichier.exists()
+
+    # Salarié puis responsable : refus, archive conservée.
+    for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+        _connexion(client, login, mot_de_passe)
+        reponse = client.post(url, follow_redirects=False)
+        assert reponse.status_code == 302, login
+        assert reponse.headers['Location'].endswith('/dashboard'), login
+        assert _archive_existe(), login
+        assert fichier.exists(), login
+        _deconnexion(client)
+
+    # Le comptable supprime effectivement l'archive (fichier compris).
+    _connexion(client, 'compta_test', 'compta123')
+    reponse = client.post(url, follow_redirects=False)
+    assert reponse.status_code == 302
+    assert '/exportation' in reponse.headers['Location']
+    assert not _archive_existe()
+    assert not fichier.exists()
+    _deconnexion(client)
+
+
+# ── Fiche mensuelle PDF : cas non couverts par tests/test_security.py ────────
+
+def test_export_pdf_mensuel_non_connecte(client, app, db, sample_users):
+    """Complète TestExportPdfMensuelAccessControl (tests/test_security.py) :
+    sans session, la fiche RH nominative n'est pas servie."""
+    with app.app_context():
+        _verrouiller_fiche(db, sample_users['salarie_id'], mois=1, annee=2026)
+
+    reponse = client.get(
+        f"/export_pdf_mensuel?user_id={sample_users['salarie_id']}&mois=1&annee=2026",
+        follow_redirects=False)
+
+    _assert_redirige_vers_login(reponse)
+
+
+def test_export_pdf_mensuel_responsable_hors_de_son_equipe(client, app, db, sample_users):
+    """Second cas manquant : un responsable n'exporte que les fiches de son
+    équipe (même secteur ou rattachement hiérarchique direct)."""
+    from werkzeug.security import generate_password_hash
+
+    with app.app_context():
+        cur = db.execute("INSERT INTO secteurs (nom) VALUES (?)", ('Secteur Voisin',))
+        secteur_voisin_id = cur.lastrowid
+        cur = db.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil, secteur_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ('Petit', 'Luc', 'salarie_voisin', generate_password_hash('sal123'),
+             'salarie', secteur_voisin_id)
+        )
+        salarie_voisin_id = cur.lastrowid
+        db.commit()
+        _verrouiller_fiche(db, salarie_voisin_id, mois=1, annee=2026)
+
+    _connexion(client, 'resp_test', 'resp123')
+    reponse = client.get(
+        f'/export_pdf_mensuel?user_id={salarie_voisin_id}&mois=1&annee=2026',
+        follow_redirects=False)
+
+    assert reponse.status_code == 302
+    assert '/vue_mensuelle' in reponse.headers['Location']
+    _assert_aucun_document(reponse)
+
+    # Contrôle positif : la fiche d'un salarié de son secteur reste exportable.
+    with app.app_context():
+        _verrouiller_fiche(db, sample_users['salarie_id'], mois=1, annee=2026)
+    reponse = client.get(
+        f"/export_pdf_mensuel?user_id={sample_users['salarie_id']}&mois=1&annee=2026")
+    assert reponse.status_code == 200
+    assert reponse.headers['Content-Type'] == 'application/pdf'
+    _deconnexion(client)

--- a/tests/test_factures.py
+++ b/tests/test_factures.py
@@ -1,6 +1,6 @@
 """
-Tests du blueprint factures_bp : contrôle d'accès et suppression (avec
-nettoyage des écritures liées).
+Tests du blueprint factures_bp : contrôle d'accès (profil et périmètre de
+secteur) et suppression (avec nettoyage des écritures liées).
 """
 
 
@@ -36,6 +36,152 @@ class TestAccesFactures:
         # Les responsables accèdent à la page d'approbation
         resp = resp_client.get('/factures/approbation')
         assert resp.status_code == 200
+
+
+def _seed_secteur_avec_responsable(app, db, nom_secteur, login, mot_de_passe):
+    """Crée un second secteur et son responsable (pour tester le cloisonnement)."""
+    from werkzeug.security import generate_password_hash
+
+    with app.app_context():
+        cur = db.execute("INSERT INTO secteurs (nom) VALUES (?)", (nom_secteur,))
+        secteur_id = cur.lastrowid
+        db.execute(
+            "INSERT INTO users (nom, prenom, login, password, profil, secteur_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ('Voisin', 'Paul', login, generate_password_hash(mot_de_passe),
+             'responsable', secteur_id),
+        )
+        db.commit()
+        return secteur_id
+
+
+def _compte(app, db, table, facture_id):
+    """Nombre de lignes liées à une facture dans la table indiquée."""
+    with app.app_context():
+        return db.execute(
+            f"SELECT COUNT(*) AS n FROM {table} WHERE facture_id=?", (facture_id,)
+        ).fetchone()['n']
+
+
+def _connexion(client, login, mot_de_passe):
+    return client.post('/login', data={'login': login, 'password': mot_de_passe},
+                       follow_redirects=True)
+
+
+class TestCommentaireFacture:
+    """Ajout d'un commentaire : profil ET périmètre de secteur, comme les
+    routes voisines (détail, téléchargement, approbation)."""
+
+    def test_commenter_controle_acces_et_perimetre(self, app, db, client, sample_users):
+        """Non connecté redirigé, salarié refusé, responsable d'un autre secteur
+        refusé sans écriture en base, responsable du secteur accepté. Les
+        fixtures de clients authentifiés partagent le même client de test : on
+        gère les connexions explicitement pour enchaîner plusieurs profils."""
+        facture_id = _seed_facture(app, db, secteur_id=sample_users['secteur_id'])
+        _seed_secteur_avec_responsable(app, db, 'Secteur Voisin', 'resp_autre', 'autre123')
+        url = f'/factures/{facture_id}/commenter'
+
+        # Non connecté : redirigé vers la connexion, aucun commentaire enregistré.
+        reponse = client.post(url, data={'commentaire': 'Anonyme'}, follow_redirects=False)
+        assert reponse.status_code in (301, 302)
+        assert _compte(app, db, 'facture_commentaires', facture_id) == 0
+
+        # Salarié : profil hors consultation des factures.
+        _connexion(client, 'salarie_test', 'sal123')
+        reponse = client.post(url, data={'commentaire': 'Salarié'}, follow_redirects=False)
+        assert reponse.status_code == 302
+        assert _compte(app, db, 'facture_commentaires', facture_id) == 0
+        client.get('/logout', follow_redirects=True)
+
+        # Responsable d'un autre secteur : refusé, aucune trace en base.
+        _connexion(client, 'resp_autre', 'autre123')
+        reponse = client.post(url, data={'commentaire': 'Hors secteur'}, follow_redirects=False)
+        assert reponse.status_code == 302
+        assert '/factures/approbation' in reponse.headers['Location']
+        assert _compte(app, db, 'facture_commentaires', facture_id) == 0
+        assert _compte(app, db, 'facture_historique', facture_id) == 0
+        client.get('/logout', follow_redirects=True)
+
+        # Responsable du secteur : commentaire vide refusé, puis cas légitime accepté.
+        _connexion(client, 'resp_test', 'resp123')
+        reponse = client.post(url, data={'commentaire': '   '}, follow_redirects=False)
+        assert reponse.status_code == 302
+        assert _compte(app, db, 'facture_commentaires', facture_id) == 0
+
+        reponse = client.post(url, data={'commentaire': 'RAS pour mon secteur'},
+                              follow_redirects=False)
+        assert reponse.status_code == 302
+        assert _compte(app, db, 'facture_commentaires', facture_id) == 1
+        assert _compte(app, db, 'facture_historique', facture_id) == 1
+        client.get('/logout', follow_redirects=True)
+
+    def test_commenter_hors_secteur_invisible_dans_le_detail(self, app, db, client, sample_users):
+        """Le refus doit aussi empêcher l'apparition du texte dans l'historique
+        visible par le responsable légitime."""
+        facture_id = _seed_facture(app, db, secteur_id=sample_users['secteur_id'])
+        _seed_secteur_avec_responsable(app, db, 'Secteur Voisin', 'resp_autre', 'autre123')
+
+        _connexion(client, 'resp_autre', 'autre123')
+        client.post(f'/factures/{facture_id}/commenter',
+                    data={'commentaire': 'Commentaire intrus'}, follow_redirects=False)
+        client.get('/logout', follow_redirects=True)
+
+        _connexion(client, 'compta_test', 'compta123')
+        html = client.get(f'/factures/{facture_id}/detail').get_data(as_text=True)
+        assert 'Commentaire intrus' not in html
+
+    def test_commenter_facture_inexistante_sans_orphelin(self, app, db, comptable_client):
+        """Une facture absente ne doit produire ni commentaire ni historique orphelin."""
+        reponse = comptable_client.post('/factures/999999/commenter',
+                                        data={'commentaire': 'Fantôme'},
+                                        follow_redirects=False)
+        assert reponse.status_code == 302
+        assert _compte(app, db, 'facture_commentaires', 999999) == 0
+        assert _compte(app, db, 'facture_historique', 999999) == 0
+
+
+class TestAssignationFacture:
+    """Assignation d'une facture : réservée à la gestion (directeur/comptable)
+    et refusée sur une facture inexistante."""
+
+    def test_assigner_controle_acces(self, app, db, client, sample_users):
+        facture_id = _seed_facture(app, db)
+        url = f'/factures/{facture_id}/assigner'
+        donnees = {'secteur_id': sample_users['secteur_id']}
+
+        # Non connecté : redirigé vers la connexion.
+        reponse = client.post(url, data=donnees, follow_redirects=False)
+        assert reponse.status_code in (301, 302)
+
+        # Salarié et responsable : profils hors gestion.
+        for login, mot_de_passe in (('salarie_test', 'sal123'), ('resp_test', 'resp123')):
+            _connexion(client, login, mot_de_passe)
+            assert client.post(url, data=donnees).status_code == 403
+            client.get('/logout', follow_redirects=True)
+
+        with app.app_context():
+            assert db.execute(
+                "SELECT secteur_id FROM factures WHERE id=?", (facture_id,)
+            ).fetchone()['secteur_id'] is None
+        assert _compte(app, db, 'facture_historique', facture_id) == 0
+
+        # Comptable : assignation effective et tracée.
+        _connexion(client, 'compta_test', 'compta123')
+        assert client.post(url, data=donnees, follow_redirects=False).status_code == 302
+        with app.app_context():
+            assert db.execute(
+                "SELECT secteur_id FROM factures WHERE id=?", (facture_id,)
+            ).fetchone()['secteur_id'] == sample_users['secteur_id']
+        assert _compte(app, db, 'facture_historique', facture_id) == 1
+
+    def test_assigner_facture_inexistante_sans_orphelin(self, app, db, comptable_client,
+                                                        sample_users):
+        reponse = comptable_client.post(
+            '/factures/999999/assigner',
+            json={'secteur_id': sample_users['secteur_id']},
+        )
+        assert reponse.status_code == 404
+        assert _compte(app, db, 'facture_historique', 999999) == 0
 
 
 class TestSuppressionFacture:

--- a/tests/test_infos_salaries.py
+++ b/tests/test_infos_salaries.py
@@ -138,3 +138,171 @@ def test_ajout_contrat_dates_mal_formees_refusees(admin_client, db, sample_users
     assert 'Date invalide' in r.get_data(as_text=True)
     nb = db.execute("SELECT COUNT(*) AS nb FROM contrats WHERE user_id = ?", (uid,)).fetchone()
     assert nb['nb'] == 0    # rien enregistré
+
+
+# ── Barrière inter-secteurs en ÉCRITURE (_est_salarie_visible) ─────────────
+#
+# La fiche salarié porte les données les plus sensibles de l'application
+# (n° de sécurité sociale, adresse, date de naissance, pesée, contrats).
+# Le pendant en LECTURE est couvert par tests/test_responsable_rh_paie_access.py ;
+# ces tests verrouillent le refus côté écriture : un responsable ne doit rien
+# pouvoir modifier sur un salarié hors de son équipe, et un salarié simple
+# n'a aucun droit d'écriture (même sur sa propre fiche).
+
+def _creer_salarie_hors_equipe(db, login='hors_equipe'):
+    """Crée un salarié dans un autre secteur, non rattaché au responsable de test.
+
+    Ni le secteur, ni `responsable_id` ne le relient à `resp_test` : il est donc
+    hors du périmètre rendu par `_est_salarie_visible`.
+    """
+    from werkzeug.security import generate_password_hash
+
+    cur = db.execute("INSERT INTO secteurs (nom, description) VALUES (?, ?)",
+                     ('Secteur Hors Equipe', 'Secteur distinct pour les tests'))
+    secteur_id = cur.lastrowid
+    cur = db.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil, secteur_id, actif) "
+        "VALUES (?, ?, ?, ?, 'salarie', ?, 1)",
+        ('Externe', 'Zoe', login, generate_password_hash('hors123'), secteur_id))
+    db.commit()
+    return cur.lastrowid
+
+
+def _creer_document(db, user_id, saisi_par):
+    """Crée une pièce jointe de fiche salarié (aucun fichier réel sur le disque)."""
+    cur = db.execute(
+        "INSERT INTO documents_salaries "
+        "(user_id, type_document, description, fichier_path, fichier_nom, saisi_par) "
+        "VALUES (?, 'CARTE-VITALE', ?, ?, ?, ?)",
+        (user_id, 'Piece de test', 'CARTE-VITALE_Externe_Zoe.pdf',
+         'carte_vitale.pdf', saisi_par))
+    db.commit()
+    return cur.lastrowid
+
+
+def test_responsable_ne_peut_pas_modifier_email_hors_equipe(resp_client, db, sample_users):
+    uid = _creer_salarie_hors_equipe(db)
+    db.execute("UPDATE users SET email = ? WHERE id = ?", ('avant@test.fr', uid))
+    db.commit()
+    r = resp_client.post('/infos_salaries/email',
+                         data={'user_id': uid, 'email': 'detourne@test.fr'},
+                         follow_redirects=True)
+    assert 'Acces non autorise.' in r.get_data(as_text=True)
+    row = db.execute("SELECT email FROM users WHERE id = ?", (uid,)).fetchone()
+    assert row['email'] == 'avant@test.fr'    # inchangé
+
+
+def test_responsable_ne_peut_pas_modifier_infos_personnelles_hors_equipe(resp_client, db, sample_users):
+    """Adresse, date de naissance et n° de sécurité sociale d'un salarié d'un
+    autre secteur restent inaccessibles en écriture."""
+    uid = _creer_salarie_hors_equipe(db)
+    db.execute("UPDATE users SET adresse = ?, date_naissance = ?, numero_secu = ? WHERE id = ?",
+               ('1 rue des Tests', '1990-05-04', '290054412345678', uid))
+    db.commit()
+    r = resp_client.post('/infos_salaries/infos_personnelles', data={
+        'user_id': uid, 'adresse': '2 rue Detournee',
+        'date_naissance': '1980-01-01', 'numero_secu': '199999999999999',
+    }, follow_redirects=True)
+    assert 'Acces non autorise.' in r.get_data(as_text=True)
+    row = db.execute(
+        "SELECT adresse, date_naissance, numero_secu FROM users WHERE id = ?", (uid,)).fetchone()
+    assert row['adresse'] == '1 rue des Tests'
+    assert row['date_naissance'] == '1990-05-04'
+    assert row['numero_secu'] == '290054412345678'
+
+
+def test_responsable_ne_peut_pas_modifier_pesee_hors_equipe(resp_client, db, sample_users):
+    uid = _creer_salarie_hors_equipe(db)
+    db.execute("UPDATE users SET pesee = 100, competence = 4, maintien = 0 WHERE id = ?", (uid,))
+    db.commit()
+    r = resp_client.post('/infos_salaries/pesee', data={
+        'user_id': uid, 'pesee': '250', 'competence': '9', 'maintien': '12',
+    }, follow_redirects=True)
+    assert 'Acces non autorise.' in r.get_data(as_text=True)
+    row = db.execute("SELECT pesee, competence, maintien FROM users WHERE id = ?", (uid,)).fetchone()
+    assert row['pesee'] == 100
+    assert row['competence'] == 4
+    assert row['maintien'] == 0
+
+
+def test_responsable_ne_peut_pas_ajouter_contrat_hors_equipe(resp_client, db, sample_users):
+    uid = _creer_salarie_hors_equipe(db)
+    r = resp_client.post('/infos_salaries/contrat', data={
+        'user_id': uid, 'type_contrat': 'CDI',
+        'date_debut': '2026-01-01', 'date_fin': '',
+    }, follow_redirects=True)
+    assert 'Acces non autorise.' in r.get_data(as_text=True)
+    nb = db.execute("SELECT COUNT(*) AS nb FROM contrats WHERE user_id = ?", (uid,)).fetchone()
+    assert nb['nb'] == 0    # rien enregistré
+
+
+def test_responsable_ne_peut_pas_modifier_date_fin_hors_equipe(resp_client, db, sample_users):
+    uid = _creer_salarie_hors_equipe(db)
+    cid = _creer_cdd(db, uid)
+    r = resp_client.post(f'/infos_salaries/contrat/{cid}/date_fin',
+                         data={'date_fin': '2027-12-31'}, follow_redirects=True)
+    assert 'Acces non autorise.' in r.get_data(as_text=True)
+    row = db.execute("SELECT date_fin FROM contrats WHERE id = ?", (cid,)).fetchone()
+    assert row['date_fin'] == '2026-06-30'    # inchangée
+
+
+def test_responsable_ne_peut_pas_supprimer_contrat_hors_equipe(resp_client, db, sample_users):
+    uid = _creer_salarie_hors_equipe(db)
+    cid = _creer_cdd(db, uid)
+    r = resp_client.post(f'/infos_salaries/supprimer_contrat/{cid}', follow_redirects=True)
+    assert 'Acces non autorise.' in r.get_data(as_text=True)
+    assert db.execute("SELECT 1 FROM contrats WHERE id = ?", (cid,)).fetchone() is not None
+
+
+def test_responsable_ne_peut_pas_supprimer_document_hors_equipe(resp_client, db, sample_users):
+    uid = _creer_salarie_hors_equipe(db)
+    did = _creer_document(db, uid, sample_users['directeur_id'])
+    r = resp_client.post(f'/infos_salaries/supprimer_document/{did}', follow_redirects=True)
+    assert 'Acces non autorise.' in r.get_data(as_text=True)
+    assert db.execute("SELECT 1 FROM documents_salaries WHERE id = ?", (did,)).fetchone() is not None
+
+
+def test_responsable_peut_modifier_un_salarie_de_son_equipe(resp_client, db, sample_users):
+    """Contrôle positif : la barrière ne bloque pas l'équipe du responsable —
+    sans quoi les refus ci-dessus seraient vrais pour une mauvaise raison."""
+    uid = sample_users['salarie_id']
+    resp_client.post('/infos_salaries/email',
+                     data={'user_id': uid, 'email': 'jean.martin@test.fr'},
+                     follow_redirects=True)
+    row = db.execute("SELECT email FROM users WHERE id = ?", (uid,)).fetchone()
+    assert row['email'] == 'jean.martin@test.fr'
+
+
+def test_salarie_ne_peut_ecrire_sur_aucune_route_de_la_fiche(auth_client, db, sample_users):
+    """Un salarié simple n'a aucun droit d'écriture sur la fiche salarié, même
+    sur la sienne : `_peut_gerer()` ne couvre que comptable, directeur et
+    responsable. Les 7 routes mutantes doivent toutes refuser sans effet."""
+    uid = sample_users['salarie_id']
+    cid = _creer_cdd(db, uid)
+    did = _creer_document(db, uid, sample_users['directeur_id'])
+    db.execute("UPDATE users SET email = ?, adresse = ?, pesee = 100 WHERE id = ?",
+               ('avant@test.fr', '1 rue des Tests', uid))
+    db.commit()
+
+    routes = [
+        ('/infos_salaries/email', {'user_id': uid, 'email': 'detourne@test.fr'}),
+        ('/infos_salaries/infos_personnelles', {'user_id': uid, 'adresse': '2 rue Detournee'}),
+        ('/infos_salaries/pesee', {'user_id': uid, 'pesee': '250', 'competence': '9', 'maintien': '0'}),
+        ('/infos_salaries/contrat', {'user_id': uid, 'type_contrat': 'CDI', 'date_debut': '2026-02-01'}),
+        (f'/infos_salaries/contrat/{cid}/date_fin', {'date_fin': '2027-12-31'}),
+        (f'/infos_salaries/supprimer_contrat/{cid}', {}),
+        (f'/infos_salaries/supprimer_document/{did}', {}),
+    ]
+    for url, data in routes:
+        r = auth_client.post(url, data=data, follow_redirects=True)
+        assert 'Acces non autorise.' in r.get_data(as_text=True), url
+
+    user = db.execute("SELECT email, adresse, pesee FROM users WHERE id = ?", (uid,)).fetchone()
+    assert user['email'] == 'avant@test.fr'
+    assert user['adresse'] == '1 rue des Tests'
+    assert user['pesee'] == 100
+    nb = db.execute("SELECT COUNT(*) AS nb FROM contrats WHERE user_id = ?", (uid,)).fetchone()
+    assert nb['nb'] == 1    # aucun contrat ajouté ni supprimé
+    row = db.execute("SELECT date_fin FROM contrats WHERE id = ?", (cid,)).fetchone()
+    assert row['date_fin'] == '2026-06-30'
+    assert db.execute("SELECT 1 FROM documents_salaries WHERE id = ?", (did,)).fetchone() is not None

--- a/tests/test_planificateur_acces.py
+++ b/tests/test_planificateur_acces.py
@@ -1,0 +1,342 @@
+"""
+Tests d'accès et d'isolation du planificateur (blueprint planificateur_bp).
+
+Le planning est strictement personnel : toutes les requêtes sont filtrées par
+`user_id`. Ces tests couvrent le versant négatif, jusqu'ici absent :
+
+- un utilisateur autorisé ne peut pas MUTER la tâche, le bloc ou la récurrence
+  d'un autre utilisateur (IDOR), et la ressource visée reste strictement
+  inchangée en base après la tentative ;
+- aucune route du planificateur n'est accessible sans connexion ;
+- un profil hors `PROFILS_AUTORISES` est refusé par le décorateur
+  `planif_required` (réponse JSON sur les API, redirection sur la page).
+
+Piège : les fixtures de clients authentifiés partagent le même client de test.
+Pour enchaîner deux profils dans un même test, on utilise la fixture `client`
+avec des connexions explicites.
+"""
+import re
+from datetime import date, timedelta
+
+import pytest
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Utilitaires
+# ──────────────────────────────────────────────────────────────────────────
+
+def _connexion(client, login, mot_de_passe):
+    """Connecte le client de test avec le compte demandé."""
+    reponse = client.post('/login', data={'login': login, 'password': mot_de_passe},
+                          follow_redirects=True)
+    assert reponse.status_code == 200
+    return reponse
+
+
+def _deconnexion(client):
+    """Termine la session en cours (avant de connecter un autre profil)."""
+    return client.get('/logout', follow_redirects=True)
+
+
+def _creer_prestataire(db):
+    """Crée le compte prestataire paie (profil hors périmètre du planificateur)."""
+    from werkzeug.security import generate_password_hash
+    db.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil) "
+        "VALUES ('Cabinet', 'Paie', 'presta_test', ?, 'prestataire')",
+        (generate_password_hash('presta123'),)
+    )
+    db.commit()
+
+
+def _etat_planning(db, user_id):
+    """Photographie complète du planning d'un utilisateur.
+
+    Sert à vérifier qu'une tentative refusée n'a rien modifié : ni la tâche ou
+    le bloc visé, ni le reste du planning (blocs orphelins, tâche « suite »
+    créée par `terminer_partiel`, occurrences d'une récurrence supprimée...).
+    """
+    return {
+        'taches': [dict(r) for r in db.execute(
+            'SELECT * FROM planif_taches WHERE user_id = ? ORDER BY id',
+            (user_id,)).fetchall()],
+        'blocs': [dict(r) for r in db.execute(
+            'SELECT * FROM planif_blocs WHERE user_id = ? ORDER BY id',
+            (user_id,)).fetchall()],
+        'recurrences': [dict(r) for r in db.execute(
+            'SELECT * FROM planif_recurrences WHERE user_id = ? ORDER BY id',
+            (user_id,)).fetchall()],
+    }
+
+
+def _payloads_tache():
+    """Corps valide pour chaque route de mutation d'une tâche.
+
+    Les payloads sont volontairement corrects : le refus attendu doit venir du
+    contrôle de propriété, pas d'une validation d'entrée.
+    """
+    return {
+        '': {'titre': 'Titre détourné', 'duree_min': 15},
+        '/supprimer': {},
+        '/statut': {'statut': 'fait'},
+        '/reporter': {'date_min': (date.today() + timedelta(days=7)).isoformat()},
+        '/terminer_partiel': {'minutes_faites': 30},
+    }
+
+
+def _payloads_bloc():
+    """Corps valide pour chaque route de mutation d'un bloc."""
+    return {
+        '/statut': {'statut': 'fait'},
+        '/supprimer': {},
+        '/deplacer': {'date': (date.today() + timedelta(days=1)).isoformat(),
+                      'heure_debut': '09:00'},
+        '/verrou': {'verrouille': 1},
+    }
+
+
+def _routes_planificateur(app):
+    """Toutes les routes du planificateur, identifiants d'URL remplacés par 1.
+
+    L'énumération vient de la table de routage : une nouvelle route est donc
+    automatiquement soumise au test « non connecté ».
+    """
+    routes = []
+    for regle in app.url_map.iter_rules():
+        if not regle.rule.startswith('/planificateur'):
+            continue
+        methode = 'POST' if 'POST' in regle.methods else 'GET'
+        routes.append((methode, re.sub(r'<[^>]+>', '1', regle.rule)))
+    return sorted(routes)
+
+
+@pytest.fixture
+def donnees_comptable(client, db, sample_users):
+    """Tâche (avec son bloc) et récurrence appartenant au comptable.
+
+    À la sortie, le client est connecté en tant que salarié : c'est lui qui
+    tentera d'agir sur les ressources d'autrui.
+    """
+    _connexion(client, 'compta_test', 'compta123')
+
+    reponse = client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Dossier confidentiel', 'duree_min': 60,
+        'secable': 0, 'duree_min_bloc': 60,
+    })
+    assert reponse.status_code == 200
+
+    reponse = client.post('/planificateur/api/recurrence', json={
+        'titre': 'Point hebdo comptable', 'frequence': 'hebdomadaire',
+        'duree_min': 30, 'jour_semaine': 0,
+    })
+    assert reponse.status_code == 200
+
+    # Le bloc est relu APRÈS la création de la récurrence : la replanification
+    # recrée les blocs non verrouillés (leur identifiant change).
+    tache = db.execute(
+        "SELECT id FROM planif_taches WHERE titre = 'Dossier confidentiel'").fetchone()
+    bloc = db.execute(
+        'SELECT id FROM planif_blocs WHERE tache_id = ?', (tache['id'],)).fetchone()
+    recurrence = db.execute(
+        "SELECT id FROM planif_recurrences WHERE titre = 'Point hebdo comptable'").fetchone()
+    assert bloc is not None, "la tâche du comptable doit avoir au moins un bloc"
+
+    _deconnexion(client)
+    _connexion(client, 'salarie_test', 'sal123')
+
+    return {
+        'tache_id': tache['id'],
+        'bloc_id': bloc['id'],
+        'recurrence_id': recurrence['id'],
+        'proprietaire_id': sample_users['comptable_id'],
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Isolation entre utilisateurs (IDOR)
+# ──────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('suffixe', ['', '/supprimer', '/statut', '/reporter',
+                                     '/terminer_partiel'])
+def test_mutation_tache_autrui_refusee(client, db, donnees_comptable, suffixe):
+    """Un salarié ne peut pas modifier la tâche d'un autre utilisateur."""
+    tache_id = donnees_comptable['tache_id']
+    avant = _etat_planning(db, donnees_comptable['proprietaire_id'])
+
+    reponse = client.post(f'/planificateur/api/tache/{tache_id}{suffixe}',
+                          json=_payloads_tache()[suffixe])
+
+    assert reponse.status_code == 404
+    corps = reponse.get_json()
+    assert corps['ok'] is False
+    assert corps['erreur'] == 'Tache introuvable.'
+    assert _etat_planning(db, donnees_comptable['proprietaire_id']) == avant
+
+
+@pytest.mark.parametrize('suffixe', ['/statut', '/supprimer', '/deplacer', '/verrou'])
+def test_mutation_bloc_autrui_refusee(client, db, donnees_comptable, suffixe):
+    """Un salarié ne peut pas agir sur le créneau d'un autre utilisateur."""
+    bloc_id = donnees_comptable['bloc_id']
+    avant = _etat_planning(db, donnees_comptable['proprietaire_id'])
+
+    reponse = client.post(f'/planificateur/api/bloc/{bloc_id}{suffixe}',
+                          json=_payloads_bloc()[suffixe])
+
+    assert reponse.status_code == 404
+    corps = reponse.get_json()
+    assert corps['ok'] is False
+    assert corps['erreur'] == 'Bloc introuvable.'
+    assert _etat_planning(db, donnees_comptable['proprietaire_id']) == avant
+
+
+def test_supprimer_recurrence_autrui_refusee(client, db, donnees_comptable):
+    """Un salarié ne peut pas supprimer la récurrence d'un autre utilisateur."""
+    avant = _etat_planning(db, donnees_comptable['proprietaire_id'])
+
+    reponse = client.post(
+        f'/planificateur/api/recurrence/{donnees_comptable["recurrence_id"]}/supprimer',
+        json={})
+
+    assert reponse.status_code == 404
+    corps = reponse.get_json()
+    assert corps['ok'] is False
+    assert corps['erreur'] == 'Recurrence introuvable.'
+    # Ni la récurrence ni ses occurrences (et leurs blocs) ne doivent bouger.
+    assert _etat_planning(db, donnees_comptable['proprietaire_id']) == avant
+
+
+def test_comparaisons_ne_reevaluent_pas_la_tache_dautrui(client, db, donnees_comptable):
+    """La priorité relative ne peut pas servir à réécrire la tâche d'autrui.
+
+    Des réponses de comparaison incohérentes réévaluent la tâche mal estimée :
+    ce chemin d'écriture ne doit s'appliquer qu'aux tâches de l'utilisateur
+    connecté.
+    """
+    tache_id = donnees_comptable['tache_id']
+    avant = _etat_planning(db, donnees_comptable['proprietaire_id'])
+
+    reponse = client.post('/planificateur/api/tache', json={
+        'type': 'tache', 'titre': 'Tâche du salarié', 'duree_min': 30,
+        'comparaisons': [{'tache_id': tache_id, 'reponse': 'superieur'}],
+    })
+
+    assert reponse.status_code == 200
+    assert _etat_planning(db, donnees_comptable['proprietaire_id']) == avant
+
+
+def test_le_proprietaire_conserve_ses_donnees_apres_les_tentatives(client, db,
+                                                                   donnees_comptable):
+    """Après une série de tentatives refusées, le comptable retrouve tout.
+
+    Vérification de bout en bout : le planning est relu par son propriétaire via
+    l'API, pas seulement en base.
+    """
+    tache_id = donnees_comptable['tache_id']
+    bloc_id = donnees_comptable['bloc_id']
+    for chemin, payload in (
+        (f'/planificateur/api/tache/{tache_id}/supprimer', {}),
+        (f'/planificateur/api/tache/{tache_id}/statut', {'statut': 'fait'}),
+        (f'/planificateur/api/bloc/{bloc_id}/supprimer', {}),
+        (f'/planificateur/api/bloc/{bloc_id}/statut', {'statut': 'fait'}),
+    ):
+        assert client.post(chemin, json=payload).status_code == 404
+
+    _deconnexion(client)
+    _connexion(client, 'compta_test', 'compta123')
+
+    debut = date.today().isoformat()
+    fin = (date.today() + timedelta(days=90)).isoformat()
+    donnees = client.get(
+        f'/planificateur/api/blocs?debut={debut}&fin={fin}').get_json()
+    assert donnees['ok'] is True
+    assert any(b['id'] == bloc_id and b['tache_id'] == tache_id
+               and b['titre'] == 'Dossier confidentiel'
+               and b['statut'] == 'planifie'
+               for b in donnees['blocs'])
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Accès non connecté
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_toutes_les_routes_refusent_un_anonyme(client, app):
+    """Aucune route du planificateur n'est servie sans connexion."""
+    routes = _routes_planificateur(app)
+    # Garde-fou : le blueprint expose 16 routes, dont 15 sous /planificateur/api.
+    assert len(routes) >= 16
+
+    for methode, chemin in routes:
+        reponse = (client.post(chemin, json={}) if methode == 'POST'
+                   else client.get(chemin))
+        assert reponse.status_code == 302, f'{methode} {chemin}'
+        assert '/login' in reponse.headers['Location'], f'{methode} {chemin}'
+
+
+def test_mutations_anonymes_sans_effet(client, db, donnees_comptable):
+    """Un anonyme ne peut rien changer aux données d'un utilisateur existant."""
+    tache_id = donnees_comptable['tache_id']
+    bloc_id = donnees_comptable['bloc_id']
+    avant = _etat_planning(db, donnees_comptable['proprietaire_id'])
+    _deconnexion(client)
+
+    for chemin, payload in (
+        (f'/planificateur/api/tache/{tache_id}/supprimer', {}),
+        (f'/planificateur/api/tache/{tache_id}/statut', {'statut': 'fait'}),
+        (f'/planificateur/api/bloc/{bloc_id}/supprimer', {}),
+        (f'/planificateur/api/recurrence/{donnees_comptable["recurrence_id"]}/supprimer', {}),
+    ):
+        reponse = client.post(chemin, json=payload)
+        assert reponse.status_code == 302, chemin
+        assert '/login' in reponse.headers['Location'], chemin
+
+    assert _etat_planning(db, donnees_comptable['proprietaire_id']) == avant
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Décorateur planif_required : profil non autorisé
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_planif_required_refuse_les_api_au_profil_non_autorise(prestataire_client):
+    """Un profil hors périmètre reçoit un refus JSON explicite sur les API."""
+    from blueprints.planificateur import PROFILS_AUTORISES
+    assert 'prestataire' not in PROFILS_AUTORISES
+
+    for chemin in ('/planificateur/api/replanifier',
+                   '/planificateur/api/tache',
+                   '/planificateur/api/recurrence'):
+        reponse = prestataire_client.post(chemin, json={'titre': 'X', 'duree_min': 30})
+        assert reponse.status_code == 403, chemin
+        assert reponse.get_json() == {'ok': False, 'erreur': 'Acces refuse.'}, chemin
+
+    # La lecture des blocs est refusée de la même façon (aucune fuite de données).
+    reponse = prestataire_client.get('/planificateur/api/blocs',
+                                     headers={'X-Requested-With': 'XMLHttpRequest'})
+    assert reponse.status_code == 403
+    assert reponse.get_json()['ok'] is False
+
+
+def test_planif_required_redirige_la_page_du_profil_non_autorise(prestataire_client):
+    """Sur la page HTML, le refus prend la forme d'une redirection avec message."""
+    reponse = prestataire_client.get('/planificateur', follow_redirects=False)
+    assert reponse.status_code == 302
+    assert '/dashboard' in reponse.headers['Location']
+
+    # Le message flash est échappé par Jinja (l'apostrophe devient &#39;) :
+    # on cherche la partie stable du libellé.
+    suite = prestataire_client.get('/planificateur', follow_redirects=True)
+    assert 'est pas accessible pour votre profil' in suite.get_data(as_text=True)
+
+
+def test_profil_non_autorise_refuse_avant_le_controle_de_propriete(client, db,
+                                                                   donnees_comptable):
+    """Le contrôle de profil précède celui de la propriété : 403, et rien ne bouge."""
+    avant = _etat_planning(db, donnees_comptable['proprietaire_id'])
+    _deconnexion(client)
+    _creer_prestataire(db)
+    _connexion(client, 'presta_test', 'presta123')
+
+    reponse = client.post(
+        f'/planificateur/api/tache/{donnees_comptable["tache_id"]}/supprimer', json={})
+    assert reponse.status_code == 403
+    assert reponse.get_json()['erreur'] == 'Acces refuse.'
+    assert _etat_planning(db, donnees_comptable['proprietaire_id']) == avant

--- a/tests/test_prestataire_paie.py
+++ b/tests/test_prestataire_paie.py
@@ -1,0 +1,198 @@
+"""
+Profil « prestataire paie » (cabinet externe) : périmètre d'accès volontaire.
+
+Le prestataire n'est pas un salarié de l'association : il est exclu de presque
+toutes les vues (il est même filtré des listes de salariés par les requêtes
+`profil != 'prestataire'`). Deux téléchargements font exception et
+court-circuitent explicitement les contrôles habituels :
+
+- `blueprints/absences.py` (route `/absences/justificatif/<id>`) ignore
+  `_peut_gerer_absences()` quand le profil est `prestataire` ;
+- `blueprints/infos_salaries.py` (route
+  `/infos_salaries/telecharger_contrat/<id>`) ignore `_peut_gerer()` **et**
+  `_est_salarie_visible()` dans le même cas.
+
+Cet élargissement est VOULU et confirmé par l'utilisateur : pour établir la
+paie, le cabinet doit disposer des pièces justificatives d'absence (arrêt
+maladie, attestation d'accident du travail…) et du contrat de travail (quotité,
+échéance, forfait). Il n'a en revanche accès ni aux pages qui les hébergent, ni
+à aucun autre module.
+
+Ces tests documentent ce contrat pour qu'un durcissement futur des accès ne le
+casse pas par inadvertance — et pour que l'élargissement reste limité au seul
+profil prestataire.
+"""
+import os
+
+
+# Modules interdits au prestataire : chaque route renvoie vers le tableau de
+# bord avec un message de refus (aucune page servie).
+ROUTES_INTERDITES = [
+    '/gestion_budgets',            # budgets par secteur
+    '/budget-previsionnel',        # budget prévisionnel
+    '/planificateur',              # planificateur de tâches
+    '/administration',             # administration système
+    '/administration/options',     # options applicatives
+    '/tresorerie',                 # trésorerie
+    '/tresorerie/comptes',         # comptes de trésorerie
+    '/variables_paie',             # variables de paie (saisie interne)
+    '/mon_equipe',                 # RH équipe
+    '/dashboard_direction',        # tableau de bord direction
+    '/dashboard_comptable',        # tableau de bord comptable
+    '/soldes_conges',              # soldes de congés de tout l'effectif
+]
+
+
+def _creer_absence_avec_justificatif(db, user_id, saisi_par, docs_dir):
+    """Crée une absence dont le justificatif existe réellement sur le disque."""
+    nom_fichier = 'ARRET-MALADIE_Martin_Jean.pdf'
+    with open(os.path.join(docs_dir, nom_fichier), 'wb') as f:
+        f.write(b'%PDF-1.4\njustificatif de test\n')
+    cur = db.execute(
+        "INSERT INTO absences (user_id, motif, date_debut, date_fin, jours_ouvres, "
+        "justificatif_path, justificatif_nom, saisi_par) "
+        "VALUES (?, 'Arrêt maladie', '2026-03-02', '2026-03-06', 5, ?, ?, ?)",
+        (user_id, nom_fichier, 'arret_maladie.pdf', saisi_par))
+    db.commit()
+    return cur.lastrowid
+
+
+def _creer_contrat_avec_pdf(db, user_id, saisi_par, docs_dir):
+    """Crée un contrat dont le PDF existe réellement sur le disque."""
+    nom_fichier = '01-01-2026_CONTRAT_Martin_Jean_CDI.pdf'
+    with open(os.path.join(docs_dir, nom_fichier), 'wb') as f:
+        f.write(b'%PDF-1.4\ncontrat de test\n')
+    cur = db.execute(
+        "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin, "
+        "fichier_path, fichier_nom, saisi_par) "
+        "VALUES (?, 'CDI', '2026-01-01', NULL, ?, ?, ?)",
+        (user_id, nom_fichier, 'contrat_martin.pdf', saisi_par))
+    db.commit()
+    return cur.lastrowid
+
+
+# ── Accès élargis VOULUS ───────────────────────────────────────────────────
+
+def test_prestataire_peut_telecharger_un_justificatif_absence(
+        prestataire_client, app, db, sample_users, monkeypatch, tmp_path):
+    """Accès voulu : le cabinet a besoin de l'arrêt de travail pour établir la
+    paie (maintien de salaire, subrogation), alors qu'il ne gère pas les
+    absences."""
+    from blueprints import absences as absences_module
+    docs_dir = tmp_path / 'documents'
+    docs_dir.mkdir()
+    monkeypatch.setattr(absences_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+    with app.app_context():
+        absence_id = _creer_absence_avec_justificatif(
+            db, sample_users['salarie_id'], sample_users['directeur_id'], str(docs_dir))
+
+    response = prestataire_client.get(f'/absences/justificatif/{absence_id}')
+    assert response.status_code == 200
+    assert response.data.startswith(b'%PDF-1.4')
+
+
+def test_prestataire_peut_telecharger_un_contrat(
+        prestataire_client, app, db, sample_users, monkeypatch, tmp_path):
+    """Accès voulu : quotité, échéance et forfait du contrat conditionnent la
+    paie. Le prestataire n'a pourtant aucun secteur, donc `_est_salarie_visible`
+    lui répondrait « non » : la route l'ignore explicitement pour ce profil."""
+    from blueprints import infos_salaries as infos_module
+    docs_dir = tmp_path / 'documents'
+    docs_dir.mkdir()
+    monkeypatch.setattr(infos_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+    with app.app_context():
+        contrat_id = _creer_contrat_avec_pdf(
+            db, sample_users['salarie_id'], sample_users['directeur_id'], str(docs_dir))
+
+    response = prestataire_client.get(f'/infos_salaries/telecharger_contrat/{contrat_id}')
+    assert response.status_code == 200
+    assert response.data.startswith(b'%PDF-1.4')
+
+
+def test_prestataire_accede_a_la_preparation_de_paie(prestataire_client):
+    """La prépa paie est le seul module métier ouvert au prestataire."""
+    assert prestataire_client.get('/prepa_paie').status_code == 200
+    assert prestataire_client.get('/prepa_paie/export_excel').status_code == 200
+
+
+def test_connexion_prestataire_ouvre_directement_la_prepa_paie(prestataire_client):
+    """Sa page d'accueil après connexion est la prépa paie, pas le tableau de
+    bord : c'est bien le seul endroit où il a quelque chose à faire."""
+    prestataire_client.get('/logout', follow_redirects=True)
+    response = prestataire_client.post(
+        '/login', data={'login': 'presta_test', 'password': 'presta123'},
+        follow_redirects=False)
+    assert response.status_code == 302
+    assert '/prepa_paie' in response.headers['Location']
+
+
+# ── Tout le reste lui reste fermé ──────────────────────────────────────────
+
+def test_prestataire_refuse_sur_les_autres_modules(prestataire_client):
+    """L'accès élargi se limite aux deux téléchargements : budget, trésorerie,
+    planificateur, administration et RH restent inaccessibles."""
+    for url in ROUTES_INTERDITES:
+        response = prestataire_client.get(url, follow_redirects=False)
+        assert response.status_code == 302, url
+        assert response.headers['Location'].endswith('/dashboard'), url
+
+
+def test_prestataire_refuse_sur_les_api_budget(prestataire_client):
+    """Les API JSON du budget répondent 403 (et non une page HTML)."""
+    from datetime import datetime
+
+    annee = datetime.now().year
+    response = prestataire_client.get(
+        f'/api/budget-previsionnel/donnees?type_budget=actualise&annee={annee}')
+    assert response.status_code == 403
+
+
+def test_prestataire_ne_voit_pas_les_pages_qui_hebergent_les_pieces(prestataire_client):
+    """Nuance importante du contrat : il télécharge la pièce s'il en connaît
+    l'identifiant (fourni par la prépa paie), mais les pages de gestion des
+    absences et des fiches salariés lui restent fermées — il ne peut donc pas
+    parcourir librement les dossiers RH."""
+    for url in ('/absences', '/infos_salaries'):
+        response = prestataire_client.get(url, follow_redirects=False)
+        assert response.status_code == 302, url
+        assert response.headers['Location'].endswith('/dashboard'), url
+
+
+def test_l_acces_elargi_est_reserve_au_prestataire(
+        client, app, db, sample_users, monkeypatch, tmp_path):
+    """Contrôle négatif : le court-circuit est bien conditionné au profil.
+    Un salarié qui appelle les mêmes URL est refusé sur les deux routes.
+    (Les fixtures de clients authentifiés partagent le même client de test :
+    on se connecte explicitement.)"""
+    from blueprints import absences as absences_module
+    from blueprints import infos_salaries as infos_module
+    docs_dir = tmp_path / 'documents'
+    docs_dir.mkdir()
+    monkeypatch.setattr(absences_module, 'DOCUMENTS_DIR', str(docs_dir))
+    monkeypatch.setattr(infos_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+    with app.app_context():
+        absence_id = _creer_absence_avec_justificatif(
+            db, sample_users['salarie_id'], sample_users['directeur_id'], str(docs_dir))
+        contrat_id = _creer_contrat_avec_pdf(
+            db, sample_users['salarie_id'], sample_users['directeur_id'], str(docs_dir))
+
+    urls = (f'/absences/justificatif/{absence_id}',
+            f'/infos_salaries/telecharger_contrat/{contrat_id}')
+
+    # Non connecté : redirigé vers la connexion, aucun fichier servi.
+    for url in urls:
+        response = client.get(url, follow_redirects=False)
+        assert response.status_code == 302, url
+        assert '/login' in response.headers['Location'], url
+
+    # Salarié : refusé, le fichier n'est pas servi.
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    for url in urls:
+        response = client.get(url, follow_redirects=False)
+        assert response.status_code == 302, url
+        assert response.headers['Location'].endswith('/dashboard'), url
+    client.get('/logout', follow_redirects=True)

--- a/tests/test_saisie.py
+++ b/tests/test_saisie.py
@@ -139,18 +139,130 @@ class TestSaisieAnomalies:
             assert anomalie is not None
 
 
+def _creer_salarie_meme_secteur(db, sample_users, login='collegue_test'):
+    """Crée un second salarié dans le secteur du salarié de test."""
+    from werkzeug.security import generate_password_hash
+
+    cur = db.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil, secteur_id, responsable_id) "
+        "VALUES (?, ?, ?, ?, 'salarie', ?, ?)",
+        ('Bernard', 'Paul', login, generate_password_hash('col123'),
+         sample_users['secteur_id'], sample_users['responsable_id']))
+    db.commit()
+    return cur.lastrowid
+
+
+def _creer_salarie_autre_secteur(db, login='hors_secteur_test'):
+    """Crée un salarié dans un autre secteur, hors équipe du responsable de test."""
+    from werkzeug.security import generate_password_hash
+
+    cur = db.execute("INSERT INTO secteurs (nom, description) VALUES (?, ?)",
+                     ('Autre Secteur Saisie', 'Secteur distinct pour les tests'))
+    autre_secteur_id = cur.lastrowid
+    cur = db.execute(
+        "INSERT INTO users (nom, prenom, login, password, profil, secteur_id) "
+        "VALUES (?, ?, ?, ?, 'salarie', ?)",
+        ('Petit', 'Luc', login, generate_password_hash('hors123'), autre_secteur_id))
+    db.commit()
+    return cur.lastrowid
+
+
 class TestSaisieDroits:
     """Tests des contrôles d'accès pour la saisie."""
 
-    def test_directeur_ne_peut_pas_saisir_pour_lui(self, admin_client, app, sample_users):
-        """Le directeur ne peut PAS modifier sa propre fiche via saisie."""
+    def test_directeur_ne_peut_pas_saisir_pour_lui(self, admin_client, app, db, sample_users):
+        """Le directeur ne peut PAS modifier sa propre fiche via saisie.
+
+        Le refus doit être visible (message français) ET sans effet en base :
+        un simple `status_code == 200` après redirection passerait même si la
+        saisie interdite avait été acceptée.
+        """
+        date_test = '2025-01-06'
+
         with app.app_context():
             response = admin_client.post('/saisie_heures', data={
-                'date': '2025-01-06',
+                'date': date_test,
                 'heure_debut_matin': '09:00',
                 'heure_fin_matin': '12:00',
             }, follow_redirects=True)
             assert response.status_code == 200
+            assert 'pas le droit de modifier cette fiche' in response.get_data(as_text=True)
+
+            row = db.execute(
+                "SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?",
+                (sample_users['directeur_id'], date_test)
+            ).fetchone()
+            assert row is None    # rien écrit
+
+    def test_salarie_ne_peut_pas_saisir_pour_autrui(self, auth_client, app, db, sample_users):
+        """Un salarié ne peut PAS saisir les heures d'un collègue, même de son
+        propre secteur : seul le profil (responsable/directeur) ouvre ce droit."""
+        date_test = '2025-01-13'
+
+        with app.app_context():
+            collegue_id = _creer_salarie_meme_secteur(db, sample_users)
+
+            response = auth_client.post('/saisie_heures', data={
+                'user_id': collegue_id,
+                'date': date_test,
+                'heure_debut_matin': '08:00',
+                'heure_fin_matin': '12:00',
+            }, follow_redirects=True)
+            assert response.status_code == 200
+            assert 'pas le droit de modifier cette fiche' in response.get_data(as_text=True)
+
+            row = db.execute(
+                "SELECT * FROM heures_reelles WHERE user_id = ?", (collegue_id,)
+            ).fetchone()
+            assert row is None    # rien écrit
+
+    def test_responsable_ne_peut_pas_saisir_hors_secteur(self, resp_client, app, db, sample_users):
+        """Le responsable ne peut PAS saisir pour un salarié d'un autre secteur
+        qui ne lui est pas non plus rattaché directement."""
+        date_test = '2025-01-14'
+
+        with app.app_context():
+            hors_equipe_id = _creer_salarie_autre_secteur(db)
+
+            response = resp_client.post('/saisie_heures', data={
+                'user_id': hors_equipe_id,
+                'date': date_test,
+                'heure_debut_matin': '08:00',
+                'heure_fin_matin': '12:00',
+            }, follow_redirects=True)
+            assert response.status_code == 200
+            assert 'pas le droit de modifier cette fiche' in response.get_data(as_text=True)
+
+            row = db.execute(
+                "SELECT * FROM heures_reelles WHERE user_id = ?", (hors_equipe_id,)
+            ).fetchone()
+            assert row is None    # rien écrit
+
+    def test_mois_verrouille_refuse_la_modification(self, auth_client, app, db, sample_users):
+        """Une fiche verrouillée (validée par le responsable ET le directeur)
+        refuse toute nouvelle saisie sur le mois concerné."""
+        date_test = '2025-02-03'    # lundi de février 2025
+
+        with app.app_context():
+            db.execute(
+                "INSERT INTO validations (user_id, mois, annee, validation_responsable, "
+                "validation_directeur, bloque) VALUES (?, 2, 2025, ?, ?, 1)",
+                (sample_users['salarie_id'], 'Dupont Marie', 'Admin Systeme'))
+            db.commit()
+
+            response = auth_client.post('/saisie_heures', data={
+                'date': date_test,
+                'heure_debut_matin': '08:00',
+                'heure_fin_matin': '12:00',
+            }, follow_redirects=True)
+            assert response.status_code == 200
+            assert 'la fiche est verrouillée' in response.get_data(as_text=True)
+
+            row = db.execute(
+                "SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?",
+                (sample_users['salarie_id'], date_test)
+            ).fetchone()
+            assert row is None    # rien écrit
 
     def test_responsable_peut_saisir_pour_son_secteur(self, resp_client, app, db, sample_users):
         """Le responsable peut saisir pour un salarié de son secteur."""

--- a/tests/test_subventions.py
+++ b/tests/test_subventions.py
@@ -716,3 +716,86 @@ class TestPerimetreResponsableSubventions:
                     follow_redirects=True)
         assert client.post('/api/subventions/analytiques/ajouter',
                            json={'nom': 'ANALYTIQUE Y'}).status_code == 403
+
+
+class TestTelechargementPiecesSubventions:
+    """Cloisonnement des pièces jointes en LECTURE (découvert par le balayage
+    des routes sensibles).
+
+    Les deux routes de téléchargement ne vérifiaient que le profil : un
+    responsable non assigné pouvait récupérer, en devinant l'identifiant, le
+    justificatif d'une subvention d'un autre secteur — alors que la page de
+    consultation ne la lui montre pas. C'est le pendant, en lecture, du
+    cloisonnement appliqué aux routes de modification.
+    """
+
+    def _seed_avec_pieces(self, app, db, sample_users, tmp_path, monkeypatch):
+        """Une subvention assignée au responsable et une qui ne l'est pas,
+        chacune avec un justificatif et un sous-élément documenté sur disque."""
+        import blueprints.subventions as mod
+        monkeypatch.setattr(mod, 'DOCUMENTS_DIR', str(tmp_path))
+        resp_id = sample_users['responsable_id']
+        ids = {}
+        with app.app_context():
+            for cle, assignee in (('mienne', resp_id), ('autre', None)):
+                fichier = f'justif_{cle}.pdf'
+                (tmp_path / fichier).write_bytes(b'%PDF-1.4\n' + cle.encode() + b'\n')
+                doc = f'doc_{cle}.pdf'
+                (tmp_path / doc).write_bytes(b'%PDF-1.4\n' + cle.encode() + b'\n')
+                sub_id = db.execute(
+                    "INSERT INTO subventions (nom, groupe, annee_action, assignee_1_id, "
+                    "justificatif_path, justificatif_nom) VALUES (?, 'en_cours', '2026', ?, ?, ?)",
+                    (cle.capitalize(), assignee, fichier, fichier)
+                ).lastrowid
+                se_id = db.execute(
+                    "INSERT INTO subventions_sous_elements (subvention_id, nom, ordre, "
+                    "document_path, document_nom) VALUES (?, 'Bilan', 0, ?, ?)",
+                    (sub_id, doc, doc)
+                ).lastrowid
+                ids[cle] = sub_id
+                ids['se_' + cle] = se_id
+            db.commit()
+        return ids
+
+    def test_responsable_non_assigne_ne_telecharge_pas_les_pieces(
+            self, app, db, resp_client, sample_users, tmp_path, monkeypatch):
+        ids = self._seed_avec_pieces(app, db, sample_users, tmp_path, monkeypatch)
+
+        for url in (f"/subventions/justificatif/{ids['autre']}",
+                    f"/subventions/sous-element-document/{ids['se_autre']}"):
+            r = resp_client.get(url, follow_redirects=False)
+            assert r.status_code in (301, 302), f"{url} devrait être refusée"
+            assert '/subventions' in r.headers.get('Location', '')
+            assert r.headers.get('Content-Disposition') is None
+            assert not r.get_data().startswith(b'%PDF'), f"pièce servie par {url}"
+
+    def test_responsable_assigne_telecharge_ses_pieces(
+            self, app, db, resp_client, sample_users, tmp_path, monkeypatch):
+        ids = self._seed_avec_pieces(app, db, sample_users, tmp_path, monkeypatch)
+
+        for url in (f"/subventions/justificatif/{ids['mienne']}",
+                    f"/subventions/sous-element-document/{ids['se_mienne']}"):
+            r = resp_client.get(url)
+            assert r.status_code == 200, f"{url} doit rester accessible à l'assigné"
+            assert r.get_data().startswith(b'%PDF')
+
+    def test_comptable_telecharge_toutes_les_pieces(
+            self, app, db, comptable_client, sample_users, tmp_path, monkeypatch):
+        ids = self._seed_avec_pieces(app, db, sample_users, tmp_path, monkeypatch)
+
+        r = comptable_client.get(f"/subventions/justificatif/{ids['autre']}")
+        assert r.status_code == 200 and r.get_data().startswith(b'%PDF')
+
+    def test_salarie_et_anonyme_refuses(
+            self, app, db, client, sample_users, tmp_path, monkeypatch):
+        ids = self._seed_avec_pieces(app, db, sample_users, tmp_path, monkeypatch)
+        url = f"/subventions/justificatif/{ids['mienne']}"
+
+        r = client.get(url, follow_redirects=False)
+        assert r.status_code in (301, 302) and '/login' in r.headers.get('Location', '')
+
+        client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                    follow_redirects=True)
+        r = client.get(url, follow_redirects=False)
+        assert r.status_code in (301, 302)
+        assert not r.get_data().startswith(b'%PDF')

--- a/tests/test_subventions.py
+++ b/tests/test_subventions.py
@@ -471,3 +471,248 @@ class TestFiltreAnnee:
         # Le filtre par année est utile à tous (contrairement à « Gérer les types »).
         html = resp_client.get('/subventions').get_data(as_text=True)
         assert 'sv-annee-select' in html
+
+
+class TestPerimetreResponsableSubventions:
+    """Cloisonnement des subventions entre responsables (escalade horizontale).
+
+    Un responsable ne doit agir que sur les subventions qui lui sont assignées :
+    exactement le périmètre déjà appliqué par la page de consultation. Sans ce
+    contrôle, il pouvait modifier ou supprimer par ID les subventions d'un autre
+    secteur.
+    """
+
+    def _seed(self, app, db, sample_users):
+        """Crée une subvention assignée au responsable de test et une subvention
+        qui ne le concerne pas, chacune avec un sous-élément."""
+        resp_id = sample_users['responsable_id']
+        with app.app_context():
+            mienne = db.execute(
+                "INSERT INTO subventions (nom, groupe, annee_action, assignee_1_id) "
+                "VALUES ('Mienne', 'en_cours', '2026', ?)",
+                (resp_id,)
+            ).lastrowid
+            se_mienne = db.execute(
+                "INSERT INTO subventions_sous_elements (subvention_id, nom, ordre) "
+                "VALUES (?, 'Bilan', 0)",
+                (mienne,)
+            ).lastrowid
+            autre = db.execute(
+                "INSERT INTO subventions (nom, groupe, annee_action) "
+                "VALUES ('AutreSecteur', 'en_cours', '2026')"
+            ).lastrowid
+            se_autre = db.execute(
+                "INSERT INTO subventions_sous_elements (subvention_id, nom, ordre) "
+                "VALUES (?, 'Bilan autre', 0)",
+                (autre,)
+            ).lastrowid
+            db.commit()
+        return {'mienne': mienne, 'se_mienne': se_mienne,
+                'autre': autre, 'se_autre': se_autre}
+
+    def _pdf(self):
+        return {'fichier': (io.BytesIO(b'%PDF-1.4\ntest\n'), 'piece.pdf')}
+
+    def test_responsable_non_assigne_refuse_sur_les_routes_mutantes(
+        self, app, resp_client, db, sample_users, monkeypatch, tmp_path
+    ):
+        from blueprints import subventions as subventions_module
+        # Dossier dédié (tmp_path héberge aussi la base de test).
+        documents_dir = tmp_path / 'documents_subventions'
+        documents_dir.mkdir()
+        monkeypatch.setattr(subventions_module, 'DOCUMENTS_DIR', str(documents_dir))
+        ids = self._seed(app, db, sample_users)
+
+        appels = [
+            resp_client.post(f"/api/subventions/{ids['autre']}/modifier",
+                             json={'field': 'nom', 'value': 'Piratee'}),
+            resp_client.post(f"/api/subventions/{ids['autre']}/sous-elements/ajouter",
+                             json={'nom': 'Etape pirate'}),
+            resp_client.post(f"/api/subventions/sous-elements/{ids['se_autre']}/modifier",
+                             json={'field': 'nom', 'value': 'Etape piratee'}),
+            resp_client.post(f"/api/subventions/sous-elements/{ids['se_autre']}/supprimer"),
+            resp_client.post(f"/api/subventions/{ids['autre']}/justificatif",
+                             data=self._pdf(), content_type='multipart/form-data'),
+            resp_client.post(f"/api/subventions/sous-elements/{ids['se_autre']}/document",
+                             data=self._pdf(), content_type='multipart/form-data'),
+            resp_client.post(f"/api/subventions/{ids['autre']}/supprimer"),
+        ]
+        for reponse in appels:
+            assert reponse.status_code == 403
+            assert reponse.get_json() == {'ok': False, 'error': 'Non autorisé'}
+
+        # Aucun effet en base : la subvention d'autrui est intacte.
+        with app.app_context():
+            sub = db.execute(
+                'SELECT nom, justificatif_path FROM subventions WHERE id = ?',
+                (ids['autre'],)
+            ).fetchone()
+            sous_elements = db.execute(
+                'SELECT nom, document_path FROM subventions_sous_elements '
+                'WHERE subvention_id = ?',
+                (ids['autre'],)
+            ).fetchall()
+        assert sub is not None
+        assert sub['nom'] == 'AutreSecteur'
+        assert sub['justificatif_path'] is None
+        assert len(sous_elements) == 1
+        assert sous_elements[0]['nom'] == 'Bilan autre'
+        assert sous_elements[0]['document_path'] is None
+        # Aucun fichier n'a été écrit malgré les tentatives de téléversement.
+        assert list(documents_dir.iterdir()) == []
+
+    def test_responsable_assigne_peut_toujours_travailler(
+        self, app, resp_client, db, sample_users, monkeypatch, tmp_path
+    ):
+        from blueprints import subventions as subventions_module
+        monkeypatch.setattr(subventions_module, 'DOCUMENTS_DIR', str(tmp_path))
+        ids = self._seed(app, db, sample_users)
+
+        assert resp_client.post(f"/api/subventions/{ids['mienne']}/modifier",
+                                json={'field': 'nom', 'value': 'Mienne suivie'}
+                                ).status_code == 200
+        ajout = resp_client.post(f"/api/subventions/{ids['mienne']}/sous-elements/ajouter",
+                                 json={'nom': 'Envoyer le bilan'})
+        assert ajout.status_code == 200
+        assert resp_client.post(f"/api/subventions/sous-elements/{ids['se_mienne']}/modifier",
+                                json={'field': 'statut', 'value': 'fait'}
+                                ).status_code == 200
+        assert resp_client.post(f"/api/subventions/{ids['mienne']}/justificatif",
+                                data=self._pdf(), content_type='multipart/form-data'
+                                ).status_code == 200
+        assert resp_client.post(f"/api/subventions/sous-elements/{ids['se_mienne']}/document",
+                                data=self._pdf(), content_type='multipart/form-data'
+                                ).status_code == 200
+        assert resp_client.post(
+            f"/api/subventions/sous-elements/{ajout.get_json()['id']}/supprimer"
+        ).status_code == 200
+        assert resp_client.post(f"/api/subventions/{ids['mienne']}/supprimer").status_code == 200
+
+        with app.app_context():
+            assert db.execute('SELECT COUNT(*) AS n FROM subventions WHERE id = ?',
+                              (ids['mienne'],)).fetchone()['n'] == 0
+
+    def test_responsable_assigne_via_sous_element_peut_agir_sur_le_parent(
+        self, app, resp_client, db, sample_users
+    ):
+        # Même périmètre que la consultation : un sous-élément attribué suffit.
+        resp_id = sample_users['responsable_id']
+        with app.app_context():
+            sub_id = db.execute(
+                "INSERT INTO subventions (nom, groupe, annee_action) "
+                "VALUES ('DossierSE', 'en_cours', '2026')"
+            ).lastrowid
+            db.execute(
+                "INSERT INTO subventions_sous_elements (subvention_id, nom, assignee_id, ordre) "
+                "VALUES (?, 'Bilan', ?, 0)",
+                (sub_id, resp_id)
+            )
+            db.commit()
+
+        reponse = resp_client.post(f'/api/subventions/{sub_id}/modifier',
+                                   json={'field': 'montant_demande', 'value': 1500})
+        assert reponse.status_code == 200
+        with app.app_context():
+            assert db.execute('SELECT montant_demande FROM subventions WHERE id = ?',
+                              (sub_id,)).fetchone()['montant_demande'] == 1500
+
+    def test_responsable_peut_toujours_creer_une_subvention(
+        self, app, resp_client, db, sample_users
+    ):
+        # La création ne porte sur aucune subvention existante : aucun périmètre
+        # à vérifier, le parcours du responsable reste ouvert.
+        reponse = resp_client.post('/api/subventions/ajouter',
+                                   json={'nom': 'Nouveau dossier', 'annee_action': '2026'})
+        assert reponse.status_code == 200
+        with app.app_context():
+            assert db.execute('SELECT COUNT(*) AS n FROM subventions WHERE id = ?',
+                              (reponse.get_json()['id'],)).fetchone()['n'] == 1
+
+    def test_salarie_refuse_sur_les_routes_mutantes(
+        self, app, auth_client, db, sample_users, monkeypatch, tmp_path
+    ):
+        from blueprints import subventions as subventions_module
+        monkeypatch.setattr(subventions_module, 'DOCUMENTS_DIR', str(tmp_path))
+        ids = self._seed(app, db, sample_users)
+
+        appels = [
+            auth_client.post(f"/api/subventions/{ids['mienne']}/modifier",
+                             json={'field': 'nom', 'value': 'Piratee'}),
+            auth_client.post(f"/api/subventions/{ids['mienne']}/sous-elements/ajouter",
+                             json={'nom': 'Etape'}),
+            auth_client.post(f"/api/subventions/sous-elements/{ids['se_mienne']}/modifier",
+                             json={'field': 'nom', 'value': 'Etape piratee'}),
+            auth_client.post(f"/api/subventions/sous-elements/{ids['se_mienne']}/supprimer"),
+            auth_client.post(f"/api/subventions/{ids['mienne']}/justificatif",
+                             data=self._pdf(), content_type='multipart/form-data'),
+            auth_client.post(f"/api/subventions/sous-elements/{ids['se_mienne']}/document",
+                             data=self._pdf(), content_type='multipart/form-data'),
+            auth_client.post(f"/api/subventions/{ids['mienne']}/supprimer"),
+        ]
+        for reponse in appels:
+            assert reponse.status_code == 403
+
+        with app.app_context():
+            assert db.execute('SELECT nom FROM subventions WHERE id = ?',
+                              (ids['mienne'],)).fetchone()['nom'] == 'Mienne'
+
+    def test_non_connecte_redirige_vers_la_connexion(self, app, client, db, sample_users):
+        ids = self._seed(app, db, sample_users)
+        routes = [
+            f"/api/subventions/{ids['mienne']}/modifier",
+            f"/api/subventions/{ids['mienne']}/supprimer",
+            f"/api/subventions/{ids['mienne']}/sous-elements/ajouter",
+            f"/api/subventions/sous-elements/{ids['se_mienne']}/modifier",
+            f"/api/subventions/sous-elements/{ids['se_mienne']}/supprimer",
+            f"/api/subventions/{ids['mienne']}/justificatif",
+            f"/api/subventions/sous-elements/{ids['se_mienne']}/document",
+        ]
+        for route in routes:
+            reponse = client.post(route, json={'field': 'nom', 'value': 'X'})
+            assert reponse.status_code == 302
+            assert '/login' in reponse.headers['Location']
+
+        with app.app_context():
+            assert db.execute('SELECT nom FROM subventions WHERE id = ?',
+                              (ids['mienne'],)).fetchone()['nom'] == 'Mienne'
+
+    def test_subvention_ou_sous_element_inexistant_renvoie_404(
+        self, app, admin_client, db, sample_users
+    ):
+        # Une ressource absente se distingue d'un refus de périmètre.
+        r_sub = admin_client.post('/api/subventions/999999/modifier',
+                                  json={'field': 'nom', 'value': 'X'})
+        assert r_sub.status_code == 404
+        assert r_sub.get_json()['error'] == 'Subvention introuvable'
+
+        r_se = admin_client.post('/api/subventions/sous-elements/999999/modifier',
+                                 json={'field': 'nom', 'value': 'X'})
+        assert r_se.status_code == 404
+        assert r_se.get_json()['error'] == 'Sous-élément introuvable'
+
+    def test_analytique_reservee_a_la_direction_et_comptabilite(
+        self, app, client, db, sample_users
+    ):
+        """Le plan analytique est un référentiel global que l'interface n'expose
+        pas aux responsables : sa création suit la règle des types."""
+        client.post('/login', data={'login': 'resp_test', 'password': 'resp123'},
+                    follow_redirects=True)
+        refus = client.post('/api/subventions/analytiques/ajouter', json={'nom': 'ANALYTIQUE X'})
+        assert refus.status_code == 403
+        with app.app_context():
+            assert db.execute(
+                'SELECT COUNT(*) AS n FROM subventions_analytiques WHERE nom = ?',
+                ('ANALYTIQUE X',)
+            ).fetchone()['n'] == 0
+        client.get('/logout', follow_redirects=True)
+
+        client.post('/login', data={'login': 'compta_test', 'password': 'compta123'},
+                    follow_redirects=True)
+        assert client.post('/api/subventions/analytiques/ajouter',
+                           json={'nom': 'ANALYTIQUE X'}).status_code == 200
+        client.get('/logout', follow_redirects=True)
+
+        client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                    follow_redirects=True)
+        assert client.post('/api/subventions/analytiques/ajouter',
+                           json={'nom': 'ANALYTIQUE Y'}).status_code == 403

--- a/tests/test_tresorerie.py
+++ b/tests/test_tresorerie.py
@@ -77,3 +77,241 @@ def test_page_tresorerie_charge_les_graphiques_depuis_un_script_local(admin_clie
     assert '/static/js/vendor/chart-4.4.7.umd.js?v=4.4.7' in html
     assert 'simple-charts.js' not in html
     assert 'cdn.jsdelivr.net/npm/chart.js' not in html
+
+
+# ============================================================
+# Contrôle d'accès des routes mutantes (directeur / comptable)
+# ============================================================
+
+def _seed_tresorerie(db):
+    """Insère un jeu de données trésorerie complet et renvoie les identifiants.
+
+    Sert de référence aux tests négatifs : après un refus, ces données doivent
+    être strictement inchangées (plusieurs routes sont des purges totales).
+    """
+    cur = db.execute("""
+        INSERT INTO tresorerie_imports (type_import, fichier_nom, annee, nb_ecritures)
+        VALUES ('historique', 'fec_2025.txt', 2025, 2)
+    """)
+    import_id = cur.lastrowid
+
+    db.execute("""
+        INSERT INTO tresorerie_comptes (compte_num, libelle_original, libelle_affiche,
+                                        type_compte, actif, ordre_affichage)
+        VALUES ('601000', 'Achats', 'Achats', 'charge', 1, 10)
+    """)
+    db.execute("""
+        INSERT INTO tresorerie_comptes (compte_num, libelle_original, libelle_affiche,
+                                        type_compte, actif, ordre_affichage)
+        VALUES ('701000', 'Ventes', 'Ventes', 'produit', 1, 20)
+    """)
+    db.execute("""
+        INSERT INTO tresorerie_donnees (compte_num, annee, mois, montant, import_id)
+        VALUES ('601000', 2025, 1, -1500.0, ?)
+    """, (import_id,))
+    db.execute("""
+        INSERT INTO tresorerie_donnees (compte_num, annee, mois, montant, import_id)
+        VALUES ('701000', 2025, 1, 2500.0, ?)
+    """, (import_id,))
+    db.execute("""
+        INSERT INTO tresorerie_solde_initial (annee, mois, montant, annee_ref, mois_ref)
+        VALUES (2025, 1, 8000.0, 2025, 1)
+    """)
+    db.execute("""
+        INSERT INTO tresorerie_budget_n (compte_num, annee, mois, montant)
+        VALUES ('601000', 2025, 2, -1200.0)
+    """)
+    db.execute("""
+        INSERT INTO tresorerie_epargne_solde (montant) VALUES (30000.0)
+    """)
+    cur = db.execute("""
+        INSERT INTO tresorerie_epargne_mouvements (type_mouvement, annee, mois, montant, commentaire)
+        VALUES ('placement', 2025, 3, 5000.0, 'Placement initial')
+    """)
+    mouvement_id = cur.lastrowid
+    db.commit()
+
+    return {'import_id': import_id, 'mouvement_id': mouvement_id}
+
+
+def _etat_tresorerie(db):
+    """Photographie l'ensemble des tables trésorerie pour détecter tout effet."""
+    requetes = {
+        'comptes': ("SELECT compte_num, libelle_affiche, type_compte, actif, ordre_affichage"
+                    " FROM tresorerie_comptes ORDER BY compte_num"),
+        'donnees': ("SELECT compte_num, annee, mois, montant FROM tresorerie_donnees"
+                    " ORDER BY compte_num, annee, mois"),
+        'imports': "SELECT id, fichier_nom FROM tresorerie_imports ORDER BY id",
+        'solde_initial': ("SELECT annee, mois, montant FROM tresorerie_solde_initial"
+                          " ORDER BY annee, mois"),
+        'budget_n': ("SELECT compte_num, annee, mois, montant FROM tresorerie_budget_n"
+                     " ORDER BY compte_num, annee, mois"),
+        'epargne_solde': "SELECT montant FROM tresorerie_epargne_solde ORDER BY id",
+        'epargne_mouvements': ("SELECT id, type_mouvement, annee, mois, montant"
+                               " FROM tresorerie_epargne_mouvements ORDER BY id"),
+    }
+    return {cle: [tuple(r) for r in db.execute(sql).fetchall()]
+            for cle, sql in requetes.items()}
+
+
+def _routes_mutantes(ids):
+    """Liste des routes POST protégées par _peut_acceder() : (chemin, corps JSON)."""
+    return [
+        ('/api/tresorerie/solde_initial', {'montant': 99999}),
+        ('/api/tresorerie/budget_n',
+         {'compte_num': '601000', 'annee': 2025, 'mois': 2, 'montant': -99999}),
+        ('/api/tresorerie/comptes/601000/modifier',
+         {'field': 'libelle_affiche', 'value': 'Libellé pirate'}),
+        ('/api/tresorerie/comptes/reordonner',
+         {'ordres': [{'compte_num': '601000', 'ordre': 999}]}),
+        ('/api/tresorerie/comptes/supprimer_tous', None),
+        (f"/api/tresorerie/imports/{ids['import_id']}/supprimer", None),
+        ('/api/tresorerie/epargne/solde', {'montant': 1.0}),
+        ('/api/tresorerie/epargne/mouvement',
+         {'type_mouvement': 'retrait', 'annee': 2025, 'mois': 4, 'montant': 5000}),
+        (f"/api/tresorerie/epargne/mouvement/{ids['mouvement_id']}/supprimer", None),
+        ('/api/tresorerie/reinitialiser', {'confirmation': 'REINITIALISER_TRESORERIE'}),
+    ]
+
+
+def _poster(client, chemin, corps):
+    """Envoie un POST, avec ou sans corps JSON selon la route."""
+    if corps is None:
+        return client.post(chemin)
+    return client.post(chemin, json=corps)
+
+
+def test_routes_mutantes_tresorerie_refusees_sans_effet_en_base(app, db, client, sample_users):
+    """Trésorerie : toutes les routes mutantes (dont deux purges totales) sont
+    refusées hors direction/comptabilité, et la base reste intacte.
+
+    Les fixtures de clients authentifiés partagent le même client de test :
+    on gère les connexions explicitement pour enchaîner plusieurs profils.
+    """
+    with app.app_context():
+        ids = _seed_tresorerie(db)
+        avant = _etat_tresorerie(db)
+
+    routes = _routes_mutantes(ids)
+
+    # Non connecté : redirection vers la page de connexion, aucune écriture.
+    for chemin, corps in routes:
+        resp = _poster(client, chemin, corps)
+        assert resp.status_code in (301, 302), chemin
+        assert '/login' in resp.headers.get('Location', ''), chemin
+
+    # Salarié : accès refusé (403).
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    for chemin, corps in routes:
+        assert _poster(client, chemin, corps).status_code == 403, chemin
+    client.get('/logout', follow_redirects=True)
+
+    # Responsable : accès refusé également (aucun secteur ne donne la trésorerie).
+    client.post('/login', data={'login': 'resp_test', 'password': 'resp123'},
+                follow_redirects=True)
+    for chemin, corps in routes:
+        assert _poster(client, chemin, corps).status_code == 403, chemin
+    client.get('/logout', follow_redirects=True)
+
+    # Aucun refus n'a modifié quoi que ce soit.
+    with app.app_context():
+        assert _etat_tresorerie(db) == avant
+
+
+def test_purges_tresorerie_refusees_au_prestataire_paie(prestataire_client, app, db):
+    """Le prestataire paie ne peut ni purger les comptes ni réinitialiser."""
+    with app.app_context():
+        _seed_tresorerie(db)
+        avant = _etat_tresorerie(db)
+
+    resp = prestataire_client.post('/api/tresorerie/comptes/supprimer_tous')
+    assert resp.status_code == 403
+    assert resp.get_json()['error'] == 'Accès non autorisé'
+
+    resp = prestataire_client.post('/api/tresorerie/reinitialiser',
+                                   json={'confirmation': 'REINITIALISER_TRESORERIE'})
+    assert resp.status_code == 403
+
+    with app.app_context():
+        assert _etat_tresorerie(db) == avant
+
+
+def test_saisie_montant_invalide_refusee_sans_effet(comptable_client, app, db):
+    """Montants non numériques ou absents : erreur 400 propre, base inchangée."""
+    with app.app_context():
+        _seed_tresorerie(db)
+        avant = _etat_tresorerie(db)
+
+    cas_invalides = [
+        # Solde initial global : montant non numérique, puis montant absent.
+        ('/api/tresorerie/solde_initial', {'montant': 'douze euros'}),
+        ('/api/tresorerie/solde_initial', {'annee': 2025}),
+        # Budget N : montant non numérique, puis paramètres incomplets.
+        ('/api/tresorerie/budget_n',
+         {'compte_num': '601000', 'annee': 2025, 'mois': 2, 'montant': 'abc'}),
+        ('/api/tresorerie/budget_n', {'annee': 2025, 'mois': 2, 'montant': 10}),
+        # Solde d'épargne : montant non numérique, puis montant absent.
+        ('/api/tresorerie/epargne/solde', {'montant': 'beaucoup'}),
+        ('/api/tresorerie/epargne/solde', {'commentaire': 'sans montant'}),
+        # Mouvement d'épargne : montant non numérique, négatif, mois hors bornes,
+        # type inconnu.
+        ('/api/tresorerie/epargne/mouvement',
+         {'type_mouvement': 'placement', 'annee': 2025, 'mois': 5, 'montant': 'x'}),
+        ('/api/tresorerie/epargne/mouvement',
+         {'type_mouvement': 'placement', 'annee': 2025, 'mois': 5, 'montant': -100}),
+        ('/api/tresorerie/epargne/mouvement',
+         {'type_mouvement': 'retrait', 'annee': 2025, 'mois': 13, 'montant': 100}),
+        ('/api/tresorerie/epargne/mouvement',
+         {'type_mouvement': 'virement', 'annee': 2025, 'mois': 5, 'montant': 100}),
+        # Modification de compte : champ hors liste blanche et type invalide.
+        ('/api/tresorerie/comptes/601000/modifier',
+         {'field': 'compte_num', 'value': '999999'}),
+        ('/api/tresorerie/comptes/601000/modifier',
+         {'field': 'type_compte', 'value': 'inconnu'}),
+        ('/api/tresorerie/comptes/601000/modifier',
+         {'field': 'ordre_affichage', 'value': 'premier'}),
+    ]
+    for chemin, corps in cas_invalides:
+        resp = comptable_client.post(chemin, json=corps)
+        assert resp.status_code == 400, (chemin, corps)
+        assert 'error' in resp.get_json(), (chemin, corps)
+
+    with app.app_context():
+        assert _etat_tresorerie(db) == avant
+
+    # Le cas légitime passe : un montant numérique remplace le solde initial.
+    resp = comptable_client.post('/api/tresorerie/solde_initial', json={'montant': '1234.56'})
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+
+    with app.app_context():
+        soldes = db.execute(
+            "SELECT montant FROM tresorerie_solde_initial"
+        ).fetchall()
+    assert [r['montant'] for r in soldes] == [1234.56]
+
+
+def test_reinitialisation_tresorerie_exige_la_confirmation_exacte(admin_client, app, db):
+    """La réinitialisation n'efface rien sans la confirmation attendue."""
+    with app.app_context():
+        _seed_tresorerie(db)
+        avant = _etat_tresorerie(db)
+
+    for corps in ({}, {'confirmation': ''}, {'confirmation': 'oui'}):
+        resp = admin_client.post('/api/tresorerie/reinitialiser', json=corps)
+        assert resp.status_code == 400, corps
+        assert resp.get_json()['error'] == 'Confirmation requise'
+
+    with app.app_context():
+        assert _etat_tresorerie(db) == avant
+
+    # Avec la confirmation exacte, le directeur vide bien les tables trésorerie.
+    resp = admin_client.post('/api/tresorerie/reinitialiser',
+                             json={'confirmation': 'REINITIALISER_TRESORERIE'})
+    assert resp.status_code == 200
+    assert resp.get_json()['success'] is True
+
+    with app.app_context():
+        apres = _etat_tresorerie(db)
+    assert all(lignes == [] for lignes in apres.values())

--- a/tests/test_upload_limite.py
+++ b/tests/test_upload_limite.py
@@ -46,16 +46,34 @@ def _creer_sous_element(app, db, nom_subvention='Subvention test'):
         ).fetchone()['id']
 
 
+def _limite_configuree_octets():
+    """Limite attendue en octets, d'après la configuration de l'exécution.
+
+    La valeur dépend de `MAX_UPLOAD_MO` : on la relit au lieu de coder 256 Mo
+    en dur, afin que les tests restent valides quand un déploiement (ou la CI)
+    surcharge la variable d'environnement.
+    """
+    import app as app_module
+    return app_module.lire_max_upload_mo() * 1024 * 1024
+
+
 class TestConfigurationLimite:
     """La limite doit être définie, large et surchargeable."""
 
-    def test_max_content_length_est_defini_et_large(self, app):
-        """La configuration expose une limite de 256 Mo par défaut."""
+    def test_max_content_length_correspond_a_la_configuration(self, app):
+        """La configuration expose la limite issue de `lire_max_upload_mo()`."""
         limite = app.config.get('MAX_CONTENT_LENGTH')
         assert limite is not None, "MAX_CONTENT_LENGTH doit être défini"
-        assert limite == 256 * 1024 * 1024
-        # Garde-fou : la limite ne doit jamais brider un envoi légitime.
-        assert limite >= 100 * 1024 * 1024
+        assert limite == _limite_configuree_octets()
+
+    def test_valeur_par_defaut_large_sans_surcharge(self, monkeypatch):
+        """Sans `MAX_UPLOAD_MO`, la limite par défaut vaut 256 Mo."""
+        import app as app_module
+
+        monkeypatch.delenv('MAX_UPLOAD_MO', raising=False)
+        assert app_module.MAX_UPLOAD_MO_DEFAUT == 256
+        # Garde-fou : la valeur par défaut ne doit brider aucun envoi légitime.
+        assert app_module.lire_max_upload_mo() * 1024 * 1024 >= 100 * 1024 * 1024
 
     def test_lecture_variable_environnement(self, monkeypatch):
         """MAX_UPLOAD_MO surcharge la valeur par défaut, avec repli sûr."""
@@ -139,8 +157,10 @@ class TestDepassementLimite:
                 "Un formulaire classique doit être redirigé (Post/Redirect/Get) "
                 "et non recevoir une erreur brute"
             )
-            assert response.headers['Location'].endswith('/absences')
-            suite = comptable_client.get('/absences', follow_redirects=True)
+            # La redirection vise le tableau de bord : l'en-tête Referer,
+            # contrôlé par le client, n'est jamais utilisé comme cible.
+            assert response.headers['Location'].endswith('/dashboard')
+            suite = comptable_client.get('/dashboard', follow_redirects=True)
         finally:
             app.config['MAX_CONTENT_LENGTH'] = limite_initiale
 
@@ -227,7 +247,12 @@ class TestControleAccesLimite:
         assert payload['ok'] is False
 
     def test_referer_externe_ignore(self, app, comptable_client, sample_users):
-        """Un Referer externe ne sert jamais de cible de redirection."""
+        """Un Referer externe ne sert jamais de cible de redirection.
+
+        L'en-tête Referer n'est pas exploité du tout : la redirection vise
+        toujours le tableau de bord (protection contre la redirection ouverte,
+        signalée par l'analyse de code).
+        """
         limite_initiale = app.config['MAX_CONTENT_LENGTH']
         app.config['MAX_CONTENT_LENGTH'] = LIMITE_TEST_OCTETS
         try:
@@ -265,7 +290,7 @@ class TestEnvoiNormalToujoursAccepte:
 
         se_id = _creer_sous_element(app, db)
 
-        assert app.config['MAX_CONTENT_LENGTH'] == 256 * 1024 * 1024
+        assert app.config['MAX_CONTENT_LENGTH'] == _limite_configuree_octets()
         response = comptable_client.post(
             f'/api/subventions/sous-elements/{se_id}/document',
             data={'fichier': (io.BytesIO(PDF_NORMAL), 'piece.pdf')},

--- a/tests/test_upload_limite.py
+++ b/tests/test_upload_limite.py
@@ -1,0 +1,321 @@
+"""
+Tests de la limite de taille des envois de fichiers (MAX_CONTENT_LENGTH).
+
+L'application compte une dizaine de points d'entrée de fichiers (justificatifs
+d'absence, contrats, modèles DOCX, imports comptables, lots de factures PDF).
+Sans borne, un envoi de taille arbitraire peut saturer la mémoire ou le disque
+du serveur. La limite est volontairement très large (256 Mo par défaut) pour ne
+pénaliser aucun usage réel ; ces tests vérifient qu'elle est bien appliquée et
+que le dépassement produit une réponse française exploitable (JSON 413 pour les
+routes d'API, message flash + redirection pour les formulaires classiques).
+
+Pour rester rapides et déterministes, les tests de dépassement abaissent
+temporairement `app.config['MAX_CONTENT_LENGTH']` au lieu de fabriquer un
+fichier de 256 Mo.
+"""
+import io
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+
+# Limite basse utilisée pour provoquer le dépassement sans gros fichier.
+LIMITE_TEST_OCTETS = 2 * 1024          # 2 Ko
+PDF_TROP_GROS = b'%PDF-1.4\n' + b'x' * (8 * 1024)   # ~8 Ko : au-dessus
+PDF_NORMAL = b'%PDF-1.4\n%justificatif de test\n'   # quelques octets
+
+
+def _creer_sous_element(app, db, nom_subvention='Subvention test'):
+    """Crée une subvention et son sous-élément, retourne l'id du sous-élément."""
+    with app.app_context():
+        db.execute(
+            'INSERT INTO subventions (nom, annee_action) VALUES (?, ?)',
+            (nom_subvention, '2026'),
+        )
+        sub_id = db.execute('SELECT MAX(id) AS id FROM subventions').fetchone()['id']
+        db.execute(
+            'INSERT INTO subventions_sous_elements (subvention_id, nom) VALUES (?, ?)',
+            (sub_id, 'Étape 1'),
+        )
+        db.commit()
+        return db.execute(
+            'SELECT MAX(id) AS id FROM subventions_sous_elements'
+        ).fetchone()['id']
+
+
+class TestConfigurationLimite:
+    """La limite doit être définie, large et surchargeable."""
+
+    def test_max_content_length_est_defini_et_large(self, app):
+        """La configuration expose une limite de 256 Mo par défaut."""
+        limite = app.config.get('MAX_CONTENT_LENGTH')
+        assert limite is not None, "MAX_CONTENT_LENGTH doit être défini"
+        assert limite == 256 * 1024 * 1024
+        # Garde-fou : la limite ne doit jamais brider un envoi légitime.
+        assert limite >= 100 * 1024 * 1024
+
+    def test_lecture_variable_environnement(self, monkeypatch):
+        """MAX_UPLOAD_MO surcharge la valeur par défaut, avec repli sûr."""
+        import app as app_module
+
+        monkeypatch.setenv('MAX_UPLOAD_MO', '512')
+        assert app_module.lire_max_upload_mo() == 512
+
+        # Valeurs invalides : on retombe sur la valeur par défaut.
+        for valeur_invalide in ('abc', '', '0', '-10', '12,5'):
+            monkeypatch.setenv('MAX_UPLOAD_MO', valeur_invalide)
+            assert app_module.lire_max_upload_mo() == app_module.MAX_UPLOAD_MO_DEFAUT
+
+        monkeypatch.delenv('MAX_UPLOAD_MO', raising=False)
+        assert app_module.lire_max_upload_mo() == app_module.MAX_UPLOAD_MO_DEFAUT
+
+
+class TestDepassementLimite:
+    """Un envoi trop volumineux doit produire une erreur 413 propre."""
+
+    def test_api_retourne_413_json_en_francais(
+        self, app, db, comptable_client, monkeypatch, tmp_path
+    ):
+        """Route d'API : JSON en 413 indiquant la taille maximale."""
+        from blueprints import subventions as subventions_module
+        docs_dir = tmp_path / 'documents'
+        docs_dir.mkdir()
+        monkeypatch.setattr(subventions_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+        se_id = _creer_sous_element(app, db)
+
+        limite_initiale = app.config['MAX_CONTENT_LENGTH']
+        app.config['MAX_CONTENT_LENGTH'] = LIMITE_TEST_OCTETS
+        try:
+            response = comptable_client.post(
+                f'/api/subventions/sous-elements/{se_id}/document',
+                data={'fichier': (io.BytesIO(PDF_TROP_GROS), 'volumineux.pdf')},
+                content_type='multipart/form-data',
+            )
+        finally:
+            app.config['MAX_CONTENT_LENGTH'] = limite_initiale
+
+        assert response.status_code == 413
+        payload = response.get_json()
+        assert payload is not None, "La réponse d'API doit rester du JSON"
+        assert payload['ok'] is False
+        message = payload['error']
+        assert 'volumineux' in message.lower()
+        assert 'dépasser' in message
+        assert '2 Ko' in message, f"Le message doit rappeler la limite : {message}"
+        # Aucun fichier ne doit avoir été écrit sur le disque.
+        assert list(docs_dir.iterdir()) == []
+
+    def test_formulaire_classique_flash_et_redirection(
+        self, app, db, comptable_client, sample_users, monkeypatch, tmp_path
+    ):
+        """Formulaire classique : message flash français puis redirection."""
+        from blueprints import absences as absences_module
+        docs_dir = tmp_path / 'documents_absences'
+        docs_dir.mkdir()
+        monkeypatch.setattr(absences_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+        donnees = {
+            'user_id': str(sample_users['salarie_id']),
+            'motif': 'Maladie',
+            'date_debut': '2026-03-02',
+            'date_fin': '2026-03-06',
+            'justificatif': (io.BytesIO(PDF_TROP_GROS), 'arret.pdf'),
+        }
+
+        limite_initiale = app.config['MAX_CONTENT_LENGTH']
+        app.config['MAX_CONTENT_LENGTH'] = LIMITE_TEST_OCTETS
+        try:
+            response = comptable_client.post(
+                '/absences', data=donnees,
+                content_type='multipart/form-data',
+                headers={'Referer': 'http://localhost/absences'},
+                follow_redirects=False,
+            )
+            assert response.status_code == 302, (
+                "Un formulaire classique doit être redirigé (Post/Redirect/Get) "
+                "et non recevoir une erreur brute"
+            )
+            assert response.headers['Location'].endswith('/absences')
+            suite = comptable_client.get('/absences', follow_redirects=True)
+        finally:
+            app.config['MAX_CONTENT_LENGTH'] = limite_initiale
+
+        contenu = suite.get_data(as_text=True)
+        assert 'Envoi trop volumineux' in contenu
+        assert '2 Ko' in contenu
+        # Aucune absence ni aucun fichier ne doit avoir été enregistré.
+        assert list(docs_dir.iterdir()) == []
+        with app.app_context():
+            nb = db.execute('SELECT COUNT(*) AS nb FROM absences').fetchone()['nb']
+        assert nb == 0
+
+    def test_aucune_trace_technique_dans_la_reponse(
+        self, app, db, comptable_client, monkeypatch, tmp_path
+    ):
+        """La réponse ne doit révéler ni exception ni chemin local."""
+        from blueprints import subventions as subventions_module
+        docs_dir = tmp_path / 'documents'
+        docs_dir.mkdir()
+        monkeypatch.setattr(subventions_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+        se_id = _creer_sous_element(app, db)
+
+        limite_initiale = app.config['MAX_CONTENT_LENGTH']
+        app.config['MAX_CONTENT_LENGTH'] = LIMITE_TEST_OCTETS
+        try:
+            response = comptable_client.post(
+                f'/api/subventions/sous-elements/{se_id}/document',
+                data={'fichier': (io.BytesIO(PDF_TROP_GROS), 'volumineux.pdf')},
+                content_type='multipart/form-data',
+            )
+        finally:
+            app.config['MAX_CONTENT_LENGTH'] = limite_initiale
+
+        contenu = response.get_data(as_text=True)
+        assert 'Traceback' not in contenu
+        assert 'RequestEntityTooLarge' not in contenu
+        assert str(tmp_path) not in contenu
+
+
+class TestControleAccesLimite:
+    """Tests négatifs : la limite ne contourne aucun contrôle d'autorisation."""
+
+    def test_non_connecte_redirige_sans_erreur_technique(
+        self, app, db, client, sample_users
+    ):
+        """Non connecté : redirection vers la connexion, jamais de 500."""
+        se_id = _creer_sous_element(app, db)
+
+        limite_initiale = app.config['MAX_CONTENT_LENGTH']
+        app.config['MAX_CONTENT_LENGTH'] = LIMITE_TEST_OCTETS
+        try:
+            response = client.post(
+                f'/api/subventions/sous-elements/{se_id}/document',
+                data={'fichier': (io.BytesIO(PDF_TROP_GROS), 'volumineux.pdf')},
+                content_type='multipart/form-data',
+                follow_redirects=False,
+            )
+        finally:
+            app.config['MAX_CONTENT_LENGTH'] = limite_initiale
+
+        assert response.status_code in (302, 401, 413)
+        assert response.status_code != 500
+
+    def test_mauvais_profil_refuse_avant_la_limite(
+        self, app, db, auth_client, sample_users
+    ):
+        """Salarié : l'accès reste refusé (403), la limite ne l'ouvre pas."""
+        se_id = _creer_sous_element(app, db)
+
+        limite_initiale = app.config['MAX_CONTENT_LENGTH']
+        app.config['MAX_CONTENT_LENGTH'] = LIMITE_TEST_OCTETS
+        try:
+            response = auth_client.post(
+                f'/api/subventions/sous-elements/{se_id}/document',
+                data={'fichier': (io.BytesIO(PDF_TROP_GROS), 'volumineux.pdf')},
+                content_type='multipart/form-data',
+            )
+        finally:
+            app.config['MAX_CONTENT_LENGTH'] = limite_initiale
+
+        assert response.status_code == 403
+        payload = response.get_json()
+        assert payload['ok'] is False
+
+    def test_referer_externe_ignore(self, app, comptable_client, sample_users):
+        """Un Referer externe ne sert jamais de cible de redirection."""
+        limite_initiale = app.config['MAX_CONTENT_LENGTH']
+        app.config['MAX_CONTENT_LENGTH'] = LIMITE_TEST_OCTETS
+        try:
+            response = comptable_client.post(
+                '/absences',
+                data={
+                    'user_id': str(sample_users['salarie_id']),
+                    'motif': 'Maladie',
+                    'date_debut': '2026-03-02',
+                    'date_fin': '2026-03-06',
+                    'justificatif': (io.BytesIO(PDF_TROP_GROS), 'arret.pdf'),
+                },
+                content_type='multipart/form-data',
+                headers={'Referer': 'https://site-externe.invalid/piege'},
+                follow_redirects=False,
+            )
+        finally:
+            app.config['MAX_CONTENT_LENGTH'] = limite_initiale
+
+        assert response.status_code == 302
+        assert 'site-externe.invalid' not in response.headers['Location']
+
+
+class TestEnvoiNormalToujoursAccepte:
+    """La limite très large ne doit gêner aucun envoi légitime."""
+
+    def test_petit_fichier_accepte_par_l_api(
+        self, app, db, comptable_client, monkeypatch, tmp_path
+    ):
+        """Un PDF de taille normale passe toujours avec la limite par défaut."""
+        from blueprints import subventions as subventions_module
+        docs_dir = tmp_path / 'documents'
+        docs_dir.mkdir()
+        monkeypatch.setattr(subventions_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+        se_id = _creer_sous_element(app, db)
+
+        assert app.config['MAX_CONTENT_LENGTH'] == 256 * 1024 * 1024
+        response = comptable_client.post(
+            f'/api/subventions/sous-elements/{se_id}/document',
+            data={'fichier': (io.BytesIO(PDF_NORMAL), 'piece.pdf')},
+            content_type='multipart/form-data',
+        )
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload['ok'] is True
+        assert (docs_dir / payload['nom']).exists()
+
+    def test_fichier_volumineux_mais_legitime_accepte(
+        self, app, db, comptable_client, monkeypatch, tmp_path
+    ):
+        """Un PDF de plusieurs Mo (cas réel : scan de contrat) reste accepté."""
+        from blueprints import subventions as subventions_module
+        docs_dir = tmp_path / 'documents'
+        docs_dir.mkdir()
+        monkeypatch.setattr(subventions_module, 'DOCUMENTS_DIR', str(docs_dir))
+
+        se_id = _creer_sous_element(app, db)
+
+        pdf_5_mo = b'%PDF-1.4\n' + b'a' * (5 * 1024 * 1024)
+        response = comptable_client.post(
+            f'/api/subventions/sous-elements/{se_id}/document',
+            data={'fichier': (io.BytesIO(pdf_5_mo), 'scan.pdf')},
+            content_type='multipart/form-data',
+        )
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload['ok'] is True
+        assert (docs_dir / payload['nom']).stat().st_size == len(pdf_5_mo)
+
+
+class TestFormatageTailleMaximale:
+    """Le message doit annoncer la limite dans une unité lisible."""
+
+    @pytest.mark.parametrize('limite,attendu', [
+        (256 * 1024 * 1024, '256 Mo'),
+        (512 * 1024 * 1024, '512 Mo'),
+        (1536 * 1024, '1.5 Mo'),
+        (2 * 1024, '2 Ko'),
+    ])
+    def test_taille_max_lisible(self, app, limite, attendu):
+        import app as app_module
+
+        limite_initiale = app.config['MAX_CONTENT_LENGTH']
+        app.config['MAX_CONTENT_LENGTH'] = limite
+        try:
+            assert app_module._taille_max_lisible() == attendu
+        finally:
+            app.config['MAX_CONTENT_LENGTH'] = limite_initiale


### PR DESCRIPTION
## Résumé

Chantier issu d'un audit de couverture des **tests négatifs** (AGENTS.md §7), le fichier AGENTS.md étant récent. L'audit a porté sur 306 routes et 1012 tests existants : ~120 tests de refus étaient en place, mais 23 fichiers de tests n'en contenaient aucun — et surtout, **quatre trous de contrôle d'accès réels** ont été trouvés dans le code, pas seulement des tests manquants.

**+257 tests** (1012 → **1269**), tous verts.

---

## 1. Trous de contrôle d'accès corrigés (code)

### Subventions — cloisonnement entre secteurs (écriture **et** lecture)
`_peut_modifier()` autorise le profil `responsable`, mais **aucune route mutante ne vérifiait que la subvention lui est assignée**, alors que la page de consultation le fait explicitement. Un responsable pouvait modifier le montant accordé ou supprimer par identifiant une subvention d'un autre secteur.

- Nouveaux helpers `_refus_acces_subvention` / `_refus_acces_sous_element` réutilisant **exactement** la clause de périmètre de la page de consultation (assigné principal, secondaire, ou assigné d'un sous-élément) ; 404 si la ressource n'existe pas, 403 hors périmètre.
- Appliqué aux **7 routes mutantes** (modifier, supprimer, sous-éléments, justificatif, document).
- **Découvert ensuite par le balayage systématique** : les deux routes de **téléchargement** (`/subventions/justificatif/`, `/subventions/sous-element-document/`) présentaient le même défaut en lecture — un responsable non assigné pouvait récupérer la pièce d'une subvention d'un autre secteur en devinant l'identifiant. Corrigé en réutilisant le même helper, pour que lecture et écriture ne divergent jamais.
- `POST /api/subventions/analytiques/ajouter` (référentiel global partagé) restreint à direction/comptabilité — vérifié : aucun template ni JS n'appelle cet endpoint, aucun parcours cassé.
- Création laissée ouverte (aucune appartenance à vérifier sur une ressource inexistante), garantie par un test.

### Factures — incohérence de périmètre
`POST /factures//commenter` n'appliquait que le contrôle de profil, sans le filtre par secteur présent sur ses voisines (détail, téléchargement, approbation) : un responsable pouvait commenter une facture d'un autre secteur. La facture n'était en outre jamais vérifiée avant l'écriture (commentaires orphelins possibles, les clés étrangères n'étant pas activées). Corrigé à l'identique de la logique voisine, sans inventer de nouvelle règle. Même défaut d'objet non vérifié corrigé sur `assigner_facture`.

### Taille des envois de fichiers
`MAX_CONTENT_LENGTH` n'était défini nulle part (14 points d'envoi). Limite volontairement **large** : **256 Mo**, surchargeable par `MAX_UPLOAD_MO`, dimensionnée sur le flux le plus lourd (import d'un lot de factures PDF). Vérifié au passage que la restauration de sauvegarde ne transite pas par un envoi HTTP (seul le nom du fichier est transmis) et n'impose donc pas de limite haute. Gestionnaire 413 dédié : JSON pour les API, message flash + redirection pour les formulaires, message français indiquant la limite. La redirection vise toujours le tableau de bord : l'en-tête `Referer`, contrôlé par le client, n'est jamais réutilisé comme cible (redirection ouverte signalée par CodeQL). La variable est documentée dans `README.md` (tableau des variables d'environnement) et `docs/quick-start.md` : unité, valeur par défaut, et repli si la valeur est absente, non numérique ou ≤ 0.

---

## 2. Tests négatifs sur les routes destructives

| Domaine | Avant | Ajouté |
|---|---|---|
| **Sauvegardes** | 5 tests, aucun refus ; `restaurer` (écrase toute la base) n'avait **aucun** test | **+51** : refus sur les 5 routes × 4 profils avec absence d'effet, path traversal (dont **liens symboliques**, que la seule regex ne couvre pas), restauration invalide (fichier non-SQLite, nom hostile) sans trace d'exception, et le test positif de restauration qui manquait |
| **Administration / clés API** | aucun | **+24** : réinitialisation de base, migrations, gestion des comptes et secteurs, clés API — refus **sans jamais déclencher l'action destructive**, vérifiés par instantané de la base. Constat rassurant : les clés API ne sont jamais renvoyées, même à un profil autorisé |
| **Trésorerie** | 3 tests, tous en directeur | **+4** couvrant les 10 routes mutantes × 3 états, dont les deux purges, avec photographie des 7 tables avant/après, plus 13 entrées invalides |
| **Planificateur** | aucun test d'accès aux données d'autrui | **+17** : IDOR sur 10 routes de mutation (tâches, blocs, récurrences), y compris un vecteur d'écriture indirect via les comparaisons de priorité ; routes anonymes ; décorateur |
| **Fiches salariés / saisie** | barrière inter-secteurs testée en lecture seulement | **+20** : refus en écriture sur les 7 routes RH (n° de sécurité sociale, adresse, pesée, contrats) ; **correction d'un test placebo** (`test_directeur_ne_peut_pas_saisir_pour_lui` n'assertionnait qu'un code 200 : il passait même si la règle était violée) ; saisie pour autrui et mois verrouillé |
| **Exports financiers** | tests portant sur les routes de *données*, jamais sur les *exports* | **+14**, dont le **cloisonnement du bilan par secteur** vérifié en extrayant le texte du PDF produit : un responsable demandant le secteur d'un collègue obtient bien le sien |

## 3. Filet de sécurité systématique

Le dépôt ne contenait **aucun test paramétré** ni liste centralisée des routes protégées : chaque route était sécurisée à la main, une nouvelle route oubliée ne déclenchait aucune alerte.

`tests/test_acces_routes_sensibles.py` introduit une **table de référence de 93 routes sensibles** (profils autorisés + forme attendue du refus), balayée par des tests paramétrés vérifiant le refus des anonymes et des profils non autorisés, avec un **test de cohérence de la table elle-même** (chaque chemin déclaré existe bien dans l'application). En-tête expliquant comment y ajouter une route lors d'une nouvelle fonctionnalité.

## 4. Prestataire paie documenté

Le profil « prestataire paie » (cabinet externe) court-circuite volontairement les vérifications sur les justificatifs d'absence et les contrats : il en a besoin pour saisir la paie. Ce comportement n'était ni documenté ni testé, et **aucun utilisateur prestataire n'existait dans les fixtures** — ce chemin n'était donc jamais emprunté. Ajout d'une fixture dédiée et de `tests/test_prestataire_paie.py` qui documente le contrat : ce à quoi il a accès, et ce qui lui reste fermé.

---

## Vérifications

- **Suite complète : 1269 tests OK** (0 échec).
- Tests de la limite d'envoi rejoués avec la variable positionnée (`MAX_UPLOAD_MO=512`) et avec une valeur invalide (`MAX_UPLOAD_MO=abc`) : verts dans les trois cas, la suite ne dépend plus de l'environnement.
- **Tests de mutation** systématiques : chaque agent a neutralisé temporairement le contrôle qu'il testait pour prouver que ses tests échouent alors (ex. `_check_admin` forcé à vrai → 15 tests rouges ; `_safe_backup_path` naïf → 9 rouges ; filtre de propriété du planificateur retiré → 6 rouges). Les tests ne sont pas vacants.
- Aucune assertion existante relâchée.

## Point relevé, non traité (hors périmètre)

`assigner_facture` accepte un `secteur_id` inexistant (l'assignation est écrite malgré tout) : problème d'intégrité des données, pas d'autorisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW