### PR TITLE
Retirer le bandeau des étapes de subvention encore ouvertes

### DIFF
--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -252,7 +252,12 @@ jamais compter plus que la destination n'affiche.** Concrètement :
   (secteur renseigné ou assignation à la direction), les factures encore non
   assignées étant signalées à part, vers la page Factures ;
 - un bandeau reprend aussi son cadrage — un responsable ne compte que les
-  fiches de son équipe, comme la vue d'ensemble le fait pour lui.
+  fiches de son équipe, comme la vue d'ensemble le fait pour lui ;
+- un bandeau ne recompte pas le tableau qu'il précède. La page Subventions ne
+  signale que les étapes échues : annoncer « 100 étapes encore ouvertes » au
+  dessus des mêmes cent lignes n'apprenait rien et repoussait la liste vers le
+  bas. Un total sans retard, sans échéance ni décision à prendre n'est pas une
+  information.
 
 Ces règles sont vérifiées par des tests dédiés dans
 `tests/test_interface_flux.py` : un écart entre un compteur et sa destination

--- a/flux_infos.py
+++ b/flux_infos.py
@@ -9,6 +9,11 @@ retard — avant la liste elle-même.
 Chaque entrée est un bandeau court : `{icone, valeur, libelle, lien,
 lien_texte, ton}`. Le ton (`alerte`, `attention`, `calme`) donne la couleur.
 
+Un bandeau ne dit que ce que la liste ne dit pas d'elle-même. Recompter ses
+lignes juste au-dessus d'elle n'apprend rien et repousse le tableau vers le
+bas : un total sans retard, sans échéance ni décision à prendre n'est pas une
+information, c'est la liste écrite deux fois.
+
 Toutes les pages n'ont pas de flux : la trésorerie, par exemple, EST son
 tableau. Une page sans constructeur n'affiche simplement rien de plus.
 """
@@ -141,7 +146,13 @@ def _ecritures(conn, contexte):
 
 
 def _subventions(conn, contexte):
-    """Ce que la page Subventions doit signaler."""
+    """Ce que la page Subventions doit signaler : le retard, et rien d'autre.
+
+    Le nombre d'étapes encore ouvertes ne vaut pas un bandeau : c'est le
+    tableau qui suit, annoncé une ligne plus haut. Le retard, lui, ne se lit
+    pas d'un coup d'œil — il se disperse dans les sous-éléments repliés, et
+    souvent hors de l'année filtrée par défaut, d'où le lien vers « toutes ».
+    """
     profil = contexte.get('profil')
     user_id = contexte.get('user_id')
     if profil == 'responsable':
@@ -169,19 +180,6 @@ def _subventions(conn, contexte):
             '🚨', retard, "étape(s) dont l'échéance est passée",
             url_for('subventions_bp.gestion_subventions', annee='toutes'), 'Voir',
             'alerte',
-        ))
-
-    en_cours = conn.execute(
-        f'''SELECT COUNT(*) AS nb
-            FROM subventions_sous_elements se
-            JOIN subventions s ON s.id = se.subvention_id
-            WHERE se.statut != 'fait' AND s.groupe != 'refusee' {scope}''',
-        params
-    ).fetchone()['nb']
-    if en_cours:
-        infos.append(_info(
-            '📋', en_cours, 'étape(s) encore ouverte(s)',
-            url_for('subventions_bp.gestion_subventions', annee='toutes'), 'Suivre',
         ))
 
     return infos

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -180,6 +180,34 @@ def test_le_flux_d_information_apparait_sur_les_factures(admin_client, db, sampl
     assert 'facture(s) sans écriture — à générer' not in corps  # page Écritures
 
 
+def test_les_subventions_ne_signalent_que_le_retard(admin_client, db):
+    """Un bandeau ne recompte pas le tableau qu'il précède.
+
+    Deux étapes ouvertes, dont une échue : seule l'échue mérite d'être
+    annoncée. Compter les étapes encore ouvertes n'apprenait rien de plus que
+    la liste et la repoussait vers le bas de la page.
+    """
+    from datetime import timedelta
+
+    from utils import aujourd_hui
+    today = aujourd_hui()
+    with db:
+        db.execute("INSERT INTO subventions (nom, groupe, annee_action) "
+                   "VALUES ('Ville Fonctionnement', 'depose', ?)", (str(today.year),))
+        sub_id = db.execute("SELECT id FROM subventions "
+                            "WHERE nom = 'Ville Fonctionnement'").fetchone()['id']
+        db.execute("INSERT INTO subventions_sous_elements "
+                   "(subvention_id, nom, statut, date_echeance) VALUES (?, ?, 'non_commence', ?)",
+                   (sub_id, 'Bilan financier', (today - timedelta(days=5)).isoformat()))
+        db.execute("INSERT INTO subventions_sous_elements "
+                   "(subvention_id, nom, statut, date_echeance) VALUES (?, ?, 'non_commence', ?)",
+                   (sub_id, 'Dépôt du dossier', (today + timedelta(days=30)).isoformat()))
+
+    corps = admin_client.get('/subventions').get_data(as_text=True)
+    assert 'étape(s) encore ouverte(s)' not in corps
+    assert "étape(s) dont l&#39;échéance est passée" in corps
+
+
 def test_bascule_vers_le_menu_classique_et_retour(admin_client):
     reponse = admin_client.post('/api/interface/basculer', json={'actif': False})
     assert reponse.status_code == 200


### PR DESCRIPTION
## Le problème

Sur la page Subventions, un bandeau annonçait « 100 étape(s) encore ouverte(s) — Suivre → » juste au-dessus du tableau des mêmes étapes. Il recomptait la liste qu'il précédait : aucune information gagnée, le tableau repoussé vers le bas, et un lien qui ramenait à la page où le lecteur se trouvait déjà.

## Le changement

`_subventions` ne construit plus que le bandeau du retard. Celui-là mérite sa place : les étapes échues se dispersent dans les sous-éléments repliés, souvent hors de l'année filtrée par défaut, et son lien vers `annee=toutes` les rend effectivement visibles.

La règle qui manquait est écrite en toutes lettres, dans le module et dans `docs/interface-sans-menu.md` : **un bandeau ne recompte pas le tableau qu'il précède**. Un total sans retard, sans échéance ni décision à prendre n'est pas une information, c'est la liste écrite deux fois.

## Vérification

`test_les_subventions_ne_signalent_que_le_retard` pose deux étapes ouvertes dont une échue, et vérifie que la page annonce l'échue et rien d'autre. Il échoue bien sur le code d'avant (vérifié en remisant le correctif). Suite complète verte : 1477 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUUpfmfCvHTPtbwCiNhMS9)_