### PR TITLE
Interface sans menu : accueil en flux, barre au clavier, vue d'ensemble par zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,33 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 - Historique complet des demandes et modifications
 - Suivi des anomalies
 
+### Interface sans menu (accueil en flux)
+
+Pour la direction, la comptabilite, les responsables et les salaries porteurs
+d'une delegation, le menu lateral est remplace par :
+
+- un **accueil en fil d'actions** : uniquement ce qui attend une decision, avec
+  validation / refus / approbation en un clic ;
+- une zone **« A l'horizon »** : les echeances a venir mais pas immediates
+  (fins de contrat, retours d'absence, etapes de subventions, taches
+  planifiees), separees en une ligne RH et une ligne Echeances ;
+- une **barre intelligente** qui se remplit des la premiere touche frappee,
+  n'importe ou dans la page (ou Ctrl/Cmd + K) ;
+- une **vue d'ensemble** (touche Echap, ou le bouton de la barre du bas) :
+  l'application representee par zones, les themes au centre et les acces
+  directs a l'exterieur ;
+- **Mon espace** (le nom en haut a droite) : soldes de conges et de
+  recuperations, depot d'une demande, suivi de ses demandes.
+
+Les autres pages perdent leur menu et gagnent, en haut, les boutons des pages
+voisines de leur zone, ainsi qu'un flux d'information quand la page s'y prete
+(factures non validees, ecritures a generer, etapes en retard).
+
+Les autres salaries conservent l'interface habituelle. L'option
+d'administration **« Activer l'interface sans menu »** desactive la nouveaute
+pour tout le centre, et chaque utilisateur concerne peut revenir au menu
+classique depuis « Mon espace ».
+
 ### Multi-profils (5 profils)
 - **Salarie** : saisie de ses heures, consultation de son solde, demandes de recup
 - **Responsable** : validation equipe, vue "Mon equipe" hebdomadaire par secteur
@@ -136,6 +163,7 @@ Application web de gestion RH, comptable et operationnelle, conçue pour les str
 ## Documentation
 
 - **[Guide de démarrage rapide](docs/quick-start.md)** — installation, premier lancement, configuration initiale, création des salariés et de leur fiche RH.
+- **[Interface sans menu](docs/interface-sans-menu.md)** — l'accueil en fil d'actions, la barre intelligente, la vue d'ensemble par zones, et comment revenir au menu classique.
 
 ## Installation
 
@@ -193,11 +221,16 @@ CS-PILOT/
 ├── backup_db.py               # Sauvegarde / restauration
 ├── migration_manager.py       # Systeme de migrations
 ├── utils.py                   # Utilitaires (decorateurs, chiffrement)
+├── navigation.py              # Carte des zones et pages (interface sans menu)
+├── interface_flux.py          # Activation et contexte de l'interface sans menu
+├── flux_accueil.py            # Zone « A l'horizon » de l'accueil
+├── flux_infos.py              # Flux d'information par page
 ├── requirements.txt           # Dependances Python
 ├── LANCER.bat                 # Script de lancement Windows
 │
 ├── blueprints/                # Modules fonctionnels Flask
 │   ├── auth.py                # Authentification
+│   ├── accueil.py             # Accueil sans menu et « Mon espace »
 │   ├── dashboard.py           # Tableau de bord salarie
 │   ├── dashboard_direction.py # Tableau de bord direction
 │   ├── saisie.py              # Saisie des heures

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ d'une delegation, le menu lateral est remplace par :
 - **Mon espace** (le nom en haut a droite) : soldes de conges et de
   recuperations, depot d'une demande, suivi de ses demandes.
 
+Le nom est accompagne de la **fonction** du salarie, renseignee avec les
+informations de contrat (liste deroulante completable : Directeur, EJE,
+Auxiliaire Puer., Agent d'accueil, Gardien...).
+
 Les autres pages perdent leur menu et gagnent, en haut, les boutons des pages
 voisines de leur zone, ainsi qu'un flux d'information quand la page s'y prete
 (factures non validees, ecritures a generer, etapes en retard).

--- a/app.py
+++ b/app.py
@@ -306,8 +306,10 @@ from blueprints.cse import cse_bp
 from blueprints.planificateur import planificateur_bp
 from blueprints.contrats import contrats_bp
 from blueprints.recherche import recherche_bp
+from blueprints.accueil import accueil_bp
 
 app.register_blueprint(auth)
+app.register_blueprint(accueil_bp)
 app.register_blueprint(dashboard_bp)
 app.register_blueprint(dashboard_responsable_bp)
 app.register_blueprint(dashboard_comptable_bp)
@@ -529,6 +531,25 @@ def inject_delegation_benevoles():
             "Delegation benevoles illisible, entree de menu masquee", exc_info=True
         )
         return {'is_delegue_benevoles': False}
+
+
+@app.context_processor
+def inject_interface_flux():
+    """Injecte l'état et la carte de l'interface sans menu.
+
+    Le calcul est mémorisé dans `flask.g` : plusieurs gabarits peuvent lire la
+    carte sans relancer les lectures de droits. Toute défaillance retombe sur
+    l'interface historique plutôt que de faire échouer le rendu.
+    """
+    try:
+        import interface_flux
+        contexte = dict(interface_flux.contexte())
+        if contexte.get('ui_flux'):
+            contexte['flux_infos'] = interface_flux.flux_infos_page()
+        return contexte
+    except Exception:
+        logger.warning("Contexte de l'interface sans menu indisponible", exc_info=True)
+        return {'ui_flux': False, 'ui_flux_eligible': False}
 
 
 @app.errorhandler(429)

--- a/app_options.py
+++ b/app_options.py
@@ -29,6 +29,18 @@ OPTION_DEFINITIONS = {
         ),
         'default': False,
     },
+    'interface_sans_menu_active': {
+        'label': "Activer l'interface sans menu",
+        'description': (
+            "Remplace le menu latéral par un accueil en fil d'actions, une barre "
+            'de recherche qui se remplit dès la première touche frappée et une vue '
+            "d'ensemble par zones (touche Échap). Concerne la direction, la "
+            'comptabilité, les responsables et les salariés porteurs d\'une '
+            'délégation ; les autres salariés gardent leur interface habituelle. '
+            'Chacun peut revenir au menu classique depuis « Mon espace ».'
+        ),
+        'default': True,
+    },
     'generation_contrats_responsable_autorise': {
         'label': 'Autoriser les responsables à accéder à la page Génération contrats',
         'description': (

--- a/blueprints/accueil.py
+++ b/blueprints/accueil.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from flask import (Blueprint, jsonify, redirect, render_template, request,
                    session, url_for)
 
+import interface_flux
 import navigation
 from dashboard_actions import construire_actions
 from database import get_db
@@ -72,6 +73,23 @@ def _secteur_de(user_id):
         return None
 
 
+def _fil_du_profil(conn, profil, user_id, secteur_id):
+    """Fil d'actions de l'accueil, à parité avec le tableau de bord remplacé.
+
+    Pour la direction et la comptabilité, l'accueil prend la place du centre de
+    contrôle : il doit donc porter la même file étendue — factures assignées à
+    la direction, relances de fiches, surcharges, soldes de congés élevés — et
+    pas seulement les demandes et les subventions. Sans cela, les factures à
+    approuver disparaîtraient alors que leurs boutons existent dans le gabarit.
+    """
+    if profil in ('directeur', 'comptable'):
+        from blueprints.dashboard_direction import (_construire_file_actions,
+                                                    _lire_seuils)
+        actions, _ = _construire_file_actions(conn, profil, user_id, _lire_seuils())
+        return actions
+    return construire_actions(conn, profil, user_id, secteur_id=secteur_id)
+
+
 @accueil_bp.route('/accueil')
 @login_required
 def accueil():
@@ -79,9 +97,10 @@ def accueil():
     profil = session.get('profil')
     user_id = session.get('user_id')
 
-    # L'accueil sans menu n'a de sens que pour qui y a droit ; les autres
-    # gardent leur tableau de bord et son menu.
-    if not navigation.est_eligible(profil, user_id):
+    # L'accueil sans menu n'a de sens que si l'interface est réellement active :
+    # éligibilité du profil, mais aussi option du centre et choix personnel.
+    # Sinon la page s'afficherait à l'intérieur du gabarit à menu latéral.
+    if not interface_flux.interface_active(profil, user_id):
         return redirect(url_for('dashboard_bp.dashboard'))
 
     secteur_id = _secteur_de(user_id) if profil == 'responsable' else None
@@ -89,7 +108,7 @@ def accueil():
 
     conn = get_db()
     try:
-        actions = construire_actions(conn, profil, user_id, secteur_id=secteur_id)
+        actions = _fil_du_profil(conn, profil, user_id, secteur_id)
         horizon = construire_horizon(conn, profil, user_id, secteur_id)
     finally:
         conn.close()
@@ -115,6 +134,9 @@ def mon_espace():
     """Le dossier personnel : compteurs, dépôt d'une demande, demandes en cours."""
     user_id = session.get('user_id')
     profil = session.get('profil')
+    if not interface_flux.interface_active(profil, user_id):
+        return redirect(url_for('dashboard_bp.dashboard'))
+
     conn = get_db()
     try:
         user = conn.execute(
@@ -140,6 +162,14 @@ def mon_espace():
                ORDER BY date_demande DESC LIMIT 20''',
             (user_id,)
         ).fetchall()
+
+        # Jours fériés de l'année en cours et de la suivante : le décompte
+        # affiché avant l'envoi doit donner le même résultat que
+        # `utils.calculer_jours_ouvres`, qui les exclut côté serveur.
+        annee = aujourd_hui().year
+        feries = [r['date'] for r in conn.execute(
+            'SELECT date FROM jours_feries WHERE annee IN (?, ?)',
+            (annee, annee + 1)).fetchall()]
     finally:
         conn.close()
 
@@ -209,6 +239,7 @@ def mon_espace():
         solde_cp=solde_cp,
         solde_cc=solde_cc,
         solde_recup=round(solde_recup, 1),
+        feries=feries,
         aujourdhui=aujourd_hui().isoformat(),
     )
 
@@ -219,12 +250,12 @@ def api_flux_fragment():
     """Fragment HTML du fil d'actions (rafraîchissement sans rechargement)."""
     profil = session.get('profil')
     user_id = session.get('user_id')
-    if not navigation.est_eligible(profil, user_id):
+    if not interface_flux.interface_active(profil, user_id):
         return jsonify({'error': 'Accès non autorisé'}), 403
     secteur_id = _secteur_de(user_id) if profil == 'responsable' else None
     conn = get_db()
     try:
-        actions = construire_actions(conn, profil, user_id, secteur_id=secteur_id)
+        actions = _fil_du_profil(conn, profil, user_id, secteur_id)
     finally:
         conn.close()
     return render_template('_flux_actions.html', actions=separer_actions(actions))
@@ -238,13 +269,17 @@ def api_basculer():
     Le choix est personnel : il ne change rien pour les autres utilisateurs, et
     ne peut pas donner accès à l'interface sans menu à qui n'y a pas droit.
     """
-    from interface_flux import definir_preference_utilisateur
     profil = session.get('profil')
     user_id = session.get('user_id')
     if not navigation.est_eligible(profil, user_id):
         return jsonify({'error': 'Accès non autorisé'}), 403
     data = request.get_json(silent=True) or {}
     actif = bool(data.get('actif'))
-    definir_preference_utilisateur(user_id, actif)
-    cible = url_for('accueil_bp.accueil') if actif else url_for('dashboard_bp.dashboard')
-    return jsonify({'success': True, 'actif': actif, 'redirect': cible})
+    interface_flux.definir_preference_utilisateur(user_id, actif)
+    # L'option du centre prime : si elle est décochée, la préférence est bien
+    # enregistrée mais l'accueil sans menu reste fermé. On renvoie alors vers le
+    # tableau de bord plutôt que vers une page qui redirigerait aussitôt.
+    vers_le_flux = actif and interface_flux.interface_active(profil, user_id)
+    cible = (url_for('accueil_bp.accueil') if vers_le_flux
+             else url_for('dashboard_bp.dashboard'))
+    return jsonify({'success': True, 'actif': vers_le_flux, 'redirect': cible})

--- a/blueprints/accueil.py
+++ b/blueprints/accueil.py
@@ -1,0 +1,250 @@
+"""
+Blueprint accueil_bp : l'accueil de l'interface sans menu.
+
+Deux pages :
+- `/accueil` : le flux. Les décisions du jour, puis « À l'horizon » : ce qui
+  arrive sans rien demander aujourd'hui.
+- `/mon-espace` : le dossier personnel ouvert par le nom, en haut à droite —
+  compteurs de congés et de récupérations, dépôt d'une demande, et les demandes
+  en cours.
+
+Plus une bascule (`/api/interface/basculer`) qui permet à chaque utilisateur
+concerné de revenir au menu latéral historique, et d'y retourner.
+"""
+import logging
+from datetime import datetime
+
+from flask import (Blueprint, jsonify, redirect, render_template, request,
+                   session, url_for)
+
+import navigation
+from dashboard_actions import construire_actions
+from database import get_db
+from flux_accueil import construire_horizon, separer_actions
+from utils import (aujourd_hui, calculer_solde_recup, get_user_info,
+                   login_required, NOMS_MOIS)
+
+logger = logging.getLogger(__name__)
+
+accueil_bp = Blueprint('accueil_bp', __name__)
+
+JOURS_SEMAINE = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche']
+
+# Libellés des statuts de demande, et le ton qui les colore.
+_STATUTS = {
+    'en_attente_responsable': ('En attente', 'attente'),
+    'en_attente_direction': ('En attente', 'attente'),
+    'validee': ('Acceptée', 'ok'),
+    'refusee': ('Refusée', 'refus'),
+}
+
+
+def _fr_num(valeur):
+    """Nombre -> notation française compacte ('3', '3,5')."""
+    return f"{valeur:g}".replace('.', ',')
+
+
+def _fr_date(valeur):
+    """'YYYY-MM-DD' -> 'JJ/MM/AAAA' (chaîne vide si illisible)."""
+    if not valeur:
+        return ''
+    texte = str(valeur)[:10]
+    try:
+        return datetime.strptime(texte, '%Y-%m-%d').strftime('%d/%m/%Y')
+    except ValueError:
+        return texte
+
+
+def _periode(debut, fin):
+    """« du 12/08 au 19/08 » — ou « le 12/08 » si la période tient en un jour."""
+    d, f = _fr_date(debut), _fr_date(fin)
+    if not d:
+        return ''
+    return f"le {d}" if (not f or f == d) else f"du {d} au {f}"
+
+
+def _secteur_de(user_id):
+    """Secteur du responsable, pour borner ce qu'il voit à son équipe."""
+    user = get_user_info(user_id)
+    try:
+        return user['secteur_id'] if user else None
+    except (KeyError, IndexError, TypeError):
+        return None
+
+
+@accueil_bp.route('/accueil')
+@login_required
+def accueil():
+    """Le flux : les décisions du jour, puis l'horizon."""
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+
+    # L'accueil sans menu n'a de sens que pour qui y a droit ; les autres
+    # gardent leur tableau de bord et son menu.
+    if not navigation.est_eligible(profil, user_id):
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    secteur_id = _secteur_de(user_id) if profil == 'responsable' else None
+    today = datetime.now()
+
+    conn = get_db()
+    try:
+        actions = construire_actions(conn, profil, user_id, secteur_id=secteur_id)
+        horizon = construire_horizon(conn, profil, user_id, secteur_id)
+    finally:
+        conn.close()
+
+    actions = separer_actions(actions)
+    prenom = session.get('prenom') or ''
+    salutation = ('Bonjour' if today.hour < 18 else 'Bonsoir')
+
+    return render_template(
+        'accueil_flux.html',
+        salutation=f"{salutation}{' ' + prenom if prenom else ''}.",
+        date_texte=(f"{JOURS_SEMAINE[today.weekday()]} {today.day} "
+                    f"{NOMS_MOIS[today.month].lower()} {today.year}"),
+        actions=actions,
+        nb_actions=len(actions),
+        horizon=horizon,
+    )
+
+
+@accueil_bp.route('/mon-espace')
+@login_required
+def mon_espace():
+    """Le dossier personnel : compteurs, dépôt d'une demande, demandes en cours."""
+    user_id = session.get('user_id')
+    profil = session.get('profil')
+    conn = get_db()
+    try:
+        user = conn.execute(
+            '''SELECT nom, prenom, profil,
+                      COALESCE(cp_a_prendre, 0) AS cp_a_prendre,
+                      COALESCE(cp_pris, 0) AS cp_pris,
+                      COALESCE(cc_solde, 0) AS cc_solde
+               FROM users WHERE id = ?''',
+            (user_id,)
+        ).fetchone()
+
+        conges = conn.execute(
+            '''SELECT id, type_conge, date_debut, date_fin, nb_jours, statut,
+                      date_demande, motif_refus
+               FROM demandes_conges WHERE user_id = ?
+               ORDER BY date_demande DESC LIMIT 20''',
+            (user_id,)
+        ).fetchall()
+        recups = conn.execute(
+            '''SELECT id, date_debut, date_fin, nb_jours, nb_heures, statut,
+                      date_demande, motif_refus
+               FROM demandes_recup WHERE user_id = ?
+               ORDER BY date_demande DESC LIMIT 20''',
+            (user_id,)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    solde_cp = (user['cp_a_prendre'] - user['cp_pris']) if user else 0
+    solde_cc = user['cc_solde'] if user else 0
+    try:
+        solde_recup = calculer_solde_recup(user_id)
+    except Exception:
+        logger.warning("Solde de récupération illisible pour %s", user_id, exc_info=True)
+        solde_recup = 0
+
+    compteurs = [
+        {'nom': 'Congés payés', 'valeur': f"{_fr_num(solde_cp)} j",
+         'detail': f"Acquis {_fr_num(user['cp_a_prendre'])} · pris {_fr_num(user['cp_pris'])}"
+                   if user else '',
+         'ton': 'vert' if solde_cp >= 0 else 'orange'},
+        {'nom': 'Congés conventionnels', 'valeur': f"{_fr_num(solde_cc)} j",
+         'detail': 'Solde à planifier avec votre responsable',
+         'ton': 'orange' if solde_cc >= 5 else 'neutre'},
+        {'nom': 'Récupérations', 'valeur': f"{_fr_num(round(solde_recup, 1))} h",
+         'detail': 'Heures acquises, nettes des heures déjà payées',
+         'ton': 'orange' if solde_recup >= 7 else 'neutre'},
+    ]
+
+    demandes = []
+    for c in conges:
+        libelle, ton = _STATUTS.get(c['statut'], (c['statut'], 'clos'))
+        demandes.append({
+            'type': c['type_conge'] or 'Congé',
+            'periode': _periode(c['date_debut'], c['date_fin']),
+            'quantite': f"{_fr_num(c['nb_jours'])} j",
+            'statut': libelle, 'ton': ton,
+            'depot': _fr_date(c['date_demande']),
+            'motif_refus': c['motif_refus'],
+            'lien': url_for('recup_bp.mes_demandes_conges'),
+            'tri': str(c['date_demande'] or ''),
+        })
+    for r in recups:
+        libelle, ton = _STATUTS.get(r['statut'], (r['statut'], 'clos'))
+        quantite = (f"{_fr_num(r['nb_heures'])} h" if r['nb_heures']
+                    else f"{_fr_num(r['nb_jours'])} j")
+        demandes.append({
+            'type': 'Récupération',
+            'periode': _periode(r['date_debut'], r['date_fin']),
+            'quantite': quantite,
+            'statut': libelle, 'ton': ton,
+            'depot': _fr_date(r['date_demande']),
+            'motif_refus': r['motif_refus'],
+            'lien': url_for('recup_bp.mes_demandes_recup'),
+            'tri': str(r['date_demande'] or ''),
+        })
+    demandes.sort(key=lambda d: d['tri'], reverse=True)
+
+    # Types proposés au dépôt : ceux de la page « Demander un congé », plus la
+    # récupération quand le profil y a droit (la direction est au forfait jour).
+    from blueprints.recup import _types_conge_pour
+    types = [{'nom': t, 'mode': 'conge'} for t in _types_conge_pour(profil)]
+    if profil != 'directeur':
+        types.append({'nom': 'Récupération', 'mode': 'recup'})
+
+    return render_template(
+        'mon_espace.html',
+        compteurs=compteurs,
+        demandes=demandes[:12],
+        nb_attente=sum(1 for d in demandes if d['ton'] == 'attente'),
+        types_demande=types,
+        solde_cp=solde_cp,
+        solde_cc=solde_cc,
+        solde_recup=round(solde_recup, 1),
+        aujourdhui=aujourd_hui().isoformat(),
+    )
+
+
+@accueil_bp.route('/api/accueil/flux-fragment')
+@login_required
+def api_flux_fragment():
+    """Fragment HTML du fil d'actions (rafraîchissement sans rechargement)."""
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+    if not navigation.est_eligible(profil, user_id):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    secteur_id = _secteur_de(user_id) if profil == 'responsable' else None
+    conn = get_db()
+    try:
+        actions = construire_actions(conn, profil, user_id, secteur_id=secteur_id)
+    finally:
+        conn.close()
+    return render_template('_flux_actions.html', actions=separer_actions(actions))
+
+
+@accueil_bp.route('/api/interface/basculer', methods=['POST'])
+@login_required
+def api_basculer():
+    """Bascule l'utilisateur entre l'interface sans menu et le menu historique.
+
+    Le choix est personnel : il ne change rien pour les autres utilisateurs, et
+    ne peut pas donner accès à l'interface sans menu à qui n'y a pas droit.
+    """
+    from interface_flux import definir_preference_utilisateur
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+    if not navigation.est_eligible(profil, user_id):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+    data = request.get_json(silent=True) or {}
+    actif = bool(data.get('actif'))
+    definir_preference_utilisateur(user_id, actif)
+    cible = url_for('accueil_bp.accueil') if actif else url_for('dashboard_bp.dashboard')
+    return jsonify({'success': True, 'actif': actif, 'redirect': cible})

--- a/blueprints/accueil.py
+++ b/blueprints/accueil.py
@@ -113,6 +113,14 @@ def accueil():
     finally:
         conn.close()
 
+    # Les seuils d'alerte façonnent la file étendue : ils se règlent depuis
+    # l'accueil, qui remplace le centre de contrôle où ils vivaient. Seuls la
+    # direction et la comptabilité y ont droit — comme l'API qui les enregistre.
+    seuils = None
+    if profil in ('directeur', 'comptable'):
+        from blueprints.dashboard_direction import _lire_seuils
+        seuils = _lire_seuils()
+
     actions = separer_actions(actions)
     prenom = session.get('prenom') or ''
     salutation = ('Bonjour' if today.hour < 18 else 'Bonsoir')
@@ -125,6 +133,7 @@ def accueil():
         actions=actions,
         nb_actions=len(actions),
         horizon=horizon,
+        seuils=seuils,
     )
 
 

--- a/blueprints/dashboard.py
+++ b/blueprints/dashboard.py
@@ -20,6 +20,14 @@ def dashboard():
     """Tableau de bord selon le profil"""
     profil = session.get('profil')
     user = None
+
+    # Interface sans menu : l'accueil devient le fil d'actions. Le tableau de
+    # bord historique reste accessible par son URL propre, pour qui la garde en
+    # favori ou revient au menu classique.
+    import interface_flux
+    if interface_flux.interface_active(profil, session.get('user_id')):
+        return redirect(url_for('accueil_bp.accueil'))
+
     if profil == 'directeur':
         return redirect(url_for('dashboard_direction_bp.dashboard_direction'))
     if profil == 'responsable':

--- a/blueprints/infos_salaries.py
+++ b/blueprints/infos_salaries.py
@@ -6,6 +6,7 @@ Fiche de renseignement salarie : email, contrats, documents
 import os
 import re
 import logging
+import sqlite3
 import unicodedata
 from flask import (Blueprint, render_template, request, redirect,
                    url_for, session, flash, send_file)
@@ -37,6 +38,10 @@ def _date_iso_valide(valeur):
 DOCUMENTS_DIR = os.path.join(DATA_DIR, 'documents')
 
 TYPES_CONTRAT = ['CDI', 'CDD', 'CEE', 'Autre']
+
+# Valeur de l'entrée « + Ajouter une fonction… » de la liste déroulante : elle
+# ouvre le champ libre et n'est jamais enregistrée telle quelle.
+SENTINELLE_NOUVELLE_FONCTION = '__autre__'
 
 TYPES_DOCUMENT = [
     ('FICHE-RENSEIGNEMENT', 'Fiche de renseignement'),
@@ -223,6 +228,15 @@ def infos_salaries():
                 ORDER BY d.type_document
             ''', (selected_id,)).fetchall()
 
+    # Référentiel des fonctions proposées (table absente tant que la migration
+    # 0064 n'est pas appliquée : la fiche doit rester affichable).
+    try:
+        fonctions = [r['libelle'] for r in conn.execute(
+            'SELECT libelle FROM fonctions ORDER BY ordre, libelle').fetchall()]
+    except sqlite3.Error:
+        logger.warning("Liste des fonctions illisible", exc_info=True)
+        fonctions = []
+
     conn.close()
 
     # Construire un dict des documents existants par type pour le template
@@ -237,6 +251,8 @@ def infos_salaries():
                            contrats=contrats,
                            documents=documents,
                            docs_par_type=docs_par_type,
+                           fonctions=fonctions,
+                           sentinelle_fonction=SENTINELLE_NOUVELLE_FONCTION,
                            types_contrat=TYPES_CONTRAT,
                            types_document=TYPES_DOCUMENT)
 
@@ -299,6 +315,81 @@ def modifier_infos_personnelles():
     conn.close()
 
     flash("Informations personnelles mises a jour.", 'success')
+    return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+
+@infos_salaries_bp.route('/infos_salaries/fonction', methods=['POST'])
+@login_required
+def modifier_fonction():
+    """Enregistrer la fonction d'un salarié.
+
+    La liste proposée est complétable : une fonction saisie dans le champ
+    « Autre » est ajoutée au référentiel commun, pour être ensuite proposée à
+    tout le monde. Elle est normalisée (espaces superflus retirés) et la table
+    porte une contrainte d'unicité, donc un doublon ne crée pas de seconde
+    entrée.
+    """
+    if not _peut_gerer():
+        flash("Acces non autorise.", 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    user_id = request.form.get('user_id', type=int)
+    fonction = request.form.get('fonction', '').strip()
+    nouvelle = request.form.get('nouvelle_fonction', '').strip()
+
+    if not user_id:
+        flash("Salarie invalide.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries'))
+
+    # Le champ libre l'emporte : il n'est rempli que si on veut créer.
+    if nouvelle:
+        fonction = nouvelle
+    elif fonction == SENTINELLE_NOUVELLE_FONCTION:
+        flash("Saisissez le nom de la nouvelle fonction.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+    if len(fonction) > 60:
+        flash("La fonction ne doit pas depasser 60 caracteres.", 'error')
+        return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+    conn = get_db()
+    try:
+        if not _est_salarie_visible(conn, user_id):
+            flash("Acces non autorise.", 'error')
+            return redirect(url_for('infos_salaries_bp.infos_salaries'))
+
+        # Hors création, la valeur doit venir du référentiel — ou être celle
+        # déjà portée par le salarié (fonction retirée de la liste depuis).
+        # Le référentiel reste ainsi la seule source des libellés.
+        if fonction and not nouvelle:
+            connue = conn.execute(
+                'SELECT 1 FROM fonctions WHERE libelle = ?', (fonction,)
+            ).fetchone()
+            actuelle = conn.execute(
+                'SELECT fonction FROM users WHERE id = ?', (user_id,)
+            ).fetchone()
+            if not connue and not (actuelle and actuelle['fonction'] == fonction):
+                flash("Fonction inconnue : choisissez-la dans la liste ou "
+                      "ajoutez-la.", 'error')
+                return redirect(
+                    url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
+
+        if nouvelle:
+            ordre = conn.execute(
+                'SELECT COALESCE(MAX(ordre), 0) + 1 AS suivant FROM fonctions'
+            ).fetchone()['suivant']
+            conn.execute(
+                'INSERT OR IGNORE INTO fonctions (libelle, ordre) VALUES (?, ?)',
+                (nouvelle, ordre)
+            )
+
+        conn.execute('UPDATE users SET fonction = ? WHERE id = ?',
+                     (fonction or None, user_id))
+        conn.commit()
+    finally:
+        conn.close()
+
+    flash("Fonction enregistree." if fonction else "Fonction retiree.", 'success')
     return redirect(url_for('infos_salaries_bp.infos_salaries', user_id=user_id))
 
 

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -196,9 +196,14 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
     # Le responsable voit les étapes des subventions dont il est assigné (parent)
     # ainsi que celles des sous-éléments qui lui sont directement attribués — en
     # cohérence avec la notification d'attribution par e-mail.
-    # La direction et la comptabilité suivent tous les dossiers. Tout autre
-    # profil — responsable, ou salarié délégué — ne voit que les étapes qui lui
-    # sont confiées.
+    # Une carte de subvention mène à la page des subventions et propose de
+    # marquer l'étape faite : les deux sont fermés à tout profil hors direction,
+    # comptabilité et responsables. On ne propose donc pas d'action que le
+    # lecteur ne pourrait ni ouvrir ni conclure.
+    suit_des_subventions = profil in ('directeur', 'comptable', 'responsable')
+
+    # La direction et la comptabilité suivent tous les dossiers ; un
+    # responsable, seulement ceux qui lui sont confiés.
     if profil in ('directeur', 'comptable'):
         sub_scope = ''
         sub_params = ()
@@ -219,7 +224,7 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
             ORDER BY se.date_echeance ASC
             LIMIT 25""",
         sub_params
-    ).fetchall()
+    ).fetchall() if suit_des_subventions else []
     # La page subventions filtre par année (année courante par défaut). Pour que
     # la subvention pointée reste visible, on cible son année si elle est dans la
     # plage du filtre (N-3..N+2), sinon « toutes » (année absente ou hors plage).

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -92,6 +92,12 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
     today = aujourd_hui()
     seuils = seuils or {}
 
+    # Seuls ces profils valident des demandes. Un salarié — même porteur d'une
+    # délégation qui lui ouvre l'accueil sans menu — n'a rien à valider : lui
+    # servir la branche « toutes les demandes » exposerait les congés, les
+    # dates et les soldes de tout le monde.
+    valide_des_demandes = profil in ('directeur', 'comptable', 'responsable')
+
     # 1. Demandes de récupération / congé à valider.
     if profil == 'responsable':
         # Équipe = secteur + rattachés directs (responsable_id), même d'un
@@ -113,7 +119,7 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
             ORDER BY d.date_demande ASC
             LIMIT 25""",
         scope_params
-    ).fetchall()
+    ).fetchall() if valide_des_demandes else []
     for r in rows:
         depot = _to_date(r['date_demande'])
         parts = [p for p in (_periode_demande(r),
@@ -157,7 +163,7 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
             ORDER BY d.date_demande ASC
             LIMIT 25""",
         scope_params
-    ).fetchall()
+    ).fetchall() if valide_des_demandes else []
     for r in rows:
         depot = _to_date(r['date_demande'])
         parts = [p for p in (_periode_demande(r),
@@ -190,12 +196,15 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
     # Le responsable voit les étapes des subventions dont il est assigné (parent)
     # ainsi que celles des sous-éléments qui lui sont directement attribués — en
     # cohérence avec la notification d'attribution par e-mail.
-    if profil == 'responsable':
-        sub_scope = 'AND (s.assignee_1_id = ? OR s.assignee_2_id = ? OR se.assignee_id = ?)'
-        sub_params = (user_id, user_id, user_id)
-    else:
+    # La direction et la comptabilité suivent tous les dossiers. Tout autre
+    # profil — responsable, ou salarié délégué — ne voit que les étapes qui lui
+    # sont confiées.
+    if profil in ('directeur', 'comptable'):
         sub_scope = ''
         sub_params = ()
+    else:
+        sub_scope = 'AND (s.assignee_1_id = ? OR s.assignee_2_id = ? OR se.assignee_id = ?)'
+        sub_params = (user_id, user_id, user_id)
 
     # On exclut uniquement les subventions refusées : une subvention acceptée
     # garde des échéances actionnables (bilans qualitatif / financier).

--- a/database.py
+++ b/database.py
@@ -81,6 +81,7 @@ ALL_MIGRATION_VERSIONS = [
     ('0061', 'Type de benevolat, date de fin et suivi des heures'),
     ('0062', 'Charte du benevolat signee'),
     ('0063', 'Delegation de la gestion des benevoles'),
+    ('0064', 'Fonction du salarie'),
 ]
 
 # Types de subvention par defaut (migration 0052)

--- a/database.py
+++ b/database.py
@@ -241,10 +241,28 @@ def init_db():
             adresse TEXT,
             date_naissance TEXT,
             numero_secu TEXT,
+            fonction TEXT,
             FOREIGN KEY (secteur_id) REFERENCES secteurs(id),
             FOREIGN KEY (responsable_id) REFERENCES users(id)
         )
     ''')
+
+    # ===== Liste des fonctions proposees (migration 0064) =====
+    # Renseignee avec les informations de contrat, completable par la direction.
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS fonctions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            libelle TEXT NOT NULL UNIQUE,
+            ordre INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+    from migrations import FONCTIONS_INITIALES
+    for ordre, libelle in enumerate(FONCTIONS_INITIALES):
+        cursor.execute(
+            'INSERT OR IGNORE INTO fonctions (libelle, ordre) VALUES (?, ?)',
+            (libelle, ordre)
+        )
 
     # ===== Table des secteurs =====
     cursor.execute('''

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -101,9 +101,35 @@ L'application représentée par zones :
 | `↵` | ouvre la proposition sélectionnée |
 | `Échap` | ferme la barre, sinon ouvre la vue d'ensemble |
 
-La barre propose d'abord les zones et les pages (c'est ce qui remplace le
-menu), puis une entrée « Rechercher … » qui envoie la requête au moteur
-existant (`POST /api/search`) et en traite le verdict comme auparavant.
+La barre fait deux choses distinctes :
+
+1. **La navigation locale** — zones et pages, filtrées par les droits du
+   lecteur. C'est ce qui remplace le menu, et cela vaut pour **tous** les
+   profils de l'interface sans menu. Personne ne se retrouve donc sans menu
+   *et* sans barre.
+2. **La recherche métier** — l'entrée « Rechercher … », qui envoie la requête
+   au moteur existant (`POST /api/search`) et en traite le verdict comme
+   auparavant. Elle route vers un enregistrement : une facture par son numéro,
+   une fiche fournisseur, un budget, la fiche temps d'un salarié…
+
+La seconde n'est proposée qu'à la **direction et à la comptabilité**. C'est la
+seule liste que `/api/search` autorise, et c'était déjà l'état antérieur : la
+barre intelligente n'existait que sur les tableaux de bord direction et
+comptabilité. La proposer à un responsable lui vaudrait un « Accès non
+autorisé » ; quand aucune page ne correspond, la palette lui suggère plutôt la
+vue d'ensemble.
+
+Pour que les deux ne divergent jamais,
+`interface_flux.recherche_globale_autorisee()` lit la liste à la source, dans
+le blueprint qui la fait respecter, et un test le verrouille.
+
+**Ouvrir la recherche métier aux autres profils** est un chantier à part
+entière, pas un élargissement de liste : le moteur reçoit bien le profil mais
+ne s'en sert jamais pour filtrer ses verdicts, il route vers 23 destinations
+dont 8 seulement sont ouvertes à un responsable, et il interroge l'effectif
+entier pour retrouver un salarié par son nom. Il faudrait donc à la fois
+filtrer les verdicts (la carte de navigation ferait un bon oracle : elle sait
+déjà quelles pages chacun peut ouvrir) et cadrer les lectures de données.
 
 ## Les autres pages
 

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -21,6 +21,13 @@ réservation de salle** ne compte pas : elle n'ouvre aucune page supplémentaire
 
 La règle est dans `navigation.est_eligible()`.
 
+Un salarié délégué reste cadré sur ce qui le concerne : il ne valide aucune
+demande, donc son fil n'en contient aucune, et l'horizon ne lui montre ni les
+contrats ni les absences de l'effectif. Il ne voit que les étapes de
+subventions qui lui sont assignées et ses propres tâches planifiées. Le cadrage
+est appliqué à la source, dans `dashboard_actions.construire_actions()` et
+`flux_accueil.construire_horizon()`, et vaut donc pour tout appelant.
+
 ## Les trois écrans
 
 ### L'accueil (`/accueil`)
@@ -34,9 +41,17 @@ La règle est dans `navigation.est_eligible()`.
   lignes à défilement horizontal — *RH* (fins de contrat, retours d'absence
   longue) et *Échéances* (étapes de subventions, tâches du planificateur).
 
-Une échéance à 7 jours ou moins appartient au fil ; au-delà, elle passe à
-l'horizon. Le seuil est `flux_accueil.JOURS_IMMEDIAT`, l'horizon s'arrête à
-`JOURS_HORIZON` (120 jours).
+Le fil et l'horizon ne se recouvrent que là où c'est nécessaire. Les **étapes
+de subventions** figurent dans le fil quelle que soit leur date : l'horizon ne
+les reprend qu'au-delà de `flux_accueil.JOURS_IMMEDIAT` (7 jours), pour ne pas
+les afficher deux fois. Les **fins de contrat, retours d'absence et tâches
+planifiées** n'apparaissent que dans l'horizon : il démarre donc à aujourd'hui
+pour elles, sans quoi elles disparaîtraient au moment précis où elles
+deviennent urgentes. L'horizon s'arrête à `JOURS_HORIZON` (120 jours).
+
+Pour la direction et la comptabilité, le fil reprend la file étendue du centre
+de contrôle qu'il remplace : factures assignées à la direction, relance des
+fiches non validées, surcharges, soldes de congés élevés.
 
 ### Le nom et la fonction, en haut à droite
 
@@ -117,7 +132,9 @@ Pour ajouter un flux d'information à une page, écrire un constructeur dans
 ## Revenir en arrière
 
 - **Pour tout le centre** : Administration → Options → décocher « Activer
-  l'interface sans menu ».
+  l'interface sans menu ». `/accueil` et `/mon-espace` redirigent alors vers le
+  tableau de bord, et le bouton « Essayer la nouvelle interface » disparaît du
+  menu latéral.
 - **Pour une personne** : « Mon espace » → « Revenir au menu classique ». Le
   choix est enregistré dans `app_settings` sous la clé
   `interface_sans_menu_user_<id>` et reste réversible.

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -38,6 +38,17 @@ Une échéance à 7 jours ou moins appartient au fil ; au-delà, elle passe à
 l'horizon. Le seuil est `flux_accueil.JOURS_IMMEDIAT`, l'horizon s'arrête à
 `JOURS_HORIZON` (120 jours).
 
+### Le nom et la fonction, en haut à droite
+
+Le nom vient de la session ; la **fonction** est celle renseignée sur la fiche
+du salarié, dans la section Contrats de « Infos salariés ». Elle se choisit
+dans une liste (table `fonctions`, pré-remplie à l'installation) complétable
+via « + Ajouter une fonction… » : la fonction créée est affectée au salarié et
+proposée ensuite pour tous.
+
+Tant qu'aucune fonction n'est renseignée, l'affichage retombe sur le profil,
+précisé par le secteur (« direction · Famille »).
+
 ### Mon espace (`/mon-espace`)
 
 Ouvert par le nom, en haut à droite. Compteurs de congés payés, de congés

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -136,6 +136,26 @@ chaque entrée pointe vers une route réelle.
 Pour ajouter un flux d'information à une page, écrire un constructeur dans
 `flux_infos.py` et l'inscrire dans `CONSTRUCTEURS` sous son endpoint.
 
+## La règle qui gouverne cartes et bandeaux
+
+**Ne jamais proposer ce que le lecteur ne peut ni ouvrir ni conclure, et ne
+jamais compter plus que la destination n'affiche.** Concrètement :
+
+- une carte du fil ou de l'horizon n'est construite que pour les profils que sa
+  page de destination accepte — pas de carte de subvention pour un salarié
+  délégué, pas de retour d'absence pour un responsable (la page Absences lui
+  est fermée) ;
+- un bandeau reprend le filtre de la page qu'il annonce — le compteur de
+  factures à approuver applique le même prédicat que la page d'approbation
+  (secteur renseigné ou assignation à la direction), les factures encore non
+  assignées étant signalées à part, vers la page Factures ;
+- un bandeau reprend aussi son cadrage — un responsable ne compte que les
+  fiches de son équipe, comme la vue d'ensemble le fait pour lui.
+
+Ces règles sont vérifiées par des tests dédiés dans
+`tests/test_interface_flux.py` : un écart entre un compteur et sa destination
+fait tomber la suite.
+
 ## Revenir en arrière
 
 - **Pour tout le centre** : Administration → Options → décocher « Activer

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -1,0 +1,123 @@
+# Interface sans menu
+
+Ce document décrit l'accueil « en flux » qui remplace le menu latéral pour une
+partie des profils, et explique comment l'ajuster.
+
+## À qui elle s'applique
+
+| Profil | Interface |
+| --- | --- |
+| Direction | sans menu |
+| Comptabilité | sans menu |
+| Responsable | sans menu |
+| Salarié **porteur d'une délégation** | sans menu |
+| Salarié sans délégation | menu latéral habituel |
+| Prestataire paie | menu latéral habituel (page unique) |
+
+Les délégations qui font basculer un salarié sont celles qui lui confient des
+pages à suivre : suivi des validations et relances, suivi et commande des
+fournitures, gestion des bénévoles. La délégation des **récurrences de
+réservation de salle** ne compte pas : elle n'ouvre aucune page supplémentaire.
+
+La règle est dans `navigation.est_eligible()`.
+
+## Les trois écrans
+
+### L'accueil (`/accueil`)
+
+- **Le fil** : uniquement ce qui attend une décision — demandes de congé et de
+  récupération à valider, factures à approuver, étapes de subventions échues,
+  relances de fiches, alertes de surcharge. Chaque carte porte ses boutons
+  d'action : valider, refuser, approuver, marquer comme fait, relancer. La
+  carte disparaît une fois traitée et l'anneau de progression avance.
+- **« À l'horizon »** : ce qui arrive sans rien demander aujourd'hui, en deux
+  lignes à défilement horizontal — *RH* (fins de contrat, retours d'absence
+  longue) et *Échéances* (étapes de subventions, tâches du planificateur).
+
+Une échéance à 7 jours ou moins appartient au fil ; au-delà, elle passe à
+l'horizon. Le seuil est `flux_accueil.JOURS_IMMEDIAT`, l'horizon s'arrête à
+`JOURS_HORIZON` (120 jours).
+
+### Mon espace (`/mon-espace`)
+
+Ouvert par le nom, en haut à droite. Compteurs de congés payés, de congés
+conventionnels et de récupérations ; dépôt d'une demande (le formulaire poste
+sur les routes existantes `/demande_conge` et `/demande_recup`, donc le circuit
+de validation et les notifications sont inchangés) ; liste des demandes en
+cours. C'est aussi de là qu'on revient au menu classique.
+
+### La vue d'ensemble (touche Échap)
+
+L'application représentée par zones :
+
+- le **cercle intérieur** porte les zones thématiques ; s'attarder sur l'une
+  d'elles déplie ses pages en couronne ;
+- le **cercle extérieur** porte les accès directs (salles, planificateur,
+  administration) ;
+- le centre porte les initiales de l'utilisateur.
+
+Échap, ou un clic dans le vide, referme.
+
+## Le clavier
+
+| Touche | Effet |
+| --- | --- |
+| n'importe quelle lettre | ouvre la barre intelligente et s'y inscrit |
+| `Ctrl` / `⌘` + `K` | ouvre la barre vide |
+| `↑` `↓` | parcourt les propositions |
+| `↵` | ouvre la proposition sélectionnée |
+| `Échap` | ferme la barre, sinon ouvre la vue d'ensemble |
+
+La barre propose d'abord les zones et les pages (c'est ce qui remplace le
+menu), puis une entrée « Rechercher … » qui envoie la requête au moteur
+existant (`POST /api/search`) et en traite le verdict comme auparavant.
+
+## Les autres pages
+
+Elles perdent leur menu et reçoivent, au-dessus de leur contenu habituel :
+
+1. un lien **« Revenir au flux »** ;
+2. les **boutons des pages voisines** de leur zone (le sous-menu d'avant) ;
+3. un **flux d'information** quand la page s'y prête.
+
+Leur titre, leurs boutons d'action (importer, relancer…) et leur contenu ne
+changent pas. Une page qui est déjà un tableau complet — la trésorerie, par
+exemple — n'a pas de flux d'information : elle reste telle quelle.
+
+## Ajouter ou déplacer une page
+
+Tout se joue dans `navigation.py` :
+
+- `ZONES` décrit le cercle intérieur, `ACCES_DIRECTS` le cercle extérieur ;
+- chaque page est déclarée par `_page(endpoint, label, profils=…)` ;
+- `condition=` nomme un drapeau du contexte utilisateur. Avec `profils` vide,
+  la condition **suffit** (délégation, appartenance au CSE) ; avec `profils`
+  renseignés, elle **restreint** (option d'administration) ;
+- `labels=` permet de nommer une même page différemment selon le profil.
+
+Les droits reproduisent ceux du menu latéral historique : ce fichier réorganise
+la présentation, il n'ouvre aucun accès. Les routes gardent leur propre
+contrôle. Un test (`test_tous_les_endpoints_de_la_carte_existent`) vérifie que
+chaque entrée pointe vers une route réelle.
+
+Pour ajouter un flux d'information à une page, écrire un constructeur dans
+`flux_infos.py` et l'inscrire dans `CONSTRUCTEURS` sous son endpoint.
+
+## Revenir en arrière
+
+- **Pour tout le centre** : Administration → Options → décocher « Activer
+  l'interface sans menu ».
+- **Pour une personne** : « Mon espace » → « Revenir au menu classique ». Le
+  choix est enregistré dans `app_settings` sous la clé
+  `interface_sans_menu_user_<id>` et reste réversible.
+
+Les tableaux de bord historiques (`/dashboard_direction`,
+`/dashboard_responsable`, `/dashboard_comptable`) restent accessibles par leur
+URL dans les deux cas.
+
+## Tests
+
+`tests/test_interface_flux.py` couvre l'éligibilité, le filtrage de la carte
+par profil et par délégation, le rendu des trois écrans, le flux d'information
+et la bascule. Les tests qui décrivent le menu latéral historique demandent la
+fixture `menu_classique`.

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -53,6 +53,13 @@ Pour la direction et la comptabilité, le fil reprend la file étendue du centre
 de contrôle qu'il remplace : factures assignées à la direction, relance des
 fiches non validées, surcharges, soldes de congés élevés.
 
+Ce sont les **seuils d'alerte** qui décident de ce qui remonte. Comme ils
+façonnent le fil, ils se règlent là où le fil s'affiche : bouton ⚙ à droite de
+l'en-tête de l'accueil, réservé à la direction et à la comptabilité. La fenêtre
+est le gabarit partagé `_seuils_modal.html`, également inclus par le centre de
+contrôle historique — les deux pages règlent donc exactement les mêmes valeurs,
+et il n'y a qu'un seul endroit à modifier pour en ajouter une.
+
 ### Le nom et la fonction, en haut à droite
 
 Le nom vient de la session ; la **fonction** est celle renseignée sur la fiche
@@ -141,7 +148,9 @@ Pour ajouter un flux d'information à une page, écrire un constructeur dans
 
 Les tableaux de bord historiques (`/dashboard_direction`,
 `/dashboard_responsable`, `/dashboard_comptable`) restent accessibles par leur
-URL dans les deux cas.
+URL dans les deux cas. Ils ne figurent pas dans la carte : l'accueil les
+remplace. Rien n'y est pour autant inaccessible — les seuils d'alerte, seul
+réglage qui n'existait que là, sont désormais sur l'accueil.
 
 ## Tests
 

--- a/flux_accueil.py
+++ b/flux_accueil.py
@@ -95,7 +95,13 @@ def _fins_de_contrat(conn, today, borne_min, borne_max, scope_sql, scope_params)
 
 
 def _retours_absence(conn, today, borne_min, borne_max, scope_sql, scope_params):
-    """Retours d'absence longue (plus de deux semaines) à préparer."""
+    """Retours d'absence longue (plus de deux semaines) à préparer.
+
+    La carte mène à la page des absences, fermée aux responsables : l'appelant
+    ne la construit donc que pour la direction et la comptabilité (voir
+    `construire_horizon`). Mieux vaut ne rien annoncer qu'annoncer un retour
+    dont on ne peut pas ouvrir le détail.
+    """
     rows = conn.execute(
         f'''SELECT a.date_fin, a.motif, a.jours_ouvres, u.nom, u.prenom
             FROM absences a
@@ -229,8 +235,13 @@ def construire_horizon(conn, profil, user_id, secteur_id=None):
 
     rh = []
     if suit_l_effectif:
-        for lecture, args in ((_fins_de_contrat, (scope_sql, scope_params)),
-                              (_retours_absence, (scope_sql, scope_params))):
+        # Les fins de contrat mènent à « Infos salariés », ouverte aussi aux
+        # responsables ; les retours d'absence mènent à « Absences », qui ne
+        # l'est pas. Chaque carte n'est produite que pour qui peut la suivre.
+        lectures = [(_fins_de_contrat, (scope_sql, scope_params))]
+        if profil in ('directeur', 'comptable'):
+            lectures.append((_retours_absence, (scope_sql, scope_params)))
+        for lecture, args in lectures:
             try:
                 rh.extend(lecture(conn, today, borne_min, borne_max, *args))
             except Exception:

--- a/flux_accueil.py
+++ b/flux_accueil.py
@@ -124,12 +124,16 @@ def _retours_absence(conn, today, borne_min, borne_max, scope_sql, scope_params)
 
 
 def _etapes_subventions(conn, today, borne_min, borne_max, profil, user_id):
-    """Étapes de subventions dont l'échéance n'est pas encore imminente."""
-    if profil == 'responsable':
+    """Étapes de subventions dont l'échéance n'est pas encore imminente.
+
+    Même règle que le fil d'actions : la direction et la comptabilité suivent
+    tous les dossiers, les autres seulement ceux qui leur sont confiés.
+    """
+    if profil in ('directeur', 'comptable'):
+        scope, params = '', ()
+    else:
         scope = 'AND (s.assignee_1_id = ? OR s.assignee_2_id = ? OR se.assignee_id = ?)'
         params = (user_id, user_id, user_id)
-    else:
-        scope, params = '', ()
     rows = conn.execute(
         f'''SELECT se.nom AS etape, se.date_echeance, s.nom AS sub_nom, s.annee_action
             FROM subventions_sous_elements se
@@ -202,10 +206,19 @@ def construire_horizon(conn, profil, user_id, secteur_id=None):
     (base non migrée) neutralise seulement la ligne concernée.
     """
     today = aujourd_hui()
-    borne_min = today + timedelta(days=JOURS_IMMEDIAT)
     borne_max = today + timedelta(days=JOURS_HORIZON)
+    # Seules les étapes de subventions remontent aussi dans le fil d'actions :
+    # elles seules démarrent après le délai d'immédiateté, pour ne pas y figurer
+    # deux fois. Les fins de contrat, les retours d'absence et les tâches
+    # planifiées n'apparaissent nulle part ailleurs : les écarter à sept jours
+    # les ferait disparaître au moment précis où elles deviennent urgentes.
+    borne_subventions = today + timedelta(days=JOURS_IMMEDIAT)
+    borne_min = today
 
-    # Un responsable ne voit que son équipe ; direction et comptabilité voient tout.
+    # Direction et comptabilité voient tout l'effectif ; un responsable, son
+    # équipe. Tout autre profil — un salarié délégué, par exemple — n'a pas à
+    # connaître les contrats ni les absences de qui que ce soit.
+    suit_l_effectif = profil in ('directeur', 'comptable', 'responsable')
     if profil == 'responsable':
         scope_sql = 'AND (u.secteur_id = ? OR u.responsable_id = ?)'
         scope_params = (secteur_id, user_id)
@@ -215,20 +228,21 @@ def construire_horizon(conn, profil, user_id, secteur_id=None):
     lignes = []
 
     rh = []
-    for lecture, args in ((_fins_de_contrat, (scope_sql, scope_params)),
-                          (_retours_absence, (scope_sql, scope_params))):
-        try:
-            rh.extend(lecture(conn, today, borne_min, borne_max, *args))
-        except Exception:
-            logger.warning("Horizon RH : lecture ignorée", exc_info=True)
+    if suit_l_effectif:
+        for lecture, args in ((_fins_de_contrat, (scope_sql, scope_params)),
+                              (_retours_absence, (scope_sql, scope_params))):
+            try:
+                rh.extend(lecture(conn, today, borne_min, borne_max, *args))
+            except Exception:
+                logger.warning("Horizon RH : lecture ignorée", exc_info=True)
     if rh:
         rh.sort(key=lambda i: i['jours'])
         lignes.append({'titre': 'RH', 'items': rh[:12]})
 
     echeances = []
     try:
-        echeances.extend(_etapes_subventions(conn, today, borne_min, borne_max,
-                                             profil, user_id))
+        echeances.extend(_etapes_subventions(conn, today, borne_subventions,
+                                             borne_max, profil, user_id))
     except Exception:
         logger.warning("Horizon subventions : lecture ignorée", exc_info=True)
     try:

--- a/flux_accueil.py
+++ b/flux_accueil.py
@@ -1,0 +1,254 @@
+"""
+Zone « À l'horizon » de l'accueil sans menu.
+
+Le fil d'actions (`dashboard_actions.construire_actions`) ne montre que ce qui
+appelle une décision maintenant. « À l'horizon » montre l'inverse : ce qui ne
+demande rien aujourd'hui mais arrive — pour qu'aucune échéance ne soit
+découverte en retard.
+
+Deux lignes, à défilement horizontal :
+- « RH » : fins de contrat et retours d'absence à préparer ;
+- « Échéances » : étapes de subventions et tâches planifiées.
+
+Le seuil de bascule est `JOURS_IMMEDIAT` : en deçà, l'élément appartient au fil
+d'actions et n'est pas repris ici, pour ne jamais afficher deux fois la même
+échéance.
+"""
+import logging
+from datetime import date, timedelta
+
+from flask import url_for
+
+from utils import aujourd_hui
+
+logger = logging.getLogger(__name__)
+
+# Une échéance à 7 jours ou moins relève du fil d'actions, pas de l'horizon.
+JOURS_IMMEDIAT = 7
+# Au-delà, l'information devient du bruit.
+JOURS_HORIZON = 120
+
+_MOIS_COURTS = ['', 'janv.', 'févr.', 'mars', 'avr.', 'mai', 'juin',
+                'juil.', 'août', 'sept.', 'oct.', 'nov.', 'déc.']
+
+
+def _to_date(valeur):
+    """Parse les 10 premiers caractères (YYYY-MM-DD) ; None si invalide."""
+    if not valeur:
+        return None
+    try:
+        return date.fromisoformat(str(valeur)[:10])
+    except ValueError:
+        return None
+
+
+def _date_courte(d):
+    """date -> « 12 sept. » (l'année n'apparaît que si elle change)."""
+    if not d:
+        return ''
+    if d.year != aujourd_hui().year:
+        return f"{d.day} {_MOIS_COURTS[d.month]} {d.year}"
+    return f"{d.day} {_MOIS_COURTS[d.month]}"
+
+
+def _item(titre, detail, echeance, lien, today):
+    """Élément d'horizon, coloré par la distance à l'échéance."""
+    jours = (echeance - today).days
+    return {
+        'titre': titre,
+        'detail': detail,
+        'date': _date_courte(echeance),
+        'jours': jours,
+        'ton': 'proche' if jours <= 21 else ('moyen' if jours <= 60 else 'lointain'),
+        'lien': lien,
+    }
+
+
+def _fins_de_contrat(conn, today, borne_min, borne_max, scope_sql, scope_params):
+    """Contrats à durée déterminée qui arrivent à leur terme."""
+    rows = conn.execute(
+        f'''SELECT c.date_fin, c.type_contrat, u.nom, u.prenom
+            FROM contrats c
+            JOIN users u ON u.id = c.user_id
+            WHERE c.date_fin IS NOT NULL AND c.date_fin != ''
+              AND c.date_fin > ? AND c.date_fin <= ?
+              AND u.actif = 1 AND u.profil != 'prestataire'
+              {scope_sql}
+            ORDER BY c.date_fin ASC
+            LIMIT 12''',
+        (borne_min.isoformat(), borne_max.isoformat()) + scope_params
+    ).fetchall()
+    items = []
+    for r in rows:
+        fin = _to_date(r['date_fin'])
+        if not fin:
+            continue
+        type_contrat = (r['type_contrat'] or 'contrat').strip()
+        items.append(_item(
+            f"Fin de {type_contrat} — {r['prenom']} {r['nom']}",
+            'Renouveler, transformer ou solder',
+            fin,
+            url_for('infos_salaries_bp.infos_salaries'),
+            today,
+        ))
+    return items
+
+
+def _retours_absence(conn, today, borne_min, borne_max, scope_sql, scope_params):
+    """Retours d'absence longue (plus de deux semaines) à préparer."""
+    rows = conn.execute(
+        f'''SELECT a.date_fin, a.motif, a.jours_ouvres, u.nom, u.prenom
+            FROM absences a
+            JOIN users u ON u.id = a.user_id
+            WHERE a.date_fin > ? AND a.date_fin <= ?
+              AND a.jours_ouvres >= 10
+              AND u.actif = 1
+              {scope_sql}
+            ORDER BY a.date_fin ASC
+            LIMIT 8''',
+        (borne_min.isoformat(), borne_max.isoformat()) + scope_params
+    ).fetchall()
+    items = []
+    for r in rows:
+        fin = _to_date(r['date_fin'])
+        if not fin:
+            continue
+        items.append(_item(
+            f"Retour de {r['prenom']} {r['nom']}",
+            f"{(r['motif'] or 'absence').capitalize()} — reprise à organiser",
+            fin,
+            url_for('absences_bp.absences'),
+            today,
+        ))
+    return items
+
+
+def _etapes_subventions(conn, today, borne_min, borne_max, profil, user_id):
+    """Étapes de subventions dont l'échéance n'est pas encore imminente."""
+    if profil == 'responsable':
+        scope = 'AND (s.assignee_1_id = ? OR s.assignee_2_id = ? OR se.assignee_id = ?)'
+        params = (user_id, user_id, user_id)
+    else:
+        scope, params = '', ()
+    rows = conn.execute(
+        f'''SELECT se.nom AS etape, se.date_echeance, s.nom AS sub_nom, s.annee_action
+            FROM subventions_sous_elements se
+            JOIN subventions s ON s.id = se.subvention_id
+            WHERE se.date_echeance IS NOT NULL AND se.date_echeance != ''
+              AND se.date_echeance > ? AND se.date_echeance <= ?
+              AND se.statut != 'fait'
+              AND s.groupe != 'refusee'
+              {scope}
+            ORDER BY se.date_echeance ASC
+            LIMIT 12''',
+        (borne_min.isoformat(), borne_max.isoformat()) + params
+    ).fetchall()
+    # La page subventions filtre par année : on cible celle du dossier si elle
+    # est dans la plage du filtre, sinon « toutes ».
+    annee_min, annee_max = today.year - 3, today.year + 2
+    items = []
+    for r in rows:
+        ech = _to_date(r['date_echeance'])
+        if not ech:
+            continue
+        annee = (r['annee_action'] or '').strip()
+        if annee.isdigit() and len(annee) == 4 and annee_min <= int(annee) <= annee_max:
+            lien = url_for('subventions_bp.gestion_subventions', annee=annee)
+        else:
+            lien = url_for('subventions_bp.gestion_subventions', annee='toutes')
+        items.append(_item(
+            f"{r['sub_nom']} — {r['etape']}",
+            f"Subvention{f' {annee}' if annee else ''}",
+            ech, lien, today,
+        ))
+    return items
+
+
+def _taches_planifiees(conn, today, borne_min, borne_max, user_id):
+    """Tâches du planificateur dont l'échéance approche."""
+    if not user_id:
+        return []
+    rows = conn.execute(
+        '''SELECT titre, deadline, priorite
+           FROM planif_taches
+           WHERE user_id = ? AND statut NOT IN ('fait', 'annule')
+             AND deadline IS NOT NULL AND deadline != ''
+             AND deadline > ? AND deadline <= ?
+           ORDER BY deadline ASC
+           LIMIT 8''',
+        (user_id, borne_min.isoformat(), borne_max.isoformat())
+    ).fetchall()
+    items = []
+    for r in rows:
+        ech = _to_date(r['deadline'])
+        if not ech:
+            continue
+        priorite = (r['priorite'] or 'normale').replace('_', ' ')
+        items.append(_item(
+            r['titre'],
+            f"Tâche planifiée — priorité {priorite}",
+            ech,
+            url_for('planificateur_bp.planificateur'),
+            today,
+        ))
+    return items
+
+
+def construire_horizon(conn, profil, user_id, secteur_id=None):
+    """Retourne les deux lignes de la zone « À l'horizon ».
+
+    Chaque ligne est `{'titre', 'items'}` ; une ligne sans élément est omise.
+    Aucune de ces lectures ne doit faire tomber l'accueil : une table absente
+    (base non migrée) neutralise seulement la ligne concernée.
+    """
+    today = aujourd_hui()
+    borne_min = today + timedelta(days=JOURS_IMMEDIAT)
+    borne_max = today + timedelta(days=JOURS_HORIZON)
+
+    # Un responsable ne voit que son équipe ; direction et comptabilité voient tout.
+    if profil == 'responsable':
+        scope_sql = 'AND (u.secteur_id = ? OR u.responsable_id = ?)'
+        scope_params = (secteur_id, user_id)
+    else:
+        scope_sql, scope_params = '', ()
+
+    lignes = []
+
+    rh = []
+    for lecture, args in ((_fins_de_contrat, (scope_sql, scope_params)),
+                          (_retours_absence, (scope_sql, scope_params))):
+        try:
+            rh.extend(lecture(conn, today, borne_min, borne_max, *args))
+        except Exception:
+            logger.warning("Horizon RH : lecture ignorée", exc_info=True)
+    if rh:
+        rh.sort(key=lambda i: i['jours'])
+        lignes.append({'titre': 'RH', 'items': rh[:12]})
+
+    echeances = []
+    try:
+        echeances.extend(_etapes_subventions(conn, today, borne_min, borne_max,
+                                             profil, user_id))
+    except Exception:
+        logger.warning("Horizon subventions : lecture ignorée", exc_info=True)
+    try:
+        echeances.extend(_taches_planifiees(conn, today, borne_min, borne_max, user_id))
+    except Exception:
+        logger.warning("Horizon planificateur : lecture ignorée", exc_info=True)
+    if echeances:
+        echeances.sort(key=lambda i: i['jours'])
+        lignes.append({'titre': 'Échéances', 'items': echeances[:12]})
+
+    return lignes
+
+
+def separer_actions(actions):
+    """Sépare le fil d'actions de ce qui relève de l'horizon.
+
+    Les étapes de subventions lointaines remontent déjà dans « À l'horizon » :
+    les laisser dans le fil ferait doublon et noierait les vraies décisions. Le
+    reste (demandes à valider, factures, relances, surcharges) reste dans le fil
+    quelle que soit son urgence — ce sont des décisions, pas des échéances.
+    """
+    return [a for a in actions
+            if not (a.get('categorie') == 'subvention' and a.get('urgence') == 'normal')]

--- a/flux_infos.py
+++ b/flux_infos.py
@@ -36,14 +36,24 @@ def _info(icone, valeur, libelle, lien, lien_texte, ton='calme'):
 
 
 def _factures(conn, contexte):
-    """Ce que la page Factures doit signaler avant sa liste."""
+    """Ce que la page Factures doit signaler avant sa liste.
+
+    Les compteurs d'approbation reprennent le filtre de la page d'approbation
+    (`factures_bp.approbation_factures`) : elle n'affiche que les factures
+    rattachées à un secteur ou assignées à la direction. Annoncer un nombre
+    plus grand enverrait vers une page qui en montre moins — ou vide. Les
+    factures non assignées sont signalées à part, vers leur vraie destination.
+    """
     if contexte.get('profil') not in _COMPTA:
         return []
     today = aujourd_hui().isoformat()
+    # Ce que la page d'approbation liste réellement.
+    approuvables = "(secteur_id IS NOT NULL OR assigned_direction = 1)"
     infos = []
 
     attente = conn.execute(
-        "SELECT COUNT(*) AS nb FROM factures WHERE approbation = 'en_attente'"
+        f"""SELECT COUNT(*) AS nb FROM factures
+            WHERE approbation = 'en_attente' AND {approuvables}"""
     ).fetchone()['nb']
     if attente:
         infos.append(_info(
@@ -53,10 +63,10 @@ def _factures(conn, contexte):
         ))
 
     retard = conn.execute(
-        '''SELECT COUNT(*) AS nb FROM factures
-           WHERE approbation = 'en_attente'
-             AND date_echeance IS NOT NULL AND date_echeance != ''
-             AND date_echeance < ?''',
+        f'''SELECT COUNT(*) AS nb FROM factures
+            WHERE approbation = 'en_attente' AND {approuvables}
+              AND date_echeance IS NOT NULL AND date_echeance != ''
+              AND date_echeance < ?''',
         (today,)
     ).fetchone()['nb']
     if retard:
@@ -64,6 +74,20 @@ def _factures(conn, contexte):
             '⏰', retard, "facture(s) dont l'échéance est dépassée",
             url_for('factures_bp.approbation_factures'), 'Traiter',
             'alerte',
+        ))
+
+    # Une facture importée sans secteur ni direction n'est encore entrée dans
+    # aucun circuit : elle n'est pas « à approuver », elle est à assigner.
+    a_assigner = conn.execute(
+        """SELECT COUNT(*) AS nb FROM factures
+           WHERE approbation = 'en_attente'
+             AND secteur_id IS NULL AND assigned_direction = 0"""
+    ).fetchone()['nb']
+    if a_assigner:
+        infos.append(_info(
+            '📥', a_assigner, 'facture(s) à assigner à un secteur',
+            url_for('factures_bp.liste_factures'), 'Assigner',
+            'attention',
         ))
 
     orphelines = conn.execute(
@@ -164,36 +188,78 @@ def _subventions(conn, contexte):
 
 
 def _validations(conn, contexte):
-    """Ce que la vue d'ensemble des validations doit signaler."""
+    """Ce que la vue d'ensemble des validations doit signaler.
+
+    Deux cadrages distincts, calqués sur ce que le lecteur peut réellement
+    voir et faire :
+    - le décompte des fiches suit la page elle-même, qui borne un responsable
+      sans délégation à son équipe ;
+    - le bandeau des demandes à valider n'apparaît que pour les profils que
+      `recup_bp.validation_demandes_recup` accepte. Un salarié délégué au
+      suivi des validations n'y a pas droit — sa délégation porte sur le suivi
+      des fiches, pas sur les décisions de congés.
+    """
+    profil = contexte.get('profil')
+    user_id = contexte.get('user_id')
     today = aujourd_hui()
     mois_prec = today.month - 1 or 12
     annee_prec = today.year if today.month > 1 else today.year - 1
     infos = []
 
+    # Un responsable ne suit que son équipe ; les autres lecteurs de la page
+    # (direction, comptabilité, délégué au suivi) la voient en entier.
+    equipe_seule = profil == 'responsable'
+    if equipe_seule:
+        secteur = conn.execute('SELECT secteur_id FROM users WHERE id = ?',
+                               (user_id,)).fetchone()
+        scope = 'AND (u.secteur_id = ? OR u.responsable_id = ?)'
+        params = (secteur['secteur_id'] if secteur else None, user_id)
+    else:
+        scope, params = '', ()
+
     non_validees = conn.execute(
-        '''SELECT COUNT(*) AS nb FROM users u
-           WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
-             AND NOT EXISTS (
-                 SELECT 1 FROM validations v
-                 WHERE v.user_id = u.id AND v.mois = ? AND v.annee = ? AND v.bloque = 1
-             )''',
-        (mois_prec, annee_prec)
+        f'''SELECT COUNT(*) AS nb FROM users u
+            WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+              {scope}
+              AND NOT EXISTS (
+                  SELECT 1 FROM validations v
+                  WHERE v.user_id = u.id AND v.mois = ? AND v.annee = ? AND v.bloque = 1
+              )''',
+        params + (mois_prec, annee_prec)
     ).fetchone()['nb']
     if non_validees:
         infos.append(_info(
             '✅', non_validees,
-            f"fiche(s) de {NOMS_MOIS[mois_prec].lower()} non validée(s)",
+            f"fiche(s) de {NOMS_MOIS[mois_prec].lower()} non validée(s)"
+            + (' dans votre équipe' if equipe_seule else ''),
             url_for('validation_bp.vue_ensemble_validation'), 'Vue mensuelle',
             'alerte' if today.day > 10 else 'attention',
         ))
 
-    attente = conn.execute(
-        '''SELECT (SELECT COUNT(*) FROM demandes_recup
-                   WHERE statut IN ('en_attente_responsable', 'en_attente_direction'))
-                + (SELECT COUNT(*) FROM demandes_conges
-                   WHERE statut IN ('en_attente_responsable', 'en_attente_direction'))
-                AS nb'''
-    ).fetchone()['nb']
+    if profil not in ('directeur', 'comptable', 'responsable'):
+        return infos
+
+    if equipe_seule:
+        attente = conn.execute(
+            '''SELECT (SELECT COUNT(*) FROM demandes_recup d
+                       JOIN users u ON u.id = d.user_id
+                       WHERE d.statut = 'en_attente_responsable'
+                         AND (u.secteur_id = ? OR u.responsable_id = ?))
+                    + (SELECT COUNT(*) FROM demandes_conges d
+                       JOIN users u ON u.id = d.user_id
+                       WHERE d.statut = 'en_attente_responsable'
+                         AND (u.secteur_id = ? OR u.responsable_id = ?))
+                    AS nb''',
+            params + params
+        ).fetchone()['nb']
+    else:
+        attente = conn.execute(
+            '''SELECT (SELECT COUNT(*) FROM demandes_recup
+                       WHERE statut IN ('en_attente_responsable', 'en_attente_direction'))
+                    + (SELECT COUNT(*) FROM demandes_conges
+                       WHERE statut IN ('en_attente_responsable', 'en_attente_direction'))
+                    AS nb'''
+        ).fetchone()['nb']
     if attente:
         infos.append(_info(
             '📋', attente, 'demande(s) en attente de validation',

--- a/flux_infos.py
+++ b/flux_infos.py
@@ -1,0 +1,231 @@
+"""
+Flux d'information des pages, dans l'interface sans menu.
+
+Sans menu, une page ne s'ouvre plus « pour voir » : on y arrive depuis le fil,
+la barre intelligente ou la vue d'ensemble. Elle doit donc dire d'emblée ce
+qu'elle a à signaler — factures non validées, écritures à générer, étapes en
+retard — avant la liste elle-même.
+
+Chaque entrée est un bandeau court : `{icone, valeur, libelle, lien,
+lien_texte, ton}`. Le ton (`alerte`, `attention`, `calme`) donne la couleur.
+
+Toutes les pages n'ont pas de flux : la trésorerie, par exemple, EST son
+tableau. Une page sans constructeur n'affiche simplement rien de plus.
+"""
+import logging
+
+from flask import url_for
+
+from utils import NOMS_MOIS, aujourd_hui
+
+logger = logging.getLogger(__name__)
+
+# Profils qui voient les flux financiers (mêmes droits que les pages elles-mêmes).
+_COMPTA = ('directeur', 'comptable')
+
+
+def _info(icone, valeur, libelle, lien, lien_texte, ton='calme'):
+    return {
+        'icone': icone,
+        'valeur': valeur,
+        'libelle': libelle,
+        'lien': lien,
+        'lien_texte': lien_texte,
+        'ton': ton,
+    }
+
+
+def _factures(conn, contexte):
+    """Ce que la page Factures doit signaler avant sa liste."""
+    if contexte.get('profil') not in _COMPTA:
+        return []
+    today = aujourd_hui().isoformat()
+    infos = []
+
+    attente = conn.execute(
+        "SELECT COUNT(*) AS nb FROM factures WHERE approbation = 'en_attente'"
+    ).fetchone()['nb']
+    if attente:
+        infos.append(_info(
+            '🧾', attente, 'facture(s) en attente d\'approbation',
+            url_for('factures_bp.approbation_factures'), 'Approuver',
+            'attention',
+        ))
+
+    retard = conn.execute(
+        '''SELECT COUNT(*) AS nb FROM factures
+           WHERE approbation = 'en_attente'
+             AND date_echeance IS NOT NULL AND date_echeance != ''
+             AND date_echeance < ?''',
+        (today,)
+    ).fetchone()['nb']
+    if retard:
+        infos.append(_info(
+            '⏰', retard, "facture(s) dont l'échéance est dépassée",
+            url_for('factures_bp.approbation_factures'), 'Traiter',
+            'alerte',
+        ))
+
+    orphelines = conn.execute(
+        'SELECT COUNT(*) AS nb FROM factures WHERE fournisseur_id IS NULL'
+    ).fetchone()['nb']
+    if orphelines:
+        infos.append(_info(
+            '🏢', orphelines, 'facture(s) sans fournisseur rattaché',
+            url_for('fournisseurs_bp.liste_fournisseurs'), 'Fournisseurs',
+        ))
+
+    return infos
+
+
+def _ecritures(conn, contexte):
+    """Ce que la page Écritures doit signaler."""
+    if contexte.get('profil') not in _COMPTA:
+        return []
+    infos = []
+
+    a_generer = conn.execute(
+        "SELECT COUNT(*) AS nb FROM factures WHERE statut = 'a_traiter'"
+    ).fetchone()['nb']
+    if a_generer:
+        infos.append(_info(
+            '⚙', a_generer, 'facture(s) sans écriture — à générer',
+            url_for('ecritures_bp.liste_ecritures'), 'Générer',
+            'attention',
+        ))
+
+    brouillons = conn.execute(
+        "SELECT COUNT(*) AS nb FROM ecritures_comptables WHERE statut = 'brouillon'"
+    ).fetchone()['nb']
+    if brouillons:
+        infos.append(_info(
+            '📝', brouillons, 'écriture(s) en brouillon à valider',
+            url_for('ecritures_bp.liste_ecritures'), 'Valider',
+            'attention',
+        ))
+
+    validees = conn.execute(
+        "SELECT COUNT(*) AS nb FROM ecritures_comptables WHERE statut = 'validee'"
+    ).fetchone()['nb']
+    if validees:
+        infos.append(_info(
+            '📤', validees, 'écriture(s) validée(s), prêtes à exporter',
+            url_for('exportation_bp.liste_exportation'), 'Exporter',
+        ))
+
+    return infos
+
+
+def _subventions(conn, contexte):
+    """Ce que la page Subventions doit signaler."""
+    profil = contexte.get('profil')
+    user_id = contexte.get('user_id')
+    if profil == 'responsable':
+        scope = 'AND (s.assignee_1_id = ? OR s.assignee_2_id = ? OR se.assignee_id = ?)'
+        params = (user_id, user_id, user_id)
+    elif profil in _COMPTA:
+        scope, params = '', ()
+    else:
+        return []
+
+    today = aujourd_hui().isoformat()
+    infos = []
+
+    retard = conn.execute(
+        f'''SELECT COUNT(*) AS nb
+            FROM subventions_sous_elements se
+            JOIN subventions s ON s.id = se.subvention_id
+            WHERE se.date_echeance IS NOT NULL AND se.date_echeance != ''
+              AND se.date_echeance < ? AND se.statut != 'fait'
+              AND s.groupe != 'refusee' {scope}''',
+        (today,) + params
+    ).fetchone()['nb']
+    if retard:
+        infos.append(_info(
+            '🚨', retard, "étape(s) dont l'échéance est passée",
+            url_for('subventions_bp.gestion_subventions', annee='toutes'), 'Voir',
+            'alerte',
+        ))
+
+    en_cours = conn.execute(
+        f'''SELECT COUNT(*) AS nb
+            FROM subventions_sous_elements se
+            JOIN subventions s ON s.id = se.subvention_id
+            WHERE se.statut != 'fait' AND s.groupe != 'refusee' {scope}''',
+        params
+    ).fetchone()['nb']
+    if en_cours:
+        infos.append(_info(
+            '📋', en_cours, 'étape(s) encore ouverte(s)',
+            url_for('subventions_bp.gestion_subventions', annee='toutes'), 'Suivre',
+        ))
+
+    return infos
+
+
+def _validations(conn, contexte):
+    """Ce que la vue d'ensemble des validations doit signaler."""
+    today = aujourd_hui()
+    mois_prec = today.month - 1 or 12
+    annee_prec = today.year if today.month > 1 else today.year - 1
+    infos = []
+
+    non_validees = conn.execute(
+        '''SELECT COUNT(*) AS nb FROM users u
+           WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+             AND NOT EXISTS (
+                 SELECT 1 FROM validations v
+                 WHERE v.user_id = u.id AND v.mois = ? AND v.annee = ? AND v.bloque = 1
+             )''',
+        (mois_prec, annee_prec)
+    ).fetchone()['nb']
+    if non_validees:
+        infos.append(_info(
+            '✅', non_validees,
+            f"fiche(s) de {NOMS_MOIS[mois_prec].lower()} non validée(s)",
+            url_for('validation_bp.vue_ensemble_validation'), 'Vue mensuelle',
+            'alerte' if today.day > 10 else 'attention',
+        ))
+
+    attente = conn.execute(
+        '''SELECT (SELECT COUNT(*) FROM demandes_recup
+                   WHERE statut IN ('en_attente_responsable', 'en_attente_direction'))
+                + (SELECT COUNT(*) FROM demandes_conges
+                   WHERE statut IN ('en_attente_responsable', 'en_attente_direction'))
+                AS nb'''
+    ).fetchone()['nb']
+    if attente:
+        infos.append(_info(
+            '📋', attente, 'demande(s) en attente de validation',
+            url_for('recup_bp.validation_demandes_recup'), 'Valider',
+            'attention',
+        ))
+
+    return infos
+
+
+# Constructeurs par endpoint. Une page absente de cette table n'affiche pas de
+# flux : c'est le cas voulu pour les pages qui sont déjà un tableau complet.
+CONSTRUCTEURS = {
+    'factures_bp.liste_factures': _factures,
+    'ecritures_bp.liste_ecritures': _ecritures,
+    'subventions_bp.gestion_subventions': _subventions,
+    'validation_bp.vue_ensemble_validation': _validations,
+}
+
+
+def construire(conn, endpoint, contexte):
+    """Flux d'information d'une page, ou liste vide.
+
+    Ne doit jamais faire tomber la page qu'elle décore : toute erreur de lecture
+    (table absente sur une base non migrée, base verrouillée) se solde par un
+    flux vide.
+    """
+    constructeur = CONSTRUCTEURS.get(endpoint)
+    if not constructeur:
+        return []
+    try:
+        return constructeur(conn, contexte)
+    except Exception:
+        logger.warning("Flux d'information indisponible pour %s", endpoint, exc_info=True)
+        return []

--- a/interface_flux.py
+++ b/interface_flux.py
@@ -1,0 +1,237 @@
+"""
+Activation et contexte de l'interface sans menu.
+
+Trois questions, une réponse par requête (mémorisée dans `flask.g`) :
+- l'interface est-elle active pour cet utilisateur ?
+- quelles zones et quelles pages a-t-il le droit de voir ?
+- que doit afficher la page courante en plus de son contenu ?
+
+L'activation se décide à trois niveaux, du plus général au plus personnel :
+1. l'option d'administration `interface_sans_menu_active` (tout le centre) ;
+2. l'éligibilité du profil (`navigation.est_eligible`) ;
+3. le choix de l'utilisateur, qui peut toujours revenir au menu historique.
+"""
+import logging
+
+from flask import has_request_context, request, session
+
+import navigation
+from utils import delete_setting, get_setting, save_setting
+
+logger = logging.getLogger(__name__)
+
+OPTION_GLOBALE = 'interface_sans_menu_active'
+
+# Libellés de profil affichés sous le nom, en haut à droite.
+LIBELLES_PROFIL = {
+    'directeur': 'direction',
+    'comptable': 'comptabilité',
+    'responsable': 'responsable',
+    'salarie': 'salarié',
+    'prestataire': 'prestataire',
+}
+
+
+def _cle_preference(user_id):
+    return f'interface_sans_menu_user_{user_id}'
+
+
+def preference_utilisateur(user_id):
+    """Choix personnel : True, False, ou None si l'utilisateur n'a rien choisi."""
+    if not user_id:
+        return None
+    try:
+        valeur = get_setting(_cle_preference(user_id))
+    except Exception:
+        logger.warning("Préférence d'interface illisible", exc_info=True)
+        return None
+    if valeur is None:
+        return None
+    return str(valeur).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def definir_preference_utilisateur(user_id, actif):
+    """Enregistre le choix personnel d'un utilisateur."""
+    if not user_id:
+        return
+    if actif:
+        # Revenir au défaut plutôt que de figer un « oui » : si l'option
+        # globale change un jour, l'utilisateur suit le centre.
+        delete_setting(_cle_preference(user_id))
+    else:
+        save_setting(_cle_preference(user_id), '0')
+
+
+def option_globale_active():
+    """L'interface sans menu est-elle activée pour le centre ?"""
+    try:
+        from app_options import get_option_bool
+        return get_option_bool(OPTION_GLOBALE)
+    except Exception:
+        logger.warning("Option interface sans menu illisible", exc_info=True)
+        return False
+
+
+def interface_active(profil, user_id):
+    """Décide si la requête courante doit être servie sans menu."""
+    if not user_id:
+        return False
+    if not option_globale_active():
+        return False
+    if not navigation.est_eligible(profil, user_id):
+        return False
+    return preference_utilisateur(user_id) is not False
+
+
+def _drapeaux(profil, user_id):
+    """Drapeaux de droits utilisés pour filtrer la carte de navigation.
+
+    Reprend exactement les conditions du menu latéral historique : ce module
+    n'ouvre aucune page qui n'était pas déjà proposée.
+    """
+    drapeaux = {
+        'profil': profil,
+        'user_id': user_id,
+        'is_cse_membre': False,
+        'is_delegue_benevoles': False,
+        'can_access_vue_ensemble_validation': profil in ('directeur', 'comptable', 'responsable'),
+        'generation_contrats_responsable_autorise': True,
+        'budget_previsionnel_responsable_autorise': True,
+    }
+
+    try:
+        from app_options import get_option_bool
+        drapeaux['generation_contrats_responsable_autorise'] = get_option_bool(
+            'generation_contrats_responsable_autorise')
+        drapeaux['budget_previsionnel_responsable_autorise'] = get_option_bool(
+            'budget_previsionnel_responsable_autorise')
+    except Exception:
+        logger.warning("Options applicatives illisibles", exc_info=True)
+
+    # La direction et la comptabilité voient déjà les bénévoles, le CSE et la
+    # vue d'ensemble par leur profil : inutile d'interroger la base pour des
+    # droits qu'elles ont de toute façon. Ces lectures ne concernent que les
+    # responsables et les salariés délégués.
+    if profil in ('directeur', 'comptable'):
+        return drapeaux
+
+    try:
+        from blueprints.delegations import (MISSION_SUIVI_VALIDATIONS_RELANCES,
+                                            user_has_delegation,
+                                            user_peut_gerer_benevoles)
+        drapeaux['is_delegue_benevoles'] = user_peut_gerer_benevoles(user_id)
+        if not drapeaux['can_access_vue_ensemble_validation']:
+            drapeaux['can_access_vue_ensemble_validation'] = user_has_delegation(
+                user_id, MISSION_SUIVI_VALIDATIONS_RELANCES)
+    except Exception:
+        logger.warning("Délégations illisibles", exc_info=True)
+
+    try:
+        from blueprints.cse import est_membre_cse
+        from database import get_db
+        conn = get_db()
+        try:
+            drapeaux['is_cse_membre'] = est_membre_cse(conn, user_id)
+        finally:
+            conn.close()
+    except Exception:
+        logger.warning("Appartenance au CSE illisible", exc_info=True)
+
+    return drapeaux
+
+
+def _identite(profil, user_id):
+    """Nom, fonction et initiales affichés en haut à droite.
+
+    Faute de champ « fonction » sur les comptes, la fonction affichée est le
+    profil, précisé par le secteur quand il y en a un — c'est l'information
+    dont dispose réellement l'application.
+    """
+    prenom = (session.get('prenom') or '').strip()
+    nom = (session.get('nom') or '').strip()
+    fonction = LIBELLES_PROFIL.get(profil, profil or '')
+
+    try:
+        from database import get_db
+        conn = get_db()
+        try:
+            row = conn.execute(
+                '''SELECT s.nom AS secteur FROM users u
+                   LEFT JOIN secteurs s ON s.id = u.secteur_id
+                   WHERE u.id = ?''', (user_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        if row and row['secteur']:
+            fonction = f"{fonction} · {row['secteur']}"
+    except Exception:
+        logger.warning("Secteur de l'utilisateur illisible", exc_info=True)
+
+    initiales = ((prenom[:1] + nom[:1]) or '?').upper()
+    return {
+        'nom': f"{prenom} {nom}".strip() or 'Mon dossier',
+        'fonction': fonction,
+        'initiales': initiales,
+    }
+
+
+def contexte():
+    """Contexte complet de l'interface sans menu pour la requête courante.
+
+    Le résultat est mémorisé sur l'objet `request` : plusieurs gabarits peuvent
+    lire la carte sans relancer les lectures de droits. La mémorisation est
+    volontairement portée par la requête et non par `flask.g`, qui vit aussi
+    longtemps que le contexte d'application — partagé entre plusieurs requêtes
+    dans certains montages (les fixtures de test, notamment). Une carte mise en
+    cache trop largement afficherait la zone d'une page précédente.
+    """
+    if not has_request_context():
+        return {'ui_flux': False, 'ui_flux_eligible': False}
+
+    memo = getattr(request, '_interface_flux', None)
+    if memo is not None:
+        return memo
+
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+
+    if not interface_active(profil, user_id):
+        donnees = {
+            'ui_flux': False,
+            'ui_flux_eligible': bool(user_id) and navigation.est_eligible(profil, user_id),
+        }
+    else:
+        drapeaux = _drapeaux(profil, user_id)
+        carte = navigation.carte_navigation(drapeaux)
+        zone, page = navigation.localiser(carte, request.endpoint)
+        donnees = {
+            'ui_flux': True,
+            'ui_flux_eligible': True,
+            'nav_carte': carte,
+            'nav_zone': zone,
+            'nav_page': page,
+            'nav_identite': _identite(profil, user_id),
+        }
+
+    try:
+        request._interface_flux = donnees
+    except Exception:   # objet Request immuable : on recalculera, sans casser
+        pass
+    return donnees
+
+
+def flux_infos_page():
+    """Flux d'information de la page courante (liste vide si elle n'en a pas)."""
+    import flux_infos
+    endpoint = request.endpoint
+    if endpoint not in flux_infos.CONSTRUCTEURS:
+        return []
+    from database import get_db
+    conn = get_db()
+    try:
+        return flux_infos.construire(conn, endpoint, {
+            'profil': session.get('profil'),
+            'user_id': session.get('user_id'),
+        })
+    finally:
+        conn.close()

--- a/interface_flux.py
+++ b/interface_flux.py
@@ -83,6 +83,25 @@ def interface_active(profil, user_id):
     return preference_utilisateur(user_id) is not False
 
 
+def recherche_globale_autorisee(profil):
+    """La recherche métier (`POST /api/search`) est-elle ouverte à ce profil ?
+
+    La barre intelligente propose deux choses : la navigation locale — zones et
+    pages, qui remplace le menu et vaut pour tout le monde — et la recherche
+    métier, qui route vers une facture, un fournisseur, un budget, la fiche
+    temps d'un salarié… Cette dernière n'a jamais existé que sur les tableaux
+    de bord direction et comptabilité, et son moteur ne filtre pas ses verdicts
+    par profil. On lit la liste d'autorisation à la source, dans le blueprint
+    qui la fait respecter, pour que la palette et l'API ne divergent jamais.
+    """
+    try:
+        from blueprints.recherche import PROFILS_AUTORISES
+        return profil in PROFILS_AUTORISES
+    except Exception:
+        logger.warning("Profils de recherche illisibles", exc_info=True)
+        return False
+
+
 def _drapeaux(profil, user_id):
     """Drapeaux de droits utilisés pour filtrer la carte de navigation.
 
@@ -218,6 +237,7 @@ def contexte():
             'nav_zone': zone,
             'nav_page': page,
             'nav_identite': _identite(profil, user_id),
+            'nav_recherche_globale': recherche_globale_autorisee(profil),
         }
 
     try:

--- a/interface_flux.py
+++ b/interface_flux.py
@@ -143,9 +143,9 @@ def _drapeaux(profil, user_id):
 def _identite(profil, user_id):
     """Nom, fonction et initiales affichés en haut à droite.
 
-    Faute de champ « fonction » sur les comptes, la fonction affichée est le
-    profil, précisé par le secteur quand il y en a un — c'est l'information
-    dont dispose réellement l'application.
+    La fonction est celle renseignée sur la fiche du salarié, avec les
+    informations de contrat. Tant qu'elle ne l'est pas, on retombe sur le
+    profil précisé par le secteur — l'information dont dispose l'application.
     """
     prenom = (session.get('prenom') or '').strip()
     nom = (session.get('nom') or '').strip()
@@ -156,16 +156,18 @@ def _identite(profil, user_id):
         conn = get_db()
         try:
             row = conn.execute(
-                '''SELECT s.nom AS secteur FROM users u
+                '''SELECT u.fonction, s.nom AS secteur FROM users u
                    LEFT JOIN secteurs s ON s.id = u.secteur_id
                    WHERE u.id = ?''', (user_id,)
             ).fetchone()
         finally:
             conn.close()
-        if row and row['secteur']:
+        if row and (row['fonction'] or '').strip():
+            fonction = row['fonction'].strip()
+        elif row and row['secteur']:
             fonction = f"{fonction} · {row['secteur']}"
     except Exception:
-        logger.warning("Secteur de l'utilisateur illisible", exc_info=True)
+        logger.warning("Fonction de l'utilisateur illisible", exc_info=True)
 
     initiales = ((prenom[:1] + nom[:1]) or '?').upper()
     return {

--- a/interface_flux.py
+++ b/interface_flux.py
@@ -198,9 +198,14 @@ def contexte():
     user_id = session.get('user_id')
 
     if not interface_active(profil, user_id):
+        # « Essayer la nouvelle interface » ne s'affiche que si la bascule peut
+        # réellement aboutir : quand l'option du centre est décochée, le bouton
+        # mènerait à un accueil qui redirige aussitôt.
         donnees = {
             'ui_flux': False,
-            'ui_flux_eligible': bool(user_id) and navigation.est_eligible(profil, user_id),
+            'ui_flux_eligible': (bool(user_id)
+                                 and option_globale_active()
+                                 and navigation.est_eligible(profil, user_id)),
         }
     else:
         drapeaux = _drapeaux(profil, user_id)

--- a/migrations/0064_fonction_salarie.py
+++ b/migrations/0064_fonction_salarie.py
@@ -1,0 +1,61 @@
+"""
+Migration 0064 : fonction du salarié.
+
+L'application connaissait le profil (droits) et le secteur, mais pas la
+fonction occupée. Elle est désormais renseignée avec les informations de
+contrat, et s'affiche sous le nom du salarié dans l'interface sans menu.
+
+Deux objets :
+- `users.fonction` : la fonction du salarié ;
+- `fonctions` : la liste proposée, pré-remplie avec les fonctions courantes
+  d'un centre social et complétable par la direction.
+"""
+import sqlite3
+
+NOM = "Fonction du salarié"
+DESCRIPTION = (
+    "Ajoute users.fonction et la table fonctions (liste des fonctions "
+    "proposées, complétable)."
+)
+
+# La liste de départ vit dans migrations/__init__.py : une base neuve
+# (database.init_db) et une base migrée partent ainsi du même jeu.
+from migrations import FONCTIONS_INITIALES
+
+
+def upgrade(conn):
+    """Applique la migration (idempotente)."""
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute('SELECT fonction FROM users LIMIT 1')
+    except sqlite3.OperationalError:
+        cursor.execute('ALTER TABLE users ADD COLUMN fonction TEXT')
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS fonctions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            libelle TEXT NOT NULL UNIQUE,
+            ordre INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    for ordre, libelle in enumerate(FONCTIONS_INITIALES):
+        cursor.execute(
+            'INSERT OR IGNORE INTO fonctions (libelle, ordre) VALUES (?, ?)',
+            (libelle, ordre)
+        )
+
+    conn.commit()
+
+
+def downgrade(conn):
+    """Retire la liste des fonctions.
+
+    SQLite ne supprime pas simplement une colonne : `users.fonction` reste en
+    place, inerte tant que le code ne la lit pas.
+    """
+    cursor = conn.cursor()
+    cursor.execute('DROP TABLE IF EXISTS fonctions')
+    conn.commit()

--- a/migrations/__init__.py
+++ b/migrations/__init__.py
@@ -1,1 +1,25 @@
 # Dossier de migrations de la base de donnees
+
+# Liste de depart des fonctions proposees pour les salaries (migration 0064).
+# Source unique : lue par la migration ET par la creation initiale du schema
+# dans database.py, pour qu'une base neuve et une base migree partent du meme
+# jeu. Elle n'est inseree qu'a la creation de la table : une fonction retiree
+# par la direction ne reapparait pas au demarrage suivant.
+FONCTIONS_INITIALES = [
+    'Directeur',
+    'Direction adjointe',
+    'Comptable',
+    'Responsable',
+    'EJE',
+    'Auxiliaire Puér.',
+    'Aide Aux.',
+    "Agent d'accueil",
+    'Assist.Direction',
+    'Accueil&Comm.',
+    'Conseillé insertion',
+    'Anim.Formateur',
+    'Dir.Adjointe AL',
+    'Entretien/restauration',
+    'Entretien',
+    'Gardien',
+]

--- a/navigation.py
+++ b/navigation.py
@@ -1,0 +1,422 @@
+"""
+Carte de navigation de l'interface sans menu.
+
+L'interface « flux » remplace le menu latéral par trois choses :
+- un fil d'actions sur l'accueil ;
+- une barre intelligente qui s'ouvre dès la première touche frappée ;
+- une vue d'ensemble (touche Échap) où l'application est représentée par zones.
+
+Ce module est la source unique de cette représentation. Il décrit :
+- les ZONES thématiques (cercle intérieur de la vue d'ensemble), qui regroupent
+  les pages du menu historique en thèmes cohérents ;
+- les ACCÈS DIRECTS (cercle extérieur), pour les pages qu'on ouvre sans passer
+  par un thème (salles, planificateur, administration…).
+
+Chaque page porte les profils qui y ont droit et, si besoin, une condition
+nommée évaluée dans le contexte de l'utilisateur (délégation, option, rôle CSE).
+Les listes reproduisent les droits du menu latéral historique : ce module ne
+donne aucun accès nouveau, il réorganise seulement la présentation. Les routes
+conservent leur propre contrôle d'accès.
+"""
+import logging
+
+from flask import url_for
+
+logger = logging.getLogger(__name__)
+
+TOUS_PROFILS = ('directeur', 'comptable', 'responsable', 'salarie')
+
+# Profils qui basculent d'office sur l'interface sans menu. Les salariés s'y
+# ajoutent uniquement s'ils portent une délégation (voir `est_eligible`).
+PROFILS_FLUX = ('directeur', 'comptable', 'responsable')
+
+
+def _page(endpoint, label, profils=TOUS_PROFILS, condition=None, labels=None,
+          resume=''):
+    """Décrit une page de la carte.
+
+    - `profils` : profils qui voient l'entrée sans condition supplémentaire.
+    - `condition` : nom d'un drapeau du contexte utilisateur ; s'il est vrai,
+      l'entrée est visible quel que soit le profil (délégation, rôle CSE) ou,
+      combiné à `profils`, la restreint (option d'administration).
+    - `labels` : libellés alternatifs par profil (une même page ne se nomme pas
+      pareil selon qu'on gère son planning ou celui de l'équipe).
+    """
+    return {
+        'endpoint': endpoint,
+        'label': label,
+        'labels': labels or {},
+        'profils': tuple(profils),
+        'condition': condition,
+        'resume': resume,
+    }
+
+
+# ── Zones thématiques : le cercle intérieur ────────────────────────────────
+# `mots` alimente la recherche locale de la barre intelligente (sans accents,
+# la comparaison étant faite sur une forme normalisée).
+ZONES = [
+    {
+        'id': 'validations',
+        'nom': 'Validations & suivi',
+        'icone': '✓',
+        'description': "Demandes, fiches d'heures, anomalies et factures en attente de votre décision.",
+        'mots': 'validation valider suivi demande conge recup anomalie surcharge facture approbation fiche heures historique',
+        'pages': [
+            _page('validation_bp.vue_ensemble_validation', "Vue d'ensemble",
+                  profils=('directeur', 'comptable', 'responsable'),
+                  condition='can_access_vue_ensemble_validation',
+                  resume="L'état de validation des fiches, mois par mois."),
+            _page('recup_bp.validation_demandes_recup', 'Validation des demandes',
+                  profils=('directeur', 'comptable', 'responsable'),
+                  resume='Congés et récupérations à valider ou refuser.'),
+            _page('recup_bp.historique_demandes_recup', 'Historique des demandes',
+                  profils=('directeur', 'comptable')),
+            _page('suivi_bp.historique_modifications', 'Historique des modifications',
+                  profils=('directeur',)),
+            _page('suivi_bp.suivi_anomalies', 'Suivi des anomalies',
+                  profils=('directeur', 'comptable')),
+            _page('suivi_bp.alertes_surcharge', 'Alertes de surcharge',
+                  profils=('directeur', 'comptable')),
+            _page('factures_bp.approbation_factures', 'Approbation des factures',
+                  profils=('directeur', 'responsable')),
+        ],
+    },
+    {
+        'id': 'temps',
+        'nom': 'Temps & plannings',
+        'icone': '◷',
+        'description': "Saisie des heures, plannings, présence de l'équipe et temps annualisé.",
+        'mots': 'temps heure saisie saisir planning plannings mensuelle calendrier equipe presence effectif annualise forfait jour',
+        'pages': [
+            _page('saisie_bp.saisie_heures', 'Saisir mes heures',
+                  profils=('comptable', 'responsable', 'salarie')),
+            _page('validation_bp.vue_mensuelle', 'Vue mensuelle',
+                  profils=('comptable', 'responsable', 'salarie')),
+            _page('validation_bp.vue_calendrier', 'Vue calendrier',
+                  profils=('comptable', 'responsable', 'salarie')),
+            _page('planning_bp.planning_theorique', 'Mon planning',
+                  labels={'directeur': 'Plannings des salariés',
+                          'comptable': 'Plannings des salariés'}),
+            _page('mon_equipe_bp.mon_equipe', 'Mon équipe',
+                  profils=('comptable', 'responsable', 'salarie')),
+            _page('presence_effectif_bp.presence_effectif', "Présence de l'effectif",
+                  profils=('directeur', 'comptable')),
+            _page('planning_enfance_bp.planning_enfance', 'Temps annualisé',
+                  profils=('directeur', 'comptable', 'responsable')),
+            _page('forfait_bp.dashboard_forfait_jour', 'Forfait jour',
+                  profils=('directeur',)),
+            _page('forfait_bp.calendrier_forfait_jour', 'Calendrier forfait jour',
+                  profils=('directeur',)),
+        ],
+    },
+    {
+        'id': 'rh',
+        'nom': 'RH & Paie',
+        'icone': '◈',
+        'description': 'Dossiers salariés, contrats, absences, variables et préparation de la paie.',
+        'mots': 'rh paie salarie contrat absence maladie solde conge statistique alisfa pesee poste assistant variable prepa embauche',
+        'pages': [
+            _page('infos_salaries_bp.infos_salaries', 'Infos salariés',
+                  profils=('directeur', 'comptable', 'responsable')),
+            _page('generation_contrats_bp.generation_contrats', 'Génération de contrats',
+                  profils=('directeur', 'comptable')),
+            _page('generation_contrats_bp.generation_contrats', 'Génération de contrats',
+                  profils=('responsable',),
+                  condition='generation_contrats_responsable_autorise'),
+            _page('absences_bp.absences', 'Absences',
+                  profils=('directeur', 'comptable')),
+            _page('infos_salaries_bp.soldes_conges', 'Soldes de congés',
+                  profils=('directeur', 'comptable')),
+            _page('rh_statistiques_bp.rh_statistiques', 'Statistiques RH',
+                  profils=('directeur', 'comptable')),
+            _page('pesee_alisfa_bp.pesee_alisfa', 'Pesée ALISFA',
+                  profils=('directeur', 'comptable')),
+            _page('pesee_alisfa_bp.postes_alisfa', 'Postes ALISFA',
+                  profils=('directeur', 'comptable')),
+            _page('assistant_rh_bp.assistant_rh', 'Assistant RH',
+                  profils=('directeur', 'comptable')),
+            _page('variables_paie_bp.variables_paie', 'Variables de paie',
+                  profils=('directeur', 'comptable')),
+            _page('prepa_paie_bp.prepa_paie', 'Préparation de la paie',
+                  profils=('directeur', 'comptable')),
+        ],
+    },
+    {
+        'id': 'factures',
+        'nom': 'Factures & achats',
+        'icone': '▤',
+        'description': 'Factures fournisseurs, règles comptables, écritures et exportation.',
+        'mots': 'facture fournisseur achat commande ecriture export exportation regle comptable piece justificatif',
+        'pages': [
+            _page('factures_bp.liste_factures', 'Factures',
+                  profils=('directeur', 'comptable'),
+                  resume='Le suivi des factures reçues, de leur import à leur approbation.'),
+            _page('fournisseurs_bp.liste_fournisseurs', 'Fournisseurs',
+                  profils=('directeur', 'comptable')),
+            _page('regles_comptables_bp.liste_regles', 'Règles comptables',
+                  profils=('directeur', 'comptable')),
+            _page('ecritures_bp.liste_ecritures', 'Écritures',
+                  profils=('directeur', 'comptable')),
+            _page('exportation_bp.liste_exportation', 'Exportation',
+                  profils=('directeur', 'comptable')),
+            _page('commandes_salaries_bp.commandes_salaries', 'Commandes salariés'),
+        ],
+    },
+    {
+        'id': 'comptabilite',
+        'nom': 'Comptabilité',
+        'icone': '∑',
+        'description': "Compte de résultat, bilan, indicateurs et plans comptables.",
+        'mots': 'comptabilite comptable bilan compte resultat indicateur financier import bi plan analytique general grand livre',
+        'pages': [
+            _page('compte_resultat_bp.compte_resultat', 'Compte de résultat & bilan',
+                  profils=('directeur', 'comptable')),
+            _page('indicateurs_financiers_bp.indicateurs_financiers', 'Indicateurs financiers',
+                  profils=('directeur', 'comptable')),
+            _page('import_bi_bp.import_bi', 'Import BI',
+                  profils=('directeur', 'comptable')),
+            _page('comptabilite_analytique_bp.plan_comptable_analytique', 'Plan comptable analytique',
+                  profils=('directeur', 'comptable')),
+            _page('plan_comptable_general_bp.plan_comptable_general', 'Plan comptable général',
+                  profils=('directeur', 'comptable')),
+        ],
+    },
+    {
+        'id': 'financier',
+        'nom': 'Financier',
+        'icone': '◇',
+        'description': 'Budgets, subventions, trésorerie et bilans par secteur.',
+        'mots': 'financier budget previsionnel subvention convention tresorerie secteur action alsh bilan caf',
+        'pages': [
+            _page('budget_bp.gestion_budgets', 'Budgets',
+                  profils=('directeur', 'comptable')),
+            _page('budget_bp.mon_budget', 'Mon budget',
+                  profils=('responsable',)),
+            _page('budget_bp.budget_previsionnel', 'Budget prévisionnel',
+                  profils=('directeur', 'comptable')),
+            _page('budget_bp.budget_previsionnel', 'Budget prévisionnel',
+                  profils=('responsable',),
+                  condition='budget_previsionnel_responsable_autorise'),
+            _page('subventions_bp.gestion_subventions', 'Subventions',
+                  profils=('directeur', 'comptable', 'responsable'),
+                  resume='Les dossiers, leurs étapes et leurs échéances.'),
+            _page('tresorerie_bp.tresorerie', 'Trésorerie',
+                  profils=('directeur', 'comptable')),
+            _page('bilan_secteurs_bp.bilan_secteurs', 'Bilan secteurs & actions',
+                  profils=('directeur', 'comptable', 'responsable')),
+            _page('bilan_action_bp.bilan_action', 'Budget action',
+                  profils=('directeur', 'comptable')),
+            _page('alsh_bp.analyse_alsh', 'Analyse ALSH',
+                  profils=('directeur', 'comptable')),
+        ],
+    },
+    {
+        'id': 'vie_associative',
+        'nom': 'Vie associative',
+        'icone': '✚',
+        'description': "Bénévoles, heures valorisées et espace du comité social et économique.",
+        'mots': 'benevole benevolat association cse comite social economique message budget heures valorisees',
+        'pages': [
+            _page('benevoles_bp.gestion_benevoles', 'Bénévoles',
+                  profils=('directeur', 'comptable')),
+            _page('benevoles_bp.gestion_benevoles', 'Bénévoles',
+                  profils=(), condition='is_delegue_benevoles'),
+            _page('cse_bp.cse_accueil', 'Espace CSE',
+                  profils=('directeur', 'comptable')),
+            _page('cse_bp.cse_accueil', 'Espace CSE',
+                  profils=(), condition='is_cse_membre'),
+        ],
+    },
+    {
+        'id': 'moi',
+        'nom': 'Mon espace',
+        'icone': '◉',
+        'description': 'Vos compteurs de congés et de récupérations, et vos demandes.',
+        'mots': 'moi mon espace dossier personnel compteur solde conge recuperation recup demande poser absence vacances parametre',
+        'pages': [
+            _page('accueil_bp.mon_espace', 'Mes compteurs',
+                  resume='Congés, récupérations et demandes en cours.'),
+            _page('recup_bp.demande_conge', 'Demander un congé'),
+            _page('recup_bp.demande_recup', 'Demander une récupération',
+                  profils=('comptable', 'responsable', 'salarie')),
+            _page('recup_bp.mes_demandes_conges', 'Mes demandes de congés'),
+            _page('recup_bp.mes_demandes_recup', 'Mes demandes de récupération',
+                  profils=('comptable', 'responsable', 'salarie')),
+            _page('parametres_bp.parametres', 'Mes paramètres',
+                  profils=('salarie',)),
+        ],
+    },
+]
+
+# ── Accès directs : le cercle extérieur ────────────────────────────────────
+# Des pages qu'on ouvre pour elles-mêmes, sans passer par un thème. Un accès
+# direct qui ne porte qu'une page y mène d'un clic ; s'il en porte plusieurs,
+# il se déplie comme une zone.
+ACCES_DIRECTS = [
+    {
+        'id': 'salles',
+        'nom': 'Salles',
+        'icone': '⌂',
+        'description': 'Réservations et calendrier d\'occupation des salles.',
+        'mots': 'salle reservation reserver occupation calendrier disponibilite creneau',
+        'pages': [
+            _page('salles_bp.salles', 'Réserver une salle'),
+        ],
+    },
+    {
+        'id': 'planificateur',
+        'nom': 'Planificateur',
+        'icone': '◴',
+        'description': 'Vos tâches et échéances organisées en blocs de temps.',
+        'mots': 'planificateur tache echeance bloc organiser semaine deadline',
+        'pages': [
+            _page('planificateur_bp.planificateur', 'Planificateur'),
+        ],
+    },
+    {
+        'id': 'administration',
+        'nom': 'Administration',
+        'icone': '⚙',
+        'description': 'Comptes, sécurité, options, sauvegardes et mises à jour.',
+        'mots': 'administration parametre option compte utilisateur securite droit vacances ferie cle api email delegation sauvegarde mise a jour base',
+        'pages': [
+            _page('admin_bp.gestion_users', 'Utilisateurs',
+                  profils=('directeur', 'comptable')),
+            _page('securite_bp.journal_acces', 'Sécurité',
+                  profils=('directeur', 'comptable')),
+            _page('admin_bp.gestion_vacances', 'Vacances scolaires',
+                  profils=('directeur', 'comptable')),
+            _page('admin_bp.gestion_jours_feries', 'Jours fériés',
+                  profils=('directeur', 'comptable')),
+            _page('api_keys_bp.gestion_cles_api', 'Clés API',
+                  profils=('directeur', 'comptable')),
+            _page('notifications_bp.configuration_email', 'Notifications email',
+                  profils=('directeur', 'comptable')),
+            _page('admin_bp.delegations', 'Délégations',
+                  profils=('directeur', 'comptable')),
+            _page('administration_bp.options', 'Options',
+                  profils=('directeur', 'comptable')),
+            _page('backup_bp.liste_sauvegardes', 'Sauvegardes',
+                  profils=('directeur', 'comptable')),
+            _page('administration_bp.administration', 'Mises à jour de la base',
+                  profils=('directeur', 'comptable')),
+            _page('mise_a_jour_bp.mise_a_jour', "Mise à jour de l'application",
+                  profils=('directeur', 'comptable')),
+        ],
+    },
+]
+
+
+def _page_visible(page, contexte):
+    """Une page est visible si le profil y a droit, ou si sa condition est vraie.
+
+    Deux usages de `condition` cohabitent :
+    - avec `profils` vide, la condition SUFFIT (délégation, rôle CSE) ;
+    - avec `profils` renseignés, elle RESTREINT (option d'administration).
+    """
+    profil = contexte.get('profil')
+    condition = page['condition']
+    if not page['profils']:
+        return bool(condition) and bool(contexte.get(condition))
+    if profil not in page['profils']:
+        return False
+    if condition and not contexte.get(condition):
+        return False
+    return True
+
+
+def _lien(endpoint):
+    """URL d'un endpoint, ou None s'il n'est pas monté (blueprint absent)."""
+    try:
+        return url_for(endpoint)
+    except Exception:
+        logger.warning("Navigation : endpoint inconnu %s, entrée masquée", endpoint)
+        return None
+
+
+def _construire_groupe(groupe, contexte):
+    """Filtre les pages d'une zone pour un utilisateur ; None si tout est masqué."""
+    pages = []
+    vus = set()
+    for page in groupe['pages']:
+        if not _page_visible(page, contexte):
+            continue
+        if page['endpoint'] in vus:
+            continue
+        lien = _lien(page['endpoint'])
+        if lien is None:
+            continue
+        vus.add(page['endpoint'])
+        pages.append({
+            'endpoint': page['endpoint'],
+            'label': page['labels'].get(contexte.get('profil'), page['label']),
+            'resume': page['resume'],
+            'lien': lien,
+        })
+    if not pages:
+        return None
+    return {
+        'id': groupe['id'],
+        'nom': groupe['nom'],
+        'icone': groupe['icone'],
+        'description': groupe['description'],
+        'mots': groupe['mots'],
+        'pages': pages,
+    }
+
+
+def carte_navigation(contexte):
+    """Zones et accès directs visibles par un utilisateur.
+
+    Retourne `{'zones': [...], 'directs': [...]}`, chaque entrée portant ses
+    pages déjà filtrées et leurs URL résolues.
+    """
+    zones = [z for z in (_construire_groupe(g, contexte) for g in ZONES) if z]
+    directs = [d for d in (_construire_groupe(g, contexte) for g in ACCES_DIRECTS) if d]
+    return {'zones': zones, 'directs': directs}
+
+
+def localiser(carte, endpoint):
+    """Zone (ou accès direct) contenant un endpoint, et la page elle-même.
+
+    Retourne `(groupe, page)` ou `(None, None)`. Sert à afficher, en haut de
+    chaque page, le titre et les boutons des pages voisines — ce qui remplace
+    le sous-menu du menu latéral.
+    """
+    if not endpoint:
+        return None, None
+    for groupe in carte['zones'] + carte['directs']:
+        for page in groupe['pages']:
+            if page['endpoint'] == endpoint:
+                return groupe, page
+    return None, None
+
+
+def est_eligible(profil, user_id):
+    """Indique si un utilisateur relève de l'interface sans menu.
+
+    Direction, comptabilité et responsables y basculent. Un salarié n'y bascule
+    que s'il porte une délégation qui lui donne des pages à suivre — la seule
+    délégation des récurrences de salle ne compte pas, elle n'ouvre aucune page
+    supplémentaire. Les prestataires gardent leur page unique.
+    """
+    if profil in PROFILS_FLUX:
+        return True
+    if profil != 'salarie' or not user_id:
+        return False
+    from blueprints.delegations import (MISSION_SUIVI_COMMANDES_FOURNITURES,
+                                        MISSION_SUIVI_VALIDATIONS_RELANCES,
+                                        user_has_delegation,
+                                        user_peut_gerer_benevoles)
+    try:
+        return bool(
+            user_has_delegation(user_id, MISSION_SUIVI_VALIDATIONS_RELANCES)
+            or user_has_delegation(user_id, MISSION_SUIVI_COMMANDES_FOURNITURES)
+            or user_peut_gerer_benevoles(user_id)
+        )
+    except Exception:
+        # Base non migrée ou verrouillée : on retombe sur l'interface historique
+        # plutôt que de priver l'utilisateur de son menu.
+        logger.warning("Éligibilité interface sans menu illisible", exc_info=True)
+        return False

--- a/navigation.py
+++ b/navigation.py
@@ -65,7 +65,13 @@ ZONES = [
         'pages': [
             _page('validation_bp.vue_ensemble_validation', "Vue d'ensemble",
                   profils=('directeur', 'comptable', 'responsable'),
-                  condition='can_access_vue_ensemble_validation',
+                  resume="L'état de validation des fiches, mois par mois."),
+            # La délégation « suivi des validations et relances » ouvre cette
+            # page à un salarié — c'est même elle qui le fait basculer sur
+            # l'interface sans menu. Sans cette seconde déclaration, la page
+            # que la délégation accorde disparaîtrait de sa carte.
+            _page('validation_bp.vue_ensemble_validation', "Vue d'ensemble",
+                  profils=(), condition='can_access_vue_ensemble_validation',
                   resume="L'état de validation des fiches, mois par mois."),
             _page('recup_bp.validation_demandes_recup', 'Validation des demandes',
                   profils=('directeur', 'comptable', 'responsable'),

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4386,3 +4386,615 @@ a.btn-icon:-webkit-any-link {
     .action-item { flex-wrap: wrap; }
     .action-lien { width: 100%; text-align: center; }
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   INTERFACE SANS MENU (« flux »)
+   Le menu latéral disparaît : la navigation passe par le fil d'actions, la
+   barre intelligente (une touche suffit) et la vue d'ensemble (Échap).
+   Les couleurs reprennent les variables du thème, donc le mode sombre suit.
+   ══════════════════════════════════════════════════════════════════════════ */
+:root {
+    --flx-display: "Space Grotesk", "Inter", "Segoe UI", system-ui, sans-serif;
+    --flx-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --flx-entete: 96px;
+    --flx-pied: 92px;
+    --flx-retard: #bf4444;
+    --flx-urgent: #c56a2a;
+    --flx-planifier: #2f5d50;
+    --flx-ok: #2f7050;
+}
+[data-theme="dark"] {
+    --flx-retard: #e2807f;
+    --flx-urgent: #e0a165;
+    --flx-planifier: #7fb9a5;
+    --flx-ok: #6fb894;
+}
+
+/* ── Ossature ─────────────────────────────────────────────────────────── */
+body.flx { background: var(--gray-50); }
+body.flx .main-content.has-sidebar { margin-left: 0; }
+body.flx .container { max-width: 880px; }
+body.flx footer { display: none; }
+
+.flx-fond { position: fixed; inset: 0; pointer-events: none; z-index: 0; overflow: hidden; }
+.flx-fond span { position: absolute; display: block; }
+.flx-fond .flx-halo-1 {
+    top: -320px; left: 50%; margin-left: -460px; width: 920px; height: 720px;
+    background: radial-gradient(circle at 50% 50%, rgba(47,93,80,0.12) 0%, rgba(47,93,80,0) 68%);
+}
+.flx-fond .flx-halo-2 {
+    bottom: -380px; right: -180px; width: 820px; height: 820px;
+    background: radial-gradient(circle at 50% 50%, rgba(197,106,42,0.1) 0%, rgba(197,106,42,0) 66%);
+}
+.flx-fond .flx-grille {
+    inset: 0;
+    background-image: linear-gradient(rgba(47,93,80,0.05) 1px, transparent 1px),
+                      linear-gradient(90deg, rgba(47,93,80,0.05) 1px, transparent 1px);
+    background-size: 64px 64px;
+    -webkit-mask-image: radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+    mask-image: radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
+}
+[data-theme="dark"] .flx-fond .flx-grille { opacity: 0.4; }
+
+body.flx .main-content {
+    position: relative; z-index: 1;
+    padding-top: calc(var(--flx-entete) + 26px);
+    padding-bottom: calc(var(--flx-pied) + 32px);
+}
+
+/* ── En-tête fixe : marque, barre intelligente, identité ──────────────── */
+.flx-entete {
+    position: fixed; top: 0; left: 0; right: 0; height: var(--flx-entete);
+    display: flex; align-items: center; gap: 26px; padding: 0 30px;
+    z-index: 60; pointer-events: none;
+}
+.flx-marque {
+    display: flex; align-items: center; gap: 11px; flex: 0 0 auto;
+    pointer-events: auto; background: none; border: none; cursor: pointer;
+    padding: 0; text-decoration: none;
+}
+.flx-marque img { height: 40px; width: auto; display: block; }
+.flx-marque-texte { display: flex; flex-direction: column; align-items: flex-start; gap: 1px; }
+.flx-marque-titre {
+    font-family: var(--flx-display); font-size: 1.05rem; font-weight: 700;
+    letter-spacing: 0.3px; color: var(--primary); line-height: 1.1;
+}
+.flx-marque-sous { font-size: 0.62rem; color: var(--gray-500); white-space: nowrap; }
+
+.flx-recherche { flex: 1 1 auto; display: flex; justify-content: center; pointer-events: none; }
+.flx-recherche-boite { width: 100%; max-width: 620px; pointer-events: auto; }
+.flx-barre {
+    display: flex; align-items: center; gap: 12px; padding: 12px 16px;
+    border-radius: 14px; background: color-mix(in srgb, var(--white) 90%, transparent);
+    border: 1px solid var(--gray-300);
+    box-shadow: 0 10px 30px -14px rgba(35,70,61,0.12);
+    -webkit-backdrop-filter: blur(14px); backdrop-filter: blur(14px);
+    transition: border-color .18s, background .18s, box-shadow .18s;
+    cursor: text;
+}
+.flx-barre.flx-ouverte {
+    background: var(--white); border-color: rgba(47,93,80,0.38);
+    box-shadow: 0 0 0 4px rgba(47,93,80,0.08);
+}
+.flx-barre-icone { font-size: 0.9rem; color: var(--primary); flex: 0 0 auto; }
+.flx-barre input {
+    flex: 1 1 auto; min-width: 0; background: none; border: none; outline: none;
+    color: var(--gray-900); font-size: 0.94rem; padding: 0;
+}
+.flx-kbd {
+    font-family: var(--flx-mono); font-size: 0.66rem; padding: 4px 8px;
+    border-radius: 5px; background: var(--gray-200); color: var(--gray-500);
+    flex: 0 0 auto; white-space: nowrap;
+}
+
+.flx-identite {
+    display: flex; align-items: center; gap: 12px; pointer-events: auto; flex: 0 0 auto;
+    background: none; border: 1px solid transparent; border-radius: 99px;
+    padding: 5px 5px 5px 13px; cursor: pointer; text-decoration: none;
+    transition: background .15s, border-color .15s;
+}
+.flx-identite:hover {
+    background: color-mix(in srgb, var(--white) 80%, transparent);
+    border-color: rgba(47,93,80,0.26);
+}
+.flx-identite-texte { display: flex; flex-direction: column; align-items: flex-end; gap: 2px; }
+.flx-identite-nom { font-size: 0.82rem; font-weight: 500; color: var(--gray-700); white-space: nowrap; }
+.flx-identite-role {
+    font-family: var(--flx-mono); font-size: 0.62rem; letter-spacing: 1.2px;
+    text-transform: uppercase; color: var(--gray-500); white-space: nowrap;
+}
+.flx-entete-droite { display: flex; align-items: center; gap: 6px; pointer-events: auto; flex: 0 0 auto; }
+.flx-icone-btn {
+    width: 34px; height: 34px; flex: 0 0 auto; border-radius: 50%; display: grid;
+    place-items: center; background: none; border: 1px solid transparent;
+    color: var(--gray-500); font-size: 0.95rem; cursor: pointer; text-decoration: none;
+    font-family: inherit; line-height: 1; transition: background .15s, border-color .15s, color .15s;
+}
+.flx-icone-btn:hover {
+    background: color-mix(in srgb, var(--white) 80%, transparent);
+    border-color: rgba(47,93,80,0.26); color: var(--primary);
+}
+.flx-avatar {
+    width: 38px; height: 38px; border-radius: 50%; display: grid; place-items: center;
+    background: var(--gray-200); border: 1px solid var(--gray-300);
+    font-family: var(--flx-display); font-size: 0.78rem; font-weight: 600;
+    color: var(--gray-700); flex: 0 0 auto;
+}
+
+/* ── Micro-typographie commune ───────────────────────────────────────── */
+.flx-etiquette {
+    font-family: var(--flx-mono); font-size: 0.66rem; letter-spacing: 2.2px;
+    text-transform: uppercase; color: var(--gray-500);
+}
+.flx-titre {
+    font-family: var(--flx-display); font-size: 2.6rem; font-weight: 500;
+    margin: 0 0 10px; letter-spacing: -1.1px; line-height: 1.06; color: var(--gray-900);
+}
+
+/* ── Accueil : en-tête du flux ───────────────────────────────────────── */
+.flx-flux-entete {
+    display: flex; align-items: flex-end; justify-content: space-between;
+    gap: 24px; margin-bottom: 34px; flex-wrap: wrap;
+}
+.flx-date {
+    font-family: var(--flx-mono); font-size: 0.68rem; letter-spacing: 2.4px;
+    text-transform: uppercase; color: var(--gray-500); margin-bottom: 12px;
+}
+.flx-resume { margin: 0; font-size: 1.02rem; color: var(--gray-500); max-width: 46ch; }
+.flx-compte { display: flex; align-items: center; gap: 14px; }
+.flx-compte-chiffres { text-align: right; }
+.flx-compte-valeur {
+    font-family: var(--flx-display); font-size: 1.5rem; font-weight: 600;
+    line-height: 1; color: var(--gray-900);
+}
+.flx-compte-valeur span { color: var(--gray-300); font-weight: 400; }
+.flx-compte-label {
+    font-family: var(--flx-mono); font-size: 0.6rem; letter-spacing: 1.6px;
+    text-transform: uppercase; color: var(--gray-500); margin-top: 5px;
+}
+.flx-anneau {
+    width: 52px; height: 52px; border-radius: 50%; display: grid; place-items: center;
+    background: conic-gradient(var(--primary) var(--p, 0%), var(--gray-200) 0);
+    flex: 0 0 auto;
+}
+.flx-anneau i {
+    width: 42px; height: 42px; border-radius: 50%; background: var(--white);
+    display: grid; place-items: center; font-size: 0.85rem; color: var(--primary); font-style: normal;
+}
+
+/* ── Cartes du fil ───────────────────────────────────────────────────── */
+.flx-carte {
+    display: grid; grid-template-columns: 52px 1fr auto; gap: 18px; align-items: center;
+    padding: 20px 22px; margin-bottom: 12px; border-radius: 16px;
+    background: var(--white); border: 1px solid var(--gray-200);
+    border-left: 2px solid var(--flx-planifier);
+    transition: opacity .3s ease, transform .3s ease, box-shadow .15s ease;
+}
+.flx-carte:hover { box-shadow: var(--shadow-md); }
+.flx-carte.flx-retard { border-left-color: var(--flx-retard); }
+.flx-carte.flx-urgent { border-left-color: var(--flx-urgent); }
+.flx-carte.flx-sortie { opacity: 0; transform: translateX(30px); }
+.flx-glyphe {
+    width: 52px; height: 52px; border-radius: 15px; display: grid; place-items: center;
+    font-size: 1.15rem; background: rgba(47,93,80,0.12); color: var(--flx-planifier);
+}
+.flx-retard .flx-glyphe { background: rgba(191,68,68,0.1); color: var(--flx-retard); }
+.flx-urgent .flx-glyphe { background: rgba(197,106,42,0.12); color: var(--flx-urgent); }
+.flx-carte-corps { min-width: 0; }
+.flx-carte-meta { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; flex-wrap: wrap; }
+.flx-badge {
+    font-family: var(--flx-mono); font-size: 0.62rem; letter-spacing: 1.4px;
+    text-transform: uppercase; padding: 3px 9px; border-radius: 5px;
+    background: rgba(47,93,80,0.12); color: var(--flx-planifier);
+}
+.flx-retard .flx-badge { background: rgba(191,68,68,0.1); color: var(--flx-retard); }
+.flx-urgent .flx-badge { background: rgba(197,106,42,0.12); color: var(--flx-urgent); }
+.flx-carte-zone {
+    font-family: var(--flx-mono); font-size: 0.66rem; letter-spacing: 1.3px;
+    color: var(--gray-500); text-transform: uppercase;
+}
+.flx-carte-titre {
+    font-family: var(--flx-display); font-size: 1.12rem; font-weight: 500;
+    letter-spacing: -0.3px; margin-bottom: 6px; color: var(--gray-900);
+}
+.flx-carte-detail { font-size: 0.87rem; color: var(--gray-500); line-height: 1.5; }
+.flx-carte-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.flx-btn {
+    padding: 10px 17px; border-radius: 9px; font-size: 0.85rem; cursor: pointer;
+    white-space: nowrap; font-family: inherit; border: 1px solid var(--gray-300);
+    background: var(--gray-100); color: var(--gray-700); text-decoration: none;
+    display: inline-block;
+}
+.flx-btn:hover { border-color: var(--primary); color: var(--primary); }
+.flx-btn-plein {
+    background: var(--primary); color: #fff; border-color: var(--primary-dark); font-weight: 600;
+}
+.flx-btn-plein:hover { background: var(--primary-dark); color: #fff; }
+.flx-btn[disabled] { opacity: 0.55; cursor: default; }
+
+/* ── Flux vide ───────────────────────────────────────────────────────── */
+.flx-vide {
+    text-align: center; padding: 72px 24px; border: 1px dashed var(--gray-300);
+    border-radius: 20px; animation: scaleIn .4s ease;
+}
+.flx-vide-glyphe {
+    width: 64px; height: 64px; margin: 0 auto 22px; border-radius: 50%;
+    background: radial-gradient(circle, rgba(47,93,80,0.28) 0%, rgba(47,93,80,0) 70%);
+    display: grid; place-items: center; font-size: 1.5rem; color: var(--primary);
+    animation: flxRespire 3.4s ease-in-out infinite;
+}
+.flx-vide-titre {
+    font-family: var(--flx-display); font-size: 1.5rem; font-weight: 500;
+    letter-spacing: -0.5px; margin-bottom: 10px; color: var(--gray-900);
+}
+@keyframes flxRespire { 0%,100% { opacity: .55; transform: scale(1); } 50% { opacity: 1; transform: scale(1.06); } }
+
+/* ── « À l'horizon » : deux lignes à défilement horizontal ───────────── */
+.flx-section { margin-top: 46px; padding-top: 24px; border-top: 1px solid var(--gray-200); }
+.flx-section-entete {
+    display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; margin-bottom: 18px;
+}
+.flx-section-note { font-size: 0.82rem; color: var(--gray-500); }
+.flx-ligne { display: flex; align-items: center; gap: 16px; margin-bottom: 12px; }
+.flx-ligne-titre {
+    flex: 0 0 78px; font-family: var(--flx-mono); font-size: 0.68rem;
+    letter-spacing: 1.6px; text-transform: uppercase; color: var(--primary);
+}
+.flx-piste {
+    flex: 1 1 auto; min-width: 0; display: flex; gap: 9px; overflow-x: auto;
+    scroll-snap-type: x proximity; padding: 2px 2px 9px;
+}
+.flx-pastille {
+    display: flex; align-items: center; gap: 11px; flex: 0 0 auto;
+    scroll-snap-align: start; padding: 9px 14px; border-radius: 11px;
+    background: var(--white); border: 1px solid var(--gray-200);
+    cursor: pointer; text-align: left; text-decoration: none;
+    transition: border-color .15s, box-shadow .15s;
+}
+.flx-pastille:hover { border-color: var(--primary); box-shadow: var(--shadow-sm); }
+.flx-point { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; background: var(--flx-ok); }
+.flx-proche .flx-point { background: var(--flx-retard); }
+.flx-moyen .flx-point { background: var(--flx-urgent); }
+.flx-pastille-corps { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; }
+.flx-pastille-titre { font-size: 0.84rem; color: var(--gray-900); white-space: nowrap; }
+.flx-pastille-detail { font-size: 0.74rem; color: var(--gray-500); white-space: nowrap; }
+.flx-pastille-date {
+    font-family: var(--flx-mono); font-size: 0.74rem; font-weight: 600;
+    letter-spacing: 0.8px; text-transform: uppercase; white-space: nowrap;
+    flex: 0 0 auto; padding-left: 4px; color: var(--flx-ok);
+}
+.flx-proche .flx-pastille-date { color: var(--flx-retard); }
+.flx-moyen .flx-pastille-date { color: var(--flx-urgent); }
+
+/* ── Astuces clavier ─────────────────────────────────────────────────── */
+.flx-astuces {
+    margin-top: 52px; padding-top: 26px; border-top: 1px solid var(--gray-200);
+    display: flex; gap: 34px; flex-wrap: wrap;
+}
+.flx-astuce { display: flex; align-items: center; gap: 11px; }
+.flx-astuce kbd {
+    font-family: var(--flx-mono); font-size: 0.68rem; padding: 5px 9px; border-radius: 6px;
+    background: var(--gray-100); border: 1px solid var(--gray-200); border-bottom-width: 2px;
+    color: var(--gray-700);
+}
+.flx-astuce span { font-size: 0.8rem; color: var(--gray-500); }
+
+/* ── En-tête de page (remplace le sous-menu du menu latéral) ─────────── */
+.flx-page-entete { margin-bottom: 30px; animation: fadeInUp .32s ease; }
+.flx-retour {
+    display: inline-flex; align-items: center; gap: 9px; background: none; border: none;
+    color: var(--gray-500); font-size: 0.82rem; cursor: pointer; padding: 0;
+    margin-bottom: 26px; text-decoration: none; font-family: inherit;
+}
+.flx-retour:hover { color: var(--primary); }
+.flx-page-titre { display: flex; align-items: center; gap: 20px; margin-bottom: 26px; }
+.flx-page-icone {
+    width: 62px; height: 62px; border-radius: 18px; display: grid; place-items: center;
+    font-size: 1.5rem; background: rgba(47,93,80,0.09);
+    border: 1px solid rgba(47,93,80,0.22); color: var(--primary); flex: 0 0 auto;
+}
+.flx-page-titre h1 {
+    font-family: var(--flx-display); font-size: 2rem; font-weight: 500;
+    margin: 0 0 6px; letter-spacing: -0.9px; color: var(--gray-900);
+    padding: 0; border: none;
+}
+.flx-page-titre p { margin: 0; color: var(--gray-500); font-size: 0.92rem; }
+.flx-chips {
+    display: flex; flex-wrap: wrap; gap: 8px; padding-bottom: 26px;
+    border-bottom: 1px solid var(--gray-200);
+}
+.flx-chips-label {
+    font-family: var(--flx-mono); font-size: 0.62rem; letter-spacing: 1.8px;
+    text-transform: uppercase; color: var(--gray-500); align-self: center; margin-right: 6px;
+}
+.flx-chip {
+    padding: 7px 14px; border-radius: 99px; font-size: 0.81rem; cursor: pointer;
+    white-space: nowrap; background: var(--white); border: 1px solid var(--gray-200);
+    color: var(--gray-700); text-decoration: none; transition: border-color .15s, background .15s;
+}
+.flx-chip:hover { border-color: rgba(47,93,80,0.42); color: var(--primary); }
+.flx-chip.flx-chip-actif {
+    background: rgba(47,93,80,0.14); border-color: rgba(47,93,80,0.42);
+    color: var(--primary); font-weight: 600;
+}
+
+/* ── Flux d'information d'une page ───────────────────────────────────── */
+.flx-infos {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: 12px; margin: 24px 0 6px;
+}
+.flx-info {
+    display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; padding: 14px 16px;
+    border-radius: 14px; background: var(--white); border: 1px solid var(--gray-200);
+    border-left: 2px solid var(--gray-300); text-decoration: none;
+    transition: box-shadow .15s ease, transform .15s ease;
+}
+.flx-info:hover { box-shadow: var(--shadow-md); transform: translateY(-2px); }
+.flx-info.flx-alerte { border-left-color: var(--flx-retard); }
+.flx-info.flx-attention { border-left-color: var(--flx-urgent); }
+.flx-info-icone { font-size: 1.2rem; grid-row: 1 / span 2; align-self: start; }
+.flx-info-corps { min-width: 0; }
+.flx-info-valeur {
+    font-family: var(--flx-display); font-size: 1.35rem; font-weight: 600;
+    line-height: 1; color: var(--gray-900);
+}
+.flx-alerte .flx-info-valeur { color: var(--flx-retard); }
+.flx-attention .flx-info-valeur { color: var(--flx-urgent); }
+.flx-info-libelle { font-size: 0.78rem; color: var(--gray-500); line-height: 1.35; margin-top: 4px; }
+.flx-info-lien { font-size: 0.78rem; font-weight: 600; color: var(--primary); grid-column: 2; }
+
+/* ── Mon espace ──────────────────────────────────────────────────────── */
+.flx-compteurs {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: 12px; margin-bottom: 16px;
+}
+.flx-compteur { padding: 16px 18px; border-radius: 14px; background: var(--white); border: 1px solid var(--gray-200); }
+.flx-compteur-nom {
+    font-family: var(--flx-mono); font-size: 0.62rem; letter-spacing: 1.6px;
+    text-transform: uppercase; color: var(--gray-500); margin-bottom: 9px;
+}
+.flx-compteur-valeur {
+    font-family: var(--flx-display); font-size: 1.5rem; font-weight: 600;
+    letter-spacing: -0.6px; margin-bottom: 5px; color: var(--gray-900);
+}
+.flx-compteur-valeur.flx-ton-vert { color: var(--flx-ok); }
+.flx-compteur-valeur.flx-ton-orange { color: var(--flx-urgent); }
+.flx-compteur-detail { font-size: 0.76rem; color: var(--gray-500); line-height: 1.45; }
+
+.flx-demande {
+    padding: 22px 24px; border-radius: 16px; background: var(--white);
+    border: 1px solid rgba(47,93,80,0.28); margin-bottom: 16px;
+}
+.flx-demande-entete {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 18px; flex-wrap: wrap; margin-bottom: 17px;
+}
+.flx-demande-note { font-size: 0.78rem; color: var(--gray-500); max-width: 52ch; }
+.flx-demande-champs { display: flex; flex-wrap: wrap; align-items: flex-end; gap: 14px; }
+.flx-champ { display: flex; flex-direction: column; gap: 6px; }
+.flx-champ > span {
+    font-family: var(--flx-mono); font-size: 0.62rem; letter-spacing: 1.4px;
+    text-transform: uppercase; color: var(--gray-500);
+}
+.flx-champ input, .flx-champ textarea {
+    padding: 10px 12px; border-radius: 10px; border: 1px solid var(--gray-300);
+    background: var(--gray-50); font-size: 0.89rem; color: var(--gray-900);
+    outline: none; font-family: inherit;
+}
+.flx-champ-large { flex: 1 1 260px; }
+.flx-champ-large input { width: 100%; }
+.flx-calcul { font-size: 0.85rem; color: var(--gray-700); padding-bottom: 11px; }
+
+.flx-liste { padding: 20px 22px; border-radius: 16px; background: var(--white); border: 1px solid var(--gray-200); }
+.flx-liste-titre {
+    font-family: var(--flx-mono); font-size: 0.64rem; letter-spacing: 1.8px;
+    text-transform: uppercase; color: var(--primary); margin-bottom: 12px;
+}
+.flx-liste-item {
+    display: grid; grid-template-columns: 1fr auto; gap: 14px; align-items: start;
+    padding: 12px 0; border-bottom: 1px solid var(--gray-100);
+}
+.flx-liste-item:last-child { border-bottom: none; }
+.flx-liste-item-titre { font-size: 0.9rem; color: var(--gray-900); margin-bottom: 4px; }
+.flx-liste-item-meta { font-size: 0.76rem; color: var(--gray-500); line-height: 1.45; }
+.flx-statut {
+    flex: 0 0 auto; font-family: var(--flx-mono); font-size: 0.64rem; letter-spacing: 1.2px;
+    text-transform: uppercase; padding: 5px 10px; border-radius: 99px; white-space: nowrap;
+    color: var(--gray-500); background: var(--gray-100);
+}
+.flx-statut.flx-ton-ok { color: var(--flx-ok); background: rgba(47,112,80,0.12); }
+.flx-statut.flx-ton-attente { color: var(--flx-urgent); background: rgba(197,106,42,0.13); }
+.flx-statut.flx-ton-refus { color: var(--flx-retard); background: rgba(191,68,68,0.1); }
+
+/* ── Barre du bas ────────────────────────────────────────────────────── */
+.flx-pied {
+    position: fixed; bottom: 0; left: 0; right: 0; padding: 0 30px 26px;
+    display: flex; justify-content: center; z-index: 50; pointer-events: none;
+}
+.flx-pied-barre {
+    display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 99px;
+    background: var(--primary); border: 1px solid var(--primary-dark);
+    box-shadow: 0 14px 34px -10px rgba(35,70,61,0.45), 0 2px 6px -1px rgba(35,70,61,0.25);
+    pointer-events: auto; max-width: 100%; overflow-x: auto;
+}
+.flx-pied-btn {
+    display: flex; align-items: center; gap: 9px; flex: 0 0 auto;
+    background: rgba(255,255,255,0.14); border: 1px solid rgba(255,255,255,0.26);
+    color: #fff; padding: 8px 15px; border-radius: 99px; font-size: 0.82rem;
+    cursor: pointer; white-space: nowrap; font-family: inherit; text-decoration: none;
+}
+.flx-pied-btn:hover { background: rgba(255,255,255,0.24); color: #fff; }
+.flx-pied-sep { width: 1px; height: 22px; background: rgba(255,255,255,0.22); flex: 0 0 auto; }
+.flx-pied-lien {
+    flex: 0 0 auto; background: transparent; border: 1px solid transparent;
+    color: rgba(255,255,255,0.74); padding: 7px 13px; border-radius: 99px;
+    font-size: 0.82rem; cursor: pointer; white-space: nowrap; font-family: inherit;
+    text-decoration: none;
+}
+.flx-pied-lien:hover, .flx-pied-lien.flx-actif { background: rgba(255,255,255,0.17); color: #fff; }
+
+/* ── Palette de recherche ────────────────────────────────────────────── */
+.flx-voile {
+    position: fixed; inset: 0; background: rgba(58,48,38,0.3);
+    -webkit-backdrop-filter: blur(3px); backdrop-filter: blur(3px); z-index: 55;
+}
+.flx-palette {
+    position: fixed; top: 104px; left: 50%; transform: translateX(-50%);
+    width: calc(100% - 60px); max-width: 620px; z-index: 70;
+    background: var(--white); border: 1px solid var(--gray-300); border-radius: 18px;
+    box-shadow: 0 32px 80px -20px rgba(35,70,61,0.16); overflow: hidden;
+    animation: fadeInUp .18s ease;
+}
+.flx-palette-corps { max-height: min(58vh, 470px); overflow-y: auto; padding: 8px; }
+.flx-palette-groupe {
+    font-family: var(--flx-mono); font-size: 0.62rem; letter-spacing: 1.8px;
+    text-transform: uppercase; color: var(--gray-500); padding: 14px 14px 8px;
+}
+.flx-res {
+    display: flex; align-items: center; gap: 13px; width: 100%; padding: 11px 14px;
+    border-radius: 11px; border: 1px solid transparent; background: transparent;
+    cursor: pointer; text-align: left; text-decoration: none; font-family: inherit;
+}
+.flx-res.flx-res-actif { border-color: rgba(47,93,80,0.24); background: rgba(47,93,80,0.09); }
+.flx-res-icone {
+    width: 32px; height: 32px; flex: 0 0 auto; border-radius: 9px; display: grid;
+    place-items: center; font-size: 0.85rem; background: var(--gray-100); color: var(--gray-500);
+}
+.flx-res-actif .flx-res-icone { background: rgba(47,93,80,0.16); color: var(--primary); }
+.flx-res-corps { flex: 1 1 auto; min-width: 0; }
+.flx-res-titre { display: block; font-size: 0.92rem; color: var(--gray-900); margin-bottom: 2px; }
+.flx-res-sous { display: block; font-size: 0.78rem; color: var(--gray-500); }
+.flx-res-fleche { flex: 0 0 auto; font-size: 0.72rem; color: var(--primary); opacity: 0; }
+.flx-res-actif .flx-res-fleche { opacity: 1; }
+.flx-palette-vide { padding: 38px 20px; text-align: center; color: var(--gray-500); font-size: 0.88rem; }
+.flx-palette-pied {
+    display: flex; align-items: center; justify-content: space-between; padding: 11px 16px;
+    border-top: 1px solid var(--gray-200); background: var(--gray-50);
+    font-family: var(--flx-mono); font-size: 0.64rem; letter-spacing: 1.1px;
+    color: var(--gray-500); text-transform: uppercase;
+}
+
+/* ── Vue d'ensemble (Échap) ──────────────────────────────────────────── */
+.flx-ensemble {
+    position: fixed; inset: 0; z-index: 80;
+    background: radial-gradient(circle at 50% 42%, var(--white) 0%, var(--gray-100) 58%, var(--gray-200) 100%);
+    animation: scaleIn .28s ease;
+}
+.flx-ensemble-fond { position: absolute; inset: 0; }
+.flx-ensemble-entete {
+    position: absolute; top: 36px; left: 50%; transform: translateX(-50%);
+    text-align: center; pointer-events: none; padding: 0 20px;
+}
+.flx-ensemble-sur {
+    font-family: var(--flx-mono); font-size: 0.64rem; letter-spacing: 2.6px;
+    text-transform: uppercase; color: var(--gray-500); margin-bottom: 9px;
+}
+.flx-ensemble-titre {
+    font-family: var(--flx-display); font-size: 1.3rem; font-weight: 400;
+    color: var(--gray-700); letter-spacing: -0.4px; margin-bottom: 7px;
+}
+.flx-ensemble-sous { font-size: 0.82rem; color: var(--gray-500); max-width: 56ch; margin: 0 auto; }
+.flx-ensemble-pied {
+    position: absolute; bottom: 38px; left: 50%; transform: translateX(-50%);
+    font-family: var(--flx-mono); font-size: 0.66rem; letter-spacing: 1.6px;
+    text-transform: uppercase; color: var(--gray-500); pointer-events: none;
+    text-align: center; padding: 0 20px;
+}
+.flx-anneau-carte {
+    position: absolute; top: 50%; left: 50%; width: 0; height: 0;
+    transition: transform .85s cubic-bezier(.25,.72,.2,1);
+}
+.flx-rayon {
+    position: absolute; left: 0; top: 0; height: 1px; transform-origin: 0 0;
+    background: linear-gradient(90deg, rgba(47,93,80,0.2), rgba(47,93,80,0.02));
+    transition: opacity .4s ease;
+}
+.flx-noeud {
+    position: absolute; display: flex; flex-direction: column; align-items: center;
+    gap: 11px; background: none; border: none; cursor: pointer; padding: 0;
+    transition: opacity .55s ease; font-family: inherit; text-decoration: none;
+}
+.flx-noeud-disque {
+    position: relative; border-radius: 50%; display: grid; place-items: center;
+    font-size: 1.14rem; background: var(--white); border: 1px solid var(--gray-300);
+    color: var(--gray-500);
+    transition: background .5s ease, border-color .5s ease, box-shadow .5s ease, color .5s ease;
+}
+.flx-noeud-chaud .flx-noeud-disque {
+    background: rgba(47,93,80,0.08); border-color: rgba(47,93,80,0.45);
+    color: var(--primary); box-shadow: 0 4px 14px -6px rgba(47,93,80,0.28);
+}
+.flx-noeud-ouvert .flx-noeud-disque {
+    background: rgba(47,93,80,0.12); border-color: var(--primary); color: var(--primary);
+    box-shadow: 0 10px 26px -8px rgba(47,93,80,0.4);
+}
+.flx-noeud-nom { line-height: 1.28; color: var(--gray-500); text-align: center; letter-spacing: 0.2px; transition: opacity .35s ease; }
+.flx-noeud-chaud .flx-noeud-nom, .flx-noeud-ouvert .flx-noeud-nom { color: var(--gray-900); }
+.flx-pastille-compte {
+    position: absolute; border-radius: 99px; background: var(--primary); color: #fff;
+    font-weight: 700; display: grid; place-items: center; font-family: var(--flx-display);
+}
+.flx-satellite {
+    position: absolute; display: flex; flex-direction: column; align-items: center;
+    gap: 8px; background: none; border: none; padding: 0; cursor: pointer;
+    font-family: inherit; text-decoration: none;
+}
+.flx-satellite-disque {
+    width: 36px; height: 36px; flex: 0 0 auto; border-radius: 50%; display: grid;
+    place-items: center; background: rgba(47,93,80,0.09);
+    border: 1px solid rgba(47,93,80,0.34); color: var(--primary);
+}
+.flx-satellite-nom { line-height: 1.28; color: var(--gray-700); text-align: center; }
+.flx-centre {
+    position: absolute; left: -84px; top: -84px; width: 168px; height: 168px;
+    border-radius: 50%; display: grid; place-items: center;
+    background: radial-gradient(circle, rgba(47,93,80,0.16) 0%, rgba(47,93,80,0) 68%);
+}
+.flx-centre-disque {
+    width: 68px; height: 68px; border-radius: 50%; background: var(--white);
+    border: 1px solid rgba(47,93,80,0.4); display: grid; place-items: center;
+    font-family: var(--flx-display); font-size: 0.92rem; font-weight: 600;
+    color: var(--primary); transition: opacity .55s ease;
+}
+
+/* ── Message éphémère ────────────────────────────────────────────────── */
+.flx-toast {
+    position: fixed; bottom: 104px; left: 50%; transform: translateX(-50%); z-index: 90;
+    display: flex; align-items: center; gap: 12px; padding: 13px 20px; border-radius: 99px;
+    background: var(--white); border: 1px solid rgba(47,93,80,0.3);
+    box-shadow: 0 18px 44px -14px rgba(35,70,61,0.16);
+    font-size: 0.88rem; color: var(--gray-900); white-space: nowrap;
+    animation: fadeInUp .22s ease;
+}
+
+/* ── Cohabitation avec le chatbot flottant ───────────────────────────── */
+/* La barre du bas occupe le centre : on remonte la bulle pour qu'elles ne se
+   chevauchent pas sur les écrans étroits. */
+body.flx #cspChatBtn { bottom: 92px; }
+body.flx #cspChatWindow { bottom: 154px; }
+@media (max-width: 480px) {
+    body.flx #cspChatBtn { bottom: 80px; }
+    body.flx #cspChatWindow { bottom: 140px; height: 55vh; }
+}
+
+/* ── Écrans étroits ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+    .flx-entete { gap: 12px; padding: 0 16px; }
+    .flx-marque-texte { display: none; }
+    .flx-identite-texte { display: none; }
+    .flx-titre { font-size: 2rem; }
+}
+@media (max-width: 640px) {
+    :root { --flx-entete: 76px; }
+    .flx-recherche-boite { max-width: none; }
+    .flx-kbd { display: none; }
+    .flx-carte { grid-template-columns: 1fr; gap: 12px; }
+    .flx-carte-actions { justify-content: flex-start; }
+    .flx-glyphe { width: 40px; height: 40px; border-radius: 12px; }
+    .flx-ligne { flex-direction: column; align-items: stretch; gap: 8px; }
+    .flx-ligne-titre { flex: 0 0 auto; }
+    .flx-page-titre { gap: 14px; }
+    .flx-page-icone { width: 48px; height: 48px; border-radius: 14px; font-size: 1.2rem; }
+    .flx-page-titre h1 { font-size: 1.5rem; }
+    .flx-pied { padding: 0 12px 14px; }
+}

--- a/static/js/flux.js
+++ b/static/js/flux.js
@@ -1,0 +1,639 @@
+/* Interface sans menu : clavier, barre intelligente et vue d'ensemble.
+ *
+ * Trois comportements, tous pilotés par le clavier :
+ * - une touche imprimable, n'importe où, ouvre la barre et s'y inscrit ;
+ * - Ctrl/⌘ + K ouvre la barre vide ;
+ * - Échap ouvre la vue d'ensemble (et la referme).
+ *
+ * La recherche garde le moteur existant : la barre propose d'abord les zones
+ * et les pages (ce qui remplace le menu), et « Rechercher … » envoie la requête
+ * à /api/search, dont le verdict est traité comme avant (redirect / choices /
+ * none).
+ */
+(function () {
+    'use strict';
+
+    var socle = document.getElementById('flxSocle');
+    if (!socle) return;
+
+    var CARTE = {zones: [], directs: []};
+    try {
+        CARTE = JSON.parse(socle.getAttribute('data-carte') || '{}') || {};
+    } catch (e) { /* carte illisible : la vue d'ensemble restera vide */ }
+    CARTE.zones = CARTE.zones || [];
+    CARTE.directs = CARTE.directs || [];
+
+    var INITIALES = socle.getAttribute('data-initiales') || '?';
+    var URL_ACCUEIL = socle.getAttribute('data-accueil') || '/accueil';
+
+    var champ = document.getElementById('flxChamp');
+    var barre = document.getElementById('flxBarre');
+    var palette = null;      // élément DOM de la palette ouverte
+    var ensemble = null;     // élément DOM de la vue d'ensemble ouverte
+    var selection = 0;
+    var resultats = [];
+
+    /* ── Utilitaires ──────────────────────────────────────────────────── */
+
+    function ech(s) {
+        var d = document.createElement('div');
+        d.appendChild(document.createTextNode(s == null ? '' : String(s)));
+        return d.innerHTML;
+    }
+
+    /* Comparaison insensible aux accents et à la casse : « échéance » doit se
+       trouver en tapant « echeance ». */
+    function pliable(s) {
+        return String(s == null ? '' : s)
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '');
+    }
+
+    function toast(message) {
+        var t = document.createElement('div');
+        t.className = 'flx-toast';
+        t.textContent = message;
+        document.body.appendChild(t);
+        setTimeout(function () { t.remove(); }, 2600);
+    }
+
+    /* Lieux fréquentés : alimente la barre du bas, sans rien demander. */
+    function usage() {
+        try { return JSON.parse(localStorage.getItem('flx_usage') || '{}') || {}; }
+        catch (e) { return {}; }
+    }
+    function noterUsage(id) {
+        try {
+            var u = usage();
+            u[id] = (u[id] || 0) + 1;
+            localStorage.setItem('flx_usage', JSON.stringify(u));
+        } catch (e) { /* stockage indisponible : le sillage restera vide */ }
+    }
+
+    function groupes() { return CARTE.zones.concat(CARTE.directs); }
+
+    /* ── Palette : construction des propositions ──────────────────────── */
+
+    function propositionsVides() {
+        var liste = [];
+        var u = usage();
+        var frequents = groupes()
+            .filter(function (g) { return (u[g.id] || 0) > 0; })
+            .sort(function (a, b) { return (u[b.id] || 0) - (u[a.id] || 0); })
+            .slice(0, 3);
+        if (frequents.length) {
+            frequents.forEach(function (g, i) {
+                liste.push({
+                    entete: i === 0 ? 'Vos lieux' : null,
+                    icone: g.icone, titre: g.nom,
+                    sous: g.pages.length + ' page(s)',
+                    url: g.pages[0].lien, zone: g.id
+                });
+            });
+        }
+        groupes().slice(0, 6).forEach(function (g, i) {
+            liste.push({
+                entete: i === 0 ? 'Zones' : null,
+                icone: g.icone, titre: g.nom, sous: g.description,
+                url: g.pages[0].lien, zone: g.id
+            });
+        });
+        liste.push({
+            entete: 'Explorer', icone: '⊕', titre: "Voir tout l'espace",
+            sous: inventaire(),
+            action: 'ensemble'
+        });
+        return liste;
+    }
+
+    function nbPages() {
+        return groupes().reduce(function (n, g) { return n + g.pages.length; }, 0);
+    }
+
+    /* « 8 zones · 3 accès directs · 58 pages » : le décompte dit ce que la
+       carte montre, les deux cercles ayant des rôles différents. */
+    function inventaire() {
+        var t = [CARTE.zones.length + ' zone' + (CARTE.zones.length > 1 ? 's' : '')];
+        if (CARTE.directs.length) {
+            t.push(CARTE.directs.length + ' accès direct' + (CARTE.directs.length > 1 ? 's' : ''));
+        }
+        t.push(nbPages() + ' pages');
+        return t.join(' · ');
+    }
+
+    function propositions(q) {
+        if (!q) return propositionsVides();
+        var qp = pliable(q);
+        var liste = [];
+
+        var zones = groupes().filter(function (g) {
+            return pliable(g.nom + ' ' + g.mots + ' ' + g.description).indexOf(qp) !== -1;
+        });
+        zones.forEach(function (g, i) {
+            liste.push({
+                entete: i === 0 ? 'Zones' : null,
+                icone: g.icone, titre: g.nom, sous: g.description,
+                url: g.pages[0].lien, zone: g.id
+            });
+        });
+
+        /* Les pages se cherchent par leur propre nom, pas par les mots-clés de
+           leur zone : sans cela, « facture » ferait remonter les onze pages de
+           la zone Validations, dont les mots-clés contiennent « facture ». La
+           zone, elle, reste proposée juste au-dessus. */
+        var parNom = [], parZone = [];
+        groupes().forEach(function (g) {
+            var zoneMatch = pliable(g.nom).indexOf(qp) !== -1;
+            g.pages.forEach(function (p) {
+                var item = {icone: g.icone, titre: p.label,
+                            sous: 'Page · ' + g.nom, url: p.lien, zone: g.id};
+                if (pliable(p.label).indexOf(qp) !== -1) parNom.push(item);
+                else if (zoneMatch) parZone.push(item);
+            });
+        });
+        /* Une page qui porte le mot cherché passe avant celles qui ne font que
+           partager sa zone : « facture » propose Factures avant Fournisseurs. */
+        parNom.concat(parZone).slice(0, 8).forEach(function (p, i) {
+            liste.push(Object.assign({entete: i === 0 ? 'Pages' : null}, p));
+        });
+
+        liste.push({
+            entete: 'Rechercher', icone: '⌕', titre: 'Rechercher « ' + q + ' »',
+            sous: 'Fournisseur, salarié, facture, budget…', action: 'recherche'
+        });
+        return liste;
+    }
+
+    /* ── Palette : rendu ──────────────────────────────────────────────── */
+
+    function ouvrirPalette(valeurInitiale) {
+        if (!palette) {
+            var voile = document.createElement('div');
+            voile.className = 'flx-voile';
+            voile.addEventListener('click', fermerPalette);
+
+            palette = document.createElement('div');
+            palette.className = 'flx-palette';
+            palette.innerHTML =
+                '<div class="flx-palette-corps" id="flxPaletteCorps"></div>' +
+                '<div class="flx-palette-pied"><span>↑↓ parcourir · ↵ ouvrir</span>' +
+                "<span>Échap : vue d'ensemble</span></div>";
+            palette._voile = voile;
+            document.body.appendChild(voile);
+            document.body.appendChild(palette);
+            if (barre) barre.classList.add('flx-ouverte');
+        }
+        if (typeof valeurInitiale === 'string' && champ) champ.value = valeurInitiale;
+        selection = 0;
+        rendrePalette();
+        if (champ) champ.focus();
+    }
+
+    function fermerPalette() {
+        if (!palette) return;
+        if (palette._voile) palette._voile.remove();
+        palette.remove();
+        palette = null;
+        if (barre) barre.classList.remove('flx-ouverte');
+        if (champ) { champ.value = ''; champ.blur(); }
+    }
+
+    function rendrePalette() {
+        if (!palette) return;
+        resultats = propositions(champ ? champ.value.trim() : '');
+        if (selection >= resultats.length) selection = Math.max(0, resultats.length - 1);
+        var corps = palette.querySelector('#flxPaletteCorps');
+        if (!resultats.length) {
+            corps.innerHTML = '<div class="flx-palette-vide">Rien ne correspond.</div>';
+            return;
+        }
+        corps.innerHTML = resultats.map(function (r, i) {
+            return (r.entete ? '<div class="flx-palette-groupe">' + ech(r.entete) + '</div>' : '') +
+                '<button type="button" class="flx-res' + (i === selection ? ' flx-res-actif' : '') +
+                '" data-i="' + i + '">' +
+                '<span class="flx-res-icone">' + ech(r.icone) + '</span>' +
+                '<span class="flx-res-corps">' +
+                '<span class="flx-res-titre">' + ech(r.titre) + '</span>' +
+                '<span class="flx-res-sous">' + ech(r.sous) + '</span></span>' +
+                '<span class="flx-res-fleche">↵</span></button>';
+        }).join('');
+        corps.querySelectorAll('.flx-res').forEach(function (b) {
+            b.addEventListener('click', function () { executer(resultats[+b.dataset.i]); });
+            b.addEventListener('mouseenter', function () {
+                selection = +b.dataset.i;
+                corps.querySelectorAll('.flx-res').forEach(function (x) {
+                    x.classList.toggle('flx-res-actif', +x.dataset.i === selection);
+                });
+            });
+        });
+        var actif = corps.querySelector('.flx-res-actif');
+        if (actif && actif.scrollIntoView) actif.scrollIntoView({block: 'nearest'});
+    }
+
+    function executer(r) {
+        if (!r) return;
+        if (r.action === 'ensemble') { fermerPalette(); ouvrirEnsemble(); return; }
+        if (r.action === 'recherche') { lancerRecherche(); return; }
+        if (r.zone) noterUsage(r.zone);
+        window.location = r.url;
+    }
+
+    /* Recherche intelligente : le moteur existant, inchangé. */
+    function lancerRecherche() {
+        var q = champ ? champ.value.trim() : '';
+        if (!q) return;
+        var corps = palette && palette.querySelector('#flxPaletteCorps');
+        if (corps) corps.innerHTML = '<div class="flx-palette-vide">Recherche…</div>';
+        fetch('/api/search', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({query: q})
+        }).then(function (r) { return r.json(); })
+          .then(function (v) { rendreVerdict(v, corps); })
+          .catch(function () {
+              if (corps) corps.innerHTML = '<div class="flx-palette-vide">Erreur de recherche.</div>';
+          });
+    }
+
+    function rendreVerdict(v, corps) {
+        if (!corps) return;
+        if (v.type === 'redirect') {
+            corps.innerHTML = '<div class="flx-palette-vide">Ouverture : ' + ech(v.label) + '…</div>';
+            window.location = v.url;
+            return;
+        }
+        if (v.type === 'choices') {
+            corps.innerHTML = '<div class="flx-palette-groupe">' + ech(v.prompt) + '</div>' +
+                (v.options || []).map(function (o) {
+                    return '<a class="flx-res" href="' + ech(o.url) + '">' +
+                        '<span class="flx-res-icone">→</span>' +
+                        '<span class="flx-res-corps">' +
+                        '<span class="flx-res-titre">' + ech(o.label) + '</span>' +
+                        (o.sous_titre ? '<span class="flx-res-sous">' + ech(o.sous_titre) + '</span>' : '') +
+                        '</span></a>';
+                }).join('');
+            return;
+        }
+        var h = '<div class="flx-palette-vide">' + ech(v.message) + '</div>';
+        if (v.exemples && v.exemples.length) {
+            h += '<div class="flx-palette-groupe">Essayez</div>' + v.exemples.map(function (e) {
+                return '<button type="button" class="flx-res" data-ex="' + ech(e) + '">' +
+                    '<span class="flx-res-icone">⌕</span>' +
+                    '<span class="flx-res-corps"><span class="flx-res-titre">' + ech(e) +
+                    '</span></span></button>';
+            }).join('');
+        }
+        corps.innerHTML = h;
+        corps.querySelectorAll('[data-ex]').forEach(function (b) {
+            b.addEventListener('click', function () {
+                if (champ) champ.value = b.dataset.ex;
+                lancerRecherche();
+            });
+        });
+    }
+
+    /* ── Vue d'ensemble : géométrie ───────────────────────────────────── */
+
+    var latch = null;        // zone dépliée
+    var tEntree = null, tSortie = null, cible = null, cam = null;
+
+    function ouvrirEnsemble() {
+        if (ensemble) return;
+        fermerPalette();
+        ensemble = document.createElement('div');
+        ensemble.className = 'flx-ensemble';
+        ensemble.innerHTML =
+            '<div class="flx-ensemble-fond" id="flxEnsFond"></div>' +
+            '<div class="flx-ensemble-entete">' +
+            '<div class="flx-ensemble-sur">Vue d\'ensemble</div>' +
+            '<div class="flx-ensemble-titre" id="flxEnsTitre"></div>' +
+            '<div class="flx-ensemble-sous" id="flxEnsSous"></div></div>' +
+            '<div class="flx-anneau-carte" id="flxAnneauCarte"></div>' +
+            '<div class="flx-ensemble-pied" id="flxEnsPied"></div>';
+        document.body.appendChild(ensemble);
+        ensemble.querySelector('#flxEnsFond').addEventListener('click', function () {
+            if (latch) { latch = null; dessinerEnsemble(); } else { fermerEnsemble(); }
+        });
+        ensemble.addEventListener('mousemove', survolerEspace);
+        ensemble.addEventListener('mouseleave', function () {
+            annulerEntree(); maintenir();
+            if (latch) { latch = null; dessinerEnsemble(); }
+        });
+        window.addEventListener('resize', dessinerEnsemble);
+        latch = null;
+        dessinerEnsemble();
+    }
+
+    function fermerEnsemble() {
+        if (!ensemble) return;
+        window.removeEventListener('resize', dessinerEnsemble);
+        ensemble.remove();
+        ensemble = null;
+        latch = null;
+        cam = null;
+    }
+
+    function maintenir() { clearTimeout(tSortie); tSortie = null; }
+    function annulerEntree() { clearTimeout(tEntree); tEntree = null; cible = null; }
+
+    /* Acquisition au survol : il faut s'attarder sur une zone pour la déplier,
+       la traverser ne déclenche rien. Une fois dépliée, elle le reste tant
+       qu'aucune autre zone n'est franchement plus proche. */
+    function survolerEspace(ev) {
+        if (!cam) return;
+        var cx = ev.clientX, cy = ev.clientY;
+
+        if (latch) {
+            var a = cam.actif;
+            if (!a) return;
+            var d = Math.hypot(cx - a.ex, cy - a.ey);
+            if (d < a.halo) { maintenir(); return; }
+            var dAutre = Infinity;
+            cam.noeuds.forEach(function (n) {
+                if (n.id === latch) return;
+                dAutre = Math.min(dAutre, Math.hypot(cx - n.ex, cy - n.ey));
+            });
+            if (dAutre > d * 0.92) { maintenir(); return; }
+            if (!tSortie) {
+                tSortie = setTimeout(function () {
+                    tSortie = null; latch = null; dessinerEnsemble();
+                }, 420);
+            }
+            return;
+        }
+
+        var plus = null, dMin = Infinity;
+        cam.noeuds.forEach(function (n) {
+            var d = Math.hypot(cx - n.ex, cy - n.ey);
+            if (d < dMin) { dMin = d; plus = n; }
+        });
+        if (!plus || dMin > (plus.r + 40) * cam.k) { annulerEntree(); return; }
+        if (cible === plus.id) return;
+        annulerEntree();
+        cible = plus.id;
+        tEntree = setTimeout(function () {
+            tEntree = null; cible = null; maintenir();
+            latch = plus.id;
+            dessinerEnsemble();
+        }, 280);
+    }
+
+    function dessinerEnsemble() {
+        if (!ensemble) return;
+        var W = window.innerWidth, H = window.innerHeight;
+        var HAUT = H < 640 ? 116 : 162, BAS = H < 640 ? 56 : 84;
+        var dGrand = 68, dPetit = 56;
+        var RO = 332, RI = 178, RS = 150;
+
+        var ajuste = function (dec) {
+            return Math.max(0.45, Math.min(1, (H - HAUT - BAS) / (2 * (RO + dec)),
+                                           (W - 56) / (2 * (RO + 78))));
+        };
+        var k = ajuste((dGrand + 10 + 34) / 2);
+        k = ajuste((dGrand + 10 + 38 / k) / 2);
+        var decNoeud = (dGrand + 10 + 38 / k) / 2;
+        var centreY = (HAUT + (H - BAS)) / 2 - H / 2;
+        var etire = Math.max(1, Math.min(1.55, ((W - 96) / 2) / ((RO + 84) * k)));
+
+        function pos(rayon, i, n, depart) {
+            var ang = ((i + depart) / n) * Math.PI * 2 - Math.PI / 2;
+            var x = Math.cos(ang) * rayon * etire, y = Math.sin(ang) * rayon;
+            return {x: x, y: y, deg: Math.atan2(y, x) * 180 / Math.PI,
+                    dist: Math.hypot(x, y), corde: (2 * Math.PI * rayon) / n};
+        }
+
+        /* Cercle intérieur : les zones thématiques. Cercle extérieur : les
+           pages qu'on ouvre en accès direct. */
+        var places = [];
+        var zones = CARTE.zones, directs = CARTE.directs;
+        if (!zones.length || !directs.length) {
+            var tous = zones.concat(directs);
+            tous.forEach(function (g, i) {
+                places.push(Object.assign({g: g, interieur: true}, pos(RO, i, tous.length, 0)));
+            });
+        } else {
+            zones.forEach(function (g, i) {
+                places.push(Object.assign({g: g, interieur: true}, pos(RI, i, zones.length, 0)));
+            });
+            directs.forEach(function (g, i) {
+                places.push(Object.assign({g: g, interieur: false}, pos(RO, i, directs.length, 0.5)));
+            });
+        }
+
+        var actif = places.filter(function (p) { return p.g.id === latch; })[0] || null;
+        var S = k * (actif ? 1.13 : 1);
+        var derive = actif ? 0.3 : 0;
+        var TX = -derive * S * (actif ? actif.x : 0);
+        var TY = centreY - derive * S * (actif ? actif.y : 0);
+
+        cam = {
+            k: k,
+            noeuds: places.map(function (p) {
+                return {id: p.g.id, r: (p.interieur ? dGrand : dPetit) / 2,
+                        ex: W / 2 + k * p.x, ey: H / 2 + centreY + k * p.y};
+            }),
+            actif: actif ? {
+                ex: W / 2 + TX + S * actif.x, ey: H / 2 + TY + S * actif.y,
+                halo: (dGrand / 2 + Math.max(RS, 138 / S) + 84) * S
+            } : null
+        };
+
+        var T = function (px) { return (px / S) + 'px'; };
+        var carte = ensemble.querySelector('#flxAnneauCarte');
+        carte.style.transform = 'translate(' + TX + 'px, ' + TY + 'px) scale(' + S + ')';
+        carte.innerHTML = '';
+
+        places.forEach(function (p) {
+            var r = document.createElement('div');
+            r.className = 'flx-rayon';
+            r.style.width = Math.max(16, p.dist - (p.interieur ? dGrand : dPetit) / 2 - 10) + 'px';
+            r.style.transform = 'rotate(' + p.deg + 'deg)';
+            r.style.opacity = (actif && actif.g.id !== p.g.id) ? '0.15' : '1';
+            carte.appendChild(r);
+        });
+
+        var centre = document.createElement('div');
+        centre.className = 'flx-centre';
+        centre.innerHTML = '<div class="flx-centre-disque">' + ech(INITIALES) + '</div>';
+        centre.querySelector('.flx-centre-disque').style.opacity = actif ? '0.3' : '1';
+        carte.appendChild(centre);
+
+        places.forEach(function (p) {
+            var ici = actif && actif.g.id === p.g.id;
+            var taille = p.interieur ? dGrand : dPetit;
+            var larg = Math.max(76, Math.min(p.corde - 12, 150 / S));
+
+            var n = document.createElement('button');
+            n.type = 'button';
+            n.className = 'flx-noeud' + (p.interieur ? ' flx-noeud-chaud' : '') +
+                          (ici ? ' flx-noeud-ouvert' : '');
+            n.style.left = (p.x - larg / 2) + 'px';
+            n.style.top = (p.y - decNoeud) + 'px';
+            n.style.width = larg + 'px';
+            n.style.opacity = actif ? (ici ? '1' : '0.32') : '1';
+            n.style.pointerEvents = (actif && !ici) ? 'none' : 'auto';
+            n.innerHTML =
+                '<span class="flx-noeud-disque" style="width:' + taille + 'px;height:' + taille + 'px">' +
+                ech(p.g.icone) +
+                (p.g.pages.length > 1 ? '<span class="flx-pastille-compte" style="top:' + T(-6) +
+                    ';right:' + T(-6) + ';min-width:' + T(19) + ';height:' + T(19) +
+                    ';padding:0 ' + T(5) + ';font-size:' + T(10.5) + '">' + p.g.pages.length + '</span>' : '') +
+                '</span>' +
+                '<span class="flx-noeud-nom" style="font-size:' + T(13.5) +
+                ';opacity:' + (actif ? 0 : 1) + '">' + ech(p.g.nom) + '</span>';
+            n.addEventListener('click', function (ev) {
+                ev.stopPropagation();
+                annulerEntree();
+                if (p.g.pages.length === 1 || latch === p.g.id) {
+                    noterUsage(p.g.id);
+                    window.location = p.g.pages[0].lien;
+                } else {
+                    latch = p.g.id;
+                    dessinerEnsemble();
+                }
+            });
+            n.addEventListener('mousemove', function (ev) {
+                if (ici) { ev.stopPropagation(); maintenir(); }
+            });
+            carte.appendChild(n);
+
+            if (!ici) return;
+
+            /* Les pages de la zone dépliée, en couronne autour d'elle. */
+            var rs = Math.max(RS, 138 / S);
+            var nb = p.g.pages.length;
+            var largeSat = Math.max(80, Math.min((2 * Math.PI * rs) / nb - 10, 138 / S));
+            p.g.pages.forEach(function (page, j) {
+                var ang = (j / nb) * Math.PI * 2 - Math.PI / 2 + 0.42;
+                var sx = p.x + Math.cos(ang) * rs, sy = p.y + Math.sin(ang) * rs;
+                var s = document.createElement('a');
+                s.className = 'flx-satellite';
+                s.href = page.lien;
+                s.style.left = (sx - largeSat / 2) + 'px';
+                s.style.top = (sy - 40) + 'px';
+                s.style.width = largeSat + 'px';
+                s.innerHTML =
+                    '<span class="flx-satellite-disque" style="font-size:' + T(11) + '">' +
+                    ech(p.g.icone) + '</span>' +
+                    '<span class="flx-satellite-nom" style="font-size:' + T(12.5) + '">' +
+                    ech(page.label) + '</span>';
+                s.addEventListener('click', function () { noterUsage(p.g.id); });
+                s.addEventListener('mousemove', function (ev) { ev.stopPropagation(); maintenir(); });
+                carte.appendChild(s);
+            });
+        });
+
+        ensemble.querySelector('#flxEnsTitre').textContent =
+            actif ? actif.g.nom : "Tout l'espace, en un geste — puis il disparaît.";
+        ensemble.querySelector('#flxEnsSous').textContent =
+            actif ? actif.g.description
+                  : inventaire() + " · approchez-vous d'une zone, son contenu apparaît";
+        ensemble.querySelector('#flxEnsPied').textContent =
+            actif ? 'Cliquez une page pour y entrer · éloignez-vous pour revenir à la carte'
+                  : 'Échap ou clic dans le vide pour refermer';
+    }
+
+    /* ── Clavier ──────────────────────────────────────────────────────── */
+
+    function dansUnChamp(el) {
+        if (!el) return false;
+        var t = (el.tagName || '').toUpperCase();
+        return t === 'INPUT' || t === 'TEXTAREA' || t === 'SELECT' || el.isContentEditable;
+    }
+
+    document.addEventListener('keydown', function (e) {
+        if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+            e.preventDefault();
+            ouvrirPalette('');
+            return;
+        }
+
+        if (e.key === 'Escape') {
+            if (palette) { e.preventDefault(); fermerPalette(); return; }
+            if (ensemble) {
+                e.preventDefault();
+                if (latch) { latch = null; dessinerEnsemble(); } else { fermerEnsemble(); }
+                return;
+            }
+            // Sur une page où Échap sert déjà (fenêtre modale ouverte), on ne
+            // vole pas la touche : les modales du reste de l'application posent
+            // leur propre écouteur et sont visibles à ce moment-là.
+            if (document.querySelector('.modal-overlay[style*="flex"]')) return;
+            e.preventDefault();
+            ouvrirEnsemble();
+            return;
+        }
+
+        if (palette) {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                selection = (selection + 1) % Math.max(resultats.length, 1);
+                rendrePalette();
+                return;
+            }
+            if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                selection = (selection - 1 + resultats.length) % Math.max(resultats.length, 1);
+                rendrePalette();
+                return;
+            }
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                executer(resultats[selection]);
+                return;
+            }
+            return;
+        }
+
+        // Le cœur du dispositif : taper, n'importe où, remplit la barre.
+        if (!dansUnChamp(e.target) && !e.metaKey && !e.ctrlKey && !e.altKey &&
+            e.key.length === 1 && /\S/.test(e.key)) {
+            e.preventDefault();
+            ouvrirPalette(e.key);
+        }
+    });
+
+    if (champ) {
+        champ.addEventListener('input', function () {
+            if (!palette) { ouvrirPalette(champ.value); return; }
+            selection = 0;
+            rendrePalette();
+        });
+        champ.addEventListener('focus', function () { if (!palette) ouvrirPalette(champ.value); });
+    }
+    if (barre) {
+        barre.addEventListener('click', function () { if (champ) champ.focus(); });
+    }
+
+    document.querySelectorAll('[data-flx-ensemble]').forEach(function (b) {
+        b.addEventListener('click', function (e) { e.preventDefault(); ouvrirEnsemble(); });
+    });
+
+    /* Mémorise la zone visitée, pour alimenter la barre du bas. */
+    var zoneCourante = socle.getAttribute('data-zone');
+    if (zoneCourante) noterUsage(zoneCourante);
+
+    /* Sillage : les trois zones les plus ouvertes, plus celle où l'on se trouve
+       si elle n'y figure pas encore. Le raccourci se forme par l'usage, sans
+       rien demander à personne. */
+    (function () {
+        var hote = document.getElementById('flxSillage');
+        if (!hote) return;
+        var u = usage();
+        var frequents = groupes()
+            .filter(function (g) { return (u[g.id] || 0) > 0; })
+            .sort(function (a, b) { return (u[b.id] || 0) - (u[a.id] || 0); })
+            .slice(0, 3);
+        if (zoneCourante && !frequents.some(function (g) { return g.id === zoneCourante; })) {
+            groupes().forEach(function (g) { if (g.id === zoneCourante) frequents.push(g); });
+        }
+        hote.innerHTML = frequents.map(function (g) {
+            var actif = g.id === zoneCourante ? ' flx-actif' : '';
+            return '<a class="flx-pied-lien' + actif + '" href="' + ech(g.pages[0].lien) +
+                '" title="Ouvert ' + (u[g.id] || 0) + ' fois">' + ech(g.nom) + '</a>';
+        }).join('');
+    })();
+
+    window.flxToast = toast;
+})();

--- a/static/js/flux.js
+++ b/static/js/flux.js
@@ -24,6 +24,10 @@
     CARTE.directs = CARTE.directs || [];
 
     var INITIALES = socle.getAttribute('data-initiales') || '?';
+    /* La recherche métier n'est ouverte qu'aux profils que /api/search accepte.
+       Pour les autres, la barre reste un moyen d'aller à une page — proposer
+       « Rechercher » leur renverrait un « Accès non autorisé ». */
+    var RECHERCHE_GLOBALE = socle.getAttribute('data-recherche-globale') === '1';
     var URL_ACCUEIL = socle.getAttribute('data-accueil') || '/accueil';
 
     var champ = document.getElementById('flxChamp');
@@ -158,10 +162,12 @@
             liste.push(Object.assign({entete: i === 0 ? 'Pages' : null}, p));
         });
 
-        liste.push({
-            entete: 'Rechercher', icone: '⌕', titre: 'Rechercher « ' + q + ' »',
-            sous: 'Fournisseur, salarié, facture, budget…', action: 'recherche'
-        });
+        if (RECHERCHE_GLOBALE) {
+            liste.push({
+                entete: 'Rechercher', icone: '⌕', titre: 'Rechercher « ' + q + ' »',
+                sous: 'Fournisseur, salarié, facture, budget…', action: 'recherche'
+            });
+        }
         return liste;
     }
 
@@ -205,7 +211,10 @@
         if (selection >= resultats.length) selection = Math.max(0, resultats.length - 1);
         var corps = palette.querySelector('#flxPaletteCorps');
         if (!resultats.length) {
-            corps.innerHTML = '<div class="flx-palette-vide">Rien ne correspond.</div>';
+            corps.innerHTML = '<div class="flx-palette-vide">Aucune page ne correspond. ' +
+                'Essayez « congés », « facture », « salle »' +
+                (RECHERCHE_GLOBALE ? '' : ' — ou ouvrez la vue d\'ensemble avec Échap') +
+                '.</div>';
             return;
         }
         corps.innerHTML = resultats.map(function (r, i) {

--- a/templates/_flux_actions.html
+++ b/templates/_flux_actions.html
@@ -1,0 +1,59 @@
+{# Cartes du fil d'actions. Fragment autonome : rechargé tel quel par
+   /api/accueil/flux-fragment. Attend `actions` (dashboard_actions). #}
+{% set tons = {'retard': ('flx-retard', 'En retard'),
+               'urgent': ('flx-urgent', "Aujourd'hui"),
+               'normal': ('flx-planifier', 'À planifier')} %}
+{# La carte annonce la zone dont relève la décision, comme dans la vue
+   d'ensemble : on sait d'où vient l'action avant même de la lire. #}
+{% set zones_par_categorie = {'validation': 'Validations & suivi',
+                              'facture': 'Factures & achats',
+                              'subvention': 'Financier',
+                              'surcharge': 'Temps & plannings',
+                              'conges': 'RH & Paie'} %}
+{% for a in actions %}
+{% set ton = tons.get(a.urgence, tons['normal']) %}
+<div class="flx-carte {{ ton[0] }}" data-flx-item data-flx-id="{{ a.id }}">
+    <div class="flx-glyphe">{{ a.icone }}</div>
+    <div class="flx-carte-corps">
+        <div class="flx-carte-meta">
+            <span class="flx-badge">{{ ton[1] }}</span>
+            <span class="flx-carte-zone">{{ zones_par_categorie.get(a.categorie, a.categorie) }}</span>
+        </div>
+        <div class="flx-carte-titre" data-flx-titre>{{ a.titre }}</div>
+        {% if a.detail %}<div class="flx-carte-detail" data-flx-detail>{{ a.detail }}</div>{% endif %}
+    </div>
+    <div class="flx-carte-actions" data-flx-btns>
+        {% if a.type == 'demande' %}
+        <button type="button" class="flx-btn flx-btn-plein" data-flx-act="valider"
+                data-flx-ref="{{ a.id }}" data-demande-id="{{ a.demande_id }}"
+                data-demande-type="{{ a.demande_type }}">✓ Valider</button>
+        <button type="button" class="flx-btn" data-flx-act="refuser"
+                data-flx-ref="{{ a.id }}" data-demande-id="{{ a.demande_id }}"
+                data-demande-type="{{ a.demande_type }}">Refuser</button>
+        {% elif a.type == 'facture' %}
+        <button type="button" class="flx-btn flx-btn-plein" data-flx-act="facture"
+                data-flx-ref="{{ a.id }}" data-facture-id="{{ a.facture_id }}">✓ Approuver</button>
+        <a href="{{ a.lien }}" class="flx-btn">Ouvrir</a>
+        {% elif a.type == 'subvention' %}
+        <button type="button" class="flx-btn flx-btn-plein" data-flx-act="subvention"
+                data-flx-ref="{{ a.id }}" data-se-id="{{ a.se_id }}">✓ C'est fait</button>
+        <a href="{{ a.lien }}" class="flx-btn">Ouvrir</a>
+        {% elif a.type == 'relance' %}
+        <button type="button" class="flx-btn flx-btn-plein" data-flx-act="relance"
+                data-flx-ref="{{ a.id }}" data-mois="{{ a.relance_mois }}"
+                data-annee="{{ a.relance_annee }}">📧 Relancer</button>
+        <a href="{{ a.lien }}" class="flx-btn">{{ a.lien_texte }}</a>
+        {% else %}
+        <a href="{{ a.lien }}" class="flx-btn">{{ a.lien_texte }} →</a>
+        {% endif %}
+    </div>
+</div>
+{% endfor %}
+
+<div class="flx-vide" id="flxToutFait" {% if actions %}style="display:none;"{% endif %}>
+    <div class="flx-vide-glyphe">◉</div>
+    <div class="flx-vide-titre">Flux vide.</div>
+    <p style="margin:0 auto 26px;color:var(--gray-500);max-width:38ch;font-size:0.94rem;">
+        Plus rien n'attend de décision. L'application n'a rien à vous montrer — c'est le but.</p>
+    <button type="button" class="flx-btn" data-flx-ensemble>Explorer l'espace complet</button>
+</div>

--- a/templates/_flux_page_entete.html
+++ b/templates/_flux_page_entete.html
@@ -1,0 +1,35 @@
+{# En-tête des pages dans l'interface sans menu : le retour au flux, la zone à
+   laquelle la page appartient et les boutons de ses pages voisines. C'est ce
+   qui remplace le sous-menu du menu latéral.
+
+   Le titre propre de la page n'est pas repris ici : chaque page a déjà le sien
+   (et ses boutons d'action : importer, relancer…), qui restent en place. #}
+{# Le retour est proposé partout : une page hors carte (détail d'une facture,
+   calendrier d'une salle…) doit elle aussi offrir une sortie. #}
+<div class="flx-page-entete">
+    <a href="{{ url_for('accueil_bp.accueil') }}" class="flx-retour">← Revenir au flux</a>
+    {% if nav_zone %}
+    <div class="flx-chips">
+        <span class="flx-chips-label">{{ nav_zone.icone }} {{ nav_zone.nom }}</span>
+        {% for p in nav_zone.pages %}
+        <a href="{{ p.lien }}"
+           class="flx-chip{% if nav_page and p.endpoint == nav_page.endpoint %} flx-chip-actif{% endif %}">{{ p.label }}</a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+
+{% if flux_infos %}
+<div class="flx-infos">
+    {% for info in flux_infos %}
+    <a href="{{ info.lien }}" class="flx-info flx-{{ info.ton }}">
+        <span class="flx-info-icone">{{ info.icone }}</span>
+        <span class="flx-info-corps">
+            <span class="flx-info-valeur">{{ info.valeur }}</span>
+            <span class="flx-info-libelle">{{ info.libelle }}</span>
+        </span>
+        <span class="flx-info-lien">{{ info.lien_texte }} →</span>
+    </a>
+    {% endfor %}
+</div>
+{% endif %}

--- a/templates/_flux_shell.html
+++ b/templates/_flux_shell.html
@@ -1,0 +1,66 @@
+{# Ossature de l'interface sans menu : décor, en-tête fixe et barre du bas.
+   Incluse par base.html à la place du menu latéral. Le socle porte la carte de
+   navigation (déjà filtrée par les droits) que `static/js/flux.js` utilise pour
+   la barre intelligente et la vue d'ensemble. #}
+<div class="flx-fond" aria-hidden="true">
+    <span class="flx-halo-1"></span>
+    <span class="flx-halo-2"></span>
+    <span class="flx-grille"></span>
+</div>
+
+<div id="flxSocle"
+     data-carte="{{ nav_carte|tojson|forceescape }}"
+     data-initiales="{{ nav_identite.initiales }}"
+     data-accueil="{{ url_for('accueil_bp.accueil') }}"
+     {% if nav_zone %}data-zone="{{ nav_zone.id }}"{% endif %}></div>
+
+<header class="flx-entete">
+    <a href="{{ url_for('accueil_bp.accueil') }}" class="flx-marque" title="Revenir au flux">
+        <img src="{{ url_for('static', filename='img/petit-logo.png') }}" alt="">
+        <span class="flx-marque-texte">
+            <span class="flx-marque-titre">CS-PILOT</span>
+            <span class="flx-marque-sous">La plateforme libre des centres sociaux</span>
+        </span>
+    </a>
+
+    <div class="flx-recherche">
+        <div class="flx-recherche-boite">
+            <div class="flx-barre" id="flxBarre">
+                <span class="flx-barre-icone">⌕</span>
+                <input type="text" id="flxChamp" autocomplete="off" spellcheck="false"
+                       aria-label="Rechercher ou naviguer"
+                       placeholder="Que voulez-vous faire ? Tapez n'importe où…">
+                <kbd class="flx-kbd">Ctrl K</kbd>
+            </div>
+        </div>
+    </div>
+
+    <div class="flx-entete-droite">
+        <a href="{{ url_for('accueil_bp.mon_espace') }}" class="flx-identite"
+           title="Mon espace — congés, récupérations, demandes">
+            <span class="flx-identite-texte">
+                <span class="flx-identite-nom">{{ nav_identite.nom }}</span>
+                <span class="flx-identite-role">{{ nav_identite.fonction }}</span>
+            </span>
+            <span class="flx-avatar">{{ nav_identite.initiales }}</span>
+        </a>
+        <button type="button" class="flx-icone-btn" id="themeToggle"
+                title="Changer le thème" onclick="toggleTheme()">🌙</button>
+        <a href="{{ url_for('auth.logout') }}" class="flx-icone-btn" title="Déconnexion">⎋</a>
+    </div>
+</header>
+
+<div class="flx-pied">
+    <div class="flx-pied-barre">
+        <button type="button" class="flx-pied-btn" data-flx-ensemble>
+            <span>⊕</span>Tout l'espace
+        </button>
+        <span class="flx-pied-sep"></span>
+        <a href="{{ url_for('accueil_bp.accueil') }}"
+           class="flx-pied-lien{% if request.endpoint == 'accueil_bp.accueil' %} flx-actif{% endif %}"
+           title="Vos décisions du jour">◈ Flux</a>
+        <span id="flxSillage" style="display:contents;"></span>
+    </div>
+</div>
+
+<script src="{{ url_for('static', filename='js/flux.js') }}?v=1"></script>

--- a/templates/_flux_shell.html
+++ b/templates/_flux_shell.html
@@ -12,6 +12,7 @@
      data-carte="{{ nav_carte|tojson|forceescape }}"
      data-initiales="{{ nav_identite.initiales }}"
      data-accueil="{{ url_for('accueil_bp.accueil') }}"
+     data-recherche-globale="{{ '1' if nav_recherche_globale else '0' }}"
      {% if nav_zone %}data-zone="{{ nav_zone.id }}"{% endif %}></div>
 
 <header class="flx-entete">
@@ -29,7 +30,7 @@
                 <span class="flx-barre-icone">⌕</span>
                 <input type="text" id="flxChamp" autocomplete="off" spellcheck="false"
                        aria-label="Rechercher ou naviguer"
-                       placeholder="Que voulez-vous faire ? Tapez n'importe où…">
+                       placeholder="{% if nav_recherche_globale %}Que voulez-vous faire ? Tapez n'importe où…{% else %}Où voulez-vous aller ? Tapez n'importe où…{% endif %}">
                 <kbd class="flx-kbd">Ctrl K</kbd>
             </div>
         </div>

--- a/templates/_seuils_modal.html
+++ b/templates/_seuils_modal.html
@@ -1,0 +1,104 @@
+{# Fenêtre « Seuils d'alerte », partagée par le centre de contrôle et l'accueil
+   sans menu. Les seuils décident de ce qui remonte : trésorerie, budget
+   consommé, congés conventionnels à planifier, score de surcharge. Ils
+   alimentent aussi le fil d'actions, d'où leur présence sur l'accueil.
+
+   Attend `seuils`. Expose `window.ccOuvrirSeuils()` pour l'ouvrir. #}
+<div id="ccSeuilsModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)ccFermerSeuils()">
+    <div class="modal-content" style="max-width:480px;" role="dialog" aria-modal="true">
+        <div class="modal-header">
+            <h3>⚙ Seuils d'alerte</h3>
+            <button class="modal-close" type="button" onclick="ccFermerSeuils()" aria-label="Fermer">&times;</button>
+        </div>
+        <div style="padding:0 1.5rem;">
+            <p style="font-size:0.85rem;color:var(--gray-500);margin:0 0 1.25rem;">
+                Un indicateur ne remonte que s'il franchit son seuil.
+                Ajustez-les à votre structure.</p>
+            <div style="display:flex;flex-direction:column;gap:1rem;">
+                <label class="cc-seuil-label">Trésorerie minimum (€)
+                    <input type="number" id="ccSeuilTreso" value="{{ seuils.treso|int }}" min="0" step="1000"></label>
+                <label class="cc-seuil-label">Budget consommé (%)
+                    <input type="number" id="ccSeuilBudget" value="{{ seuils.budget|int }}" min="0" max="200"></label>
+                <label class="cc-seuil-label">Solde congés conventionnels (jours)
+                    <input type="number" id="ccSeuilConges" value="{{ seuils.conges|int }}" min="0" step="0.5"></label>
+                <label class="cc-seuil-label">Score de surcharge (/100)
+                    <input type="number" id="ccSeuilSurcharge" value="{{ seuils.surcharge|int }}" min="0" max="100"></label>
+                <label class="cc-seuil-label" style="border-top:1px solid var(--gray-200);padding-top:1rem;align-items:flex-start;">
+                    <span>Digest quotidien par email<br>
+                        <span style="font-weight:400;font-size:0.78rem;color:var(--gray-500);">
+                            Envoyé à la direction et à la comptabilité au premier accès après 8 h.
+                            Les personnes en congé ce jour-là ne le reçoivent pas.</span></span>
+                    <input type="checkbox" id="ccSeuilDigest" style="width:auto;margin-top:4px;" {% if seuils.digest %}checked{% endif %}>
+                </label>
+            </div>
+        </div>
+        <div style="display:flex;justify-content:flex-end;gap:0.75rem;padding:1.25rem 1.5rem 1.5rem;align-items:center;">
+            <span id="ccSeuilsMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>
+            <button class="btn btn-secondary" type="button" onclick="ccFermerSeuils()">Annuler</button>
+            <button class="btn btn-primary" type="button" onclick="ccEnregistrerSeuils()">Enregistrer</button>
+        </div>
+    </div>
+</div>
+
+<style>
+.cc-seuil-label {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 1rem; font-size: 0.9rem; font-weight: 600; color: var(--gray-700);
+}
+.cc-seuil-label input {
+    width: 120px; padding: 0.5rem; border: 1px solid var(--gray-300);
+    border-radius: 6px; font-size: 0.9rem; text-align: right;
+}
+</style>
+
+<script>
+(function () {
+    var modal = document.getElementById('ccSeuilsModal');
+    if (!modal) return;
+
+    function signaler(message) {
+        // L'accueil sans menu a ses propres messages éphémères ; ailleurs on
+        // se rabat sur le champ de statut de la fenêtre.
+        if (window.flxToast) { window.flxToast(message); return; }
+        document.getElementById('ccSeuilsMsg').textContent = message;
+    }
+
+    window.ccOuvrirSeuils = function () { modal.style.display = 'flex'; };
+    window.ccFermerSeuils = function () { modal.style.display = 'none'; };
+
+    window.ccEnregistrerSeuils = function () {
+        var msg = document.getElementById('ccSeuilsMsg');
+        msg.textContent = 'Enregistrement…';
+        fetch('/api/dashboard-direction/seuils', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                treso: Number(document.getElementById('ccSeuilTreso').value),
+                budget: Number(document.getElementById('ccSeuilBudget').value),
+                conges: Number(document.getElementById('ccSeuilConges').value),
+                surcharge: Number(document.getElementById('ccSeuilSurcharge').value),
+                digest: document.getElementById('ccSeuilDigest').checked
+            })
+        }).then(function (r) { return r.json(); })
+          .then(function (d) {
+              if (!d.success) {
+                  msg.textContent = '';
+                  signaler(d.error || 'Enregistrement impossible');
+                  return;
+              }
+              msg.textContent = '✓ Enregistré';
+              // Les seuils décident du contenu affiché : on recharge pour que
+              // la page reflète immédiatement le nouveau réglage.
+              window.location.reload();
+          })
+          .catch(function () {
+              msg.textContent = '';
+              signaler("Erreur — les seuils n'ont pas pu être enregistrés");
+          });
+    };
+
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && modal.style.display === 'flex') ccFermerSeuils();
+    });
+})();
+</script>

--- a/templates/accueil_flux.html
+++ b/templates/accueil_flux.html
@@ -17,6 +17,12 @@
         </p>
     </div>
     <div class="flx-compte">
+        {% if seuils %}
+        {# Les seuils décident de ce qui remonte dans le fil : ils se règlent
+           donc là où le fil s'affiche. #}
+        <button type="button" class="flx-icone-btn" onclick="ccOuvrirSeuils()"
+                title="Seuils d'alerte — trésorerie, budget, congés, surcharge">⚙</button>
+        {% endif %}
         <div class="flx-compte-chiffres">
             <div class="flx-compte-valeur"><span id="flxFaites">0</span><span>/{{ nb_actions }}</span></div>
             <div class="flx-compte-label">traitées</div>
@@ -24,6 +30,8 @@
         <div class="flx-anneau" id="flxAnneau"><i>◈</i></div>
     </div>
 </div>
+
+{% if seuils %}{% include '_seuils_modal.html' %}{% endif %}
 
 {# ── Le fil : ce qui attend une décision ── #}
 <div id="flxActions">

--- a/templates/accueil_flux.html
+++ b/templates/accueil_flux.html
@@ -1,0 +1,198 @@
+{% extends "base.html" %}
+
+{% block title %}Accueil - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="flx-flux-entete">
+    <div>
+        <div class="flx-date">{{ date_texte }}</div>
+        <h1 class="flx-titre">{{ salutation }}</h1>
+        <p class="flx-resume">
+            {% if nb_actions %}
+            {{ nb_actions }} décision{{ 's' if nb_actions > 1 }} vous attend{{ 'ent' if nb_actions > 1 }}.
+            Rien d'autre ne bloque — le reste de l'application viendra à vous quand il le faudra.
+            {% else %}
+            Tout est traité. L'application se tait.
+            {% endif %}
+        </p>
+    </div>
+    <div class="flx-compte">
+        <div class="flx-compte-chiffres">
+            <div class="flx-compte-valeur"><span id="flxFaites">0</span><span>/{{ nb_actions }}</span></div>
+            <div class="flx-compte-label">traitées</div>
+        </div>
+        <div class="flx-anneau" id="flxAnneau"><i>◈</i></div>
+    </div>
+</div>
+
+{# ── Le fil : ce qui attend une décision ── #}
+<div id="flxActions">
+    {% include '_flux_actions.html' %}
+</div>
+
+{# ── À l'horizon : ce qui arrive, sans rien demander aujourd'hui ── #}
+{% if horizon %}
+<div class="flx-section">
+    <div class="flx-section-entete">
+        <span class="flx-etiquette">À l'horizon</span>
+        <span class="flx-section-note">Rien à décider aujourd'hui — mais rien à découvrir en retard non plus.</span>
+    </div>
+    {% for ligne in horizon %}
+    <div class="flx-ligne">
+        <span class="flx-ligne-titre">{{ ligne.titre }}</span>
+        <div class="flx-piste">
+            {% for it in ligne['items'] %}
+            <a href="{{ it.lien }}" class="flx-pastille flx-{{ it.ton }}">
+                <span class="flx-point"></span>
+                <span class="flx-pastille-corps">
+                    <span class="flx-pastille-titre">{{ it.titre }}</span>
+                    <span class="flx-pastille-detail">{{ it.detail }}</span>
+                </span>
+                <span class="flx-pastille-date">{{ it.date }}</span>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
+{# ── Ce que le clavier sait faire ── #}
+<div class="flx-astuces">
+    <div class="flx-astuce"><kbd>A–Z</kbd><span>tapez n'importe où pour chercher ou agir</span></div>
+    <div class="flx-astuce"><kbd>Échap</kbd><span>la vue d'ensemble apparaît, puis s'efface</span></div>
+    <div class="flx-astuce"><kbd>↵</kbd><span>la première proposition est la bonne</span></div>
+    <div class="flx-astuce"><kbd>◉</kbd><span>votre nom, en haut à droite : congés et récupérations</span></div>
+</div>
+
+<script>
+/* Le fil se vide au fur et à mesure : chaque décision prise retire sa carte,
+   l'anneau de progression suit. Les appels reprennent les points d'entrée
+   existants (approbation de facture, validation de demande, relance). */
+(function () {
+    var faites = 0;
+
+    function items() {
+        return Array.prototype.slice.call(document.querySelectorAll('[data-flx-item]'));
+    }
+
+    function majCompteurs() {
+        var restantes = items().length;
+        var total = faites + restantes;
+        document.getElementById('flxFaites').textContent = faites;
+        var anneau = document.getElementById('flxAnneau');
+        if (anneau) {
+            anneau.style.setProperty('--p', (total ? Math.round(faites / total * 100) : 0) + '%');
+        }
+        var vide = document.getElementById('flxToutFait');
+        if (vide) vide.style.display = restantes ? 'none' : '';
+    }
+
+    function retirer(ref, message) {
+        items().filter(function (el) { return el.getAttribute('data-flx-id') === ref; })
+            .forEach(function (el) {
+                el.classList.add('flx-sortie');
+                setTimeout(function () { el.remove(); majCompteurs(); }, 320);
+            });
+        faites += 1;
+        if (message && window.flxToast) window.flxToast(message);
+    }
+
+    function echec(msg) {
+        if (window.flxToast) window.flxToast(msg || "Erreur — l'action n'a pas pu être traitée");
+    }
+
+    document.addEventListener('click', function (e) {
+        var btn = e.target.closest('[data-flx-act]');
+        if (!btn || btn.disabled) return;
+        var act = btn.getAttribute('data-flx-act');
+        var ref = btn.getAttribute('data-flx-ref');
+        btn.disabled = true;
+
+        if (act === 'facture') {
+            fetch('/factures/' + btn.getAttribute('data-facture-id') + '/approuver', {method: 'POST'})
+                .then(function (r) { if (!r.ok) throw 0; retirer(ref, '🧾 Facture approuvée'); })
+                .catch(function () { btn.disabled = false; echec(); });
+
+        } else if (act === 'valider' || act === 'refuser') {
+            var corps = new URLSearchParams();
+            corps.set('demande_id', btn.getAttribute('data-demande-id'));
+            corps.set('demande_type', btn.getAttribute('data-demande-type'));
+            corps.set('action', act);
+            if (act === 'refuser') {
+                var motif = window.prompt('Motif du refus (obligatoire) :');
+                if (!motif || !motif.trim()) { btn.disabled = false; return; }
+                corps.set('motif_refus', motif.trim());
+            }
+            fetch('/validation_demandes_recup', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: corps.toString()
+            }).then(function (r) {
+                if (!r.ok) throw 0;
+                retirer(ref, act === 'valider'
+                    ? '✓ Demande validée — le salarié est notifié'
+                    : 'Demande refusée — le salarié est notifié');
+            }).catch(function () { btn.disabled = false; echec(); });
+
+        } else if (act === 'subvention') {
+            fetch('/api/subventions/sous-elements/' + btn.getAttribute('data-se-id') + '/modifier', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({field: 'statut', value: 'fait'})
+            }).then(function (r) { return r.json().then(function (d) { return {ok: r.ok, d: d}; }); })
+              .then(function (res) {
+                  if (!res.ok || !res.d.ok) throw 0;
+                  retirer(ref, '💶 Étape marquée comme faite');
+              })
+              .catch(function () { btn.disabled = false; echec(); });
+
+        } else if (act === 'relance') {
+            fetch('/api/email/relance_validation', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({mois: Number(btn.getAttribute('data-mois')),
+                                      annee: Number(btn.getAttribute('data-annee'))})
+            }).then(function (r) { return r.json().then(function (d) { return {ok: r.ok, d: d}; }); })
+              .then(function (res) {
+                  if (!res.ok || res.d.error) throw 0;
+                  faites += 1;
+                  majCompteurs();
+                  if (window.flxToast) {
+                      window.flxToast('📧 ' + (res.d.message || 'Relance envoyée aux responsables'));
+                  }
+                  // Les fiches ne sont pas validées pour autant : l'item reste,
+                  // mais son bouton dit que la relance est partie.
+                  document.querySelectorAll('[data-flx-act="relance"][data-flx-ref="' + ref + '"]')
+                      .forEach(function (b) { b.textContent = '✓ Relancé'; b.disabled = true; });
+              })
+              .catch(function () {
+                  btn.disabled = false;
+                  echec('Relance impossible — vérifiez la configuration email');
+              });
+
+        } else {
+            btn.disabled = false;
+        }
+    });
+
+    // Rafraîchissement du fil toutes les 10 minutes : une demande déposée
+    // pendant que la page reste ouverte apparaît sans rechargement. On ne
+    // touche à rien tant qu'une palette ou la vue d'ensemble est ouverte, pour
+    // ne pas déplacer le sol sous les pieds de qui est en train de naviguer.
+    setInterval(function () {
+        if (document.querySelector('.flx-palette, .flx-ensemble')) return;
+        fetch('/api/accueil/flux-fragment')
+            .then(function (r) { return r.ok ? r.text() : null; })
+            .then(function (html) {
+                if (html === null) return;
+                document.getElementById('flxActions').innerHTML = html;
+                majCompteurs();
+            })
+            .catch(function () { /* réseau indisponible : on réessaiera */ });
+    }, 600000);
+
+    majCompteurs();
+})();
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}CS-PILOT{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=19">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=20">
     <script>
         (function(){var t=localStorage.getItem('theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark');})();
     </script>
 </head>
-<body>
-    {% if session.user_id %}
+<body{% if ui_flux %} class="flx"{% endif %}>
+    {% if session.user_id and not ui_flux %}
     {# ── Bouton hamburger mobile ── #}
     <button class="sidebar-toggle" id="sidebarToggle" onclick="toggleSidebar()">&#9776;</button>
 
@@ -391,13 +391,23 @@
                 <button class="theme-toggle" id="themeToggle" title="Changer le thème" onclick="toggleTheme()">🌙</button>
                 <a href="{{ url_for('auth.logout') }}" class="btn-logout">Déconnexion</a>
             </div>
+            {% if ui_flux_eligible %}
+            <button type="button" class="sidebar-link" style="width:100%;text-align:left;background:none;border:none;cursor:pointer;"
+                    onclick="basculerInterface(true)" title="Accueil sans menu, recherche au clavier">
+                ✨ Essayer la nouvelle interface
+            </button>
+            {% endif %}
         </div>
     </aside>
     {% endif %}
 
-    <div class="main-content{% if session.user_id %} has-sidebar{% endif %}">
+    {% if ui_flux %}{% include '_flux_shell.html' %}{% endif %}
+
+    <div class="main-content{% if session.user_id and not ui_flux %} has-sidebar{% endif %}">
         <div class="container">
-            {% set cse_dashboard_endpoints = ['dashboard_bp.dashboard', 'dashboard_direction_bp.dashboard_direction', 'dashboard_comptable_bp.dashboard_comptable', 'dashboard_responsable_bp.dashboard_responsable'] %}
+            {# L'accueil sans menu remplace les tableaux de bord : le message du
+               CSE doit y apparaître comme il apparaissait sur les leurs. #}
+            {% set cse_dashboard_endpoints = ['dashboard_bp.dashboard', 'dashboard_direction_bp.dashboard_direction', 'dashboard_comptable_bp.dashboard_comptable', 'dashboard_responsable_bp.dashboard_responsable', 'accueil_bp.accueil'] %}
             {% if cse_message_actif and request.endpoint in cse_dashboard_endpoints %}
             <button type="button" class="cse-banner" onclick="cseOpenMessage()">
                 <span class="cse-banner-icon">📢</span>
@@ -414,6 +424,10 @@
                     {% endfor %}
                 {% endif %}
             {% endwith %}
+
+            {% if ui_flux and request.endpoint not in ('accueil_bp.accueil', 'accueil_bp.mon_espace') %}
+            {% include '_flux_page_entete.html' %}
+            {% endif %}
 
             {% block content %}{% endblock %}
         </div>
@@ -663,6 +677,21 @@
             return _fetch.call(this, url, opts);
         };
     })();
+
+    // Bascule entre l'interface sans menu et le menu latéral historique.
+    // Le choix est personnel et réversible : il ne change rien pour les autres.
+    function basculerInterface(actif) {
+        fetch('/api/interface/basculer', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({actif: !!actif})
+        }).then(function (r) { return r.json(); })
+          .then(function (d) {
+              if (d && d.redirect) { window.location = d.redirect; }
+              else { window.location.reload(); }
+          })
+          .catch(function () { alert("La bascule d'interface a échoué. Réessayez."); });
+    }
 
     // Sidebar : toggle sections accordéon
     function toggleSection(btn) {

--- a/templates/dashboard_direction.html
+++ b/templates/dashboard_direction.html
@@ -100,44 +100,9 @@
     </div>
 </div>
 
-{# ── Fenêtre seuils d'alerte (classes modales globales de style.css :
-     en-tête à bord franc, corps et pied avec padding — .modal-content a
-     volontairement padding:0). ── #}
-<div id="ccSeuilsModal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)ccFermerSeuils()">
-    <div class="modal-content" style="max-width:480px;" role="dialog" aria-modal="true">
-        <div class="modal-header">
-            <h3>⚙ Seuils d'alerte</h3>
-            <button class="modal-close" type="button" onclick="ccFermerSeuils()" aria-label="Fermer">&times;</button>
-        </div>
-        <div style="padding:0 1.5rem;">
-            <p style="font-size:0.85rem;color:var(--gray-500);margin:0 0 1.25rem;">
-                Le tableau de bord n'affiche un indicateur que s'il franchit son seuil.
-                Ajustez-les à votre structure.</p>
-            <div style="display:flex;flex-direction:column;gap:1rem;">
-                <label class="cc-seuil-label">Trésorerie minimum (€)
-                    <input type="number" id="ccSeuilTreso" value="{{ seuils.treso|int }}" min="0" step="1000"></label>
-                <label class="cc-seuil-label">Budget consommé (%)
-                    <input type="number" id="ccSeuilBudget" value="{{ seuils.budget|int }}" min="0" max="200"></label>
-                <label class="cc-seuil-label">Solde congés conventionnels (jours)
-                    <input type="number" id="ccSeuilConges" value="{{ seuils.conges|int }}" min="0" step="0.5"></label>
-                <label class="cc-seuil-label">Score de surcharge (/100)
-                    <input type="number" id="ccSeuilSurcharge" value="{{ seuils.surcharge|int }}" min="0" max="100"></label>
-                <label class="cc-seuil-label" style="border-top:1px solid var(--gray-200);padding-top:1rem;align-items:flex-start;">
-                    <span>Digest quotidien par email<br>
-                        <span style="font-weight:400;font-size:0.78rem;color:var(--gray-500);">
-                            Envoyé à la direction et à la comptabilité au premier accès après 8 h.
-                            Les personnes en congé ce jour-là ne le reçoivent pas.</span></span>
-                    <input type="checkbox" id="ccSeuilDigest" style="width:auto;margin-top:4px;" {% if seuils.digest %}checked{% endif %}>
-                </label>
-            </div>
-        </div>
-        <div style="display:flex;justify-content:flex-end;gap:0.75rem;padding:1.25rem 1.5rem 1.5rem;align-items:center;">
-            <span id="ccSeuilsMsg" style="margin-right:auto;color:var(--primary);font-weight:600;"></span>
-            <button class="btn btn-secondary" type="button" onclick="ccFermerSeuils()">Annuler</button>
-            <button class="btn btn-primary" type="button" onclick="ccEnregistrerSeuils()">Enregistrer</button>
-        </div>
-    </div>
-</div>
+{# ── Fenêtre des seuils d'alerte : gabarit partagé avec l'accueil sans menu,
+     pour que les deux pages règlent exactement les mêmes valeurs. ── #}
+{% include '_seuils_modal.html' %}
 
 <div id="ccToast" style="display:none;position:fixed;bottom:24px;left:50%;transform:translateX(-50%);background:var(--primary-dark);color:#fff;padding:0.7rem 1.4rem;border-radius:99px;font-size:0.9rem;font-weight:600;box-shadow:0 12px 24px -4px rgba(0,0,0,0.25);z-index:3000;"></div>
 
@@ -207,14 +172,6 @@
     box-shadow: 0 4px 12px -2px rgba(0,0,0,0.1); transform: translateY(-2px);
 }
 
-.cc-seuil-label {
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 1rem; font-size: 0.9rem; font-weight: 600; color: var(--gray-700);
-}
-.cc-seuil-label input {
-    width: 120px; padding: 0.5rem; border: 1px solid var(--gray-300);
-    border-radius: 6px; font-size: 0.9rem; text-align: right;
-}
 </style>
 
 <script>
@@ -348,34 +305,6 @@
         } else {
             btn.disabled = false;
         }
-    });
-
-    // Seuils d'alerte
-    window.ccOuvrirSeuils = function () { document.getElementById('ccSeuilsModal').style.display = 'flex'; };
-    window.ccFermerSeuils = function () { document.getElementById('ccSeuilsModal').style.display = 'none'; };
-    window.ccEnregistrerSeuils = function () {
-        var msg = document.getElementById('ccSeuilsMsg');
-        msg.textContent = 'Enregistrement…';
-        fetch('/api/dashboard-direction/seuils', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({
-                treso: Number(document.getElementById('ccSeuilTreso').value),
-                budget: Number(document.getElementById('ccSeuilBudget').value),
-                conges: Number(document.getElementById('ccSeuilConges').value),
-                surcharge: Number(document.getElementById('ccSeuilSurcharge').value),
-                digest: document.getElementById('ccSeuilDigest').checked
-            })
-        }).then(function (r) { return r.json(); })
-          .then(function (d) {
-              if (!d.success) { msg.textContent = ''; echec(d.error || 'Enregistrement impossible'); return; }
-              msg.textContent = '✓ Enregistré';
-              window.location.reload();
-          })
-          .catch(function () { msg.textContent = ''; echec(); });
-    };
-    document.addEventListener('keydown', function (e) {
-        if (e.key === 'Escape') ccFermerSeuils();
     });
 
     // Rafraîchissement automatique de la file toutes les 10 minutes : les

--- a/templates/infos_salaries.html
+++ b/templates/infos_salaries.html
@@ -30,6 +30,7 @@
         <h2 style="margin-top: 0;">{{ salarie.nom }} {{ salarie.prenom }}</h2>
         <div style="display: flex; gap: 2rem; flex-wrap: wrap; margin-bottom: 1rem;">
             <div><strong>Profil :</strong> {{ salarie.profil }}</div>
+            <div><strong>Fonction :</strong> {{ salarie.fonction or '-' }}</div>
             <div><strong>Secteur :</strong> {{ salarie.secteur_nom or '-' }}</div>
             <div><strong>Login :</strong> {{ salarie.login }}</div>
             <div><strong>Statut :</strong>
@@ -97,6 +98,37 @@
     <!-- Contrats -->
     <div class="section" id="contrats" style="margin-bottom: 1.5rem;">
         <h2>Contrats</h2>
+
+        <!-- Fonction occupee : elle accompagne les informations de contrat et
+             s'affiche sous le nom du salarie dans l'interface sans menu. -->
+        <form method="POST" action="{{ url_for('infos_salaries_bp.modifier_fonction') }}"
+              style="background: var(--gray-50, #f8f9fa); padding: 1rem; border-radius: 8px; margin-bottom: 1rem;">
+            <input type="hidden" name="user_id" value="{{ salarie.id }}">
+            <div style="display: flex; gap: 1rem; flex-wrap: wrap; align-items: flex-end;">
+                <div class="form-group" style="margin-bottom: 0;">
+                    <label for="fonction">Fonction</label>
+                    <select name="fonction" id="fonction" onchange="fonctionAutre()">
+                        <option value="">— Non renseignee —</option>
+                        {% for f in fonctions %}
+                        <option value="{{ f }}" {% if salarie.fonction == f %}selected{% endif %}>{{ f }}</option>
+                        {% endfor %}
+                        {# Fonction enregistree autrefois puis retiree de la liste :
+                           on la garde visible plutot que de l'effacer en silence. #}
+                        {% if salarie.fonction and salarie.fonction not in fonctions %}
+                        <option value="{{ salarie.fonction }}" selected>{{ salarie.fonction }}</option>
+                        {% endif %}
+                        <option value="{{ sentinelle_fonction }}">+ Ajouter une fonction…</option>
+                    </select>
+                </div>
+                <div class="form-group" id="fonction-autre-champ" style="margin-bottom: 0; display: none;">
+                    <label for="nouvelle_fonction">Nouvelle fonction</label>
+                    <input type="text" name="nouvelle_fonction" id="nouvelle_fonction" maxlength="60"
+                           placeholder="Ex: Mediateur numerique"
+                           title="Elle sera ajoutee a la liste proposee pour tous les salaries">
+                </div>
+                <button type="submit" class="btn btn-primary">Enregistrer la fonction</button>
+            </div>
+        </form>
 
         <!-- Formulaire ajout contrat -->
         <form method="POST" action="{{ url_for('infos_salaries_bp.ajouter_contrat') }}" enctype="multipart/form-data"
@@ -303,6 +335,17 @@ function dfEditer(id) {
 function dfAnnuler(id) {
     document.getElementById('df-form-' + id).style.display = 'none';
     document.getElementById('df-aff-' + id).style.display = '';
+}
+// « + Ajouter une fonction… » ouvre le champ libre ; sa valeur l'emporte
+// cote serveur et vient enrichir la liste proposee a tous.
+function fonctionAutre() {
+    var select = document.getElementById('fonction');
+    var champ = document.getElementById('fonction-autre-champ');
+    var saisie = document.getElementById('nouvelle_fonction');
+    if (!select || !champ) return;
+    var ouvert = select.value === {{ sentinelle_fonction|tojson }};
+    champ.style.display = ouvert ? '' : 'none';
+    if (ouvert) { saisie.focus(); } else { saisie.value = ''; }
 }
 document.addEventListener('DOMContentLoaded', function() {
     var typeSelect = document.getElementById('type_contrat');

--- a/templates/mon_espace.html
+++ b/templates/mon_espace.html
@@ -128,6 +128,16 @@
     };
     var mode = 'conge';
 
+    // Les jours fériés sont exclus, comme le fait utils.calculer_jours_ouvres
+    // côté serveur : sans cela le solde projeté annoncerait un jour de trop.
+    var FERIES = {{ feries|tojson }};
+
+    function iso(d) {
+        return d.getFullYear() + '-' +
+               String(d.getMonth() + 1).padStart(2, '0') + '-' +
+               String(d.getDate()).padStart(2, '0');
+    }
+
     function joursOuvres(a, b) {
         if (!a || !b) return 0;
         var d1 = new Date(a + 'T12:00'), d2 = new Date(b + 'T12:00');
@@ -135,7 +145,7 @@
         var n = 0;
         for (var d = new Date(d1); d <= d2; d.setDate(d.getDate() + 1)) {
             var j = d.getDay();
-            if (j !== 0 && j !== 6) n++;
+            if (j !== 0 && j !== 6 && FERIES.indexOf(iso(d)) === -1) n++;
         }
         return n;
     }

--- a/templates/mon_espace.html
+++ b/templates/mon_espace.html
@@ -1,0 +1,187 @@
+{% extends "base.html" %}
+
+{% block title %}Mon espace - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="flx-page-entete">
+    <a href="{{ url_for('accueil_bp.accueil') }}" class="flx-retour">← Revenir au flux</a>
+    <div class="flx-page-titre">
+        <div class="flx-page-icone">◉</div>
+        <div>
+            <h1>Mon espace</h1>
+            <p>Vos compteurs, vos demandes — ce que l'application sait de vous comme salarié.</p>
+        </div>
+    </div>
+</div>
+
+{# ── Compteurs ── #}
+<div class="flx-compteurs">
+    {% for c in compteurs %}
+    <div class="flx-compteur">
+        <div class="flx-compteur-nom">{{ c.nom }}</div>
+        <div class="flx-compteur-valeur flx-ton-{{ c.ton }}">{{ c.valeur }}</div>
+        <div class="flx-compteur-detail">{{ c.detail }}</div>
+    </div>
+    {% endfor %}
+</div>
+
+{# ── Poser une demande ── #}
+<form method="POST" action="{{ url_for('recup_bp.demande_conge') }}" id="flxDemandeForm" class="flx-demande">
+    <input type="hidden" name="type_conge" id="flxTypeConge" value="{{ types_demande[0].nom if types_demande }}">
+    <input type="hidden" name="type_demande" value="journee">
+
+    <div class="flx-demande-entete">
+        <span class="flx-etiquette">Poser une demande</span>
+        <span class="flx-demande-note">
+            {% if session.profil == 'directeur' %}
+            Les demandes de votre équipe ne sont pas ici : elles arrivent dans votre flux.
+            {% elif session.profil == 'responsable' %}
+            Vos demandes partent à la direction · vous êtes averti dès qu'elle tranche.
+            {% else %}
+            Vos demandes partent à votre responsable · vous êtes averti dès qu'il tranche.
+            {% endif %}
+        </span>
+    </div>
+
+    <div class="flx-chips" style="border-bottom:none;padding-bottom:18px;">
+        {% for t in types_demande %}
+        <button type="button" class="flx-chip{% if loop.first %} flx-chip-actif{% endif %}"
+                data-flx-type="{{ t.nom }}" data-flx-mode="{{ t.mode }}">{{ t.nom }}</button>
+        {% endfor %}
+    </div>
+
+    <div class="flx-demande-champs">
+        <label class="flx-champ">
+            <span>Du</span>
+            <input type="date" name="date_debut" id="flxDu" value="{{ aujourdhui }}" required>
+        </label>
+        <label class="flx-champ">
+            <span>Au</span>
+            <input type="date" name="date_fin" id="flxAu" value="{{ aujourdhui }}" required>
+        </label>
+        <label class="flx-champ flx-champ-large">
+            <span>Motif (facultatif)</span>
+            <input type="text" name="motif_demande" maxlength="200" placeholder="Précisez si besoin">
+        </label>
+        <button type="submit" class="flx-btn flx-btn-plein">Transmettre</button>
+        <span class="flx-calcul" id="flxCalcul"></span>
+    </div>
+
+    <p style="margin:16px 0 0;font-size:0.78rem;color:var(--gray-500);">
+        Pour une récupération sur une partie de journée seulement, passez par
+        <a href="{{ url_for('recup_bp.demande_recup') }}">la page Demander une récupération</a>.
+    </p>
+</form>
+
+{# ── Mes demandes ── #}
+<div class="flx-liste">
+    <div class="flx-liste-titre">Mes demandes</div>
+    {% if demandes %}
+    {% for d in demandes %}
+    <div class="flx-liste-item">
+        <div style="min-width:0;">
+            <div class="flx-liste-item-titre">{{ d.type }} · {{ d.periode }}</div>
+            <div class="flx-liste-item-meta">
+                {{ d.quantite }}{% if d.depot %} · déposée le {{ d.depot }}{% endif %}
+                {%- if d.motif_refus %} · motif : {{ d.motif_refus }}{% endif %}
+            </div>
+        </div>
+        <span class="flx-statut flx-ton-{{ d.ton }}">{{ d.statut }}</span>
+    </div>
+    {% endfor %}
+    <p style="margin:14px 0 0;font-size:0.78rem;color:var(--gray-500);">
+        Le détail et la suppression restent sur
+        <a href="{{ url_for('recup_bp.mes_demandes_conges') }}">mes demandes de congés</a>
+        {%- if session.profil != 'directeur' %} et
+        <a href="{{ url_for('recup_bp.mes_demandes_recup') }}">mes demandes de récupération</a>{% endif %}.
+    </p>
+    {% else %}
+    <p style="margin:0;color:var(--gray-500);font-size:0.88rem;">Aucune demande pour l'instant.</p>
+    {% endif %}
+</div>
+
+<p style="margin:26px 0 0;font-size:0.8rem;color:var(--gray-500);">
+    Cette interface ne convient pas à votre usage ?
+    <button type="button" onclick="basculerInterface(false)"
+            style="background:none;border:none;padding:0;font:inherit;color:var(--primary);cursor:pointer;text-decoration:underline;">
+        Revenir au menu classique</button>. Vous pourrez y revenir à tout moment.
+</p>
+
+<script>
+/* Le formulaire change de destination selon le type choisi : les congés et les
+   récupérations ont chacun leur circuit de validation, on réutilise les routes
+   existantes plutôt que d'en créer une troisième. */
+(function () {
+    var form = document.getElementById('flxDemandeForm');
+    if (!form) return;
+    var champType = document.getElementById('flxTypeConge');
+    var du = document.getElementById('flxDu');
+    var au = document.getElementById('flxAu');
+    var calcul = document.getElementById('flxCalcul');
+    var ACTIONS = {
+        conge: {{ url_for('recup_bp.demande_conge')|tojson }},
+        recup: {{ url_for('recup_bp.demande_recup')|tojson }}
+    };
+    var SOLDES = {
+        'Congé payé': {{ solde_cp|tojson }},
+        'Congé conventionnel': {{ solde_cc|tojson }}
+    };
+    var mode = 'conge';
+
+    function joursOuvres(a, b) {
+        if (!a || !b) return 0;
+        var d1 = new Date(a + 'T12:00'), d2 = new Date(b + 'T12:00');
+        if (isNaN(d1) || isNaN(d2) || d2 < d1) return 0;
+        var n = 0;
+        for (var d = new Date(d1); d <= d2; d.setDate(d.getDate() + 1)) {
+            var j = d.getDay();
+            if (j !== 0 && j !== 6) n++;
+        }
+        return n;
+    }
+
+    function fr(x) { return String(Math.round(x * 10) / 10).replace('.', ','); }
+
+    function majCalcul() {
+        var n = joursOuvres(du.value, au.value);
+        if (!n) {
+            // Distinguer « dates manquantes ou inversées » de « période qui ne
+            // contient aucun jour ouvré » : ce n'est pas la même correction.
+            var d1 = new Date(du.value + 'T12:00'), d2 = new Date(au.value + 'T12:00');
+            calcul.textContent = (du.value && au.value && !isNaN(d1) && !isNaN(d2) && d2 >= d1)
+                ? 'Aucun jour ouvré sur cette période.'
+                : 'Choisissez une date de début et une date de fin.';
+            return;
+        }
+        var texte = n + ' jour' + (n > 1 ? 's' : '') + ' ouvré' + (n > 1 ? 's' : '');
+        var type = champType.value;
+        if (mode === 'recup') {
+            texte += ' · imputés sur vos récupérations ({{ solde_recup|round(1) }} h)';
+        } else if (SOLDES[type] !== undefined) {
+            texte += ' · solde projeté ' + fr(SOLDES[type] - n) + ' j';
+        }
+        calcul.textContent = texte;
+    }
+
+    form.querySelectorAll('[data-flx-type]').forEach(function (b) {
+        b.addEventListener('click', function () {
+            form.querySelectorAll('[data-flx-type]').forEach(function (x) {
+                x.classList.remove('flx-chip-actif');
+            });
+            b.classList.add('flx-chip-actif');
+            mode = b.getAttribute('data-flx-mode');
+            champType.value = b.getAttribute('data-flx-type');
+            form.setAttribute('action', ACTIONS[mode]);
+            majCalcul();
+        });
+    });
+
+    du.addEventListener('change', function () {
+        if (au.value < du.value) au.value = du.value;
+        majCalcul();
+    });
+    au.addEventListener('change', majCalcul);
+    majCalcul();
+})();
+</script>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,3 +254,21 @@ def sample_planning(app, db, sample_users):
             'planning_id': planning_id,
             **planning_data,
         }
+
+
+@pytest.fixture
+def menu_classique(app):
+    """Bascule l'application sur le menu latéral historique.
+
+    L'interface sans menu (accueil en fil d'actions, recherche au clavier, vue
+    d'ensemble par zones) est active par défaut pour la direction, la
+    comptabilité, les responsables et les salariés délégués. Les tests qui
+    vérifient le contenu du menu latéral ou le routage de `/dashboard` par
+    profil décrivent le mode classique, qui reste pleinement supporté : ils le
+    demandent donc explicitement. Les tests de l'interface sans menu vivent
+    dans `tests/test_interface_flux.py`.
+    """
+    with app.app_context():
+        from app_options import set_option_bool
+        set_option_bool('interface_sans_menu_active', False)
+    return True

--- a/tests/test_commandes_salaries.py
+++ b/tests/test_commandes_salaries.py
@@ -146,7 +146,7 @@ def test_delegation_ouvre_le_suivi_global_au_salarie(app, db, sample_users):
     assert 'Ramette papier A4' in html
 
 
-def test_menus_affichent_les_liens_commandes_et_delegation(app, sample_users):
+def test_menus_affichent_les_liens_commandes_et_delegation(app, sample_users, menu_classique):
     salarie_client = app.test_client()
     admin_client = app.test_client()
     _login(salarie_client, 'salarie_test', 'sal123')

--- a/tests/test_comptabilite_analytique.py
+++ b/tests/test_comptabilite_analytique.py
@@ -368,13 +368,13 @@ class TestBilanSecteurs:
 class TestNavigationMenus:
     """Vérifie que les nouveaux menus apparaissent dans la sidebar."""
 
-    def test_menu_financier_bilan_directeur(self, admin_client):
+    def test_menu_financier_bilan_directeur(self, admin_client, menu_classique):
         """Le menu Financier du directeur contient le lien Bilan secteurs/actions."""
         resp = admin_client.get('/', follow_redirects=True)
         html = resp.get_data(as_text=True)
         assert 'Bilan secteurs/actions' in html
 
-    def test_menu_comptable_directeur(self, admin_client):
+    def test_menu_comptable_directeur(self, admin_client, menu_classique):
         """Le directeur voit le menu Comptable avec Plan comptable analytique."""
         resp = admin_client.get('/', follow_redirects=True)
         html = resp.get_data(as_text=True)

--- a/tests/test_dashboard_comptable.py
+++ b/tests/test_dashboard_comptable.py
@@ -83,7 +83,7 @@ def test_dashboard_comptable_refuse_responsable(resp_client):
     assert response.status_code == 302
 
 
-def test_dashboard_redirect_comptable(comptable_client):
+def test_dashboard_redirect_comptable(comptable_client, menu_classique):
     """Verifie que /dashboard redirige vers dashboard_comptable pour un comptable."""
     response = comptable_client.get('/dashboard', follow_redirects=False)
     assert response.status_code == 302

--- a/tests/test_dashboard_responsable.py
+++ b/tests/test_dashboard_responsable.py
@@ -86,14 +86,14 @@ def test_dashboard_responsable_refuse_directeur(admin_client):
     assert response.status_code == 302
 
 
-def test_dashboard_redirect_responsable(resp_client):
+def test_dashboard_redirect_responsable(resp_client, menu_classique):
     """Verifie que /dashboard redirige vers dashboard_responsable pour un responsable."""
     response = resp_client.get('/dashboard', follow_redirects=False)
     assert response.status_code == 302
     assert 'dashboard_responsable' in response.headers.get('Location', '')
 
 
-def test_dashboard_responsable_sans_secteur_ne_boucle_pas(resp_client, app, db, sample_users):
+def test_dashboard_responsable_sans_secteur_ne_boucle_pas(resp_client, app, db, sample_users, menu_classique):
     """Pas de boucle de redirection pour un responsable sans secteur.
 
     - avec des rattachés directs : /dashboard renvoie vers le tableau

--- a/tests/test_delegation_benevoles.py
+++ b/tests/test_delegation_benevoles.py
@@ -245,7 +245,7 @@ def test_section_benevoles_active_pour_le_comptable(app, sample_users):
     assert 'disabled' not in section.split('form-actions')[0]
 
 
-def test_menu_benevoles_visible_pour_le_salarie_delegue(app, sample_users):
+def test_menu_benevoles_visible_pour_le_salarie_delegue(app, sample_users, menu_classique):
     sal = app.test_client()
     _login(sal, 'salarie_test', 'sal123')
     assert '🤝 Bénévoles' not in sal.get('/dashboard').get_data(as_text=True)

--- a/tests/test_demandes_conges.py
+++ b/tests/test_demandes_conges.py
@@ -254,7 +254,7 @@ def test_historique_inclut_conges(admin_client, app, db, sample_users):
     assert 'CP' in html
 
 
-def test_pending_count_includes_conges(admin_client, app, db, sample_users):
+def test_pending_count_includes_conges(admin_client, app, db, sample_users, menu_classique):
     """Le compteur de demandes en attente inclut les conges."""
     with app.app_context():
         db.execute('''

--- a/tests/test_equipe_responsable.py
+++ b/tests/test_equipe_responsable.py
@@ -179,7 +179,7 @@ def test_selecteur_infos_salaries_liste_le_rattache(resp_client, db, sample_user
     assert f'value="{agent_id}"' in html or 'Agent' in html
 
 
-def test_entree_dashboard_redirige_responsable_sans_secteur(resp_client, app, db, sample_users):
+def test_entree_dashboard_redirige_responsable_sans_secteur(resp_client, app, db, sample_users, menu_classique):
     """/dashboard envoie vers le tableau responsable même sans secteur, dès
     lors qu'il y a des rattachés directs — revue Codex."""
     with app.app_context():

--- a/tests/test_fonction_salarie.py
+++ b/tests/test_fonction_salarie.py
@@ -163,3 +163,9 @@ def test_la_migration_recree_la_liste_et_reste_idempotente(app, db):
     libelles = _fonctions(db)
     assert 'Médiateur' in libelles
     assert len(libelles) == len(FONCTIONS_INITIALES) + 1
+
+
+def test_la_migration_0064_est_declaree_pour_les_bases_neuves(app, db):
+    """Une base fraîche ne doit pas signaler 0064 comme migration en attente."""
+    from database import ALL_MIGRATION_VERSIONS
+    assert '0064' in {version for version, _ in ALL_MIGRATION_VERSIONS}

--- a/tests/test_fonction_salarie.py
+++ b/tests/test_fonction_salarie.py
@@ -1,0 +1,165 @@
+"""
+Tests de la fonction du salarié.
+
+La fonction est renseignée avec les informations de contrat, choisie dans une
+liste complétable, et s'affiche sous le nom dans l'interface sans menu.
+"""
+import pytest
+
+from migrations import FONCTIONS_INITIALES
+
+
+def _fonctions(db):
+    return [r['libelle'] for r in
+            db.execute('SELECT libelle FROM fonctions ORDER BY ordre').fetchall()]
+
+
+def _fonction_de(db, user_id):
+    return db.execute('SELECT fonction FROM users WHERE id = ?',
+                      (user_id,)).fetchone()['fonction']
+
+
+# ── Référentiel ────────────────────────────────────────────────────────────
+
+def test_la_liste_est_prete_a_l_installation(app, db):
+    """Une base neuve porte déjà les fonctions courantes d'un centre social."""
+    libelles = _fonctions(db)
+    assert libelles == FONCTIONS_INITIALES
+    for attendu in ('Directeur', 'EJE', 'Auxiliaire Puér.', "Agent d'accueil",
+                    'Conseillé insertion', 'Gardien'):
+        assert attendu in libelles
+
+
+def test_la_liste_est_proposee_sur_la_fiche(admin_client, sample_users):
+    corps = admin_client.get(
+        f"/infos_salaries?user_id={sample_users['salarie_id']}").get_data(as_text=True)
+    assert 'Fonction' in corps
+    assert 'Auxiliaire Puér.' in corps
+    assert 'Ajouter une fonction' in corps
+
+
+# ── Enregistrement ─────────────────────────────────────────────────────────
+
+def test_enregistrer_une_fonction_de_la_liste(admin_client, db, sample_users):
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'], 'fonction': 'EJE'},
+        follow_redirects=True)
+    assert _fonction_de(db, sample_users['salarie_id']) == 'EJE'
+
+
+def test_ajouter_une_fonction_enrichit_la_liste(admin_client, db, sample_users):
+    """La fonction créée est affectée ET proposée ensuite à tout le monde."""
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'],
+        'fonction': '__autre__',
+        'nouvelle_fonction': 'Médiateur numérique'}, follow_redirects=True)
+    assert _fonction_de(db, sample_users['salarie_id']) == 'Médiateur numérique'
+    assert 'Médiateur numérique' in _fonctions(db)
+
+
+def test_ajouter_une_fonction_deja_presente_ne_cree_pas_de_doublon(
+        admin_client, db, sample_users):
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'],
+        'fonction': '__autre__', 'nouvelle_fonction': 'EJE'}, follow_redirects=True)
+    assert _fonctions(db).count('EJE') == 1
+    assert _fonction_de(db, sample_users['salarie_id']) == 'EJE'
+
+
+def test_choisir_ajouter_sans_rien_saisir_n_enregistre_rien(
+        admin_client, db, sample_users):
+    """La valeur technique de l'entrée « + Ajouter » ne doit jamais être stockée."""
+    reponse = admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'], 'fonction': '__autre__'},
+        follow_redirects=True)
+    assert 'Saisissez le nom de la nouvelle fonction' in reponse.get_data(as_text=True)
+    assert _fonction_de(db, sample_users['salarie_id']) is None
+
+
+def test_une_fonction_hors_referentiel_est_refusee(admin_client, db, sample_users):
+    """Le référentiel reste la seule source des libellés."""
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'], 'fonction': 'Grand manitou'},
+        follow_redirects=True)
+    assert _fonction_de(db, sample_users['salarie_id']) is None
+    assert 'Grand manitou' not in _fonctions(db)
+
+
+def test_retirer_la_fonction(admin_client, db, sample_users):
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'], 'fonction': 'EJE'},
+        follow_redirects=True)
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'], 'fonction': ''},
+        follow_redirects=True)
+    assert _fonction_de(db, sample_users['salarie_id']) is None
+
+
+def test_fonction_trop_longue_refusee(admin_client, db, sample_users):
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'], 'fonction': '__autre__',
+        'nouvelle_fonction': 'x' * 61}, follow_redirects=True)
+    assert _fonction_de(db, sample_users['salarie_id']) is None
+
+
+# ── Droits ─────────────────────────────────────────────────────────────────
+
+def test_un_salarie_ne_peut_pas_modifier_les_fonctions(auth_client, db, sample_users):
+    auth_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['salarie_id'], 'fonction': 'EJE'},
+        follow_redirects=True)
+    assert _fonction_de(db, sample_users['salarie_id']) is None
+
+
+def test_un_responsable_ne_sort_pas_de_son_equipe(resp_client, db, sample_users):
+    """Le comptable n'est pas dans l'équipe du responsable de test."""
+    resp_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['comptable_id'], 'fonction': 'Comptable'},
+        follow_redirects=True)
+    assert _fonction_de(db, sample_users['comptable_id']) is None
+
+
+# ── Affichage dans l'interface sans menu ───────────────────────────────────
+
+def test_la_fonction_remplace_le_profil_en_haut_a_droite(admin_client, db, sample_users):
+    admin_client.post('/infos_salaries/fonction', data={
+        'user_id': sample_users['directeur_id'], 'fonction': 'Direction adjointe'},
+        follow_redirects=True)
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'Direction adjointe' in corps
+
+
+def test_sans_fonction_le_profil_reste_affiche(admin_client):
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'flx-identite-role' in corps
+    assert 'direction' in corps
+
+
+# ── Migration ──────────────────────────────────────────────────────────────
+
+def test_la_migration_recree_la_liste_et_reste_idempotente(app, db):
+    """Rejouer la migration ne double rien et répare une table manquante."""
+    import importlib.util
+    import os
+
+    chemin = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                          'migrations', '0064_fonction_salarie.py')
+    spec = importlib.util.spec_from_file_location('migration_0064', chemin)
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    # Base d'avant la migration : la liste n'existe pas encore.
+    db.execute('DROP TABLE IF EXISTS fonctions')
+    db.commit()
+
+    migration.upgrade(db)
+    assert _fonctions(db) == FONCTIONS_INITIALES
+
+    # Une fonction ajoutée par la direction survit à un nouveau passage, et la
+    # liste initiale n'est pas dupliquée.
+    db.execute("INSERT INTO fonctions (libelle, ordre) VALUES ('Médiateur', 99)")
+    db.commit()
+    migration.upgrade(db)
+    libelles = _fonctions(db)
+    assert 'Médiateur' in libelles
+    assert len(libelles) == len(FONCTIONS_INITIALES) + 1

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -1,0 +1,318 @@
+"""
+Tests de l'interface sans menu.
+
+Vérifient ce qui est facile à casser sans s'en apercevoir :
+- qui bascule et qui ne bascule pas ;
+- que le menu latéral disparaît bien pour les uns et reste pour les autres ;
+- que la carte de navigation n'expose que des pages autorisées ;
+- que l'accueil, « Mon espace » et les pages ordinaires s'affichent.
+"""
+import html as html_module
+import json
+import re
+
+import pytest
+
+import navigation
+
+
+def _carte_embarquee(corps):
+    """Relit la carte de navigation déposée dans l'attribut `data-carte`."""
+    trouve = re.search(r'data-carte="([^"]*)"', corps)
+    assert trouve, "attribut data-carte absent de la page"
+    return json.loads(html_module.unescape(trouve.group(1)))
+
+
+# ── Carte de navigation ────────────────────────────────────────────────────
+
+def test_tous_les_endpoints_de_la_carte_existent(app):
+    """Une entrée de menu qui pointe dans le vide casse la vue d'ensemble."""
+    regles = {r.endpoint for r in app.url_map.iter_rules()}
+    for groupe in navigation.ZONES + navigation.ACCES_DIRECTS:
+        for page in groupe['pages']:
+            assert page['endpoint'] in regles, (
+                f"{groupe['id']} → endpoint inconnu : {page['endpoint']}")
+
+
+def test_carte_du_salarie_ne_contient_aucune_page_de_direction(app):
+    """Un salarié délégué ne doit rien gagner d'autre que sa délégation."""
+    with app.test_request_context('/'):
+        carte = navigation.carte_navigation({'profil': 'salarie', 'user_id': 1})
+    endpoints = {p['endpoint']
+                 for g in carte['zones'] + carte['directs']
+                 for p in g['pages']}
+    for interdit in ('admin_bp.gestion_users', 'factures_bp.liste_factures',
+                     'infos_salaries_bp.infos_salaries', 'prepa_paie_bp.prepa_paie',
+                     'tresorerie_bp.tresorerie', 'budget_bp.gestion_budgets'):
+        assert interdit not in endpoints
+
+
+def test_carte_du_responsable_respecte_les_options(app):
+    """Les options d'administration ferment bien les pages concernées."""
+    contexte = {'profil': 'responsable', 'user_id': 1,
+                'can_access_vue_ensemble_validation': True,
+                'generation_contrats_responsable_autorise': False,
+                'budget_previsionnel_responsable_autorise': False}
+    with app.test_request_context('/'):
+        carte = navigation.carte_navigation(contexte)
+    endpoints = {p['endpoint']
+                 for g in carte['zones'] + carte['directs']
+                 for p in g['pages']}
+    assert 'generation_contrats_bp.generation_contrats' not in endpoints
+    assert 'budget_bp.budget_previsionnel' not in endpoints
+    assert 'budget_bp.mon_budget' in endpoints
+
+
+def test_delegation_benevoles_ouvre_la_page_au_salarie(app):
+    """Sans la délégation la page reste fermée ; avec elle, elle apparaît."""
+    with app.test_request_context('/'):
+        sans = navigation.carte_navigation({'profil': 'salarie', 'user_id': 1})
+        avec = navigation.carte_navigation({'profil': 'salarie', 'user_id': 1,
+                                            'is_delegue_benevoles': True})
+    aplat = lambda c: {p['endpoint'] for g in c['zones'] + c['directs'] for p in g['pages']}
+    assert 'benevoles_bp.gestion_benevoles' not in aplat(sans)
+    assert 'benevoles_bp.gestion_benevoles' in aplat(avec)
+
+
+def test_localiser_retrouve_la_zone_d_une_page(app):
+    with app.test_request_context('/'):
+        carte = navigation.carte_navigation({'profil': 'directeur', 'user_id': 1})
+        zone, page = navigation.localiser(carte, 'factures_bp.liste_factures')
+    assert zone['id'] == 'factures'
+    assert page['label'] == 'Factures'
+
+
+# ── Éligibilité ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('profil,attendu', [
+    ('directeur', True), ('comptable', True), ('responsable', True),
+    ('salarie', False), ('prestataire', False),
+])
+def test_eligibilite_par_profil(app, sample_users, profil, attendu):
+    with app.app_context():
+        assert navigation.est_eligible(profil, sample_users['salarie_id']) is attendu
+
+
+def test_salarie_delegue_devient_eligible(app, db, sample_users):
+    """Une délégation de mission fait basculer un salarié."""
+    from blueprints.delegations import (MISSION_SUIVI_VALIDATIONS_RELANCES,
+                                        save_delegation)
+    with app.app_context():
+        assert not navigation.est_eligible('salarie', sample_users['salarie_id'])
+        save_delegation(MISSION_SUIVI_VALIDATIONS_RELANCES,
+                        sample_users['salarie_id'], sample_users['directeur_id'])
+        assert navigation.est_eligible('salarie', sample_users['salarie_id'])
+
+
+def test_delegation_salles_seule_ne_suffit_pas(app, db, sample_users):
+    """La récurrence de salle n'ouvre aucune page : elle ne fait pas basculer."""
+    from blueprints.delegations import save_salle_recurrence_delegations
+    with app.app_context():
+        save_salle_recurrence_delegations([sample_users['salarie_id']],
+                                          sample_users['directeur_id'])
+        assert not navigation.est_eligible('salarie', sample_users['salarie_id'])
+
+
+# ── Rendu des pages ────────────────────────────────────────────────────────
+
+def test_le_directeur_arrive_sur_le_flux_sans_menu(admin_client):
+    reponse = admin_client.get('/dashboard', follow_redirects=True)
+    corps = reponse.get_data(as_text=True)
+    assert reponse.status_code == 200
+    assert 'flx-entete' in corps           # l'ossature sans menu est là
+    assert 'class="sidebar"' not in corps  # le menu latéral a disparu
+    assert "À l'horizon" in corps or 'flx-astuces' in corps
+
+
+def test_le_salarie_garde_son_menu(auth_client):
+    reponse = auth_client.get('/dashboard', follow_redirects=True)
+    corps = reponse.get_data(as_text=True)
+    assert reponse.status_code == 200
+    assert 'class="sidebar"' in corps
+    assert 'flx-entete' not in corps
+
+
+def test_mon_espace_affiche_les_compteurs(admin_client):
+    reponse = admin_client.get('/mon-espace')
+    corps = reponse.get_data(as_text=True)
+    assert reponse.status_code == 200
+    assert 'Congés payés' in corps
+    assert 'Récupérations' in corps
+    assert 'Poser une demande' in corps
+    # Retirés du modèle à la demande : pas de bulletins ni de documents.
+    assert 'Bulletins de paie' not in corps
+    assert 'Mes documents' not in corps
+
+
+def test_le_salarie_non_eligible_ne_peut_pas_ouvrir_le_flux(auth_client):
+    """L'accueil sans menu renvoie au tableau de bord habituel."""
+    reponse = auth_client.get('/accueil')
+    assert reponse.status_code == 302
+    assert '/dashboard' in reponse.headers['Location']
+
+
+def test_une_page_ordinaire_recoit_les_boutons_de_sa_zone(admin_client):
+    """Sur Factures, les pages voisines de la zone remplacent le sous-menu."""
+    reponse = admin_client.get('/factures')
+    corps = reponse.get_data(as_text=True)
+    assert reponse.status_code == 200
+    assert 'flx-chips' in corps
+    assert 'Factures &amp; achats' in corps or 'Factures & achats' in corps
+    assert 'Fournisseurs' in corps and 'Écritures' in corps
+    assert 'Revenir au flux' in corps
+
+
+def test_le_flux_d_information_apparait_sur_les_factures(admin_client, db, sample_users):
+    """Une facture en attente doit se voir avant la liste."""
+    with db:
+        db.execute(
+            "INSERT INTO factures (numero_facture, montant_ttc, approbation, statut) "
+            "VALUES ('F-1', 100, 'en_attente', 'a_traiter')"
+        )
+    corps = admin_client.get('/factures').get_data(as_text=True)
+    assert 'flx-infos' in corps
+    # L'apostrophe est échappée par Jinja dans le rendu HTML.
+    assert 'facture(s) en attente d&#39;approbation' in corps
+    assert 'facture(s) sans écriture — à générer' not in corps  # page Écritures
+
+
+def test_bascule_vers_le_menu_classique_et_retour(admin_client):
+    reponse = admin_client.post('/api/interface/basculer', json={'actif': False})
+    assert reponse.status_code == 200
+    assert reponse.get_json()['actif'] is False
+
+    corps = admin_client.get('/dashboard_direction').get_data(as_text=True)
+    assert 'class="sidebar"' in corps
+    assert 'flx-entete' not in corps
+
+    reponse = admin_client.post('/api/interface/basculer', json={'actif': True})
+    assert reponse.status_code == 200
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'flx-entete' in corps
+
+
+def test_bascule_refusee_pour_un_salarie_non_eligible(auth_client):
+    reponse = auth_client.post('/api/interface/basculer', json={'actif': True})
+    assert reponse.status_code == 403
+
+
+def test_option_globale_desactivee_rend_le_menu(admin_client, app):
+    with app.app_context():
+        from app_options import set_option_bool
+        set_option_bool('interface_sans_menu_active', False)
+    corps = admin_client.get('/dashboard', follow_redirects=True).get_data(as_text=True)
+    assert 'class="sidebar"' in corps
+    assert 'flx-entete' not in corps
+
+
+# ── « À l'horizon » ────────────────────────────────────────────────────────
+
+def test_horizon_separe_le_lointain_de_l_immediat(admin_client, db):
+    """Une échéance à 3 jours reste dans le fil ; à 40 jours elle passe à l'horizon."""
+    from datetime import timedelta
+
+    from utils import aujourd_hui
+    today = aujourd_hui()
+    with db:
+        db.execute("INSERT INTO subventions (nom, groupe, annee_action) "
+                   "VALUES ('CAF CLAS', 'depose', ?)", (str(today.year),))
+        sub_id = db.execute("SELECT id FROM subventions WHERE nom = 'CAF CLAS'").fetchone()['id']
+        db.execute("INSERT INTO subventions_sous_elements "
+                   "(subvention_id, nom, statut, date_echeance) VALUES (?, ?, 'non_commence', ?)",
+                   (sub_id, 'Bilan qualitatif', (today + timedelta(days=3)).isoformat()))
+        db.execute("INSERT INTO subventions_sous_elements "
+                   "(subvention_id, nom, statut, date_echeance) VALUES (?, ?, 'non_commence', ?)",
+                   (sub_id, 'Dépôt du dossier', (today + timedelta(days=40)).isoformat()))
+
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    # Le texte littéral d'un gabarit n'est pas échappé : seule la zone
+    # « À l'horizon » sépare le fil de ce qui vient plus tard.
+    fil, horizon = corps.split("À l'horizon", 1)
+    assert 'Bilan qualitatif' in fil          # imminent : dans le fil
+    assert 'Dépôt du dossier' not in fil      # lointain : pas dans le fil
+    assert 'Dépôt du dossier' in horizon      # …mais bien à l'horizon
+    assert 'Échéances' in horizon
+
+
+def test_horizon_annonce_les_fins_de_contrat(admin_client, db, sample_users):
+    """Une fin de CDD à venir doit apparaître dans la ligne RH."""
+    from datetime import timedelta
+
+    from utils import aujourd_hui
+    today = aujourd_hui()
+    with db:
+        db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                   "VALUES (?, 'CDD', ?, ?)",
+                   (sample_users['salarie_id'], (today - timedelta(days=200)).isoformat(),
+                    (today + timedelta(days=45)).isoformat()))
+
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'Fin de CDD — Jean Martin' in corps
+    assert '>RH<' in corps
+
+
+def test_page_hors_carte_garde_une_sortie(admin_client, db):
+    """Une page absente de la carte doit tout de même offrir le retour au flux."""
+    with db:
+        db.execute("INSERT INTO factures (id, numero_facture, montant_ttc) VALUES (77, 'F-77', 10)")
+    corps = admin_client.get('/factures/77/detail').get_data(as_text=True)
+    assert 'Revenir au flux' in corps
+    assert 'flx-chips' not in corps
+
+
+def test_fragment_du_fil_est_rechargeable(admin_client, db, sample_users):
+    """Le rafraîchissement automatique renvoie les cartes, sans l'ossature."""
+    with db:
+        db.execute(
+            "INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, "
+            "nb_jours, statut) VALUES (?, 'Congé payé', '2026-09-01', '2026-09-05', 5, "
+            "'en_attente_direction')", (sample_users['salarie_id'],))
+    reponse = admin_client.get('/api/accueil/flux-fragment')
+    corps = reponse.get_data(as_text=True)
+    assert reponse.status_code == 200
+    assert 'flx-carte' in corps
+    assert 'Demande de congé payé : Jean Martin' in corps
+    assert '<html' not in corps          # fragment seul, pas la page entière
+
+
+def test_fragment_du_fil_refuse_les_non_eligibles(auth_client):
+    assert auth_client.get('/api/accueil/flux-fragment').status_code == 403
+
+
+def test_le_salarie_delegue_recoit_le_flux_mais_pas_les_pages_de_direction(
+        client, app, db, sample_users):
+    """Le salarié délégué bascule, avec sa seule délégation en plus."""
+    from blueprints.delegations import save_benevoles_delegations
+    with app.app_context():
+        save_benevoles_delegations([sample_users['salarie_id']],
+                                   sample_users['directeur_id'])
+
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    corps = client.get('/accueil').get_data(as_text=True)
+    assert 'flx-entete' in corps
+    assert 'class="sidebar"' not in corps
+
+    # La carte de navigation voyage en JSON dans `data-carte` : on la relit
+    # comme le fait le navigateur, plutôt que de chercher du texte échappé.
+    carte = _carte_embarquee(corps)
+    pages = {p['label'] for g in carte['zones'] + carte['directs'] for p in g['pages']}
+    assert 'Bénévoles' in pages                    # sa délégation
+    assert 'Préparation de la paie' not in pages   # rien de la direction
+    assert 'Utilisateurs' not in pages
+    assert 'Factures' not in pages
+
+
+def test_le_message_du_cse_apparait_sur_le_flux(admin_client, db, sample_users):
+    """La bannière CSE suivait les tableaux de bord : elle suit l'accueil aussi."""
+    from datetime import timedelta
+
+    from utils import aujourd_hui
+    with db:
+        db.execute(
+            "INSERT INTO cse_messages (titre, contenu, date_validite, cree_par) "
+            "VALUES ('Réunion du 12', 'Ordre du jour joint.', ?, ?)",
+            ((aujourd_hui() + timedelta(days=10)).isoformat(), sample_users['directeur_id']))
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'cse-banner' in corps
+    assert 'Message du CSE à lire' in corps

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -436,3 +436,77 @@ def test_le_calcul_des_jours_ouvres_exclut_les_feries(admin_client, db):
     corps = admin_client.get('/mon-espace').get_data(as_text=True)
     assert '2026-08-15' in corps        # la liste est bien transmise au gabarit
     assert 'FERIES.indexOf' in corps    # …et réellement utilisée dans le calcul
+
+
+# ── Invariant : la carte n'excède jamais le menu latéral ───────────────────
+
+def _liens_du_menu(corps):
+    """Liens réellement rendus dans le menu latéral."""
+    aside = re.search(r'<aside class="sidebar".*?</aside>', corps, re.S)
+    return {h for h in re.findall(r'href="([^"]+)"', aside.group(0) if aside else '')
+            if h.startswith('/')}
+
+
+def _liens_de_la_carte(corps):
+    carte = _carte_embarquee(corps)
+    return {p['lien'] for g in carte['zones'] + carte['directs'] for p in g['pages']}
+
+
+# Pages dont l'écart avec le menu est voulu : « Mon espace » est créé par cette
+# interface, les tableaux de bord historiques sont ce que le flux remplace, et
+# la déconnexion vit dans l'en-tête plutôt que dans la carte.
+_ECARTS_ATTENDUS = {
+    '/',                     # le logo, présent dans les deux en-têtes
+    '/mon-espace',           # créé par cette interface
+    '/logout',               # dans l'en-tête du flux, pas dans la carte
+    '/dashboard', '/dashboard_direction',
+    '/dashboard_responsable', '/dashboard_comptable',
+}
+
+
+@pytest.mark.parametrize('login,mdp,profil', [
+    ('admin', 'Admin1234', 'directeur'),
+    ('resp_test', 'resp123', 'responsable'),
+    ('salarie_test', 'sal123', 'salarie'),
+])
+def test_la_carte_n_ouvre_rien_de_plus_que_le_menu(client, app, db, sample_users,
+                                                   login, mdp, profil):
+    """Garantie centrale : la vue d'ensemble ne montre que des pages autorisées.
+
+    On compare la carte réellement transmise au navigateur (`data-carte`) aux
+    liens réellement rendus dans le menu latéral du même utilisateur. Aucune
+    page ne doit apparaître d'un côté sans l'autre — hors écarts voulus.
+    """
+    from app_options import set_option_bool
+    if profil == 'salarie':   # un salarié ne bascule qu'avec une délégation
+        from blueprints.delegations import save_benevoles_delegations
+        with app.app_context():
+            save_benevoles_delegations([sample_users['salarie_id']],
+                                       sample_users['directeur_id'])
+
+    with app.app_context():
+        set_option_bool('interface_sans_menu_active', False)
+    client.post('/login', data={'login': login, 'password': mdp}, follow_redirects=True)
+    menu = _liens_du_menu(client.get('/dashboard', follow_redirects=True).get_data(as_text=True))
+    assert menu, "le menu latéral attendu est vide"
+
+    with app.app_context():
+        set_option_bool('interface_sans_menu_active', True)
+    carte = _liens_de_la_carte(
+        client.get('/accueil', follow_redirects=True).get_data(as_text=True))
+
+    en_trop = carte - menu - _ECARTS_ATTENDUS
+    assert not en_trop, f"{profil} : pages dans la carte mais pas dans le menu : {sorted(en_trop)}"
+    perdues = menu - carte - _ECARTS_ATTENDUS
+    assert not perdues, f"{profil} : pages du menu absentes de la carte : {sorted(perdues)}"
+
+
+def test_une_zone_entierement_fermee_disparait(client, app, sample_users):
+    """Un responsable n'a aucune page d'administration : la zone n'existe pas."""
+    client.post('/login', data={'login': 'resp_test', 'password': 'resp123'},
+                follow_redirects=True)
+    carte = _carte_embarquee(client.get('/accueil').get_data(as_text=True))
+    ids = {g['id'] for g in carte['zones'] + carte['directs']}
+    assert 'administration' not in ids
+    assert 'comptabilite' not in ids
+    assert 'validations' in ids          # celle-ci, il y a droit

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -163,11 +163,15 @@ def test_une_page_ordinaire_recoit_les_boutons_de_sa_zone(admin_client):
 
 
 def test_le_flux_d_information_apparait_sur_les_factures(admin_client, db, sample_users):
-    """Une facture en attente doit se voir avant la liste."""
+    """Une facture en attente doit se voir avant la liste.
+
+    Elle est assignée à la direction : c'est ce que la page d'approbation
+    liste, et donc ce que le bandeau doit compter.
+    """
     with db:
         db.execute(
-            "INSERT INTO factures (numero_facture, montant_ttc, approbation, statut) "
-            "VALUES ('F-1', 100, 'en_attente', 'a_traiter')"
+            "INSERT INTO factures (numero_facture, montant_ttc, approbation, statut, "
+            "assigned_direction) VALUES ('F-1', 100, 'en_attente', 'a_traiter', 1)"
         )
     corps = admin_client.get('/factures').get_data(as_text=True)
     assert 'flx-infos' in corps
@@ -552,3 +556,167 @@ def test_le_centre_de_controle_partage_le_meme_gabarit(admin_client):
                   'ccSeuilSurcharge', 'ccSeuilDigest'):
         assert champ in accueil, champ
         assert champ in controle, champ
+
+
+# ── Revue Codex n°2 : ne jamais pointer vers une page fermée au lecteur ────
+
+def test_le_bandeau_factures_compte_ce_que_la_page_d_approbation_montre(
+        admin_client, db, sample_users):
+    """Le compteur ne doit pas promettre plus que sa destination n'affiche."""
+    with db:
+        db.execute("INSERT INTO secteurs (nom) VALUES ('Enfance')")
+        sect = db.execute("SELECT id FROM secteurs WHERE nom='Enfance'").fetchone()['id']
+        # Une facture assignée : elle apparaît sur la page d'approbation.
+        db.execute("INSERT INTO factures (numero_facture, montant_ttc, approbation, "
+                   "secteur_id) VALUES ('F-A', 100, 'en_attente', ?)", (sect,))
+        # Deux factures encore non assignées : la page ne les liste pas.
+        db.execute("INSERT INTO factures (numero_facture, montant_ttc, approbation, "
+                   "assigned_direction) VALUES ('F-B', 100, 'en_attente', 0)")
+        db.execute("INSERT INTO factures (numero_facture, montant_ttc, approbation, "
+                   "assigned_direction) VALUES ('F-C', 100, 'en_attente', 0)")
+
+    corps = admin_client.get('/factures').get_data(as_text=True)
+    approbation = admin_client.get('/factures/approbation').get_data(as_text=True)
+    assert 'F-A' in approbation and 'F-B' not in approbation
+
+    bandeaux = re.findall(r'flx-info-valeur">(\d+)</span>\s*<span class="flx-info-libelle">([^<]+)',
+                          corps)
+    par_libelle = {libelle.strip(): int(n) for n, libelle in bandeaux}
+    assert par_libelle.get("facture(s) en attente d&#39;approbation") == 1
+    # Les non assignées sont signalées à part, vers leur vraie destination.
+    assert par_libelle.get('facture(s) à assigner à un secteur') == 2
+
+
+def test_le_responsable_ne_compte_que_les_fiches_de_son_equipe(
+        resp_client, db, sample_users):
+    """Le bandeau suit le cadrage de la page qu'il décore."""
+    with db:
+        db.execute("INSERT INTO secteurs (nom) VALUES ('Ailleurs')")
+        autre = db.execute("SELECT id FROM secteurs WHERE nom='Ailleurs'").fetchone()['id']
+        db.execute("INSERT INTO users (nom, prenom, login, password, profil, secteur_id) "
+                   "VALUES ('Loin', 'Paul', 'ploin', 'x', 'salarie', ?)", (autre,))
+
+    corps = resp_client.get('/vue_ensemble_validation').get_data(as_text=True)
+    assert 'dans votre équipe' in corps
+    bandeaux = re.findall(r'flx-info-valeur">(\d+)</span>', corps)
+    # Son équipe : le salarié de test et lui-même — pas le salarié d'ailleurs
+    # ni le comptable.
+    assert bandeaux and int(bandeaux[0]) == 2
+
+
+def test_le_delegue_aux_validations_ne_voit_pas_les_demandes_a_valider(
+        client, app, db, sample_users):
+    """Sa délégation porte sur le suivi des fiches, pas sur les congés."""
+    from blueprints.delegations import (MISSION_SUIVI_VALIDATIONS_RELANCES,
+                                        save_delegation)
+    with app.app_context():
+        save_delegation(MISSION_SUIVI_VALIDATIONS_RELANCES,
+                        sample_users['salarie_id'], sample_users['directeur_id'])
+    with db:
+        db.execute(
+            "INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, "
+            "nb_jours, statut) VALUES (?, 'Congé payé', '2026-09-01', '2026-09-05', 5, "
+            "'en_attente_direction')", (sample_users['comptable_id'],))
+
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    corps = client.get('/vue_ensemble_validation').get_data(as_text=True)
+    assert corps.count('flx-info') > 0                      # il voit bien la page
+    assert 'demande(s) en attente de validation' not in corps
+    assert '/validation_demandes_recup' not in corps
+
+
+def test_pas_de_carte_de_subvention_pour_un_salarie_delegue(
+        client, app, db, sample_users):
+    """La page et l'action « C'est fait » lui sont fermées : pas de carte."""
+    from blueprints.delegations import save_benevoles_delegations
+    with app.app_context():
+        save_benevoles_delegations([sample_users['salarie_id']],
+                                   sample_users['directeur_id'])
+    with db:
+        db.execute("INSERT INTO subventions (nom, groupe, annee_action) "
+                   "VALUES ('CAF CLAS', 'depose', '2026')")
+        sub = db.execute("SELECT id FROM subventions LIMIT 1").fetchone()['id']
+        db.execute("INSERT INTO subventions_sous_elements (subvention_id, nom, statut, "
+                   "date_echeance, assignee_id) VALUES (?, 'Bilan', 'non_commence', "
+                   "'2026-08-05', ?)", (sub, sample_users['salarie_id']))
+
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    corps = client.get('/accueil').get_data(as_text=True)
+    assert 'Bilan' not in corps
+    assert 'data-flx-act="subvention"' not in corps
+
+
+def test_pas_de_retour_d_absence_pour_un_responsable(resp_client, db, sample_users):
+    """La page des absences lui est fermée : la carte ne doit pas exister."""
+    from datetime import timedelta
+
+    from utils import aujourd_hui
+    with db:
+        db.execute("INSERT INTO absences (user_id, motif, date_debut, date_fin, "
+                   "jours_ouvres, saisi_par) VALUES (?, 'maladie', ?, ?, 20, ?)",
+                   (sample_users['salarie_id'],
+                    (aujourd_hui() - timedelta(days=10)).isoformat(),
+                    (aujourd_hui() + timedelta(days=20)).isoformat(),
+                    sample_users['directeur_id']))
+    corps = resp_client.get('/accueil').get_data(as_text=True)
+    assert 'Retour de' not in corps
+
+    # La direction, elle, peut ouvrir la page : la carte lui est proposée.
+    assert '/absences' not in corps
+
+
+# ── Barre intelligente : recherche métier vs navigation locale ─────────────
+
+def _drapeau_recherche(corps):
+    trouve = re.search(r'data-recherche-globale="([01])"', corps)
+    assert trouve, 'drapeau de recherche absent du socle'
+    return trouve.group(1) == '1'
+
+
+def test_la_recherche_metier_est_offerte_a_qui_l_api_autorise(admin_client):
+    """Direction : la palette peut proposer « Rechercher »."""
+    from blueprints.recherche import PROFILS_AUTORISES
+    assert 'directeur' in PROFILS_AUTORISES
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert _drapeau_recherche(corps) is True
+    assert admin_client.post('/api/search', json={'query': 'budget'}).status_code == 200
+
+
+def test_le_responsable_garde_la_navigation_sans_recherche_metier(resp_client):
+    """`/api/search` lui répond 403 : la palette ne doit pas la lui proposer.
+
+    Sa barre reste utile — elle ouvre zones et pages, ce qui remplace le menu.
+    """
+    assert resp_client.post('/api/search', json={'query': 'budget'}).status_code == 403
+    corps = resp_client.get('/accueil').get_data(as_text=True)
+    assert _drapeau_recherche(corps) is False
+    assert 'Où voulez-vous aller' in corps
+    # La navigation locale, elle, est bien alimentée.
+    carte = _carte_embarquee(corps)
+    assert carte['zones'], 'la palette du responsable serait vide'
+
+
+def test_le_salarie_delegue_garde_la_navigation_sans_recherche_metier(
+        client, app, db, sample_users):
+    from blueprints.delegations import save_benevoles_delegations
+    with app.app_context():
+        save_benevoles_delegations([sample_users['salarie_id']],
+                                   sample_users['directeur_id'])
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    assert client.post('/api/search', json={'query': 'budget'}).status_code == 403
+    corps = client.get('/accueil').get_data(as_text=True)
+    assert _drapeau_recherche(corps) is False
+    assert _carte_embarquee(corps)['zones']
+
+
+def test_le_drapeau_suit_la_liste_d_autorisation_de_l_api(app):
+    """Palette et API lisent la même source : elles ne peuvent pas diverger."""
+    import interface_flux
+    from blueprints.recherche import PROFILS_AUTORISES
+    for profil in ('directeur', 'comptable', 'responsable', 'salarie', 'prestataire'):
+        with app.app_context():
+            assert (interface_flux.recherche_globale_autorisee(profil)
+                    is (profil in PROFILS_AUTORISES)), profil

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -510,3 +510,45 @@ def test_une_zone_entierement_fermee_disparait(client, app, sample_users):
     assert 'administration' not in ids
     assert 'comptabilite' not in ids
     assert 'validations' in ids          # celle-ci, il y a droit
+
+
+# ── Seuils d'alerte, réglables depuis l'accueil ────────────────────────────
+
+def test_les_seuils_se_reglent_depuis_l_accueil(admin_client):
+    """L'accueil remplace le centre de contrôle : il en porte aussi les réglages."""
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'ccSeuilsModal' in corps
+    assert 'ccOuvrirSeuils()' in corps
+    assert 'Score de surcharge' in corps
+
+
+def test_le_responsable_n_a_pas_les_seuils(resp_client):
+    """Les seuils pilotent la file étendue : ils ne concernent pas un responsable."""
+    corps = resp_client.get('/accueil').get_data(as_text=True)
+    assert 'ccSeuilsModal' not in corps
+
+
+def test_un_seuil_enregistre_depuis_l_accueil_change_le_fil(admin_client, db, sample_users):
+    """Enregistrer un seuil doit réellement modifier ce que le fil affiche."""
+    with db:
+        db.execute('UPDATE users SET cc_solde = 9 WHERE id = ?',
+                   (sample_users['salarie_id'],))
+
+    # Seuil bas : le solde de congés conventionnels remonte dans le fil.
+    reponse = admin_client.post('/api/dashboard-direction/seuils', json={'conges': 5})
+    assert reponse.status_code == 200
+    assert 'Solde congés conventionnels élevé' in admin_client.get('/accueil').get_data(as_text=True)
+
+    # Seuil relevé au-dessus : il n'a plus lieu d'être signalé.
+    admin_client.post('/api/dashboard-direction/seuils', json={'conges': 20})
+    assert 'Solde congés conventionnels élevé' not in admin_client.get('/accueil').get_data(as_text=True)
+
+
+def test_le_centre_de_controle_partage_le_meme_gabarit(admin_client):
+    """Les deux pages règlent exactement les mêmes valeurs."""
+    accueil = admin_client.get('/accueil').get_data(as_text=True)
+    controle = admin_client.get('/dashboard_direction').get_data(as_text=True)
+    for champ in ('ccSeuilTreso', 'ccSeuilBudget', 'ccSeuilConges',
+                  'ccSeuilSurcharge', 'ccSeuilDigest'):
+        assert champ in accueil, champ
+        assert champ in controle, champ

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -316,3 +316,123 @@ def test_le_message_du_cse_apparait_sur_le_flux(admin_client, db, sample_users):
     corps = admin_client.get('/accueil').get_data(as_text=True)
     assert 'cse-banner' in corps
     assert 'Message du CSE à lire' in corps
+
+
+# ── Revue Codex #232 : parité, cadrage des données et cohérence ────────────
+
+def test_le_flux_direction_porte_les_factures_et_les_relances(
+        admin_client, db, sample_users):
+    """L'accueil remplace le centre de contrôle : il en garde la file étendue."""
+    from datetime import timedelta
+
+    from utils import aujourd_hui
+    with db:
+        db.execute("INSERT INTO fournisseurs (nom) VALUES ('ALTEO')")
+        f_id = db.execute("SELECT id FROM fournisseurs LIMIT 1").fetchone()['id']
+        db.execute(
+            "INSERT INTO factures (fournisseur_id, numero_facture, montant_ttc, "
+            "date_echeance, approbation, assigned_direction, statut) "
+            "VALUES (?, '225678', 2480.0, ?, 'en_attente', 1, 'a_traiter')",
+            (f_id, (aujourd_hui() + timedelta(days=3)).isoformat()))
+
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'ALTEO' in corps
+    assert 'data-flx-act="facture"' in corps
+    # Les fiches du mois précédent ne sont validées pour personne : la relance
+    # doit être proposée, comme sur le tableau de bord direction.
+    assert 'data-flx-act="relance"' in corps
+
+
+def test_le_salarie_delegue_ne_voit_pas_les_demandes_des_autres(
+        client, app, db, sample_users):
+    """Un délégué « bénévoles » n'a rien à valider : rien ne doit filtrer."""
+    from blueprints.delegations import save_benevoles_delegations
+    with app.app_context():
+        save_benevoles_delegations([sample_users['salarie_id']],
+                                   sample_users['directeur_id'])
+    with db:
+        db.execute(
+            "INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, "
+            "nb_jours, statut) VALUES (?, 'Congé payé', '2026-09-01', '2026-09-05', 5, "
+            "'en_attente_direction')", (sample_users['comptable_id'],))
+        db.execute(
+            "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+            "VALUES (?, 'CDD', '2026-01-01', '2026-09-15')",
+            (sample_users['comptable_id'],))
+
+    client.post('/login', data={'login': 'salarie_test', 'password': 'sal123'},
+                follow_redirects=True)
+    corps = client.get('/accueil').get_data(as_text=True)
+    assert 'flx-entete' in corps                      # il est bien sur le flux
+    assert 'Durand' not in corps                       # ni la demande du comptable
+    assert 'Fin de CDD' not in corps                   # ni son contrat
+    assert 'data-flx-act="valider"' not in corps       # ni un bouton de validation
+
+
+def test_le_responsable_ne_voit_que_son_equipe(resp_client, db, sample_users):
+    """Le cadrage par secteur vaut aussi pour l'accueil sans menu."""
+    with db:
+        db.execute(
+            "INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, "
+            "nb_jours, statut) VALUES (?, 'Congé payé', '2026-09-01', '2026-09-05', 5, "
+            "'en_attente_responsable')", (sample_users['comptable_id'],))
+    corps = resp_client.get('/accueil').get_data(as_text=True)
+    assert 'Sophie Durand' not in corps
+
+
+def test_une_echeance_rh_imminente_reste_visible(admin_client, db, sample_users):
+    """Un CDD qui se termine demain ne doit disparaître de nulle part."""
+    from datetime import timedelta
+
+    from utils import aujourd_hui
+    demain = aujourd_hui() + timedelta(days=1)
+    with db:
+        db.execute("INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                   "VALUES (?, 'CDD', '2026-01-01', ?)",
+                   (sample_users['salarie_id'], demain.isoformat()))
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'Fin de CDD — Jean Martin' in corps
+
+
+def test_option_globale_desactivee_ferme_aussi_l_accueil(admin_client, app):
+    """Sans l'option du centre, l'accueil ne doit pas s'ouvrir dans le menu."""
+    with app.app_context():
+        from app_options import set_option_bool
+        set_option_bool('interface_sans_menu_active', False)
+
+    for chemin in ('/accueil', '/mon-espace'):
+        reponse = admin_client.get(chemin)
+        assert reponse.status_code == 302, chemin
+        assert '/dashboard' in reponse.headers['Location'], chemin
+
+    assert admin_client.get('/api/accueil/flux-fragment').status_code == 403
+
+    # Le bouton « Essayer la nouvelle interface » disparaît lui aussi.
+    corps = admin_client.get('/dashboard_direction').get_data(as_text=True)
+    assert 'Essayer la nouvelle interface' not in corps
+
+
+def test_la_delegation_des_validations_expose_la_vue_d_ensemble(app):
+    """La page accordée par la délégation doit figurer dans la carte."""
+    with app.test_request_context('/'):
+        carte = navigation.carte_navigation({
+            'profil': 'salarie', 'user_id': 1,
+            'can_access_vue_ensemble_validation': True})
+    endpoints = {p['endpoint']
+                 for g in carte['zones'] + carte['directs'] for p in g['pages']}
+    assert 'validation_bp.vue_ensemble_validation' in endpoints
+    # Sans la délégation, elle reste fermée.
+    with app.test_request_context('/'):
+        sans = navigation.carte_navigation({'profil': 'salarie', 'user_id': 1})
+    assert 'validation_bp.vue_ensemble_validation' not in {
+        p['endpoint'] for g in sans['zones'] + sans['directs'] for p in g['pages']}
+
+
+def test_le_calcul_des_jours_ouvres_exclut_les_feries(admin_client, db):
+    """Le décompte affiché doit coïncider avec celui du serveur."""
+    with db:
+        db.execute("INSERT OR IGNORE INTO jours_feries (date, libelle, annee) "
+                   "VALUES ('2026-08-15', 'Assomption', 2026)")
+    corps = admin_client.get('/mon-espace').get_data(as_text=True)
+    assert '2026-08-15' in corps        # la liste est bien transmise au gabarit
+    assert 'FERIES.indexOf' in corps    # …et réellement utilisée dans le calcul

--- a/tests/test_responsable_rh_paie_access.py
+++ b/tests/test_responsable_rh_paie_access.py
@@ -1,7 +1,7 @@
 from werkzeug.security import generate_password_hash
 
 
-def test_responsable_menu_rh_paie_contient_liens_et_deplace_temps_annualise(resp_client):
+def test_responsable_menu_rh_paie_contient_liens_et_deplace_temps_annualise(resp_client, menu_classique):
     response = resp_client.get('/dashboard_responsable')
     assert response.status_code == 200
     html = response.get_data(as_text=True)

--- a/tests/test_securite.py
+++ b/tests/test_securite.py
@@ -191,12 +191,12 @@ class TestExportJournalAcces:
 class TestMenuSecurite:
     """Verifie la presence du menu Securite selon le profil."""
 
-    def test_lien_present_pour_directeur(self, admin_client):
+    def test_lien_present_pour_directeur(self, admin_client, menu_classique):
         html = admin_client.get('/securite/journal-acces').get_data(as_text=True)
         assert '🔒 Sécurité' in html
         assert url_securite() in html
 
-    def test_lien_present_pour_comptable(self, comptable_client):
+    def test_lien_present_pour_comptable(self, comptable_client, menu_classique):
         html = comptable_client.get('/dashboard_comptable').get_data(as_text=True)
         assert '🔒 Sécurité' in html
         assert url_securite() in html


### PR DESCRIPTION
Portage du modèle Claude Design « Interface sans menu » sur CS-PILOT.

Le menu latéral disparaît pour **la direction, la comptabilité, les responsables et les salariés porteurs d'une délégation**. Les autres salariés gardent l'interface habituelle : ils n'ont que le suivi de leurs heures à gérer.

## Ce qui a été fait

### L'accueil (`/accueil`)
- **Le fil** : uniquement ce qui attend une décision, avec validation / refus / approbation / relance en un clic. La carte disparaît une fois traitée, l'anneau de progression avance. Pour la direction et la comptabilité, il reprend la **file étendue** du centre de contrôle qu'il remplace : factures assignées à la direction, relance des fiches, surcharges, soldes de congés élevés.
- **« À l'horizon »** : deux lignes à défilement horizontal, *RH* (fins de contrat, retours d'absence longue) et *Échéances* (étapes de subventions, tâches du planificateur).
- Le recouvrement est limité au strict nécessaire : les étapes de subventions sont dans le fil quelle que soit leur date, l'horizon ne les reprend qu'au-delà de 7 jours pour ne pas doubler. Le reste n'apparaissant que dans l'horizon, celui-ci part d'aujourd'hui — un CDD finissant demain reste visible.
- Les **seuils d'alerte** (trésorerie, budget, congés, surcharge, digest) se règlent depuis l'accueil, bouton ⚙. Gabarit partagé avec le centre de contrôle : une seule source, aucune divergence possible.
- La ligne « Vous » du modèle n'a pas été reprise, comme demandé.

### Mon espace (`/mon-espace`)
Ouvert par le nom et la fonction, en haut à droite. Soldes de congés payés, de congés conventionnels et de récupérations ; dépôt d'une demande ; « Mes demandes ». Le formulaire poste sur les routes existantes `/demande_conge` et `/demande_recup` : **le circuit de validation et les notifications sont inchangés**. Le décompte des jours ouvrés affiché avant l'envoi exclut les jours fériés, comme le fait `utils.calculer_jours_ouvres` côté serveur.

« Mes documents » et « Bulletins de paie » ne sont pas repris, comme demandé.

### La fonction du salarié
L'application connaissait le profil (des droits) et le secteur, mais pas la fonction occupée. Elle se renseigne désormais **avec les informations de contrat**, sur la fiche « Infos salariés », par liste déroulante :

> Directeur · Direction adjointe · Comptable · Responsable · EJE · Auxiliaire Puér. · Aide Aux. · Agent d'accueil · Assist.Direction · Accueil&Comm. · Conseillé insertion · Anim.Formateur · Dir.Adjointe AL · Entretien/restauration · Entretien · Gardien

« + Ajouter une fonction… » ouvre un champ libre : la fonction créée est affectée au salarié **et rejoint la liste proposée à tout le monde**. Hors création, la valeur doit venir du référentiel — ou être celle déjà portée par le salarié si elle en a été retirée depuis.

Migration **0064** : `users.fonction` + table `fonctions`, déclarée dans `ALL_MIGRATION_VERSIONS`. La liste de départ vit dans `migrations/__init__.py`, lue par la migration et par `init_db` : base neuve et base migrée partent du même jeu, et une fonction supprimée ne réapparaît pas.

### La barre intelligente
Elle se remplit **dès la première touche frappée**, n'importe où dans la page (ou `Ctrl`/`⌘` + `K`). Elle propose d'abord les zones et les pages — ce qui remplace le menu — puis une entrée « Rechercher … » qui envoie la requête au moteur existant `POST /api/search` et en traite le verdict comme avant. Son fonctionnement est conservé tel quel, avec la présentation du modèle.

### La vue d'ensemble (`Échap`, ou le bouton de la barre du bas)
- **Cercle intérieur** : 8 zones thématiques, réorganisées à partir du menu réel. S'attarder sur l'une d'elles déplie ses pages en couronne.
- **Cercle extérieur** : les accès directs — Salles, Planificateur, Administration.
- Centre : les initiales de l'utilisateur.

### Les autres pages
Elles perdent leur menu et reçoivent en haut : le retour au flux, **les boutons des pages voisines de leur zone** (l'ancien sous-menu), et un **flux d'information** quand la page s'y prête — factures non validées et échéances dépassées, écritures à générer, étapes de subventions en retard, fiches non validées. Leur titre, leurs boutons d'action (importer, relancer…) et leur contenu ne changent pas. La trésorerie, qui est déjà son tableau, reste telle quelle.

## Cloisonnement des données
Un salarié délégué bascule sur cette interface, mais reste cadré sur ce qui le concerne : il ne valide aucune demande, donc son fil n'en contient aucune, et l'horizon ne lui montre ni les contrats ni les absences de l'effectif. Il ne voit que les étapes de subventions qui lui sont assignées et ses propres tâches. Le cadrage est appliqué **à la source** (`dashboard_actions.construire_actions`, `flux_accueil.construire_horizon`), donc pour tout appelant présent et futur.

## Réversibilité
- **Pour le centre** : option d'administration « Activer l'interface sans menu ». Décochée, `/accueil` et `/mon-espace` redirigent vers le tableau de bord et le bouton « Essayer la nouvelle interface » disparaît.
- **Pour une personne** : « Revenir au menu classique » depuis Mon espace (enregistré dans `app_settings`, réversible).
- Les tableaux de bord historiques restent accessibles par leur URL.

## Architecture
`navigation.py` est la source unique de la carte : 8 zones, 3 accès directs, 58 pages. **Aucun droit nouveau n'est ouvert** — les conditions de visibilité reprennent celles du menu latéral, et les routes gardent leur propre contrôle.

L'ossature est branchée une seule fois dans `base.html` : les ~90 pages perdent leur menu et gagnent leur barre de zone sans être modifiées une à une.

| Fichier | Rôle |
| --- | --- |
| `navigation.py` | Carte des zones et des pages, filtrée par profil et délégation |
| `interface_flux.py` | Activation (option / profil / choix personnel) et contexte par requête |
| `flux_accueil.py` | Zone « À l'horizon » |
| `flux_infos.py` | Flux d'information par page |
| `blueprints/accueil.py` | `/accueil`, `/mon-espace`, fragment de rafraîchissement, bascule |
| `templates/_seuils_modal.html` | Seuils d'alerte, partagés accueil / centre de contrôle |
| `migrations/0064_fonction_salarie.py` | `users.fonction` et le référentiel des fonctions |

## Tests

**Suite complète : 1437 tests, tous verts.**

- `tests/test_interface_flux.py` — 43 tests : éligibilité par profil et par délégation (celle des récurrences de salle ne compte pas), filtrage de la carte, rendu des trois écrans, flux d'information, séparation fil / horizon, bannière CSE, bascule, seuils.
- `tests/test_fonction_salarie.py` — 15 tests : référentiel, création d'une fonction, refus des valeurs hors référentiel, droits, affichage dans l'en-tête, idempotence de la migration sur une base qui la précède.

Un test encode l'invariant central : **la carte n'ouvre jamais rien de plus que le menu latéral**. Il compare, pour la direction, un responsable et un salarié délégué, la carte réellement transmise au navigateur aux liens réellement rendus dans le menu du même utilisateur. Aucun écart, hors ceux voulus (Mon espace, tableaux de bord remplacés, logo, déconnexion).

Les 12 tests qui décrivent le menu latéral historique demandent la fixture `menu_classique` : ils continuent de vérifier ce mode, qui reste pleinement supporté.

Au-delà des tests, l'application a été lancée sur une base de démonstration et pilotée au navigateur (aucune erreur JS) — ce qui a permis de corriger des défauts que les tests ne voyaient pas : taper « fact » remontait les onze pages de la zone Validations, et les cartes du flux d'information se coupaient sur trois lignes.

## Revue automatique
Les sept points relevés par Codex ont été vérifiés dans le code puis corrigés (`ea4909e`) — aucun n'était un faux positif. Les deux P1 étaient réels : un salarié délégué voyait les congés et les soldes de tout l'effectif, et les factures à approuver n'atteignaient jamais le nouvel accueil. Détail dans [ce commentaire](https://github.com/Cyril-CB/CS-PILOT/pull/232#issuecomment-5158242523).

## Point à valider
Le découpage en zones est une proposition : « Validations & suivi », « Temps & plannings », « RH & Paie », « Factures & achats », « Comptabilité », « Financier », « Vie associative », « Mon espace ». Tout se déplace dans `navigation.py`.

À noter : la fonction est portée par le salarié (`users.fonction`), pas par chaque contrat — elle est saisie dans la section Contrats mais ne s'historise pas contrat par contrat. Dites-moi si vous la voulez par contrat.

Documentation : [`docs/interface-sans-menu.md`](docs/interface-sans-menu.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUUpfmfCvHTPtbwCiNhMS9