### PR TITLE
Interface sans menu : largeur des pages, entrée de la vue d'ensemble, téléphone

### DIFF
--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -14,6 +14,16 @@ partie des profils, et explique comment l'ajuster.
 | Salarié sans délégation | menu latéral habituel |
 | Prestataire paie | menu latéral habituel (page unique) |
 
+**Sur téléphone, tout le monde garde le menu latéral.** L'interface sans menu
+suppose un écran large : une barre fixe en haut, une autre en bas, une vue
+d'ensemble en anneau. Le menu historique, lui, est déjà responsive avec son
+bouton hamburger. La détection se fait sur l'agent utilisateur
+(`interface_flux.est_telephone()`), la largeur d'écran n'étant pas connue du
+serveur : le marqueur normalisé `Mobi` couvre Chrome Android comme Safari iOS.
+Une tablette n'en porte pas — un iPad récent annonce même un Safari de bureau —
+et garde donc l'interface sans menu. Le même compte suit ainsi son appareil,
+sans rien avoir à régler.
+
 Les délégations qui font basculer un salarié sont celles qui lui confient des
 pages à suivre : suivi des validations et relances, suivi et commande des
 fournitures, gestion des bénévoles. La délégation des **récurrences de
@@ -91,6 +101,12 @@ L'application représentée par zones :
 
 Échap, ou un clic dans le vide, referme.
 
+L'ouverture est animée : le voile apparaît en 0,42 s et les zones se posent en
+cascade depuis le haut, décalées de 45 ms chacune. La classe
+`flx-ensemble-anime` porte cette entrée et est retirée une fois posée, pour que
+déplier une zone reste instantané. Le réglage système « animations réduites »
+est respecté.
+
 ## Le clavier
 
 | Touche | Effet |
@@ -161,6 +177,20 @@ chaque entrée pointe vers une route réelle.
 
 Pour ajouter un flux d'information à une page, écrire un constructeur dans
 `flux_infos.py` et l'inscrire dans `CONSTRUCTEURS` sous son endpoint.
+
+## La place gagnée revient au contenu
+
+Sans menu latéral, les 260 px qu'il occupait doivent revenir au contenu, pas à
+des marges. Deux largeurs coexistent donc :
+
+- les **pages ordinaires** (tableaux, listes) montent à 1500 px, au-delà du
+  plafond classique de 1400 px qui incluait la sidebar. Sur un portable de
+  1440 px, la largeur utile passe de 1180 à 1440 px ;
+- les **deux pages de lecture** — le fil et Mon espace — gardent les 880 px du
+  modèle, où une ligne trop longue nuirait à la lecture. Elles se reconnaissent
+  à la classe `flx-lecture` posée sur `<body>` par `base.html`.
+
+Un test vérifie que la classe n'est posée que sur ces deux pages.
 
 ## La règle qui gouverne cartes et bandeaux
 

--- a/interface_flux.py
+++ b/interface_flux.py
@@ -12,6 +12,7 @@ L'activation se décide à trois niveaux, du plus général au plus personnel :
 3. le choix de l'utilisateur, qui peut toujours revenir au menu historique.
 """
 import logging
+import re
 
 from flask import has_request_context, request, session
 
@@ -72,6 +73,30 @@ def option_globale_active():
         return False
 
 
+# Marqueurs de téléphone dans l'en-tête User-Agent. « Mobi » est le marqueur
+# normalisé, présent sur Chrome Android comme sur Safari iOS ; les autres
+# couvrent les cas plus anciens. Une tablette n'en porte pas — un iPad récent
+# annonce même un Safari de bureau — et garde donc l'interface sans menu, que
+# son écran peut afficher.
+_TELEPHONE = re.compile(r'Mobi|iPhone|iPod|Windows Phone|BlackBerry|Opera Mini',
+                        re.IGNORECASE)
+
+
+def est_telephone():
+    """Vrai si la requête vient d'un téléphone.
+
+    L'interface sans menu suppose un écran large : une barre fixe en haut, une
+    autre en bas, et une vue d'ensemble en anneau. Sur un téléphone, le menu
+    latéral historique — déjà responsive, avec son bouton hamburger — reste plus
+    confortable. La détection se fait sur l'agent utilisateur car la largeur de
+    l'écran n'est pas connue du serveur ; c'est une approximation assumée, et
+    elle n'ouvre aucun droit : elle ne fait que choisir un habillage.
+    """
+    if not has_request_context():
+        return False
+    return bool(_TELEPHONE.search(request.headers.get('User-Agent', '')))
+
+
 def interface_active(profil, user_id):
     """Décide si la requête courante doit être servie sans menu."""
     if not user_id:
@@ -79,6 +104,8 @@ def interface_active(profil, user_id):
     if not option_globale_active():
         return False
     if not navigation.est_eligible(profil, user_id):
+        return False
+    if est_telephone():
         return False
     return preference_utilisateur(user_id) is not False
 
@@ -223,6 +250,7 @@ def contexte():
         donnees = {
             'ui_flux': False,
             'ui_flux_eligible': (bool(user_id)
+                                 and not est_telephone()
                                  and option_globale_active()
                                  and navigation.est_eligible(profil, user_id)),
         }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4413,7 +4413,13 @@ a.btn-icon:-webkit-any-link {
 /* ── Ossature ─────────────────────────────────────────────────────────── */
 body.flx { background: var(--gray-50); }
 body.flx .main-content.has-sidebar { margin-left: 0; }
-body.flx .container { max-width: 880px; }
+/* Sans menu latéral, la place gagnée doit revenir au contenu : les pages
+   ordinaires (tableaux, listes) s'élargissent au-delà du plafond classique de
+   1400 px, sidebar comprise. Seules les deux pages de lecture — le fil et
+   Mon espace — gardent la colonne étroite du modèle, où une ligne trop longue
+   nuirait à la lecture. */
+body.flx .container { max-width: 1500px; }
+body.flx.flx-lecture .container { max-width: 880px; }
 body.flx footer { display: none; }
 
 .flx-fond { position: fixed; inset: 0; pointer-events: none; z-index: 0; overflow: hidden; }
@@ -4878,7 +4884,43 @@ body.flx .main-content {
 .flx-ensemble {
     position: fixed; inset: 0; z-index: 80;
     background: radial-gradient(circle at 50% 42%, var(--white) 0%, var(--gray-100) 58%, var(--gray-200) 100%);
-    animation: scaleIn .28s ease;
+    animation: flxVoileEntre .42s cubic-bezier(.22,.72,.2,1);
+}
+@keyframes flxVoileEntre {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+/* Les zones se posent en cascade depuis le centre : l'œil suit l'ouverture au
+   lieu de la subir. Le retard est porté par un style en ligne, calculé par
+   `flux.js` selon la position du nœud. */
+@keyframes flxNoeudEntre {
+    from { opacity: 0; transform: scale(.72); }
+    to   { opacity: 1; transform: scale(1); }
+}
+.flx-ensemble-anime .flx-noeud {
+    animation: flxNoeudEntre .5s cubic-bezier(.22,.72,.2,1) backwards;
+}
+.flx-ensemble-anime .flx-centre { animation: flxNoeudEntre .42s cubic-bezier(.22,.72,.2,1); }
+.flx-ensemble-anime .flx-rayon {
+    animation: flxRayonEntre .55s cubic-bezier(.22,.72,.2,1) backwards;
+    transform-origin: 0 0;
+}
+@keyframes flxRayonEntre { from { opacity: 0; } to { opacity: 1; } }
+.flx-ensemble-anime .flx-ensemble-entete,
+.flx-ensemble-anime .flx-ensemble-pied {
+    animation: flxMonteDoux .55s cubic-bezier(.22,.72,.2,1) backwards;
+    animation-delay: .12s;
+}
+@keyframes flxMonteDoux {
+    from { opacity: 0; transform: translate(-50%, 10px); }
+    to   { opacity: 1; transform: translate(-50%, 0); }
+}
+/* Respect du réglage système : pas d'animation pour qui n'en veut pas. */
+@media (prefers-reduced-motion: reduce) {
+    .flx-ensemble, .flx-ensemble-anime .flx-noeud, .flx-ensemble-anime .flx-centre,
+    .flx-ensemble-anime .flx-rayon, .flx-ensemble-anime .flx-ensemble-entete,
+    .flx-ensemble-anime .flx-ensemble-pied { animation: none; }
+    .flx-anneau-carte { transition: none; }
 }
 .flx-ensemble-fond { position: absolute; inset: 0; }
 .flx-ensemble-entete {

--- a/static/js/flux.js
+++ b/static/js/flux.js
@@ -395,7 +395,14 @@
 
     function dessinerEnsemble(entree) {
         if (!ensemble) return;
-        if (entree) ensemble.classList.add('flx-ensemble-anime');
+        /* `entree === true` et non `entree` : cette fonction sert aussi de
+           gestionnaire de `resize`, qui lui passe un UIEvent — toujours vrai.
+           Sans ce test strict, un redimensionnement après l'ouverture
+           réarmerait l'animation d'entrée sans que rien ne la retire, et
+           déplier une zone rejouerait la cascade au lieu d'être instantané.
+           Le gestionnaire garde volontairement cette référence, pour que
+           `removeEventListener` puisse le retirer à la fermeture. */
+        if (entree === true) ensemble.classList.add('flx-ensemble-anime');
         var W = window.innerWidth, H = window.innerHeight;
         var HAUT = H < 640 ? 116 : 162, BAS = H < 640 ? 56 : 84;
         var dGrand = 68, dPetit = 56;

--- a/static/js/flux.js
+++ b/static/js/flux.js
@@ -331,7 +331,12 @@
         });
         window.addEventListener('resize', dessinerEnsemble);
         latch = null;
-        dessinerEnsemble();
+        dessinerEnsemble(true);
+        /* L'entrée en cascade ne joue qu'à l'ouverture : la classe est retirée
+           une fois posée, pour que déplier une zone reste instantané. */
+        setTimeout(function () {
+            if (ensemble) ensemble.classList.remove('flx-ensemble-anime');
+        }, 1100);
     }
 
     function fermerEnsemble() {
@@ -388,8 +393,9 @@
         }, 280);
     }
 
-    function dessinerEnsemble() {
+    function dessinerEnsemble(entree) {
         if (!ensemble) return;
+        if (entree) ensemble.classList.add('flx-ensemble-anime');
         var W = window.innerWidth, H = window.innerHeight;
         var HAUT = H < 640 ? 116 : 162, BAS = H < 640 ? 56 : 84;
         var dGrand = 68, dPetit = 56;
@@ -456,6 +462,7 @@
         places.forEach(function (p) {
             var r = document.createElement('div');
             r.className = 'flx-rayon';
+            r.style.animationDelay = (90 + places.indexOf(p) * 45) + 'ms';
             r.style.width = Math.max(16, p.dist - (p.interieur ? dGrand : dPetit) / 2 - 10) + 'px';
             r.style.transform = 'rotate(' + p.deg + 'deg)';
             r.style.opacity = (actif && actif.g.id !== p.g.id) ? '0.15' : '1';
@@ -482,6 +489,7 @@
             n.style.width = larg + 'px';
             n.style.opacity = actif ? (ici ? '1' : '0.32') : '1';
             n.style.pointerEvents = (actif && !ici) ? 'none' : 'auto';
+            n.style.animationDelay = (120 + places.indexOf(p) * 45) + 'ms';
             n.innerHTML =
                 '<span class="flx-noeud-disque" style="width:' + taille + 'px;height:' + taille + 'px">' +
                 ech(p.g.icone) +

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,9 @@
         (function(){var t=localStorage.getItem('theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark');})();
     </script>
 </head>
-<body{% if ui_flux %} class="flx"{% endif %}>
+{# `flx-lecture` réserve la colonne étroite du modèle aux deux pages de
+   lecture ; toutes les autres récupèrent la place laissée par le menu. #}
+<body{% if ui_flux %} class="flx{% if request.endpoint in ('accueil_bp.accueil', 'accueil_bp.mon_espace') %} flx-lecture{% endif %}"{% endif %}>
     {% if session.user_id and not ui_flux %}
     {# ── Bouton hamburger mobile ── #}
     <button class="sidebar-toggle" id="sidebarToggle" onclick="toggleSidebar()">&#9776;</button>

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -720,3 +720,63 @@ def test_le_drapeau_suit_la_liste_d_autorisation_de_l_api(app):
         with app.app_context():
             assert (interface_flux.recherche_globale_autorisee(profil)
                     is (profil in PROFILS_AUTORISES)), profil
+
+
+# ── Retours d'usage : largeur, téléphone ───────────────────────────────────
+
+UA_BUREAU = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+             '(KHTML, like Gecko) Chrome/120.0 Safari/537.36')
+UA_IPHONE = ('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
+             'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1')
+UA_ANDROID = ('Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 '
+              '(KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36')
+UA_IPAD = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 '
+           '(KHTML, like Gecko) Version/17.0 Safari/605.1.15')
+
+
+def test_les_pages_ordinaires_recuperent_la_place_du_menu(admin_client):
+    """Un tableau ne doit pas être plus à l'étroit qu'avec le menu latéral."""
+    lecture = admin_client.get('/accueil').get_data(as_text=True)
+    tableau = admin_client.get('/presence-effectif').get_data(as_text=True)
+    # La colonne étroite du modèle ne concerne que les pages de lecture.
+    assert 'class="flx flx-lecture"' in lecture
+    assert 'class="flx"' in tableau and 'flx-lecture' not in tableau
+
+
+@pytest.mark.parametrize('agent', [UA_IPHONE, UA_ANDROID])
+def test_le_telephone_garde_l_interface_classique(client, sample_users, agent):
+    """Sur téléphone, le menu latéral reste plus confortable."""
+    client.post('/login', data={'login': 'admin', 'password': 'Admin1234'},
+                follow_redirects=True, headers={'User-Agent': agent})
+    corps = client.get('/dashboard', follow_redirects=True,
+                       headers={'User-Agent': agent}).get_data(as_text=True)
+    assert 'class="sidebar"' in corps
+    assert 'flx-entete' not in corps
+    # Et l'accueil sans menu n'est pas atteignable depuis le téléphone.
+    reponse = client.get('/accueil', headers={'User-Agent': agent})
+    assert reponse.status_code == 302
+    # Inutile de lui proposer une bascule qui ne changerait rien.
+    assert 'Essayer la nouvelle interface' not in corps
+
+
+@pytest.mark.parametrize('agent', [UA_BUREAU, UA_IPAD])
+def test_le_bureau_et_la_tablette_gardent_le_flux(client, sample_users, agent):
+    """Un iPad récent annonce un Safari de bureau : son écran suffit."""
+    client.post('/login', data={'login': 'admin', 'password': 'Admin1234'},
+                follow_redirects=True, headers={'User-Agent': agent})
+    corps = client.get('/dashboard', follow_redirects=True,
+                       headers={'User-Agent': agent}).get_data(as_text=True)
+    assert 'flx-entete' in corps
+    assert 'class="sidebar"' not in corps
+
+
+def test_le_meme_compte_suit_l_appareil(client, sample_users):
+    """Flux au bureau, menu classique sur le téléphone — sans rien régler."""
+    client.post('/login', data={'login': 'admin', 'password': 'Admin1234'},
+                follow_redirects=True, headers={'User-Agent': UA_BUREAU})
+    bureau = client.get('/dashboard', follow_redirects=True,
+                        headers={'User-Agent': UA_BUREAU}).get_data(as_text=True)
+    telephone = client.get('/dashboard', follow_redirects=True,
+                           headers={'User-Agent': UA_IPHONE}).get_data(as_text=True)
+    assert 'flx-entete' in bureau and 'class="sidebar"' not in bureau
+    assert 'class="sidebar"' in telephone and 'flx-entete' not in telephone


### PR DESCRIPTION
Trois retours d'usage après la mise en production de #232.

## 1. La place gagnée revient au contenu

Le conteneur du flux était fixé à **880 px** — la colonne de lecture du modèle — y compris sur les pages de tableau, alors que le gabarit classique montait à 1400 px *sidebar comprise*. Une page comme « Présence effectif » perdait donc de la place au lieu d'en gagner, alors même qu'on avait supprimé le menu.

Deux largeurs coexistent désormais :

- **pages ordinaires** (tableaux, listes) → 1500 px ;
- **les deux pages de lecture** — le fil et Mon espace → 880 px, où une ligne trop longue nuirait à la lecture. Elles se reconnaissent à la classe `flx-lecture` posée sur `<body>`.

Mesuré au navigateur sur « Présence effectif » :

| Écran | Classique | Flux (avant) | Flux (après) | Gain |
| --- | --- | --- | --- | --- |
| 1920 px | 1400 px | 880 px | **1500 px** | +100 px |
| 1512 px | 1252 px | 880 px | **1500 px** | +248 px |
| 1440 px | 1180 px | 880 px | **1440 px** | +260 px |
| 1280 px | 1020 px | 880 px | **1280 px** | +260 px |

Sur un portable, ce sont exactement les 260 px du menu qui reviennent au contenu.

## 2. L'ouverture de la vue d'ensemble est plus posée

Le voile passait en 0,28 s et les zones apparaissaient d'un bloc. Il s'ouvre maintenant en **0,42 s**, et les zones se **posent en cascade**, décalées de 45 ms chacune, ce qui laisse l'œil suivre l'ouverture.

L'animation ne joue qu'à l'ouverture : la classe `flx-ensemble-anime` est retirée une fois posée, pour que déplier une zone reste instantané. Le réglage système « animations réduites » est respecté.

Vérifié au navigateur, en échantillonnant l'opacité des nœuds : à 60 ms tous à 0 avec des retards de 0,12 / 0,165 / 0,21 s ; à 300 ms la cascade est visible (0,89 / 0,83 / 0,71) ; à 700 ms tout est posé ; à 1250 ms la classe a disparu.

## 3. Le téléphone garde le menu latéral

L'interface sans menu suppose un écran large : barre fixe en haut, barre en bas, vue d'ensemble en anneau. Le menu historique, lui, est déjà responsive avec son bouton hamburger — c'est la meilleure option sur téléphone pour le moment.

La détection se fait sur l'agent utilisateur (`interface_flux.est_telephone()`), la largeur d'écran n'étant pas connue du serveur. Le marqueur normalisé `Mobi` couvre Chrome Android comme Safari iOS ; une **tablette n'est pas concernée** — un iPad récent annonce même un Safari de bureau, et son écran suffit.

Le même compte suit ainsi son appareil, sans rien avoir à régler : flux au bureau, menu classique sur le téléphone. Et la bascule « Essayer la nouvelle interface » n'est pas proposée là où elle ne changerait rien.

C'est un choix d'habillage : la détection n'ouvre ni ne ferme aucun droit.

## Tests

**Suite complète : 1452 tests, tous verts** (+6).

Les nouveaux couvrent la séparation des deux largeurs, le repli sur le menu classique pour iPhone et Android, le maintien du flux sur bureau et iPad, et le fait qu'un même compte suive son appareil d'une requête à l'autre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUUpfmfCvHTPtbwCiNhMS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUUpfmfCvHTPtbwCiNhMS9)_