### PR TITLE
Budget actualisé : écart définitif − initial, et charges de personnel ventilées sur l'année N-1

### DIFF
--- a/blueprints/budget.py
+++ b/blueprints/budget.py
@@ -2742,23 +2742,28 @@ def _compute_paie(donnees, employes_base, cee_jours, last_real_month, montant_re
 def _paie_report_brut(conn, secteur_id, annee, type_budget, brut_compte, total_brut, user_id):
     """Reporte le brut sur le 641 et répartit 63x/64x (hors 649) au prorata.
 
-    Ratio = compte N-1 / brut N-1 (budget initial) ou réel YTD / brut YTD
-    (budget actualisé). Écrit la valeur définitive dans budget_prev_saisies.
+    Ratio = compte N-1 / brut N-1, en budget initial comme en actualisé : la
+    référence doit porter sur une année COMPLÈTE. L'actualisé se calait
+    auparavant sur le réel de l'année en cours, arrêté au dernier mois connu ;
+    sur quelques mois ce rapport n'est pas représentatif (régularisations
+    annuelles, plafonds de cotisations, versements non mensualisés). C'est
+    aussi le ratio déjà utilisé pour la colonne « Temporaire » du budget
+    (voir _compute_budget_previsionnel) : les deux calculs concordent.
+
+    Écrit la valeur définitive dans budget_prev_saisies.
     """
     data = _compute_budget_previsionnel(
         conn=conn, type_budget=type_budget, annee=annee, secteur_id=secteur_id
     )
     rows = {r['compte_num']: r for r in data['rows']}
-    actualise = (type_budget == 'actualise')
     brut_row = rows.get(brut_compte)
-    brut_prev = (brut_row['N'] if actualise else brut_row['N-1']) if brut_row else 0
+    brut_prev = brut_row['N-1'] if brut_row else 0
 
     reports = {brut_compte: round(total_brut, 2)}
     for compte, r in rows.items():
         if compte == brut_compte or not r.get('is_salary'):
             continue
-        prev = r['N'] if actualise else r['N-1']
-        ratio = (prev / brut_prev) if brut_prev else 0
+        ratio = (r['N-1'] / brut_prev) if brut_prev else 0
         reports[compte] = round(total_brut * ratio, 2)
 
     now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -2180,6 +2180,10 @@ function renderPaieSimulator(){
     var totalLabel = actualise ? 'Total à reporter (réel + simulé)' : 'Total brut annuel à reporter';
     html += '<div class="ps-total-box"><span>' + totalLabel + ' sur le compte ' + escapeHtml(paieSim.compte) +
         '</span><strong><span id="paie-total">0,00</span> €</strong></div>';
+    // Le report ventile aussi les charges : préciser l'année de référence du
+    // produit en croix, qui porte toujours sur une année complète.
+    html += '<p class="ps-legend">Le report répartit également les comptes 63x/64x (hors 649) au prorata du brut, ' +
+        'd\'après le rapport constaté sur l\'année ' + (paieSim.ctx.annee - 1) + ' complète.</p>';
 
     document.getElementById('paieSimBody').innerHTML = html;
     document.getElementById('paieSimFooter').innerHTML =

--- a/templates/budget_previsionnel.html
+++ b/templates/budget_previsionnel.html
@@ -605,11 +605,13 @@ function buildTable(rows, labelTemp, labelDef, globalMode, ctx){
     return html;
 }
 
-// Écart d'atterrissage d'une ligne (actualisé) : Définitif si saisi, sinon
-// Temporaire, moins le budget initial du compte.
+// Écart d'atterrissage d'une ligne (actualisé) : colonne Définitif moins
+// colonne Initial, sans repli sur le Temporaire. L'écart se lit ainsi
+// directement entre les deux colonnes affichées, et l'écran donne le même
+// chiffre que le PDF. Un compte dont le définitif n'est pas encore saisi
+// affiche donc l'opposé de son budget initial.
 function ecartValue(r){
-    const retenu = Number(r.def || 0) !== 0 ? Number(r.def) : Number(r.temp || 0);
-    return retenu - Number(r.initial || 0);
+    return Number(r.def || 0) - Number(r.initial || 0);
 }
 function fmtEcart(ecart){
     const signe = ecart > 0 ? '+' : '';

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1933,6 +1933,23 @@ def test_export_pdf_actualise_colonnes_initial_actualise_ecart(app, db, admin_cl
     assert b'Temp.' not in texte, "la colonne Temporaire ne doit plus figurer en actualisé"
 
 
+def test_ecart_ecran_compare_definitif_et_initial(admin_client):
+    """À l'écran, l'écart est Définitif − Initial, sans repli sur Temporaire.
+
+    L'écart retombait sur la colonne « Temporaire » tant que le définitif
+    n'était pas saisi : l'écran et le PDF affichaient alors deux chiffres
+    différents pour la même ligne.
+    """
+    import re
+    html = admin_client.get('/budget-previsionnel').get_data(as_text=True)
+    corps = re.search(r'function ecartValue\(r\)\{(.*?)\n\}', html, re.S)
+    assert corps, "la fonction ecartValue doit exister"
+    corps = corps.group(1)
+    assert 'r.def' in corps and 'r.initial' in corps
+    assert 'r.temp' not in corps, \
+        "l'écart affiché ne doit plus retomber sur la colonne Temporaire"
+
+
 def test_export_pdf_initial_conserve_ses_colonnes(app, db, admin_client):
     """PDF d'un budget initial : présentation inchangée (N, Temp., Déf.)."""
     annee = datetime.now().year

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -920,6 +920,65 @@ def test_paie_simulation_calcule_et_reporte(app, db, admin_client):
     assert d645 and abs(d645['valeur_def'] - 9200.0) < 0.01
 
 
+def test_paie_report_actualise_utilise_le_ratio_de_n_moins_1(app, db, admin_client):
+    """Budget actualisé : le produit en croix des charges prend N-1 en référence.
+
+    Le ratio se calculait sur le réel de l'année en cours, arrêté au dernier
+    mois connu. Sur quelques mois il n'est pas représentatif (régularisations,
+    plafonds, cotisations annuelles) : la référence doit être une année
+    complète. Ici le réel N donne 20 % et l'année N-1 complète 40 %.
+    """
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)   # N-1 : 641 = 100 000, 645 = 40 000
+        imp = db.execute("SELECT id FROM bilan_fec_imports ORDER BY id DESC LIMIT 1").fetchone()['id']
+        for compte, montant in (('641000', 30000), ('645000', 6000)):
+            db.execute("INSERT INTO bilan_fec_donnees (compte_num,annee,mois,montant,import_id) "
+                       "VALUES (?,?,1,?,?)", (compte, annee, montant, imp))
+        db.commit()
+
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '',
+                                       'anciennete': 0, 'competence': 0}},
+               'ajouts': [], 'fermetures': []}
+    r = admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'actualise',
+        'compte_num': '641000', 'donnees': donnees})
+    assert r.status_code == 200
+    total = r.get_json()['total']
+
+    with app.app_context():
+        lu = {c: db.execute(
+            "SELECT valeur_def FROM budget_prev_saisies WHERE compte_num=? "
+            "AND annee=? AND secteur_id=? AND type_budget='actualise'",
+            (c, annee, sid)).fetchone() for c in ('641000', '645000')}
+    assert lu['641000'] and abs(lu['641000']['valeur_def'] - total) < 0.01
+    assert lu['645000']
+    assert abs(lu['645000']['valeur_def'] - total * 0.40) < 0.01, \
+        "le ratio doit venir de l'année N-1 complète (40 %)"
+    assert abs(lu['645000']['valeur_def'] - total * 0.20) > 1.0, \
+        "le réel partiel de l'année en cours (20 %) ne doit plus servir de référence"
+
+
+def test_paie_report_initial_inchange(app, db, admin_client):
+    """Budget initial : la référence était déjà N-1, rien ne change."""
+    annee = 2026
+    with app.app_context():
+        sid, uid = _setup_paie_secteur(db, annee)
+    donnees = {'salaire_socle': 23000, 'valeur_point': 55,
+               'employes': {str(uid): {'pesee': 0, 'nouvelle_pesee': '',
+                                       'anciennete': 0, 'competence': 0}},
+               'ajouts': [], 'fermetures': []}
+    admin_client.post('/api/budget-previsionnel/paie-simulation', json={
+        'annee': annee, 'secteur_id': sid, 'type_budget': 'initial',
+        'compte_num': '641000', 'donnees': donnees})
+    with app.app_context():
+        d645 = db.execute("SELECT valeur_def FROM budget_prev_saisies WHERE compte_num='645000' "
+                          "AND annee=? AND secteur_id=? AND type_budget='initial'",
+                          (annee, sid)).fetchone()
+    assert d645 and abs(d645['valeur_def'] - 9200.0) < 0.01   # 23000 × 40 000/100 000
+
+
 def test_paie_simulation_persiste_pesee_competence(app, db, admin_client):
     annee = 2026
     with app.app_context():


### PR DESCRIPTION
Deux corrections sur le **budget actualisé**.

## 1. La colonne Écart compare le définitif à l'initial

La colonne « Écart » de la page retombait sur la colonne **Temporaire** tant que la valeur définitive n'était pas saisie, alors que le PDF a toujours comparé le **Définitif** à l'**Initial**. La même ligne pouvait donc afficher deux chiffres différents selon qu'on la lisait à l'écran ou sur le document imprimé.

L'écart est désormais **Définitif − Initial** dans les deux cas, ce qui se lit directement entre les deux colonnes affichées.

**Conséquence assumée** : un compte dont le définitif n'est pas encore saisi affiche l'opposé de son budget initial (colonne Actualisé à 0 → écart = −initial), au lieu de l'écart provisoire calculé sur le temporaire. Le PDF est inchangé — il appliquait déjà cette règle.

### Vérification navigateur

Budget actualisé de test, budget initial de 1 500 € sur deux comptes :

| Compte | Initial | Temporaire | Définitif | Écart affiché |
|---|---|---|---|---|
| 606000 | 1 500,00 | 1 050,00 | 1 800,00 | **+300,00** |
| 606100 | 1 500,00 | 1 050,00 | — (0) | **−1 500,00** |

Total catégorie : −1 200,00 € (1 800 − 3 000). Après saisie de 1 200 € sur le compte 606100, la ligne passe à −300,00 € et le total de catégorie à 0,00 € : le recalcul en direct suit la même règle.

## 2. Le produit en croix des charges de personnel prend N-1 en référence

Le report du simulateur de paie ventile les comptes **63x/64x (hors 649)** à partir du brut, au prorata du rapport constaté sur une année de référence. En budget actualisé, cette référence était le **réel de l'année en cours arrêté au dernier mois connu** : sur quelques mois, le rapport charges/brut n'est pas représentatif (régularisations annuelles, plafonds de cotisations, versements non mensualisés).

La référence est désormais l'**année N-1 complète**, comme en budget initial.

Effet secondaire favorable : c'est déjà le ratio utilisé pour la colonne « Temporaire » du budget (`_compute_budget_previsionnel`). Les deux calculs de la même page **concordent maintenant**, alors qu'ils divergeaient en actualisé — la colonne Temporaire proposait une ventilation et le report en écrivait une autre.

L'année de référence est rappelée sous le total du simulateur : « Le report répartit également les comptes 63x/64x (hors 649) au prorata du brut, d'après le rapport constaté sur l'année 2025 complète. »

À noter : un secteur sans historique N-1 (brut N-1 à zéro) n'obtient pas de ventilation automatique — comportement identique à celui de la colonne Temporaire, qui affiche déjà zéro dans ce cas.

## Vérifications

- **Suite complète : 1283 tests OK.**
- Tests écrits d'abord, échec constaté : sur un jeu où le réel partiel donne 20 % et l'année N-1 complète 40 %, le report retenait 20 % ; il retient désormais 40 %, et un second test verrouille le budget initial, inchangé.
- Test sur la fonction d'écart : elle ne doit plus référencer la colonne temporaire.
- Vérifications navigateur (Chromium) sur les deux points, capture du simulateur incluse dans la session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW