### PR TITLE
Bénévoles : case à cocher « Charte signée »

### DIFF
--- a/blueprints/benevoles.py
+++ b/blueprints/benevoles.py
@@ -290,7 +290,7 @@ def api_modifier_benevole(ben_id):
     allowed_fields = {
         'nom', 'groupe', 'responsable_id', 'date_debut', 'date_fin',
         'email', 'telephone', 'adresse', 'competences',
-        'heures_semaine', 'type_benevolat',
+        'heures_semaine', 'type_benevolat', 'charte_signee',
     }
 
     if field not in allowed_fields:
@@ -298,6 +298,10 @@ def api_modifier_benevole(ben_id):
 
     if field == 'responsable_id':
         value = int(value) if value else None
+    # Case a cocher : on n'enregistre que 0 ou 1, jamais la valeur brute du
+    # navigateur (une chaine vide ou 'false' vaudrait « vrai » en SQLite).
+    if field == 'charte_signee':
+        value = 1 if value in (True, 1, '1', 'true', 'on') else 0
     # Liste fermee : une valeur inconnue viderait la colonne au lieu de
     # laisser une etiquette qui ne correspond a aucun type.
     if field == 'type_benevolat' and value not in TYPES_BENEVOLAT_MAP:

--- a/database.py
+++ b/database.py
@@ -79,6 +79,7 @@ ALL_MIGRATION_VERSIONS = [
     ('0039', 'Journal des actions metier'),
     ('0040', 'Module CSE'),
     ('0061', 'Type de benevolat, date de fin et suivi des heures'),
+    ('0062', 'Charte du benevolat signee'),
 ]
 
 # Types de subvention par defaut (migration 0052)
@@ -910,7 +911,7 @@ def init_db():
         )
     ''')
 
-    # ===== Table benevoles (migration 0017, colonnes 0061) =====
+    # ===== Table benevoles (migration 0017, colonnes 0061 et 0062) =====
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS benevoles (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -924,6 +925,7 @@ def init_db():
             adresse TEXT,
             competences TEXT,
             type_benevolat TEXT,
+            charte_signee INTEGER DEFAULT 0,
             heures_semaine TEXT DEFAULT '',
             ordre INTEGER DEFAULT 0,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -2037,6 +2039,12 @@ def init_db():
             cursor.execute(f"SELECT {colonne} FROM benevoles LIMIT 1")
         except sqlite3.OperationalError:
             cursor.execute(f"ALTER TABLE benevoles ADD COLUMN {colonne} TEXT")
+
+    # Migration 0062 : charte du benevolat signee (0/1).
+    try:
+        cursor.execute("SELECT charte_signee FROM benevoles LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute("ALTER TABLE benevoles ADD COLUMN charte_signee INTEGER DEFAULT 0")
 
     conn.commit()
     conn.close()

--- a/migrations/0062_benevoles_charte_signee.py
+++ b/migrations/0062_benevoles_charte_signee.py
@@ -1,0 +1,31 @@
+"""
+Migration 0062 : charte du bénévolat signée.
+
+La fiche contact tenue sur tableur porte une case « Charte signée » ; elle
+manquait sur la liste des bénévoles. Colonne `charte_signee` (0/1, non signée
+par défaut : l'information n'est pas connue rétroactivement).
+"""
+
+NOM = "Charte du bénévolat signée"
+DESCRIPTION = (
+    "Ajoute benevoles.charte_signee (INTEGER 0/1) pour suivre la signature "
+    "de la charte du bénévolat."
+)
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    import sqlite3
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SELECT charte_signee FROM benevoles LIMIT 1")
+    except sqlite3.OperationalError:
+        cursor.execute(
+            "ALTER TABLE benevoles ADD COLUMN charte_signee INTEGER DEFAULT 0")
+    conn.commit()
+
+
+def downgrade(conn):
+    """SQLite ne supprime pas simplement une colonne : downgrade non destructif
+    (la colonne reste, inerte tant que le code ne la lit pas)."""
+    pass

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2494,6 +2494,8 @@ a.btn-icon:-webkit-any-link {
 /* Type de bénévolat : les combinaisons (« Gouvernance + Activité ») sont
    longues, la pastille a besoin de plus de place qu'un statut ordinaire. */
 .sv-col-type { width: 250px; min-width: 250px; }
+.sv-col-charte { width: 110px; min-width: 110px; text-align: center; }
+.sv-checkbox { width: 17px; height: 17px; cursor: pointer; accent-color: var(--primary); }
 .sv-heures-total { text-align: right; font-weight: 600; color: var(--gray-700); }
 
 /* ── Suivi des heures de bénévolat ── */

--- a/templates/benevoles.html
+++ b/templates/benevoles.html
@@ -40,6 +40,7 @@
                             <th class="sv-col-person">Responsable</th>
                             <th class="sv-col-status">Statut</th>
                             <th class="sv-col-type">Type de bénévolat</th>
+                            <th class="sv-col-charte" title="Charte du bénévolat signée">Charte signée</th>
                             <th class="sv-col-date">Date de debut</th>
                             <th class="sv-col-date">Date de fin</th>
                             <th class="sv-col-text">Email</th>
@@ -79,6 +80,13 @@
                                    pas à la boucle, la pastille resterait vide. #}
                                 {% set tc = types_map.get(ben.type_benevolat) %}
                                 <span class="sv-status-pill" style="background:{{ tc.color if tc else '#c4c4c4' }};" data-type="{{ ben.type_benevolat or '' }}" onclick="editType(this, {{ ben.id }})">{{ tc.label if tc else '—' }}</span>
+                            </td>
+                            {# ── Charte du bénévolat signée ── #}
+                            <td class="sv-col-charte">
+                                <input type="checkbox" class="sv-checkbox"
+                                       {{ 'checked' if ben.charte_signee }}
+                                       onchange="toggleCharte({{ ben.id }}, this)"
+                                       title="Charte du bénévolat signée">
                             </td>
                             {# ── Date de debut ── #}
                             <td class="sv-col-date sv-cell-date" onclick="editDate(this, {{ ben.id }}, 'date_debut')">
@@ -123,7 +131,7 @@
 
                     {% if not groupe.lignes %}
                         <tr>
-                            <td colspan="{% if not is_responsable %}13{% else %}12{% endif %}" class="sv-empty">
+                            <td colspan="{% if not is_responsable %}14{% else %}13{% endif %}" class="sv-empty">
                                 Aucun benevole dans ce groupe
                             </td>
                         </tr>
@@ -403,6 +411,23 @@ function editPastille(el, id, options, field, attr) {
     });
     sel.addEventListener('blur', function() {
         if (!done) renderPill(currentKey);
+    });
+}
+
+/* ── Charte du benevolat signee (case a cocher) ── */
+function toggleCharte(id, input) {
+    var valeur = input.checked;
+    apiCall('/api/benevoles/' + id + '/modifier',
+            {field: 'charte_signee', value: valeur}).then(function(r) {
+        /* Echec d'enregistrement : on remet la case dans son etat precedent
+           plutot que de laisser croire que c'est enregistre. */
+        if (!r || !r.ok) {
+            input.checked = !valeur;
+            alert((r && r.error) || 'Erreur');
+        }
+    }).catch(function() {
+        input.checked = !valeur;
+        alert('Erreur réseau : la modification n\'a pas été enregistrée.');
     });
 }
 

--- a/tests/test_benevoles.py
+++ b/tests/test_benevoles.py
@@ -133,6 +133,95 @@ class TestDateFin:
         assert '31/03/2026' in html
 
 
+def _case_charte(html, ben_id):
+    """Balise <input> de la case « Charte signée » du bénévole, en entier.
+
+    L'attribut `checked` et le `onchange` sont sur deux lignes différentes :
+    on récupère la balise complète plutôt qu'une ligne isolée.
+    """
+    import re
+    balise = re.search(r'<input[^>]*toggleCharte\(' + str(ben_id) + r',[^>]*>', html, re.S)
+    assert balise, f"case « charte signée » absente pour le bénévole {ben_id}"
+    return balise.group(0)
+
+
+class TestCharteSignee:
+    """Case à cocher « Charte signée » sur la liste des bénévoles."""
+
+    def test_colonne_presente_et_decochee_par_defaut(self, app, db, admin_client):
+        """L'information n'est pas connue rétroactivement : case décochée."""
+        ben_id = _creer_benevole(app, db)
+        html = admin_client.get('/benevoles').get_data(as_text=True)
+        assert 'Charte signée' in html
+        assert 'checked' not in _case_charte(html, ben_id)
+        with app.app_context():
+            assert db.execute("SELECT charte_signee FROM benevoles WHERE id = ?",
+                              (ben_id,)).fetchone()['charte_signee'] == 0
+
+    def test_cochee_puis_decochee(self, app, db, admin_client):
+        ben_id = _creer_benevole(app, db)
+        for envoye, attendu in ((True, 1), (False, 0)):
+            r = admin_client.post(f'/api/benevoles/{ben_id}/modifier',
+                                  json={'field': 'charte_signee', 'value': envoye})
+            assert r.status_code == 200
+            with app.app_context():
+                assert db.execute("SELECT charte_signee FROM benevoles WHERE id = ?",
+                                  (ben_id,)).fetchone()['charte_signee'] == attendu
+
+    def test_case_cochee_rendue_dans_la_liste(self, app, db, admin_client):
+        ben_id = _creer_benevole(app, db)
+        admin_client.post(f'/api/benevoles/{ben_id}/modifier',
+                          json={'field': 'charte_signee', 'value': True})
+        html = admin_client.get('/benevoles').get_data(as_text=True)
+        assert 'checked' in _case_charte(html, ben_id)
+
+    @pytest.mark.parametrize('valeur', ['', 'false', 'non', 0, None, [], 'faux'])
+    def test_valeurs_non_vraies_enregistrees_a_zero(self, app, db, admin_client, valeur):
+        """SQLite accepterait n'importe quoi : seule une valeur explicitement
+        vraie doit cocher la case, sinon une chaîne vide passerait pour signée."""
+        ben_id = _creer_benevole(app, db)
+        admin_client.post(f'/api/benevoles/{ben_id}/modifier',
+                          json={'field': 'charte_signee', 'value': True})
+        admin_client.post(f'/api/benevoles/{ben_id}/modifier',
+                          json={'field': 'charte_signee', 'value': valeur})
+        with app.app_context():
+            assert db.execute("SELECT charte_signee FROM benevoles WHERE id = ?",
+                              (ben_id,)).fetchone()['charte_signee'] == 0
+
+    def test_responsable_peut_cocher_pour_ses_benevoles(self, app, db, client, sample_users):
+        """Le suivi de la charte fait partie de l'accompagnement du responsable."""
+        ben_id = _creer_benevole(app, db)
+        with app.app_context():
+            db.execute("UPDATE benevoles SET responsable_id = ? WHERE id = ?",
+                       (sample_users['responsable_id'], ben_id))
+            db.commit()
+        _connexion(client, 'resp_test', 'resp123')
+        r = client.post(f'/api/benevoles/{ben_id}/modifier',
+                        json={'field': 'charte_signee', 'value': True})
+        assert r.status_code == 200
+        with app.app_context():
+            assert db.execute("SELECT charte_signee FROM benevoles WHERE id = ?",
+                              (ben_id,)).fetchone()['charte_signee'] == 1
+
+    def test_salarie_refuse(self, app, db, client, sample_users):
+        ben_id = _creer_benevole(app, db)
+        _connexion(client, 'salarie_test', 'sal123')
+        r = client.post(f'/api/benevoles/{ben_id}/modifier',
+                        json={'field': 'charte_signee', 'value': True})
+        assert r.status_code == 403
+        with app.app_context():
+            assert db.execute("SELECT charte_signee FROM benevoles WHERE id = ?",
+                              (ben_id,)).fetchone()['charte_signee'] == 0
+
+    def test_migration_0062_marquee_appliquee(self, app, db):
+        import database
+        assert any(v == '0062' for v, _ in database.ALL_MIGRATION_VERSIONS)
+        with app.app_context():
+            ligne = db.execute(
+                "SELECT statut FROM schema_migrations WHERE version = '0062'").fetchone()
+        assert ligne and ligne['statut'] == 'ok'
+
+
 class TestPresentationDuBoard:
     """Colonne figée et colonne en double retirée."""
 


### PR DESCRIPTION
## Résumé

La fiche contact tenue sur tableur porte une case **« Charte signée »** qui n'existait pas sur la liste des bénévoles. Nouvelle colonne, cochable directement dans le tableau, placée après le type de bénévolat.

Elle est **décochée par défaut** : l'information n'est pas connue rétroactivement pour les bénévoles déjà enregistrés.

Comme le reste de la liste, elle est modifiable par la direction, la comptabilité et les responsables — le suivi de la charte fait partie de l'accompagnement du responsable, qui ne voit de toute façon que les bénévoles qui lui sont assignés.

## Points de robustesse

- La valeur reçue du navigateur n'est **jamais écrite telle quelle** : seule une valeur explicitement vraie coche la case. SQLite accepterait `''`, `'false'` ou `'non'` et les traiterait ensuite comme une charte signée.
- Si l'enregistrement échoue (refus ou coupure réseau), la case **reprend son état précédent** et un message s'affiche, plutôt que de laisser croire que la modification est enregistrée.

## Vérifications

- **Suite complète : 1362 tests OK** (1349 → 1362).
- 7 tests sur la case : colonne présente et décochée par défaut, coche puis décoche persistées, rendu `checked` dans la liste, valeurs non vraies ramenées à 0 (`''`, `'false'`, `'non'`, `0`, `None`, `[]`, `'faux'`), responsable autorisé, salarié refusé **sans effet en base**, et migration 0062 déclarée dans `ALL_MIGRATION_VERSIONS`.
- **Vérification navigateur** (Chromium) : quatre cases décochées au départ, coche de la première, rechargement de la page → seule la première reste cochée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxK3ae664mMiiYqH2YSsDW)_