### PR TITLE
Simulateur de paie : proratiser les mois partiels ; assignation de facture : vérifier le secteur

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -10,6 +10,7 @@ Fonctionnalites :
 - Controle des droits : direction/comptable definissent le global,
   responsables ajustent la repartition sans depasser le global
 """
+import calendar
 import io
 import json
 import sqlite3
@@ -2371,6 +2372,59 @@ def _paie_mois_actifs(date_debut, date_fin, annee):
     return mois_debut, mois_fin
 
 
+def _paie_intervalles_annee(contrats, annee):
+    """Périodes [début, fin] des contrats, ramenées à l'année et fusionnées.
+
+    Les contrats qui se chevauchent ou s'enchaînent sont regroupés pour qu'un
+    même jour ne soit jamais compté deux fois.
+    """
+    debut_annee, fin_annee = date(annee, 1, 1), date(annee, 12, 31)
+
+    def _lire(valeur, defaut):
+        if not valeur:
+            return defaut
+        try:
+            return date.fromisoformat(str(valeur)[:10])
+        except (ValueError, TypeError):
+            return defaut
+
+    intervalles = []
+    for c in contrats:
+        dd = max(_lire(c['date_debut'], debut_annee), debut_annee)
+        df = min(_lire(c['date_fin'], fin_annee), fin_annee)
+        if dd <= df:
+            intervalles.append((dd, df))
+    intervalles.sort()
+    fusion = []
+    for dd, df in intervalles:
+        if fusion and dd <= fusion[-1][1] + timedelta(days=1):
+            fusion[-1] = (fusion[-1][0], max(fusion[-1][1], df))
+        else:
+            fusion.append((dd, df))
+    return fusion
+
+
+def _paie_ratios_mois(intervalles, annee):
+    """Part de chaque mois réellement couverte par un contrat : {mois: 0 < r <= 1}.
+
+    Le budget raisonnait en mois entiers : un CDD d'une semaine en juillet
+    coûtait un mois de salaire complet. La part est calculée en jours
+    calendaires (7 jours sur 31 = 0,2258), méthode habituelle pour un mois
+    d'entrée ou de sortie. Un mois entièrement couvert vaut 1, un mois sans
+    aucun jour de contrat est absent du dictionnaire : il n'est pas budgété,
+    ce qui écarte aussi les creux entre deux contrats successifs.
+    """
+    ratios = {}
+    for dd, df in intervalles:
+        for m in range(dd.month, df.month + 1):
+            premier = date(annee, m, 1)
+            dernier = date(annee, m, calendar.monthrange(annee, m)[1])
+            jours = (min(df, dernier) - max(dd, premier)).days + 1
+            if jours > 0:
+                ratios[m] = min(1.0, ratios.get(m, 0.0) + jours / dernier.day)
+    return ratios
+
+
 def _paie_employes_secteur(conn, secteur_id, annee):
     """Salariés actifs du secteur avec un contrat chevauchant l'année.
 
@@ -2442,6 +2496,9 @@ def _paie_employes_secteur(conn, secteur_id, annee):
         contrat = contrats_annee[0]
         mb = min(deb for deb, _ in periodes)
         mf = max(fin for _, fin in periodes)
+        # Part de chaque mois réellement travaillée : un CDD d'une semaine ne
+        # doit pas peser un mois de salaire entier dans le budget.
+        ratios = _paie_ratios_mois(_paie_intervalles_annee(contrats_annee, annee), annee)
         employes.append({
             'id': u['id'], 'nom': u['nom'], 'prenom': u['prenom'],
             'pesee': u['pesee'], 'competence': u['competence'],
@@ -2449,7 +2506,7 @@ def _paie_employes_secteur(conn, secteur_id, annee):
             'temps_hebdo': contrat['temps_hebdo'],
             'type_contrat': contrat['type_contrat'],
             'anciennete': _paie_anciennete_annees(contrat['date_debut'], annee),
-            'mois_debut': mb, 'mois_fin': mf,
+            'mois_debut': mb, 'mois_fin': mf, 'mois_ratios': ratios,
         })
     # Ordre d'affichage : CDI, puis CDD, puis les autres contrats (apprentissage…).
     ordre_contrat = {'CDI': 0, 'CDD': 1}
@@ -2615,8 +2672,13 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
         maintien = override_num(ov, 'maintien', e.get('maintien'))
         ratio = ratio_temps(override_num(ov, 'temps_hebdo', e.get('temps_hebdo')))
         mois_vals, total_e = {}, 0.0
+        ratios_mois = e.get('mois_ratios')
         for m in range(max(start_month, e['mois_debut']), e['mois_fin'] + 1):
-            val = brut_mensuel(pesee_eff, anciennete, competence, ratio) + maintien
+            # Part du mois couverte par le contrat (1 pour un mois entier).
+            part = 1.0 if ratios_mois is None else ratios_mois.get(m, 0.0)
+            if part <= 0:
+                continue
+            val = (brut_mensuel(pesee_eff, anciennete, competence, ratio) + maintien) * part
             mois_vals[m] = round(val, 2)
             monthly_totals[m] += val
             total_e += val

--- a/blueprints/factures.py
+++ b/blueprints/factures.py
@@ -280,12 +280,21 @@ def assigner_facture(facture_id):
         _add_historique(conn, facture_id, 'Assignation', 'Assignée à la direction')
     elif secteur_id:
         secteur = conn.execute('SELECT nom FROM secteurs WHERE id=?', (secteur_id,)).fetchone()
+        if not secteur:
+            # Les clés étrangères ne sont pas activées sur la base : sans ce
+            # contrôle, la facture serait rattachée à un secteur inexistant et
+            # disparaîtrait des listes filtrées par secteur, sans aucun signal.
+            conn.close()
+            if request.is_json:
+                return jsonify({'error': 'Secteur introuvable'}), 404
+            flash('Secteur introuvable.', 'error')
+            return redirect(url_for('factures_bp.liste_factures'))
         conn.execute(
             'UPDATE factures SET secteur_id=?, assigned_direction=0, updated_at=CURRENT_TIMESTAMP WHERE id=?',
             (secteur_id, facture_id)
         )
         _add_historique(conn, facture_id, 'Assignation',
-                        f'Assignée au secteur {secteur["nom"] if secteur else secteur_id}')
+                        f'Assignée au secteur {secteur["nom"]}')
 
     conn.commit()
     conn.close()

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -2041,7 +2041,14 @@ function computePaieJS(st, ctx, typeBudget){
         var maint = ovNum(ov, 'maintien', e.maintien);
         var ratio = ratioTemps(ovNum(ov, 'temps_hebdo', e.temps_hebdo));
         var mvals = {}, tot = 0;
-        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){ var v=brut(pEff,anc,comp,ratio)+maint; mvals[m]=v; monthly[m]+=v; tot+=v; }
+        // Part du mois couverte par le contrat (1 = mois entier) : un CDD d'une
+        // semaine ne pèse pas un mois de salaire complet. Même calcul serveur.
+        var parts = e.mois_ratios;
+        for (var m=Math.max(start, e.mois_debut); m<=e.mois_fin; m++){
+            var part = parts ? (parts[m] || 0) : 1;
+            if (part <= 0) continue;
+            var v=(brut(pEff,anc,comp,ratio)+maint)*part; mvals[m]=v; monthly[m]+=v; tot+=v;
+        }
         lignes[e.id] = {mois: mvals, total: tot, pesee_eff: pEff};
     });
     var ajouts = {};
@@ -2077,7 +2084,7 @@ function renderPaieSimulator(){
         '<div class="ps-field"><label>Valeur du point</label>' + paieInput('data-paie-top="valeur_point"', st.valeur_point, '0.01') + '</div>' +
         '<div class="ps-field"><label>Temps plein (h/sem.)</label>' + paieInput('data-paie-top="temps_plein"', st.temps_plein, '0.5') + '</div>' +
         '</div>';
-    html += '<div class="ps-legend">Brut mensuel = [(socle + pesée × valeur du point) × prorata + (ancienneté + compétences) × valeur du point] / 12. Le prorata (h.hebdo / temps plein) ne s\'applique qu\'au socle et à la pesée : ancienneté et compétences sont dues à temps plein. Colonnes <span class="bp-ps-calc">surlignées</span> = calculées. Les colonnes « Nv » (nouvelle pesée, ancienneté, compétences) simulent une évolution : renseignées, elles prennent le pas sur la valeur actuelle sans modifier la fiche du salarié. Survolez les en-têtes pour les libellés complets.';
+    html += '<div class="ps-legend">Brut mensuel = [(socle + pesée × valeur du point) × prorata + (ancienneté + compétences) × valeur du point] / 12. Le prorata (h.hebdo / temps plein) ne s\'applique qu\'au socle et à la pesée : ancienneté et compétences sont dues à temps plein. Les mois d\'entrée et de sortie sont comptés au prorata des jours du contrat (un CDD d\'une semaine en juillet ne coûte pas un mois entier) : survolez le montant du mois pour voir la part retenue. Colonnes <span class="bp-ps-calc">surlignées</span> = calculées. Les colonnes « Nv » (nouvelle pesée, ancienneté, compétences) simulent une évolution : renseignées, elles prennent le pas sur la valeur actuelle sans modifier la fiche du salarié. Survolez les en-têtes pour les libellés complets.';
     if (actualise){
         html += ' Budget actualisé : seuls les mois après <strong>' + (ctx.last_real_month ? MOIS_COURT[ctx.last_real_month-1] : '—') +
             '</strong> sont simulés ; réel déjà constaté : <strong>' + fmt(ctx.montant_reel || 0) + ' €</strong>.';
@@ -2212,7 +2219,16 @@ function recomputePaie(){
     var months = paieMonths();
     (paieSim.context.employes || []).forEach(function(e){
         var l = c.lignes[e.id] || {mois:{}, total:0};
-        months.forEach(function(m){ psSet('paie-emp-' + e.id + '-' + m, l.mois[m] ? fmt(l.mois[m]) : ''); });
+        months.forEach(function(m){
+            psSet('paie-emp-' + e.id + '-' + m, l.mois[m] ? fmt(l.mois[m]) : '');
+            // Mois d'entrée ou de sortie : indiquer la part réellement couverte,
+            // sinon le montant réduit paraît inexpliqué.
+            var cell = document.getElementById('paie-emp-' + e.id + '-' + m);
+            if (!cell) return;
+            var part = e.mois_ratios ? (e.mois_ratios[m] || 0) : 1;
+            if (part > 0 && part < 1) cell.title = 'Mois partiel : ' + Math.round(part * 100) + ' % du mois sous contrat';
+            else cell.removeAttribute('title');
+        });
         psSet('paie-emp-' + e.id + '-tot', fmt(l.total));
     });
     (paieSim.state.ajouts || []).forEach(function(a, i){

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1745,6 +1745,149 @@ def test_paie_context_agrege_les_periodes_de_contrats_successifs(app, db, admin_
     assert emp['temps_hebdo'] == 28
 
 
+def _remplacer_contrat(db, uid, type_contrat, date_debut, date_fin, temps_hebdo=35):
+    """Remplace les contrats du salarié par un seul, aux dates données."""
+    db.execute("DELETE FROM contrats WHERE user_id = ?", (uid,))
+    db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin, temps_hebdo) "
+               "VALUES (?, ?, ?, ?, ?)", (uid, type_contrat, date_debut, date_fin, temps_hebdo))
+    db.commit()
+
+
+def _total_paie(admin_client, annee, sid, uid):
+    """Total simulé pour un salarié sans pesée, ancienneté ni compétences."""
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '',
+                                       'anciennete': 0, 'competence': 0}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial',
+        'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    return r.get_json()['total']
+
+
+def test_paie_cdd_une_semaine_ne_compte_pas_le_mois_entier(app, db, admin_client):
+    """CDD du 6 au 12 juillet : sept jours, pas un mois de salaire complet.
+
+    Le budget raisonnait en mois entiers : le seul fait de travailler un jour en
+    juillet faisait compter juillet en totalité. Le coût attendu est celui de
+    sept jours calendaires sur trente et un : (23000 / 12) × 7/31 ≈ 432,80 €.
+    """
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        _remplacer_contrat(db, uid, 'CDD', f'{annee}-07-06', f'{annee}-07-12')
+
+    total = _total_paie(admin_client, annee, sid, uid)
+    mois_entier = 23000 / 12
+    assert abs(total - mois_entier * 7 / 31) < 0.05, \
+        f"un CDD d'une semaine ne doit pas coûter un mois entier (obtenu {total})"
+    assert total < mois_entier / 2
+
+
+def test_paie_context_expose_la_fraction_de_chaque_mois(app, db, admin_client):
+    """Le contexte fournit la part de chaque mois réellement couverte."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        _remplacer_contrat(db, uid, 'CDD', f'{annee}-07-06', f'{annee}-07-12')
+
+    data = admin_client.get(
+        f'/api/budget-previsionnel/paie-context?annee={annee}&secteur_id={sid}'
+        '&compte_num=641000&type_budget=initial'
+    ).get_json()
+    emp = next(e for e in data['employes'] if e['id'] == uid)
+    assert set(emp['mois_ratios']) == {'7'}, "seul juillet est couvert"
+    assert abs(emp['mois_ratios']['7'] - 7 / 31) < 1e-9
+
+
+def test_paie_mois_charniere_proratise_le_reste_a_taux_plein(app, db, admin_client):
+    """CDD du 15 mars au 30 juin : mars au prorata, avril à juin entiers."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        _remplacer_contrat(db, uid, 'CDD', f'{annee}-03-15', f'{annee}-06-30')
+
+    data = admin_client.get(
+        f'/api/budget-previsionnel/paie-context?annee={annee}&secteur_id={sid}'
+        '&compte_num=641000&type_budget=initial'
+    ).get_json()
+    ratios = next(e for e in data['employes'] if e['id'] == uid)['mois_ratios']
+    assert set(ratios) == {'3', '4', '5', '6'}
+    assert abs(ratios['3'] - 17 / 31) < 1e-9, "du 15 au 31 mars = 17 jours"
+    assert ratios['4'] == 1.0 and ratios['5'] == 1.0 and ratios['6'] == 1.0
+
+    mois_entier = 23000 / 12
+    total = _total_paie(admin_client, annee, sid, uid)
+    assert abs(total - mois_entier * (17 / 31 + 3)) < 0.05
+
+
+def test_paie_annee_complete_reste_au_taux_plein(app, db, admin_client):
+    """Contrat couvrant toute l'année : aucun mois n'est réduit."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+
+    data = admin_client.get(
+        f'/api/budget-previsionnel/paie-context?annee={annee}&secteur_id={sid}'
+        '&compte_num=641000&type_budget=initial'
+    ).get_json()
+    ratios = next(e for e in data['employes'] if e['id'] == uid)['mois_ratios']
+    assert set(ratios) == {str(m) for m in range(1, 13)}
+    assert all(v == 1.0 for v in ratios.values())
+    assert abs(_total_paie(admin_client, annee, sid, uid) - 23000.0) < 0.01
+
+
+def test_paie_creux_entre_deux_contrats_non_budgete(app, db, admin_client):
+    """Contrat janvier-mars puis septembre-décembre : le creux n'est pas payé.
+
+    Les mois budgétés étaient bornés par le premier début et la dernière fin,
+    ce qui facturait aussi les mois sans aucun contrat.
+    """
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        db.execute("DELETE FROM contrats WHERE user_id = ?", (uid,))
+        db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin, temps_hebdo) "
+                   "VALUES (?, 'CDD', ?, ?, 35)", (uid, f'{annee}-01-01', f'{annee}-03-31'))
+        db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin, temps_hebdo) "
+                   "VALUES (?, 'CDD', ?, ?, 35)", (uid, f'{annee}-09-01', f'{annee}-12-31'))
+        db.commit()
+
+    data = admin_client.get(
+        f'/api/budget-previsionnel/paie-context?annee={annee}&secteur_id={sid}'
+        '&compte_num=641000&type_budget=initial'
+    ).get_json()
+    ratios = next(e for e in data['employes'] if e['id'] == uid)['mois_ratios']
+    assert set(ratios) == {'1', '2', '3', '9', '10', '11', '12'}
+
+    total = _total_paie(admin_client, annee, sid, uid)
+    assert abs(total - (23000 / 12) * 7) < 0.05, "sept mois travaillés, pas douze"
+
+
+def test_paie_contrat_debute_avant_annee_est_entier(app, db, admin_client):
+    """Contrat commencé l'année précédente : janvier compte pour un mois plein."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+        _remplacer_contrat(db, uid, 'CDD', f'{annee - 1}-11-20', f'{annee}-02-10')
+
+    data = admin_client.get(
+        f'/api/budget-previsionnel/paie-context?annee={annee}&secteur_id={sid}'
+        '&compte_num=641000&type_budget=initial'
+    ).get_json()
+    ratios = next(e for e in data['employes'] if e['id'] == uid)['mois_ratios']
+    assert ratios['1'] == 1.0, "janvier est couvert du 1er au 31"
+    assert abs(ratios['2'] - 10 / 28) < 1e-9
+
+
+def test_budget_previsionnel_simulateur_js_applique_la_fraction_de_mois(admin_client):
+    """Le calcul affiché côté navigateur applique la même fraction de mois."""
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    assert 'mois_ratios' in html, \
+        "le calcul JS doit lire la part de mois couverte, comme le serveur"
+
+
 def _texte_pdf_budget(data):
     """Concatène les flux décompressés d'un PDF (le texte y est en clair).
 

--- a/tests/test_factures.py
+++ b/tests/test_factures.py
@@ -183,6 +183,64 @@ class TestAssignationFacture:
         assert reponse.status_code == 404
         assert _compte(app, db, 'facture_historique', 999999) == 0
 
+    def test_assigner_secteur_inexistant_refuse(self, app, db, comptable_client):
+        """Un secteur inconnu ne doit pas être écrit : la facture deviendrait
+        invisible (aucun secteur ne la reprend) sans que rien ne le signale.
+
+        Les clés étrangères ne sont pas activées sur cette base : c'est à la
+        route de vérifier l'existence du secteur avant l'écriture.
+        """
+        facture_id = _seed_facture(app, db)
+        reponse = comptable_client.post(
+            f'/factures/{facture_id}/assigner', json={'secteur_id': 999999})
+
+        assert reponse.status_code == 404
+        assert reponse.get_json()['error']
+        with app.app_context():
+            assert db.execute(
+                "SELECT secteur_id FROM factures WHERE id=?", (facture_id,)
+            ).fetchone()['secteur_id'] is None
+        assert _compte(app, db, 'facture_historique', facture_id) == 0
+
+    def test_assigner_secteur_inexistant_refuse_en_formulaire(self, app, db, comptable_client):
+        """Même refus hors API : message d'erreur et aucune écriture."""
+        facture_id = _seed_facture(app, db)
+        reponse = comptable_client.post(
+            f'/factures/{facture_id}/assigner', data={'secteur_id': '999999'},
+            follow_redirects=True)
+
+        assert 'Secteur introuvable' in reponse.get_data(as_text=True)
+        with app.app_context():
+            assert db.execute(
+                "SELECT secteur_id FROM factures WHERE id=?", (facture_id,)
+            ).fetchone()['secteur_id'] is None
+        assert _compte(app, db, 'facture_historique', facture_id) == 0
+
+    def test_assigner_secteur_non_numerique_refuse(self, app, db, comptable_client):
+        """Une valeur non numérique ne doit pas non plus être écrite."""
+        facture_id = _seed_facture(app, db)
+        reponse = comptable_client.post(
+            f'/factures/{facture_id}/assigner', json={'secteur_id': 'abc'})
+
+        assert reponse.status_code == 404
+        with app.app_context():
+            assert db.execute(
+                "SELECT secteur_id FROM factures WHERE id=?", (facture_id,)
+            ).fetchone()['secteur_id'] is None
+
+    def test_assigner_direction_reste_possible(self, app, db, comptable_client):
+        """L'assignation à la direction n'est pas concernée par ce contrôle."""
+        facture_id = _seed_facture(app, db)
+        reponse = comptable_client.post(
+            f'/factures/{facture_id}/assigner', json={'direction': True})
+
+        assert reponse.status_code == 200
+        with app.app_context():
+            ligne = db.execute(
+                "SELECT secteur_id, assigned_direction FROM factures WHERE id=?",
+                (facture_id,)).fetchone()
+        assert ligne['assigned_direction'] == 1 and ligne['secteur_id'] is None
+
 
 class TestSuppressionFacture:
     def test_supprimer_facture_supprime_les_ecritures(self, app, db, comptable_client):


### PR DESCRIPTION
## 1. Simulateur de paie — mois d'entrée et de sortie comptés en entier

**Constat** (signalé sur le budget actualisé) : un CDD prévu une semaine en juillet faisait budgéter **le mois de juillet en totalité**. Le simulateur ne connaissait du contrat que ses mois de début et de fin (`mois_debut` / `mois_fin`) et payait chaque mois de l'intervalle à taux plein.

Pour un socle de 23 000 € et un CDD du 6 au 12 juillet :

| | Avant | Après |
|---|---|---|
| Juillet | 1 916,67 € | **432,80 €** |

Chaque mois porte désormais la **part réellement couverte par le contrat**, calculée en jours calendaires (7 jours sur 31 = 0,2258) — la méthode usuelle pour un mois d'entrée ou de sortie. Un mois entièrement couvert vaut 1 : **les contrats sur l'année complète sont inchangés**, ce que garantit un test dédié.

### Effet de bord corrigé au passage

Les mois budgétés étaient bornés par le **premier début** et la **dernière fin** de contrat. Un salarié en CDD de janvier à mars puis de septembre à décembre se voyait donc facturer aussi **avril à août**, sans aucun contrat sur ces mois. Le calcul par jour couvert les écarte naturellement : sept mois budgétés au lieu de douze.

L'agrégation des contrats successifs voulue précédemment (apprentissage puis CDI) est préservée — c'est le creux entre deux contrats qui disparaît, pas la période antérieure au contrat en cours.

### Côté page

Le calcul JavaScript de la page applique exactement la même part (il doit rester le miroir du serveur, sans quoi l'affichage et le report divergeraient). Deux ajouts pour que le montant réduit ne paraisse pas inexpliqué :

- **infobulle** sur les mois partiels : « Mois partiel : 23 % du mois sous contrat » ;
- **phrase de légende** sous le rappel de la formule.

Les « ajouts » manuels (CDI/CDD saisis directement dans le simulateur) restent à la maille du mois : l'utilisateur y choisit des mois, pas des dates.

## 2. Assignation d'une facture à un secteur inexistant

Point relevé lors de l'audit précédent et laissé de côté (intégrité de données, pas autorisation). `POST /factures/<id>/assigner` acceptait un `secteur_id` inconnu et écrivait quand même : les clés étrangères n'étant pas activées sur la base, la facture se retrouvait rattachée à un secteur qui n'existe pas et **disparaissait des listes filtrées par secteur**, sans le moindre signal. L'historique enregistrait « Assignée au secteur 999999 ».

Le secteur est maintenant vérifié avant l'écriture : `404` avec `{"error": "Secteur introuvable"}` en API, message d'erreur et redirection en formulaire, aucune écriture ni ligne d'historique dans les deux cas. L'assignation à la direction, qui ne porte pas de secteur, n'est pas concernée.

## Vérifications

- **Suite complète : 1280 tests OK** (1269 → 1280).
- Tests écrits d'abord et échec constaté (méthode correctif d'AGENTS.md) : 7 tests sur le prorata, 4 sur l'assignation.
- **Test de mutation** : en forçant la part de mois à 1, trois tests passent au rouge (CDD d'une semaine, mois charnière, creux entre contrats) — les tests ne sont pas vacants.
- **Vérification navigateur** (Chromium) : la fonction `computePaieJS` réellement servie par la page, appelée sur le contexte réel, renvoie 432,796… € — identique au centime près au total calculé par le serveur pour la même simulation. Capture du simulateur : juillet à 432,80 €, autres mois vides, infobulle présente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_