### PR TITLE
Délégation : confier toute la page bénévoles à un ou plusieurs salariés

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Gestion des dossiers de subventions organises par type de financeur (SUBV. GLOBAL, CAF PS, CAF, VILLE, METROPOLE, ETAT, AUTRES — types personnalisables : creation / suppression)
 - Statut d'avancement editable par dossier (nouveau projet / en cours / accepte / refuse), conserve pour les tableaux de bord
 - Gestion des benevoles avec suivi des heures assignees
+- Delegation possible de la page benevoles (repertoire complet et suivi des heures) a un ou plusieurs salaries, depuis la page Delegation
 
 ### CSE (Comite Social et Economique)
 - Accessible depuis le menu **RH & Paie**

--- a/app.py
+++ b/app.py
@@ -505,6 +505,23 @@ def inject_cse_context():
             conn.close()
 
 
+@app.context_processor
+def inject_delegation_benevoles():
+    """Injecte la délégation « gestion des bénévoles » pour le menu latéral.
+
+    La direction et la comptabilité ont déjà l'entrée de menu par leur profil :
+    la lecture n'est faite que pour les salariés et responsables, seuls
+    concernés par cette délégation.
+    """
+    if 'user_id' not in session or session.get('profil') not in ('salarie', 'responsable'):
+        return {'is_delegue_benevoles': False}
+    try:
+        from blueprints.delegations import user_peut_gerer_benevoles
+        return {'is_delegue_benevoles': user_peut_gerer_benevoles(session.get('user_id'))}
+    except Exception:
+        return {'is_delegue_benevoles': False}
+
+
 @app.errorhandler(429)
 def ratelimit_handler(e):
     """Affiche un message clair quand la limite de tentatives est atteinte."""

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ Architecture en Blueprints Flask.
 import os
 import sys
 import secrets
+import sqlite3
 from dotenv import load_dotenv
 from flask import Flask, session, render_template, flash, redirect, url_for, request, jsonify
 from flask_wtf.csrf import CSRFError
@@ -13,7 +14,9 @@ import logging
 from logging.handlers import RotatingFileHandler
 import app_version
 from database import init_db, get_db, DATA_DIR
-from blueprints.delegations import MISSION_SUIVI_VALIDATIONS_RELANCES
+from blueprints.delegations import (
+    MISSION_SUIVI_VALIDATIONS_RELANCES, user_peut_gerer_benevoles,
+)
 from extensions import csrf, limiter
 
 
@@ -516,9 +519,15 @@ def inject_delegation_benevoles():
     if 'user_id' not in session or session.get('profil') not in ('salarie', 'responsable'):
         return {'is_delegue_benevoles': False}
     try:
-        from blueprints.delegations import user_peut_gerer_benevoles
         return {'is_delegue_benevoles': user_peut_gerer_benevoles(session.get('user_id'))}
-    except Exception:
+    except sqlite3.Error:
+        # Defaillance attendue : table absente sur une base dont la mise a
+        # niveau n'est pas encore appliquee (la page qui lance les migrations
+        # doit rester affichable), ou base momentanement verrouillee. Seule
+        # l'entree de menu disparait : les routes gardent leur propre controle.
+        logging.getLogger(__name__).warning(
+            "Delegation benevoles illisible, entree de menu masquee", exc_info=True
+        )
         return {'is_delegue_benevoles': False}
 
 

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -11,6 +11,7 @@ from database import get_db
 from blueprints.delegations import (
     MISSIONS, MISSIONS_MAP, save_delegation,
     get_salle_recurrence_user_ids, save_salle_recurrence_delegations,
+    get_benevoles_user_ids, save_benevoles_delegations,
 )
 from utils import login_required, validate_password_strength
 from access_log import (journaliser_action, ACTION_CREATION_USER,
@@ -51,6 +52,25 @@ def gestion_users():
     return render_template('gestion_users.html', users=users, secteurs=secteurs)
 
 
+def _salaries_delegables(conn, ids_bruts):
+    """IDs réellement délégables parmi ceux reçus du formulaire.
+
+    Le navigateur peut renvoyer n'importe quel identifiant : on ne garde que
+    les comptes actifs de profil salarié ou responsable.
+    """
+    selected = [int(x) for x in ids_bruts if x.isdigit()]
+    if not selected:
+        return []
+    placeholders = ','.join('?' * len(selected))
+    rows = conn.execute(
+        f'''SELECT id FROM users
+            WHERE id IN ({placeholders}) AND actif = 1
+              AND profil IN ('salarie', 'responsable')''',
+        selected
+    ).fetchall()
+    return [r['id'] for r in rows]
+
+
 @admin_bp.route('/delegations', methods=['GET', 'POST'])
 @login_required
 def delegations():
@@ -66,19 +86,20 @@ def delegations():
             # Modifiable par la direction ET le comptable (gestion des salles) ;
             # les autres missions restent réservées à la direction.
             if request.form.get('form_type') == 'salle_recurrence':
-                selected = [int(x) for x in request.form.getlist('salle_recurrence_users') if x.isdigit()]
-                valides = []
-                if selected:
-                    placeholders = ','.join('?' * len(selected))
-                    rows = conn.execute(
-                        f'''SELECT id FROM users
-                            WHERE id IN ({placeholders}) AND actif = 1
-                              AND profil IN ('salarie', 'responsable')''',
-                        selected
-                    ).fetchall()
-                    valides = [r['id'] for r in rows]
+                valides = _salaries_delegables(
+                    conn, request.form.getlist('salle_recurrence_users'))
                 save_salle_recurrence_delegations(valides, session['user_id'])
                 flash('Les autorisations de réservation récurrente ont été enregistrées.', 'success')
+                return redirect(url_for('admin_bp.delegations'))
+
+            # Gestion complète de la page bénévoles. Direction ET comptabilité :
+            # ce sont elles qui tiennent aujourd'hui le répertoire et le suivi
+            # des heures, elles délèguent donc un droit qu'elles détiennent.
+            if request.form.get('form_type') == 'benevoles':
+                valides = _salaries_delegables(
+                    conn, request.form.getlist('benevoles_users'))
+                save_benevoles_delegations(valides, session['user_id'])
+                flash('Les délégations de gestion des bénévoles ont été enregistrées.', 'success')
                 return redirect(url_for('admin_bp.delegations'))
 
             if session.get('profil') != 'directeur':
@@ -151,10 +172,13 @@ def delegations():
         missions=missions,
         salaries=salaries,
         salle_recurrence_user_ids=get_salle_recurrence_user_ids(),
+        benevoles_user_ids=get_benevoles_user_ids(),
         peut_modifier=session.get('profil') == 'directeur',
         # Les réservations de salle récurrentes relèvent de la gestion des
         # salles : le comptable peut aussi définir qui y a droit.
         peut_modifier_salles=session.get('profil') in ('directeur', 'comptable'),
+        # Idem pour les bénévoles, tenus par la direction et la comptabilité.
+        peut_modifier_benevoles=session.get('profil') in ('directeur', 'comptable'),
     )
 
 @admin_bp.route('/creer_user', methods=['GET', 'POST'])

--- a/blueprints/benevoles.py
+++ b/blueprints/benevoles.py
@@ -8,11 +8,16 @@ Le suivi des heures de benevolat (page /benevoles/heures) est reserve a la
 direction et a la comptabilite : le calendrier des activites (jours de CA,
 cafes seniors...) est commun a toute l'association, il n'est pas cloisonne
 par responsable.
+
+La direction (ou la comptabilite) peut confier l'integralite de la page a un
+ou plusieurs salaries depuis la page Delegation : ils disposent alors des
+memes droits que la direction sur cette page, suivi des heures compris.
 """
 from datetime import date, datetime
 from flask import (Blueprint, render_template, request, redirect,
                    url_for, session, flash, jsonify)
 from database import get_db
+from blueprints.delegations import user_peut_gerer_benevoles
 from utils import login_required
 
 benevoles_bp = Blueprint('benevoles_bp', __name__)
@@ -64,22 +69,33 @@ MODES_ACTIVITE = [
 MODES_ACTIVITE_KEYS = {m['key'] for m in MODES_ACTIVITE}
 
 
+def _est_delegue():
+    """Salarie a qui la gestion complete de la page benevoles a ete confiee.
+
+    Volontairement relu a chaque appel : un droit retire (ou un compte
+    desactive) doit prendre effet immediatement, sans dependre de la duree de
+    vie du contexte applicatif.
+    """
+    return user_peut_gerer_benevoles(session.get('user_id'))
+
+
 def _peut_voir():
-    return session.get('profil') in ('directeur', 'comptable', 'responsable')
+    return session.get('profil') in ('directeur', 'comptable', 'responsable') or _est_delegue()
 
 
 def _peut_modifier():
-    return session.get('profil') in ('directeur', 'comptable', 'responsable')
+    return session.get('profil') in ('directeur', 'comptable', 'responsable') or _est_delegue()
 
 
 def _peut_gerer_heures():
-    """Suivi des heures : direction et comptabilite uniquement.
+    """Suivi des heures : direction, comptabilite et salaries delegues.
 
     Le calendrier des activites est commun a l'association ; le confier aux
     responsables, qui ne voient qu'une partie des benevoles, fausserait les
-    totaux servant au bilan.
+    totaux servant au bilan. Un salarie delegue, lui, gere toute la page : il
+    voit tous les benevoles et tient donc le calendrier sans angle mort.
     """
-    return session.get('profil') in ('directeur', 'comptable')
+    return session.get('profil') in ('directeur', 'comptable') or _est_delegue()
 
 
 def _get_initiales(prenom, nom):
@@ -203,7 +219,10 @@ def gestion_benevoles():
                 'initiales': _get_initiales(u['prenom'], u['nom']),
             }
 
-        is_responsable = session.get('profil') == 'responsable'
+        # `is_responsable` declenche la vue restreinte (ses benevoles seuls,
+        # sans ajout ni suppression). Un responsable delegue gere toute la
+        # page : il retrouve la liste complete comme la direction.
+        is_responsable = session.get('profil') == 'responsable' and not _est_delegue()
         user_id = session.get('user_id')
 
         if is_responsable:

--- a/blueprints/delegations.py
+++ b/blueprints/delegations.py
@@ -114,3 +114,62 @@ def save_salle_recurrence_delegations(user_ids, granted_by):
         conn.commit()
     finally:
         conn.close()
+
+
+# ── Délégation : gestion complète de la page bénévoles ─────────────────────────
+# Par défaut, le répertoire des bénévoles est tenu par la direction et la
+# comptabilité (un responsable ne voit que les bénévoles qui lui sont assignés
+# et le suivi des heures leur est fermé). Cette délégation confie l'intégralité
+# de la page — répertoire ET suivi des heures — à un ou plusieurs salariés.
+
+def get_benevoles_user_ids():
+    """Retourne la liste des IDs des salariés délégués à la gestion des bénévoles."""
+    conn = get_db()
+    try:
+        rows = conn.execute('SELECT user_id FROM delegations_benevoles').fetchall()
+        return [row['user_id'] for row in rows]
+    finally:
+        conn.close()
+
+
+def user_peut_gerer_benevoles(user_id):
+    """Indique si un salarié dispose de la délégation de gestion des bénévoles.
+
+    Le profil et l'activité du compte sont revérifiés à chaque appel : une
+    délégation accordée hier ne doit pas survivre à la désactivation du compte
+    ni à un changement de profil (un prestataire n'a rien à faire dans les
+    coordonnées des bénévoles).
+    """
+    if not user_id:
+        return False
+    conn = get_db()
+    try:
+        row = conn.execute(
+            '''
+            SELECT 1
+            FROM delegations_benevoles d
+            JOIN users u ON u.id = d.user_id
+            WHERE d.user_id = ? AND u.actif = 1
+              AND u.profil IN ('salarie', 'responsable')
+            ''',
+            (user_id,)
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def save_benevoles_delegations(user_ids, granted_by):
+    """Remplace l'ensemble des salariés délégués à la gestion des bénévoles."""
+    conn = get_db()
+    try:
+        conn.execute('DELETE FROM delegations_benevoles')
+        for uid in user_ids:
+            conn.execute(
+                'INSERT OR IGNORE INTO delegations_benevoles (user_id, granted_by) '
+                'VALUES (?, ?)',
+                (uid, granted_by)
+            )
+        conn.commit()
+    finally:
+        conn.close()

--- a/database.py
+++ b/database.py
@@ -80,6 +80,7 @@ ALL_MIGRATION_VERSIONS = [
     ('0040', 'Module CSE'),
     ('0061', 'Type de benevolat, date de fin et suivi des heures'),
     ('0062', 'Charte du benevolat signee'),
+    ('0063', 'Delegation de la gestion des benevoles'),
 ]
 
 # Types de subvention par defaut (migration 0052)
@@ -1039,6 +1040,19 @@ def init_db():
     # récurrentes (par défaut réservé aux responsables / direction).
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS delegations_salles_recurrence (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL UNIQUE,
+            granted_by INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (granted_by) REFERENCES users(id)
+        )
+    ''')
+
+    # Délégation : salariés à qui la gestion complète de la page bénévoles
+    # (répertoire et suivi des heures) est confiée (migration 0063).
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS delegations_benevoles (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL UNIQUE,
             granted_by INTEGER,

--- a/migrations/0063_delegation_benevoles.py
+++ b/migrations/0063_delegation_benevoles.py
@@ -1,0 +1,35 @@
+"""
+Migration 0063 : Délégation de la gestion des bénévoles.
+
+Par défaut, le répertoire des bénévoles et le suivi des heures sont tenus par
+la direction et la comptabilité. Cette table permet de confier l'intégralité de
+la page bénévoles à un ou plusieurs salariés, depuis la page Délégation.
+"""
+
+NOM = "Délégation gestion des bénévoles"
+DESCRIPTION = (
+    "Ajoute la table delegations_benevoles (salariés chargés de la gestion "
+    "complète de la page bénévoles : répertoire et suivi des heures)."
+)
+
+
+def upgrade(conn):
+    """Applique la migration."""
+    cursor = conn.cursor()
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS delegations_benevoles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL UNIQUE,
+            granted_by INTEGER,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+            FOREIGN KEY (granted_by) REFERENCES users(id)
+        )
+    ''')
+
+
+def downgrade(conn):
+    """Suppression de la table de délégation des bénévoles."""
+    cursor = conn.cursor()
+    cursor.execute('DROP TABLE IF EXISTS delegations_benevoles')
+    conn.commit()

--- a/templates/base.html
+++ b/templates/base.html
@@ -330,6 +330,9 @@
             <a href="{{ url_for('commandes_salaries_bp.commandes_salaries') }}" class="sidebar-link">🛒 Commandes salariés</a>
             <a href="{{ url_for('factures_bp.approbation_factures') }}" class="sidebar-link">🧾 Approbation factures</a>
             <a href="{{ url_for('salles_bp.salles') }}" class="sidebar-link">🏠 Salles</a>
+            {% if is_delegue_benevoles %}
+            <a href="{{ url_for('benevoles_bp.gestion_benevoles') }}" class="sidebar-link">🤝 Bénévoles</a>
+            {% endif %}
 
             {% elif session.profil == 'prestataire' %}
             {# ── PRESTATAIRE ── #}
@@ -367,6 +370,9 @@
                 <a href="{{ url_for('cse_bp.cse_accueil') }}" class="sidebar-link">🧑‍⚖️ CSE</a>
                 {% endif %}
                 <a href="{{ url_for('salles_bp.salles') }}" class="sidebar-link">🏠 Salles</a>
+                {% if is_delegue_benevoles %}
+                <a href="{{ url_for('benevoles_bp.gestion_benevoles') }}" class="sidebar-link">🤝 Bénévoles</a>
+                {% endif %}
                 {% if can_access_vue_ensemble_validation %}
                 <a href="{{ url_for('validation_bp.vue_ensemble_validation') }}" class="sidebar-link">📋 Vue ensemble</a>
                 {% endif %}

--- a/templates/delegations.html
+++ b/templates/delegations.html
@@ -111,6 +111,41 @@
                 </div>
             </form>
         </div>
+
+        <div class="delegation-card">
+            <h2>Gestion des bénévoles</h2>
+            <p class="delegation-meta">
+                Les salariés cochés gèrent l'intégralité de la page Bénévoles : liste complète
+                des bénévoles (ajout, modification, suppression) et suivi des heures.
+            </p>
+
+            <form method="POST" action="{{ url_for('admin_bp.delegations') }}">
+                <input type="hidden" name="form_type" value="benevoles">
+
+                <div class="form-group">
+                    <div class="recurrence-users">
+                        {% for user in salaries %}
+                        <label class="recurrence-user">
+                            <input type="checkbox" name="benevoles_users" value="{{ user.id }}"
+                                   {% if user.id in benevoles_user_ids %}checked{% endif %}
+                                   {% if not peut_modifier_benevoles %}disabled{% endif %}>
+                            {{ user.prenom }} {{ user.nom }}{% if user.profil == 'responsable' %} — Responsable{% endif %}
+                        </label>
+                        {% endfor %}
+                        {% if not salaries %}
+                        <p class="delegation-meta">Aucun salarié disponible.</p>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="form-actions">
+                    <a href="{{ url_for('dashboard_bp.dashboard') }}" class="btn btn-secondary">Retour</a>
+                    {% if peut_modifier_benevoles %}
+                    <button type="submit" class="btn btn-primary">Enregistrer les délégations</button>
+                    {% endif %}
+                </div>
+            </form>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/tests/test_delegation_benevoles.py
+++ b/tests/test_delegation_benevoles.py
@@ -1,0 +1,270 @@
+"""
+Tests de la délégation de la gestion des bénévoles.
+
+Par défaut, le répertoire des bénévoles est tenu par la direction, la
+comptabilité et — pour leurs seuls bénévoles — les responsables ; le suivi des
+heures est réservé à la direction et à la comptabilité. La direction (ou la
+comptabilité) peut confier l'intégralité de la page à un ou plusieurs salariés
+depuis la page Délégation.
+"""
+from database import get_db
+
+
+def _login(c, login, password):
+    return c.post('/login', data={'login': login, 'password': password},
+                  follow_redirects=True)
+
+
+def _deleguer(client, user_ids):
+    return client.post('/delegations', data={
+        'form_type': 'benevoles',
+        'benevoles_users': user_ids,
+    }, follow_redirects=True)
+
+
+def _creer_benevole(app, nom='Bernard Bénévole', responsable_id=None):
+    with app.app_context():
+        conn = get_db()
+        cur = conn.execute(
+            "INSERT INTO benevoles (nom, groupe, responsable_id) VALUES (?, 'actif', ?)",
+            (nom, responsable_id)
+        )
+        conn.commit()
+        ben_id = cur.lastrowid
+        conn.close()
+        return ben_id
+
+
+def _delegations(app):
+    with app.app_context():
+        conn = get_db()
+        ids = [r['user_id'] for r in
+               conn.execute('SELECT user_id FROM delegations_benevoles').fetchall()]
+        conn.close()
+        return ids
+
+
+# ── Sans délégation ──
+
+def test_salarie_sans_delegation_n_accede_pas_a_la_page(app, sample_users):
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    r = sal.get('/benevoles', follow_redirects=False)
+    assert r.status_code == 302
+    assert '/dashboard' in r.headers['Location']
+
+
+def test_salarie_sans_delegation_ne_peut_pas_modifier(app, sample_users):
+    ben_id = _creer_benevole(app)
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    r = sal.post(f'/api/benevoles/{ben_id}/modifier',
+                 json={'field': 'nom', 'value': 'Piraté'})
+    assert r.status_code == 403
+    with app.app_context():
+        conn = get_db()
+        nom = conn.execute('SELECT nom FROM benevoles WHERE id = ?', (ben_id,)).fetchone()['nom']
+        conn.close()
+    assert nom == 'Bernard Bénévole'
+
+
+def test_salarie_sans_delegation_n_accede_pas_au_suivi_des_heures(app, sample_users):
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    r = sal.get('/benevoles/heures', follow_redirects=False)
+    assert r.status_code == 302
+
+
+# ── Attribution de la délégation ──
+
+def test_directeur_delegue_puis_salarie_gere_la_page(app, sample_users):
+    ben_id = _creer_benevole(app)
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    r = _deleguer(admin, [sample_users['salarie_id']])
+    assert 'ont été enregistrées' in r.get_data(as_text=True)
+    assert _delegations(app) == [sample_users['salarie_id']]
+
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    # Répertoire : consultation, modification, ajout et suppression.
+    assert sal.get('/benevoles').status_code == 200
+    assert sal.post(f'/api/benevoles/{ben_id}/modifier',
+                    json={'field': 'nom', 'value': 'Bernard B.'}).status_code == 200
+    assert sal.post('/api/benevoles/ajouter',
+                    json={'nom': 'Nouvelle recrue', 'groupe': 'nouveau'}).status_code == 200
+    assert sal.post(f'/api/benevoles/{ben_id}/supprimer', json={}).status_code == 200
+    with app.app_context():
+        conn = get_db()
+        noms = [r['nom'] for r in conn.execute('SELECT nom FROM benevoles').fetchall()]
+        conn.close()
+    assert noms == ['Nouvelle recrue']
+
+
+def test_salarie_delegue_accede_au_suivi_des_heures(app, sample_users):
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    _deleguer(admin, [sample_users['salarie_id']])
+
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    assert sal.get('/benevoles/heures').status_code == 200
+    r = sal.post('/api/benevoles/activites/ajouter',
+                 json={'nom': 'Conseil d\'administration', 'mode': 'seance'})
+    assert r.status_code == 200
+    with app.app_context():
+        conn = get_db()
+        n = conn.execute('SELECT COUNT(*) AS n FROM benevoles_activites').fetchone()['n']
+        conn.close()
+    assert n == 1
+
+
+def test_plusieurs_salaries_delegues(app, sample_users):
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    _deleguer(admin, [sample_users['salarie_id'], sample_users['responsable_id']])
+    assert sorted(_delegations(app)) == sorted(
+        [sample_users['salarie_id'], sample_users['responsable_id']])
+
+
+def test_responsable_delegue_voit_tous_les_benevoles(app, sample_users):
+    """Sans délégation le responsable ne voit que ses bénévoles ; avec la
+    délégation il gère la page entière (liste complète et bouton d'ajout)."""
+    _creer_benevole(app, 'Bénévole du responsable', sample_users['responsable_id'])
+    _creer_benevole(app, 'Bénévole sans responsable')
+
+    resp = app.test_client()
+    _login(resp, 'resp_test', 'resp123')
+    html = resp.get('/benevoles').get_data(as_text=True)
+    assert 'Bénévole du responsable' in html
+    assert 'Bénévole sans responsable' not in html
+    assert '+ Ajouter' not in html
+
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    _deleguer(admin, [sample_users['responsable_id']])
+
+    html = resp.get('/benevoles').get_data(as_text=True)
+    assert 'Bénévole sans responsable' in html
+    assert '+ Ajouter' in html
+
+
+def test_comptable_peut_deleguer(app, sample_users):
+    """La comptabilité tient la page bénévoles : elle peut aussi la déléguer."""
+    compta = app.test_client()
+    _login(compta, 'compta_test', 'compta123')
+    r = _deleguer(compta, [sample_users['salarie_id']])
+    assert 'ont été enregistrées' in r.get_data(as_text=True)
+    assert _delegations(app) == [sample_users['salarie_id']]
+
+
+# ── Retrait de la délégation ──
+
+def test_retrait_de_la_delegation(app, sample_users):
+    ben_id = _creer_benevole(app)
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    _deleguer(admin, [sample_users['salarie_id']])
+    # Retrait : aucune case cochée.
+    admin.post('/delegations', data={'form_type': 'benevoles'}, follow_redirects=True)
+    assert _delegations(app) == []
+
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    assert sal.get('/benevoles', follow_redirects=False).status_code == 302
+    assert sal.post(f'/api/benevoles/{ben_id}/modifier',
+                    json={'field': 'nom', 'value': 'Piraté'}).status_code == 403
+
+
+def test_delegation_sans_effet_si_le_compte_est_desactive(app, sample_users):
+    """Une délégation ne doit pas survivre à la désactivation du compte."""
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    _deleguer(admin, [sample_users['salarie_id']])
+
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    assert sal.get('/benevoles').status_code == 200
+
+    with app.app_context():
+        conn = get_db()
+        conn.execute('UPDATE users SET actif = 0 WHERE id = ?', (sample_users['salarie_id'],))
+        conn.commit()
+        conn.close()
+    assert sal.get('/benevoles', follow_redirects=False).status_code == 302
+
+
+# ── Contrôles d'accès de la page Délégation ──
+
+def test_salarie_ne_peut_pas_se_deleguer_lui_meme(app, sample_users):
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    r = sal.post('/delegations', data={
+        'form_type': 'benevoles',
+        'benevoles_users': [sample_users['salarie_id']],
+    }, follow_redirects=False)
+    assert r.status_code == 302
+    assert _delegations(app) == []
+
+
+def test_responsable_ne_peut_pas_deleguer(app, sample_users):
+    resp = app.test_client()
+    _login(resp, 'resp_test', 'resp123')
+    resp.post('/delegations', data={
+        'form_type': 'benevoles',
+        'benevoles_users': [sample_users['salarie_id']],
+    }, follow_redirects=True)
+    assert _delegations(app) == []
+
+
+def test_profil_non_delegable_ignore(app, sample_users, db):
+    """Seuls les comptes actifs salarié/responsable sont délégables : un
+    identifiant forgé (ici la comptabilité) est écarté côté serveur."""
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    _deleguer(admin, [sample_users['comptable_id'], sample_users['salarie_id']])
+    assert _delegations(app) == [sample_users['salarie_id']]
+
+
+# ── Page Délégation et menu ──
+
+def test_page_delegations_affiche_la_section(app, sample_users):
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    html = admin.get('/delegations').get_data(as_text=True)
+    assert 'Gestion des bénévoles' in html
+    assert 'name="benevoles_users"' in html
+
+
+def test_section_benevoles_active_pour_le_comptable(app, sample_users):
+    compta = app.test_client()
+    _login(compta, 'compta_test', 'compta123')
+    html = compta.get('/delegations').get_data(as_text=True)
+    section = html.split('Gestion des bénévoles')[1]
+    assert 'Enregistrer les délégations' in section
+    assert 'disabled' not in section.split('form-actions')[0]
+
+
+def test_menu_benevoles_visible_pour_le_salarie_delegue(app, sample_users):
+    sal = app.test_client()
+    _login(sal, 'salarie_test', 'sal123')
+    assert '🤝 Bénévoles' not in sal.get('/dashboard').get_data(as_text=True)
+
+    admin = app.test_client()
+    _login(admin, 'admin', 'Admin1234')
+    _deleguer(admin, [sample_users['salarie_id']])
+
+    assert '🤝 Bénévoles' in sal.get('/dashboard').get_data(as_text=True)
+
+
+class TestBaseNeuve:
+    """Une installation neuve ne doit pas réclamer une migration déjà incluse."""
+
+    def test_migration_0063_marquee_appliquee(self, app, db):
+        import database
+        assert any(v == '0063' for v, _ in database.ALL_MIGRATION_VERSIONS), \
+            "0063 doit figurer dans ALL_MIGRATION_VERSIONS"
+        with app.app_context():
+            ligne = db.execute(
+                "SELECT statut FROM schema_migrations WHERE version = '0063'").fetchone()
+        assert ligne and ligne['statut'] == 'ok'


### PR DESCRIPTION
## Objectif

Permettre, depuis la page **Délégation**, d'assigner un ou plusieurs salariés à l'intégralité de la gestion de la page **Bénévoles**.

## Ce que fait la délégation

Une nouvelle section « Gestion des bénévoles » (cases à cocher, comme les réservations de salle récurrentes) permet de désigner les salariés délégués. Un salarié coché obtient exactement les droits de la direction sur cette page :

- **Répertoire** : liste complète des bénévoles, ajout, modification, suppression ;
- **Suivi des heures** (`/benevoles/heures`) : activités, séances, pointage des présences, heures ponctuelles ;
- **Entrée de menu** « 🤝 Bénévoles » dans sa barre latérale (elle n'existait que pour la direction et la comptabilité).

Un **responsable** délégué passe de la vue restreinte (ses seuls bénévoles, sans ajout ni suppression) à la liste complète.

Qui peut déléguer : la **direction et la comptabilité**, qui tiennent aujourd'hui le répertoire et le suivi des heures — elles délèguent donc un droit qu'elles détiennent. Les délégations de mission (fournitures, suivi des validations) restent, elles, réservées à la direction.

## Modifications

| Fichier | Rôle |
| --- | --- |
| `migrations/0063_delegation_benevoles.py`, `database.py` | Table `delegations_benevoles` (schéma des bases neuves + migration des bases existantes), version ajoutée à `ALL_MIGRATION_VERSIONS` |
| `blueprints/delegations.py` | `get_benevoles_user_ids()`, `user_peut_gerer_benevoles()`, `save_benevoles_delegations()` |
| `blueprints/admin.py` | Traitement du formulaire `benevoles`, validation serveur des identifiants mutualisée avec celle des salles (`_salaries_delegables`) |
| `blueprints/benevoles.py` | `_peut_voir` / `_peut_modifier` / `_peut_gerer_heures` étendus aux délégués ; vue complète pour un responsable délégué |
| `templates/delegations.html`, `templates/base.html` | Section de délégation et entrée de menu |
| `README.md` | Mention de la délégation |

## Sécurité

- Les identifiants reçus du formulaire ne sont jamais crus : seuls les comptes **actifs** de profil `salarie` ou `responsable` sont retenus (un identifiant forgé — comptable, prestataire, compte désactivé — est écarté).
- `user_peut_gerer_benevoles()` **revérifie profil et activité à chaque contrôle** : une délégation ne survit ni à la désactivation du compte ni à un changement de profil, et un retrait prend effet immédiatement (aucune mise en cache de la décision).
- Le contrôle porte sur les routes (page et API), pas seulement sur l'affichage du menu.
- Salariés et responsables non délégués restent refusés partout, comme avant.

## Compatibilité des données

Table nouvelle, créée vide et de manière idempotente (`CREATE TABLE IF NOT EXISTS`) : aucune donnée existante n'est touchée, aucun droit n'est accordé tant que personne n'est coché. Le comportement par défaut est strictement inchangé.

## Tests

`tests/test_delegation_benevoles.py` (17 tests) : accès refusé sans délégation (page, API, suivi des heures), gestion complète après délégation, délégation multiple, responsable délégué voyant toute la liste, délégation par la comptabilité, retrait, compte désactivé, profils non délégables, salarié/responsable ne pouvant pas se déléguer, affichage de la section, entrée de menu, migration marquée appliquée sur base neuve.

Commandes réellement exécutées :

```
python -m compileall -q app.py blueprints migrations tests
python -m pytest tests/test_delegation_benevoles.py -q      # 17 passed
python -m pytest tests/test_delegation_recurrence_salles.py tests/test_benevoles.py tests/test_database.py -q   # 91 passed
python -m pytest -q                                          # 1379 passed
```

## Note

La branche a été rebasée sur `main` après la fusion de « Bénévoles : case à cocher Charte signée » ; la migration a été renumérotée `0062` → `0063` pour ne pas entrer en collision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kt7A3yHjCNWn1uLJkC4qSh)_