### PR TITLE
Le contrat borne la fiche d'heures et conditionne la saisie

### DIFF
--- a/blueprints/contrats.py
+++ b/blueprints/contrats.py
@@ -112,3 +112,56 @@ def liste_contrats():
         filtre_selected=filtre,
         filtres=FILTRES,
     )
+
+
+@contrats_bp.route('/contrats/sans-contrat')
+@login_required
+def salaries_sans_contrat():
+    """Salariés actifs qu'aucun contrat ne couvre aujourd'hui.
+
+    Depuis que la saisie des heures exige un contrat, cette liste dit
+    exactement qui est bloqué. Deux situations s'y côtoient, distinguées car
+    elles n'appellent pas le même geste :
+
+    - **aucun contrat au dossier** : le contrat n'a jamais été saisi. C'est
+      l'anomalie à traiter en premier, le salarié ne peut rien saisir ;
+    - **contrat échu** : le dernier contrat s'est terminé et n'a pas été
+      renouvelé. Soit le renouvellement manque, soit c'est le salarié qui
+      aurait dû être désactivé.
+
+    Le cadrage est celui de l'effectif qui saisit ses heures — actifs, hors
+    direction et prestataires — le même que la vue d'ensemble des validations.
+    """
+    if session.get('profil') not in PROFILS_AUTORISES:
+        flash('Accès non autorisé', 'error')
+        return redirect(url_for('dashboard_bp.dashboard'))
+
+    today = aujourd_hui().isoformat()
+
+    conn = get_db()
+    try:
+        salaries = conn.execute(
+            '''SELECT u.id, u.nom, u.prenom, u.profil,
+                      COALESCE(s.nom, '') AS secteur_nom,
+                      (SELECT MAX(c.date_fin) FROM contrats c
+                       WHERE c.user_id = u.id) AS derniere_fin,
+                      (SELECT COUNT(*) FROM contrats c
+                       WHERE c.user_id = u.id) AS nb_contrats
+               FROM users u
+               LEFT JOIN secteurs s ON u.secteur_id = s.id
+               WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+                 AND NOT EXISTS (
+                     SELECT 1 FROM contrats c
+                     WHERE c.user_id = u.id
+                       AND c.date_debut <= ?
+                       AND (c.date_fin IS NULL OR c.date_fin >= ?)
+                 )
+               ORDER BY nb_contrats, u.nom, u.prenom''',
+            (today, today)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    return render_template('contrats_sans_contrat.html',
+                           salaries=salaries,
+                           aujourd_hui=today)

--- a/blueprints/contrats.py
+++ b/blueprints/contrats.py
@@ -140,11 +140,17 @@ def salaries_sans_contrat():
 
     conn = get_db()
     try:
+        # `prochain_debut` distingue l'embauche à venir du contrat échu. Se
+        # fier à la seule présence d'une date de fin ne suffit pas : un CDD
+        # futur en a une, et serait annoncé « échu depuis » une date à venir.
         salaries = conn.execute(
             '''SELECT u.id, u.nom, u.prenom, u.profil,
                       COALESCE(s.nom, '') AS secteur_nom,
+                      (SELECT MIN(c.date_debut) FROM contrats c
+                       WHERE c.user_id = u.id AND c.date_debut > ?) AS prochain_debut,
                       (SELECT MAX(c.date_fin) FROM contrats c
-                       WHERE c.user_id = u.id) AS derniere_fin,
+                       WHERE c.user_id = u.id
+                         AND c.date_fin IS NOT NULL AND c.date_fin < ?) AS derniere_fin,
                       (SELECT COUNT(*) FROM contrats c
                        WHERE c.user_id = u.id) AS nb_contrats
                FROM users u
@@ -157,7 +163,7 @@ def salaries_sans_contrat():
                        AND (c.date_fin IS NULL OR c.date_fin >= ?)
                  )
                ORDER BY nb_contrats, u.nom, u.prenom''',
-            (today, today)
+            (today, today, today, today)
         ).fetchall()
     finally:
         conn.close()

--- a/blueprints/exports.py
+++ b/blueprints/exports.py
@@ -8,7 +8,8 @@ from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
                    calculer_heures_reelles_jour, duree_pause_meridienne, slot_horaire,
                    get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
-                   total_hs_payees, est_dans_equipe_responsable)
+                   total_hs_payees, est_dans_equipe_responsable,
+                   periodes_contrat, est_hors_contrat)
 
 exports_bp = Blueprint('exports_bp', __name__)
 
@@ -101,7 +102,13 @@ def export_pdf_mensuel():
     
     for h in heures_rows:
         heures_reelles[h['date']] = dict(h)
-    
+
+    # Périodes d'emploi : le PDF est le document signé, il doit dire la même
+    # chose que la fiche qu'il reproduit. Sans cela, une journée hors contrat
+    # non saisie serait comptée « conforme » au planning — le PDF attesterait
+    # d'un mois plein pour un CDD entré ou sorti en cours de mois.
+    contrats_salarie = periodes_contrat(conn, user_id_param)
+
     # Générer les journées
     journees = []
     jour_actuel = premier_jour
@@ -118,9 +125,11 @@ def export_pdf_mensuel():
                 continue
             
             type_periode = get_type_periode(date_str)
-            
+            jour_hors_contrat = est_hors_contrat(contrats_salarie, date_str)
+
             # Récupérer le planning valide à cette date (gère historisation + alternance)
-            planning = get_planning_valide_a_date(user_id_param, type_periode, date_str)
+            planning = None if jour_hors_contrat else get_planning_valide_a_date(
+                user_id_param, type_periode, date_str)
             
             # Horaires théoriques
             noms_jours_minuscule = ['lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi']
@@ -129,7 +138,10 @@ def export_pdf_mensuel():
             horaires_theo_str = ""
             heures_theo_jour = 0
             
-            if jour_semaine == 5:
+            if jour_hors_contrat:
+                horaires_theo_str = "Hors contrat"
+                heures_theo_jour = 0
+            elif jour_semaine == 5:
                 horaires_theo_str = "Samedi"
                 heures_theo_jour = 0
             elif planning and jour_nom:
@@ -195,6 +207,10 @@ def export_pdf_mensuel():
                             horaires_reels_str += " (+ pause)"
                     else:
                         horaires_reels_str = "Non saisi"
+            elif jour_hors_contrat:
+                # Le salarié n'était pas employé : ni dû, ni conforme, ni rien.
+                horaires_reels_str = "—"
+                heures_reelles_jour = 0
             else:
                 # Pas de saisie = considéré conforme
                 horaires_reels_str = "✓ Conforme"

--- a/blueprints/saisie.py
+++ b/blueprints/saisie.py
@@ -16,6 +16,11 @@ saisie_bp = Blueprint('saisie_bp', __name__)
 SEUIL_ECART_ANOMALIE_HEURES = 3
 
 
+# Lignes de `heures_reelles` écrites par les circuits absences et récup, et
+# non par quelqu'un venu saisir ses heures ici.
+_TYPES_GENERES = ('absence', 'recup_journee', 'recup_partielle')
+
+
 def _saisie_sans_contrat(conn, user_id_cible, date_str, saisie_existante):
     """La saisie doit-elle être refusée faute de contrat couvrant ce jour ?
 
@@ -24,14 +29,21 @@ def _saisie_sans_contrat(conn, user_id_cible, date_str, saisie_existante):
     L'absence de contrat au dossier vaut donc refus — c'est ce qui pousse à
     l'enregistrer plutôt que de le remettre à plus tard.
 
-    Une saisie déjà enregistrée échappe à la règle. Les heures posées avant
-    que cette règle n'existe restent en place et modifiables : on ne fige pas
-    des données que leur auteur pourrait avoir à corriger.
+    Une **saisie manuelle** déjà enregistrée échappe à la règle : les heures
+    posées avant qu'elle n'existe restent modifiables, on ne fige pas des
+    données que leur auteur pourrait avoir à corriger.
+
+    Une ligne **générée** (absence, récupération) ne rouvre en revanche pas la
+    porte. Ces circuits écrivent librement hors contrat — une absence se
+    régularise parfois après la fin d'un contrat — et leur ligne servirait
+    sinon de laissez-passer : il suffirait d'ouvrir le jour d'une absence pour
+    y substituer des heures travaillées sur une période sans contrat. Corriger
+    l'absence elle-même se fait sur la page Absences, pas ici.
 
     Le planning théorique, lui, n'est pas exigé : s'il arrive plus tard, les
     heures supplémentaires se recalculent d'elles-mêmes.
     """
-    if saisie_existante:
+    if saisie_existante and saisie_existante['type_saisie'] not in _TYPES_GENERES:
         return False
     return not est_couvert_par_contrat(periodes_contrat(conn, user_id_cible), date_str)
 

--- a/blueprints/saisie.py
+++ b/blueprints/saisie.py
@@ -8,11 +8,45 @@ from database import get_db
 from utils import (login_required, get_user_info, calculer_heures,
                     calculer_heures_reelles_jour, slot_horaire,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date,
-                    calculer_solde_recup, est_dans_equipe_responsable)
+                    calculer_solde_recup, est_dans_equipe_responsable,
+                    periodes_contrat, est_couvert_par_contrat)
 from app_options import get_option_bool
 
 saisie_bp = Blueprint('saisie_bp', __name__)
 SEUIL_ECART_ANOMALIE_HEURES = 3
+
+
+def _saisie_sans_contrat(conn, user_id_cible, date_str, saisie_existante):
+    """La saisie doit-elle être refusée faute de contrat couvrant ce jour ?
+
+    Un contrat est désormais obligatoire pour saisir des heures : c'est lui
+    qui alimente la paie, et une journée sans contrat n'est due à personne.
+    L'absence de contrat au dossier vaut donc refus — c'est ce qui pousse à
+    l'enregistrer plutôt que de le remettre à plus tard.
+
+    Une saisie déjà enregistrée échappe à la règle. Les heures posées avant
+    que cette règle n'existe restent en place et modifiables : on ne fige pas
+    des données que leur auteur pourrait avoir à corriger.
+
+    Le planning théorique, lui, n'est pas exigé : s'il arrive plus tard, les
+    heures supplémentaires se recalculent d'elles-mêmes.
+    """
+    if saisie_existante:
+        return False
+    return not est_couvert_par_contrat(periodes_contrat(conn, user_id_cible), date_str)
+
+
+def _message_sans_contrat(date_str, pour_soi):
+    """Refus de saisie : dire quoi faire, et à qui."""
+    try:
+        jour = datetime.strptime(date_str, '%Y-%m-%d').strftime('%d/%m/%Y')
+    except (ValueError, TypeError):
+        jour = date_str
+    if pour_soi:
+        return (f"Aucun contrat enregistré au {jour} : la saisie est impossible. "
+                "Signalez-le à la direction pour que le contrat soit ajouté à votre dossier.")
+    return (f"Aucun contrat enregistré au {jour} pour ce salarié : la saisie est "
+            "impossible. Ajoutez le contrat depuis Infos Salariés → Contrats.")
 
 
 @saisie_bp.route('/saisie_heures', methods=['GET', 'POST'])
@@ -74,6 +108,17 @@ def saisie_heures():
         anciennes_donnees = conn.execute('''
             SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?
         ''', (user_id_cible, date)).fetchone()
+
+        if _saisie_sans_contrat(conn, user_id_cible, date, anciennes_donnees):
+            flash(_message_sans_contrat(date, user_id_cible == session['user_id']), 'error')
+            conn.close()
+            if next_page == 'calendrier':
+                return redirect(url_for('validation_bp.vue_calendrier',
+                                        user_id=user_id_cible, mois=mois, annee=annee))
+            if next_page == 'mensuelle' or user_id_cible != session['user_id']:
+                return redirect(url_for('validation_bp.vue_mensuelle',
+                                        user_id=user_id_cible, mois=mois, annee=annee))
+            return redirect(url_for('saisie_bp.saisie_heures', date=date))
 
         preserve_declaration_conforme = (
             not declaration_conforme_active
@@ -323,6 +368,10 @@ def saisie_heures():
     ''', (user_id_cible, date_obj.month, date_obj.year)).fetchone()
     mois_verrouille = validation and validation['bloque']
 
+    sans_contrat = _saisie_sans_contrat(conn, user_id_cible, date_defaut, row)
+    message_sans_contrat = _message_sans_contrat(
+        date_defaut, user_id_cible == session['user_id']) if sans_contrat else None
+
     conn.close()
 
     next_page = request.args.get('next', '')
@@ -341,6 +390,8 @@ def saisie_heures():
                           next_page=next_page,
                           solde_recup=solde_recup,
                           mois_verrouille=mois_verrouille,
+                          sans_contrat=sans_contrat,
+                          message_sans_contrat=message_sans_contrat,
                           soir_disponible=est_vacances or a_soir,
                           soir_rempli=a_soir,
                           declaration_conforme_active=declaration_conforme_active)

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -705,6 +705,9 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
         peut_valider_mois=peut_valider_mois,
         mois_est_termine=mois_est_termine,
         nb_jours_non_declares=nb_jours_non_declares,
+        # Sans contrat au dossier, la fiche réclame ses journées mais la
+        # saisie les refuse : il faut dire pourquoi, et à qui s'adresser.
+        aucun_contrat=not contrats_salarie,
         jours_feries=jours_feries,
         premier_jour_semaine=premier_jour.weekday(),
         nb_jours_mois=dernier_jour.day,

--- a/blueprints/validation.py
+++ b/blueprints/validation.py
@@ -9,7 +9,8 @@ from blueprints.delegations import MISSION_SUIVI_VALIDATIONS_RELANCES, user_has_
 from utils import (login_required, get_user_info, calculer_heures,
                     calculer_heures_reelles_jour, duree_pause_meridienne, slot_horaire,
                     get_heures_theoriques_jour, get_type_periode, get_planning_valide_a_date, NOMS_MOIS,
-                    total_hs_payees, est_dans_equipe_responsable)
+                    total_hs_payees, est_dans_equipe_responsable,
+                    periodes_contrat, est_hors_contrat)
 from app_options import get_option_bool
 from access_log import (journaliser_action, ACTION_VALIDATION_MOIS,
                         ACTION_DEVERROUILLAGE_MOIS)
@@ -430,6 +431,13 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
     ''', (premier_jour.strftime('%Y-%m-%d'), dernier_jour.strftime('%Y-%m-%d'))).fetchall()
     jours_feries = {f['date']: f['libelle'] for f in jours_feries_rows}
 
+    # Périodes d'emploi : hors contrat, une journée n'est ni due ni à saisir.
+    # Le planning théorique ne peut pas en tenir lieu — il n'a pas de fin de
+    # validité, celui d'un CDD reste donc « valide » longtemps après son
+    # terme, et il n'existe pas avant son premier jour. C'est ce qui faisait
+    # réclamer la saisie de journées où le salarié n'était pas employé.
+    contrats_salarie = periodes_contrat(conn, user_id_a_afficher)
+
     # Generer toutes les journees du mois
     journees = []
     jour_actuel = premier_jour
@@ -449,11 +457,12 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
                 continue
 
             type_periode = get_type_periode(date_str)
+            jour_hors_contrat = est_hors_contrat(contrats_salarie, date_str)
 
             heures_theo_jour = 0
             horaires_theoriques = '-'
             planning_existe = False
-            if jour_semaine == 5:
+            if jour_semaine == 5 or jour_hors_contrat:
                 heures_theo_jour = 0
             else:
                 planning = get_planning_valide_a_date(user_id_a_afficher, type_periode, date_str)
@@ -500,7 +509,7 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
 
                 type_saisie = h['type_saisie']
                 commentaire = h['commentaire']
-            elif est_ferie and jour_semaine < 5:
+            elif est_ferie and jour_semaine < 5 and not jour_hors_contrat:
                 heures_reelles_jour = heures_theo_jour
                 horaires_reels = horaires_theoriques
                 est_declare = True
@@ -518,7 +527,8 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
                 jour_repos_planifie = planning_existe and heures_theo_jour == 0
                 if (jour_actuel.date() < datetime.now().date()
                         and jour_semaine < 5
-                        and not jour_repos_planifie):
+                        and not jour_repos_planifie
+                        and not jour_hors_contrat):
                     non_declare = True
                 heures_reelles_jour = heures_theo_jour
 
@@ -555,6 +565,10 @@ def _get_vue_mensuelle_data_impl(conn, mois, annee, user_id_param, redirect_rout
                 'est_saisi': est_saisi,
                 'est_declare': est_declare,
                 'non_declare': non_declare,
+                # Une saisie existante l'emporte sur l'affichage « hors
+                # contrat » : des heures enregistrées se montrent toujours,
+                # quitte à révéler un contrat oublié au dossier.
+                'hors_contrat': jour_hors_contrat and not est_saisi,
                 'est_repos_habituel': est_repos_habituel,
                 'type_saisie': type_saisie,
                 'commentaire': commentaire,

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -224,6 +224,20 @@ chaque entrée pointe vers une route réelle.
 Pour ajouter un flux d'information à une page, écrire un constructeur dans
 `flux_infos.py` et l'inscrire dans `CONSTRUCTEURS` sous son endpoint.
 
+### Les pages de réponse ne sont pas dans la carte
+
+Certaines pages n'existent que pour répondre à une intention formulée dans la
+barre intelligente : « contrats de mai » ouvre la liste des contrats du mois,
+« salariés sans contrat » ouvre celle des dossiers incomplets. Elles ne
+figurent **ni au menu latéral ni dans la carte** — les y mettre chargerait la
+navigation d'écrans que personne ne parcourt.
+
+Le risque est alors qu'on ignore leur existence. La réponse n'est pas de les
+ajouter au menu, mais de les faire s'annoncer : un bandeau de `flux_infos.py`
+sur la page où l'on peut agir, qui ne paraît que lorsqu'il y a lieu. Les
+salariés sans aucun contrat s'affichent ainsi en tête d'Infos Salariés — et
+disparaissent dès que les dossiers sont complets.
+
 ## La place gagnée revient au contenu
 
 Sans menu latéral, les 260 px qu'il occupait doivent revenir au contenu, pas à

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -366,6 +366,12 @@ Les contrats sont listés par ordre chronologique décroissant.
 >
 > Le **planning théorique**, lui, n'est pas exigé pour saisir. S'il est
 > renseigné plus tard, les heures supplémentaires se recalculent d'elles-mêmes.
+>
+> **Pour savoir qui est bloqué** : *RH & Paie → Salariés sans contrat*, ou le
+> bouton du même nom sur la page Contrats. La barre intelligente y mène aussi
+> (« salariés sans contrat », « contrats manquants »). La page distingue ceux
+> dont le contrat n'a jamais été saisi de ceux dont le contrat est échu et
+> n'a pas été renouvelé — les deux n'appellent pas le même geste.
 
 ---
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -338,6 +338,18 @@ L'adresse email est indispensable pour recevoir les notifications.
 
 Les contrats sont listés par ordre chronologique décroissant.
 
+> **Les dates du contrat bornent la fiche d'heures.** Les jours situés avant
+> la date de début ou après la date de fin sont marqués *Hors contrat* : ils
+> ne sont pas réclamés à la saisie, ne comptent pas dans les heures
+> théoriques du mois et n'empêchent plus la validation. C'est ce qui permet à
+> un CDD entré ou sorti en cours de mois de valider son mois partiel.
+>
+> La date de fin est **incluse** : c'est le dernier jour travaillé.
+>
+> Tant qu'aucun contrat n'est enregistré pour un salarié, rien ne change —
+> tous ses jours ouvrés restent à saisir. Une fiche entièrement vide reste
+> ainsi visible au lieu d'être silencieusement dispensée de saisie.
+
 ---
 
 ### 8.3 Déposer des documents RH

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -367,11 +367,15 @@ Les contrats sont listés par ordre chronologique décroissant.
 > Le **planning théorique**, lui, n'est pas exigé pour saisir. S'il est
 > renseigné plus tard, les heures supplémentaires se recalculent d'elles-mêmes.
 >
-> **Pour savoir qui est bloqué** : *RH & Paie → Salariés sans contrat*, ou le
-> bouton du même nom sur la page Contrats. La barre intelligente y mène aussi
-> (« salariés sans contrat », « contrats manquants »). La page distingue ceux
-> dont le contrat n'a jamais été saisi de ceux dont le contrat est échu et
-> n'a pas été renouvelé — les deux n'appellent pas le même geste.
+> **Pour savoir qui est bloqué** : dès qu'un salarié actif n'a aucun contrat
+> au dossier, un bandeau rouge l'annonce en tête d'*Infos Salariés* et de la
+> page *Contrats*, et mène à la liste. On peut aussi la demander directement à
+> la barre intelligente (« salariés sans contrat », « contrats manquants »).
+>
+> Cette liste distingue ceux dont le contrat n'a jamais été saisi de ceux dont
+> le contrat est échu et n'a pas été renouvelé — les deux n'appellent pas le
+> même geste. Seul le premier cas déclenche le bandeau : la fin d'un CDD est
+> une situation normale, pas un oubli.
 
 ---
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -338,17 +338,34 @@ L'adresse email est indispensable pour recevoir les notifications.
 
 Les contrats sont listés par ordre chronologique décroissant.
 
-> **Les dates du contrat bornent la fiche d'heures.** Les jours situés avant
-> la date de début ou après la date de fin sont marqués *Hors contrat* : ils
-> ne sont pas réclamés à la saisie, ne comptent pas dans les heures
-> théoriques du mois et n'empêchent plus la validation. C'est ce qui permet à
-> un CDD entré ou sorti en cours de mois de valider son mois partiel.
+> ### ⚠️ Le contrat conditionne la saisie des heures
+>
+> **Sans contrat couvrant la date, aucune heure ne peut être saisie.** Les
+> heures alimentent la paie : elles doivent se rattacher à un contrat. Le
+> formulaire de saisie reste fermé et affiche la raison, pour le salarié comme
+> pour son responsable.
+>
+> Enregistrez donc le contrat **dès l'embauche**, avant la première saisie.
 >
 > La date de fin est **incluse** : c'est le dernier jour travaillé.
 >
-> Tant qu'aucun contrat n'est enregistré pour un salarié, rien ne change —
-> tous ses jours ouvrés restent à saisir. Une fiche entièrement vide reste
-> ainsi visible au lieu d'être silencieusement dispensée de saisie.
+> **Sur la fiche d'heures**, les jours situés avant la date de début ou après
+> la date de fin sont marqués *Hors contrat* : ils ne sont pas réclamés, ne
+> comptent pas dans les heures théoriques du mois et n'empêchent plus la
+> validation. C'est ce qui permet à un CDD entré ou sorti en cours de mois de
+> valider son mois partiel.
+>
+> **Tant qu'aucun contrat n'est enregistré**, la fiche continue de réclamer
+> tous les jours ouvrés — mais la saisie les refuse, et un bandeau explique
+> pourquoi. Le manque reste visible au lieu qu'une fiche se vide toute seule.
+> Ajouter le contrat rouvre la saisie aussitôt.
+>
+> **Les heures déjà enregistrées ne sont pas touchées** : elles restent
+> visibles sur la fiche et modifiables, y compris hors contrat. La règle
+> refuse une saisie nouvelle, jamais la correction d'une saisie existante.
+>
+> Le **planning théorique**, lui, n'est pas exigé pour saisir. S'il est
+> renseigné plus tard, les heures supplémentaires se recalculent d'elles-mêmes.
 
 ---
 

--- a/flux_infos.py
+++ b/flux_infos.py
@@ -185,6 +185,39 @@ def _subventions(conn, contexte):
     return infos
 
 
+def _contrats_manquants(conn, contexte):
+    """Salariés actifs dont aucun contrat ne figure au dossier.
+
+    C'est une anomalie, pas une statistique : sans contrat, la saisie des
+    heures est fermée et la paie n'a rien à traiter. Elle doit donc se
+    signaler d'elle-même — la page qui la détaille ne se consulte pas, elle se
+    demande.
+
+    Volontairement limité au manque total. Un contrat échu non renouvelé se
+    voit sur la page dédiée, mais ne mérite pas d'alerte : la fin d'un CDD est
+    une situation normale, pas un oubli de saisie.
+
+    Réservé aux profils qui peuvent enregistrer un contrat — un responsable
+    lit la fiche salarié sans pouvoir y remédier.
+    """
+    if contexte.get('profil') not in _COMPTA:
+        return []
+
+    sans_contrat = conn.execute(
+        """SELECT COUNT(*) AS nb FROM users u
+           WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+             AND NOT EXISTS (SELECT 1 FROM contrats c WHERE c.user_id = u.id)"""
+    ).fetchone()['nb']
+    if not sans_contrat:
+        return []
+
+    return [_info(
+        '📄', sans_contrat, 'salarié(s) sans aucun contrat — saisie bloquée',
+        url_for('contrats_bp.salaries_sans_contrat'), 'Régulariser',
+        'alerte',
+    )]
+
+
 def _validations(conn, contexte):
     """Ce que la vue d'ensemble des validations doit signaler.
 
@@ -275,6 +308,11 @@ CONSTRUCTEURS = {
     'ecritures_bp.liste_ecritures': _ecritures,
     'subventions_bp.gestion_subventions': _subventions,
     'validation_bp.vue_ensemble_validation': _validations,
+    # Le manque de contrat s'annonce là où on le corrige (fiche salarié) et là
+    # où on regarde les contrats. Sa page dédiée ne figure pas au menu : elle
+    # répond à une intention, elle ne se consulte pas.
+    'infos_salaries_bp.infos_salaries': _contrats_manquants,
+    'contrats_bp.liste_contrats': _contrats_manquants,
 }
 
 

--- a/navigation.py
+++ b/navigation.py
@@ -170,13 +170,6 @@ ZONES = [
                   profils=('responsable',),
                   condition='generation_contrats_responsable_autorise',
                   mots='contrat modele document creer generer rediger embauche cdd cdi'),
-            _page('contrats_bp.salaries_sans_contrat', 'Salariés sans contrat',
-                  profils=('directeur', 'comptable'),
-                  mots='contrat manquant sans oublie bloque saisie regulariser echu '
-                       'renouveler embauche dossier',
-                  expressions=('salariés sans contrat', 'sans contrat',
-                               'contrats manquants', 'qui n\'a pas de contrat',
-                               'contrat oublié')),
             _page('absences_bp.absences', 'Absences',
                   profils=('directeur', 'comptable'),
                   mots='absence maladie arret travail justificatif suivi retour'),

--- a/navigation.py
+++ b/navigation.py
@@ -170,6 +170,13 @@ ZONES = [
                   profils=('responsable',),
                   condition='generation_contrats_responsable_autorise',
                   mots='contrat modele document creer generer rediger embauche cdd cdi'),
+            _page('contrats_bp.salaries_sans_contrat', 'Salariés sans contrat',
+                  profils=('directeur', 'comptable'),
+                  mots='contrat manquant sans oublie bloque saisie regulariser echu '
+                       'renouveler embauche dossier',
+                  expressions=('salariés sans contrat', 'sans contrat',
+                               'contrats manquants', 'qui n\'a pas de contrat',
+                               'contrat oublié')),
             _page('absences_bp.absences', 'Absences',
                   profils=('directeur', 'comptable'),
                   mots='absence maladie arret travail justificatif suivi retour'),

--- a/search_engine.py
+++ b/search_engine.py
@@ -398,6 +398,16 @@ _RE_SOLDE_CONGE = re.compile(
     r'|\bconges?\b\s+restants?\b'
 )
 
+# Salariés qu'aucun contrat ne couvre. Se teste avant le mot-clé, car la
+# formulation la plus naturelle (« salariés sans contrat ») commence par
+# « salarié » et partirait sinon chercher quelqu'un de ce nom.
+_RE_SANS_CONTRAT = re.compile(
+    r'\bsans\s+contrat\b'
+    r'|\bcontrats?\s+(?:manquants?|oublies?|absents?)\b'
+    r'|\b(?:pas|aucun|aucune)\s+(?:de\s+)?contrat\b'
+    r'|\bcontrats?\s+a\s+(?:saisir|enregistrer|regulariser)\b'
+)
+
 # Mots outils ignorés en tête de requête (« voir budget », « liste subventions »…)
 _MOTS_OUTILS = {
     'liste', 'listes', 'voir', 'afficher', 'montre', 'montrer', 'montrez',
@@ -457,6 +467,11 @@ def _analyser_recherche(conn, query, profil, today, user_id=None):
     # Soldes de congés de l'effectif (avant le mot-clé « solde » → trésorerie).
     if _RE_SOLDE_CONGE.search(norm):
         return _redirect(url_for('infos_salaries_bp.soldes_conges'), 'Soldes de congés')
+    # Salariés sans contrat (avant « salarié » → recherche d'une personne, et
+    # avant « contrat » → liste des contrats du mois).
+    if _RE_SANS_CONTRAT.search(norm):
+        return _redirect(url_for('contrats_bp.salaries_sans_contrat'),
+                         'Salariés sans contrat')
 
     # Retirer les mots outils en tête (« voir », « liste », « les »…) pour révéler le mot-clé.
     while reste and reste[0] in _MOTS_OUTILS:

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,6 @@
                     <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}">📁 Infos Salariés</a>
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
-                    <a href="{{ url_for('contrats_bp.salaries_sans_contrat') }}">⚠️ Salariés sans contrat</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
                     <a href="{{ url_for('infos_salaries_bp.soldes_conges') }}">🏖️ Soldes de congés</a>
                     <a href="{{ url_for('presence_effectif_bp.presence_effectif') }}">🗓️ Présence effectif</a>
@@ -193,7 +192,6 @@
                     <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}">📁 Infos Salariés</a>
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
-                    <a href="{{ url_for('contrats_bp.salaries_sans_contrat') }}">⚠️ Salariés sans contrat</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
                     <a href="{{ url_for('infos_salaries_bp.soldes_conges') }}">🏖️ Soldes de congés</a>
                     <a href="{{ url_for('rh_statistiques_bp.rh_statistiques') }}">📊 Statistiques RH</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,6 +70,7 @@
                     <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}">📁 Infos Salariés</a>
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
+                    <a href="{{ url_for('contrats_bp.salaries_sans_contrat') }}">⚠️ Salariés sans contrat</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
                     <a href="{{ url_for('infos_salaries_bp.soldes_conges') }}">🏖️ Soldes de congés</a>
                     <a href="{{ url_for('presence_effectif_bp.presence_effectif') }}">🗓️ Présence effectif</a>
@@ -192,6 +193,7 @@
                     <a href="{{ url_for('infos_salaries_bp.infos_salaries') }}">📁 Infos Salariés</a>
                     <a href="{{ url_for('planning_bp.planning_theorique') }}">🗓️ Plannings salariés</a>
                     <a href="{{ url_for('generation_contrats_bp.generation_contrats') }}">📝 Génération contrats</a>
+                    <a href="{{ url_for('contrats_bp.salaries_sans_contrat') }}">⚠️ Salariés sans contrat</a>
                     <a href="{{ url_for('absences_bp.absences') }}">🏥 Absences</a>
                     <a href="{{ url_for('infos_salaries_bp.soldes_conges') }}">🏖️ Soldes de congés</a>
                     <a href="{{ url_for('rh_statistiques_bp.rh_statistiques') }}">📊 Statistiques RH</a>

--- a/templates/contrats.html
+++ b/templates/contrats.html
@@ -44,6 +44,15 @@
             <button type="submit" class="btn btn-primary btn-sm">Afficher</button>
         </form>
 
+        <p style="margin:0.75rem 0 0;">
+            <a href="{{ url_for('contrats_bp.salaries_sans_contrat') }}" class="btn btn-secondary btn-sm">
+                ⚠️ Salariés actifs sans contrat
+            </a>
+            <span style="color:#666; font-size:0.85rem; margin-left:0.5rem;">
+                Ceux qu'aucun contrat ne couvre aujourd'hui — donc bloqués à la saisie de leurs heures.
+            </span>
+        </p>
+
         <p class="contrats-resume">
             {{ contrats|length }} contrat{{ 's' if contrats|length != 1 else '' }} —
             {{ noms_mois[mois_selected] }} {{ annee_selected }}

--- a/templates/contrats_sans_contrat.html
+++ b/templates/contrats_sans_contrat.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+
+{% block title %}Salariés sans contrat - CS-PILOT{% endblock %}
+
+{% block content %}
+<div class="factures-page">
+    <div style="margin-bottom:1rem;">
+        <h1>Salariés sans contrat</h1>
+        <p class="subtitle">Salariés actifs qu'aucun contrat ne couvre aujourd'hui</p>
+    </div>
+
+    <div class="section">
+        <p style="margin-bottom:1rem;">
+            <a href="{{ url_for('contrats_bp.liste_contrats') }}" class="btn btn-secondary btn-sm">← Tous les contrats</a>
+        </p>
+
+        {% if not salaries %}
+        <div class="help-box" style="background:#dcfce7; border-left-color:#16a34a;">
+            <h4>✅ Aucun salarié sans contrat</h4>
+            <p style="margin-bottom:0;">Tous les salariés actifs sont couverts par un contrat en cours. Personne n'est bloqué à la saisie de ses heures.</p>
+        </div>
+        {% else %}
+        <div class="help-box" style="background:#fee2e2; border-left-color:#dc2626;">
+            <h4>⚠️ {{ salaries|length }} salarié{{ 's' if salaries|length > 1 else '' }} sans contrat en cours</h4>
+            <p style="margin-bottom:0;">
+                La saisie des heures exige un contrat couvrant la date : ces salariés
+                ne peuvent rien saisir aujourd'hui. Ouvrez leur fiche pour ajouter ou
+                renouveler le contrat — la saisie se rouvre aussitôt.
+            </p>
+        </div>
+
+        <table class="data-table" style="width:100%;">
+            <thead>
+                <tr>
+                    <th>Salarié</th>
+                    <th>Secteur</th>
+                    <th>Profil</th>
+                    <th>Situation</th>
+                    <th style="text-align:center;">Fiche</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for s in salaries %}
+                <tr>
+                    <td><strong>{{ s.prenom }} {{ s.nom }}</strong></td>
+                    <td>{{ s.secteur_nom or '—' }}</td>
+                    <td>{{ s.profil }}</td>
+                    <td>
+                        {% if not s.nb_contrats %}
+                        <span class="badge" style="background:#dc2626;color:#fff;">Aucun contrat au dossier</span>
+                        {% elif s.derniere_fin %}
+                        <span class="badge" style="background:#f59e0b;color:#000;">Contrat échu</span>
+                        <span style="color:#666;"> depuis le {{ s.derniere_fin[8:10] }}/{{ s.derniere_fin[5:7] }}/{{ s.derniere_fin[0:4] }}</span>
+                        {% else %}
+                        {# Contrats au dossier, aucun en cours, aucune date de fin :
+                           tous commencent après aujourd'hui (embauche à venir). #}
+                        <span class="badge" style="background:#6366f1;color:#fff;">Contrat à venir</span>
+                        {% endif %}
+                    </td>
+                    <td style="text-align:center;">
+                        <a href="{{ url_for('infos_salaries_bp.infos_salaries', user_id=s.id) }}#contrats"
+                           class="btn-icon" title="Ouvrir la fiche salarié" aria-label="Fiche salarié">📄</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/contrats_sans_contrat.html
+++ b/templates/contrats_sans_contrat.html
@@ -48,13 +48,17 @@
                     <td>
                         {% if not s.nb_contrats %}
                         <span class="badge" style="background:#dc2626;color:#fff;">Aucun contrat au dossier</span>
+                        {% elif s.prochain_debut %}
+                        {# L'embauche à venir prime : rien à régulariser, il n'y
+                           a qu'à attendre la date. Y compris après un contrat
+                           échu — c'est alors le renouvellement déjà enregistré. #}
+                        <span class="badge" style="background:#6366f1;color:#fff;">Contrat à venir</span>
+                        <span style="color:#666;"> le {{ s.prochain_debut[8:10] }}/{{ s.prochain_debut[5:7] }}/{{ s.prochain_debut[0:4] }}</span>
                         {% elif s.derniere_fin %}
                         <span class="badge" style="background:#f59e0b;color:#000;">Contrat échu</span>
                         <span style="color:#666;"> depuis le {{ s.derniere_fin[8:10] }}/{{ s.derniere_fin[5:7] }}/{{ s.derniere_fin[0:4] }}</span>
                         {% else %}
-                        {# Contrats au dossier, aucun en cours, aucune date de fin :
-                           tous commencent après aujourd'hui (embauche à venir). #}
-                        <span class="badge" style="background:#6366f1;color:#fff;">Contrat à venir</span>
+                        <span class="badge" style="background:#f59e0b;color:#000;">Aucun contrat en cours</span>
                         {% endif %}
                     </td>
                     <td style="text-align:center;">

--- a/templates/saisie_heures.html
+++ b/templates/saisie_heures.html
@@ -142,6 +142,14 @@
         </div>
         {% endif %}
 
+        {% if sans_contrat %}
+        <div style="display: flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1rem; background: #fee2e2; border-radius: 8px; border-left: 4px solid var(--danger); margin-bottom: 1rem;">
+            <span style="font-size: 1.1rem;">📄</span>
+            <span style="flex: 1; font-size: 0.9rem; color: #991b1b; font-weight: 500;">{{ message_sans_contrat }}</span>
+            <span class="ctx-help" onclick="toggleCtxHelp(event, this)" style="background: var(--danger);">?<span class="ctx-help-bubble">Les heures alimentent la paie : elles doivent se rattacher à un contrat. Tant qu'aucun contrat ne couvre cette date, la saisie reste fermée. Les heures déjà enregistrées, elles, restent en place et modifiables. Le planning théorique n'est pas requis : s'il est saisi plus tard, les heures supplémentaires se recalculent.</span></span>
+        </div>
+        {% endif %}
+
         <div class="form-actions">
             {% if next_page == 'calendrier' %}
             <a href="{{ url_for('validation_bp.vue_calendrier', user_id=user_id_cible, mois=date_defaut.split('-')[1]|int, annee=date_defaut.split('-')[0]|int) }}" class="btn btn-secondary">Annuler</a>
@@ -150,7 +158,7 @@
             {% else %}
             <a href="{{ url_for('dashboard_bp.dashboard') }}" class="btn btn-secondary">Annuler</a>
             {% endif %}
-            <button type="submit" class="btn btn-primary" {% if mois_verrouille %}disabled{% endif %}>💾 Enregistrer</button>
+            <button type="submit" class="btn btn-primary" {% if mois_verrouille or sans_contrat %}disabled{% endif %}>💾 Enregistrer</button>
         </div>
     </form>
     

--- a/templates/vue_calendrier.html
+++ b/templates/vue_calendrier.html
@@ -138,7 +138,7 @@
             {% for j in jours_calendrier %}
             {% set d = j.donnees %}
             <div class="calendar-mobile-cell {% if d and d.hors_contrat %}calendar-mobile-cell-weekend{% elif d and d.non_declare %}calendar-mobile-cell-danger{% elif d and d.type_saisie == 'absence' %}calendar-mobile-cell-absence{% elif d and d.type_saisie == 'recup_journee' %}calendar-mobile-cell-recup{% elif j.est_ferie %}calendar-mobile-cell-ferie{% elif d and d.est_declare %}calendar-mobile-cell-declare{% elif d and d.est_saisi %}calendar-mobile-cell-saisi{% elif j.est_weekend %}calendar-mobile-cell-weekend{% endif %}"
-                 {% if d and peut_modifier and not j.est_dimanche %}
+                 {% if d and peut_modifier and not j.est_dimanche and not d.hors_contrat %}
                  onclick="window.location.href='{{ url_for('saisie_bp.saisie_heures', date=j.date, user_id=user_id_a_afficher, next='calendrier') }}'"
                  onkeydown="if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); window.location.href='{{ url_for('saisie_bp.saisie_heures', date=j.date, user_id=user_id_a_afficher, next='calendrier') }}'; }"
                  role="link"
@@ -363,10 +363,12 @@
             {% endif %}
 
             <div class="{{ cls }}"
-                 {% if d and peut_modifier and not j.est_dimanche %}
+                 {% if d and peut_modifier and not j.est_dimanche and not d.hors_contrat %}
                  onclick="window.location.href='{{ url_for('saisie_bp.saisie_heures', date=j.date, user_id=user_id_a_afficher, next='calendrier') }}'"
                  style="cursor: pointer;"
                  title="Cliquer pour {% if d.est_saisi %}modifier{% else %}saisir{% endif %}"
+                 {% elif d and d.hors_contrat %}
+                 title="Hors contrat — rien à saisir"
                  {% elif j.est_ferie %}
                  title="{{ j.libelle_ferie }}"
                  {% endif %}>

--- a/templates/vue_calendrier.html
+++ b/templates/vue_calendrier.html
@@ -137,7 +137,7 @@
 
             {% for j in jours_calendrier %}
             {% set d = j.donnees %}
-            <div class="calendar-mobile-cell {% if d and d.non_declare %}calendar-mobile-cell-danger{% elif d and d.type_saisie == 'absence' %}calendar-mobile-cell-absence{% elif d and d.type_saisie == 'recup_journee' %}calendar-mobile-cell-recup{% elif j.est_ferie %}calendar-mobile-cell-ferie{% elif d and d.est_declare %}calendar-mobile-cell-declare{% elif d and d.est_saisi %}calendar-mobile-cell-saisi{% elif j.est_weekend %}calendar-mobile-cell-weekend{% endif %}"
+            <div class="calendar-mobile-cell {% if d and d.hors_contrat %}calendar-mobile-cell-weekend{% elif d and d.non_declare %}calendar-mobile-cell-danger{% elif d and d.type_saisie == 'absence' %}calendar-mobile-cell-absence{% elif d and d.type_saisie == 'recup_journee' %}calendar-mobile-cell-recup{% elif j.est_ferie %}calendar-mobile-cell-ferie{% elif d and d.est_declare %}calendar-mobile-cell-declare{% elif d and d.est_saisi %}calendar-mobile-cell-saisi{% elif j.est_weekend %}calendar-mobile-cell-weekend{% endif %}"
                  {% if d and peut_modifier and not j.est_dimanche %}
                  onclick="window.location.href='{{ url_for('saisie_bp.saisie_heures', date=j.date, user_id=user_id_a_afficher, next='calendrier') }}'"
                  onkeydown="if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); window.location.href='{{ url_for('saisie_bp.saisie_heures', date=j.date, user_id=user_id_a_afficher, next='calendrier') }}'; }"
@@ -150,7 +150,9 @@
                  {% endif %}>
                 <div class="calendar-mobile-cell-top">
                     <span class="calendar-mobile-cell-day">{{ j.jour }}</span>
-                    {% if j.est_ferie %}
+                    {% if d and d.hors_contrat %}
+                    {# Hors contrat : aucune pastille, il n'y a rien à signaler #}
+                    {% elif j.est_ferie %}
                     <span class="calendar-mobile-cell-dot calendar-mobile-cell-dot-ferie"></span>
                     {% elif d and d.non_declare %}
                     <span class="calendar-mobile-cell-dot calendar-mobile-cell-dot-danger"></span>
@@ -166,7 +168,9 @@
                 </div>
 
                 {% if d %}
-                    {% if d.type_saisie == 'recup_journee' %}
+                    {% if d.hors_contrat %}
+                    <div class="calendar-mobile-cell-main calendar-mobile-cell-main-label">–</div>
+                    {% elif d.type_saisie == 'recup_journee' %}
                     <div class="calendar-mobile-cell-main">R</div>
                     {% elif d.est_saisi or d.est_declare or d.type_saisie == 'absence' %}
                     <div class="calendar-mobile-cell-main">{{ "%.1f"|format(d.heures_reelles) }}h</div>
@@ -174,7 +178,9 @@
                     <div class="calendar-mobile-cell-main">{{ "%.1f"|format(d.heures_theoriques) }}h</div>
                     {% endif %}
 
-                    {% if d.type_periode == 'vacances' and not d.est_samedi %}
+                    {% if d.hors_contrat %}
+                    {# Ni vacances, ni écart : le salarié n'était pas employé #}
+                    {% elif d.type_periode == 'vacances' and not d.est_samedi %}
                     <div class="calendar-mobile-cell-note">vac.</div>
                     {% elif d.ecart > 0 %}
                     <div class="calendar-mobile-cell-note calendar-mobile-cell-note-pos">+{{ "%.1f"|format(d.ecart) }}</div>
@@ -299,6 +305,10 @@
             <span>Non declare</span>
         </div>
         <div class="cal-legende-item">
+            <div class="cal-swatch" style="background: #e9ecef; border: 1px solid #ced4da;"></div>
+            <span>Hors contrat</span>
+        </div>
+        <div class="cal-legende-item">
             <div class="cal-swatch" style="background: #fce7f3; border: 1px solid #f9a8d4;"></div>
             <span>Jour ferie</span>
         </div>
@@ -332,6 +342,8 @@
 
             {% if j.est_dimanche %}
                 {% set cls = cls + ' cal-cell-dimanche' %}
+            {% elif d and d.hors_contrat %}
+                {% set cls = cls + ' cal-cell-vide' %}
             {% elif j.est_ferie %}
                 {% set cls = cls + ' cal-cell-ferie' %}
             {% elif j.est_weekend and not d %}
@@ -361,14 +373,16 @@
 
                 <div class="cal-cell-numero">{{ j.jour }}</div>
 
-                {% if j.est_ferie %}
+                {% if j.est_ferie and not (d and d.hors_contrat) %}
                 <div class="cal-cell-badge cal-badge-ferie">{{ j.libelle_ferie }}</div>
                 {% endif %}
 
                 {% if j.est_dimanche %}
                     {# Rien a afficher pour les dimanches #}
                 {% elif d %}
-                    {% if d.type_saisie == 'absence' %}
+                    {% if d.hors_contrat %}
+                    <div class="cal-cell-badge" style="background:#e9ecef;color:#6c757d;">📄 Hors contrat</div>
+                    {% elif d.type_saisie == 'absence' %}
                     <div class="cal-cell-badge cal-badge-absence">🏥 Absence</div>
                     <div class="cal-cell-info">
                         <span class="cal-cell-heures">{{ "%.1f"|format(d.heures_reelles) }}h</span>
@@ -399,7 +413,7 @@
                     </div>
                     {% endif %}
 
-                    {% if d.type_periode == 'vacances' and not d.est_samedi %}
+                    {% if d.type_periode == 'vacances' and not d.est_samedi and not d.hors_contrat %}
                     <div class="cal-cell-periode">vac.</div>
                     {% endif %}
                 {% endif %}

--- a/templates/vue_mensuelle.html
+++ b/templates/vue_mensuelle.html
@@ -244,7 +244,9 @@
                         </div>
                         <div class="month-mobile-metric month-mobile-metric-action">
                             <span>Action</span>
-                            {% if peut_modifier %}
+                            {% if j.hors_contrat %}
+                            <strong style="color: #6c757d;">—</strong>
+                            {% elif peut_modifier %}
                             <a href="{{ url_for('saisie_bp.saisie_heures', date=j.date, user_id=user_id_a_afficher, next='mensuelle') }}"
                                class="month-mobile-action-link"
                                title="{% if j.est_saisi %}Modifier{% else %}Saisir{% endif %}">
@@ -333,6 +335,19 @@
         </div>
         {% endif %}
         
+        {% if aucun_contrat %}
+        <div class="help-box" style="background: #fef3c7; border-left-color: #d97706; margin-bottom: 1rem;">
+            <h4>📄 Aucun contrat enregistré</h4>
+            <p><strong>La saisie des heures est fermée tant qu'aucun contrat ne figure au dossier.</strong></p>
+            <p>
+                Les heures alimentent la paie : elles doivent se rattacher à un
+                contrat. Ajoutez-le depuis <em>Infos Salariés → Contrats</em>, ou
+                signalez-le à la direction — les journées ci-dessous redeviendront
+                saisissables aussitôt.
+            </p>
+        </div>
+        {% endif %}
+
         {% if nb_jours_non_declares > 0 %}
         <div class="help-box" style="background: #fee2e2; border-left-color: #dc2626; margin-bottom: 1rem;">
             <h4>⚠️ Jours non déclarés</h4>
@@ -451,7 +466,9 @@
                             {{ j.commentaire or '-' }}
                         </td>
                         <td data-label="Actions">
-                            {% if peut_modifier %}
+                            {% if j.hors_contrat %}
+                            <span class="btn-icon" style="opacity: 0.3;" title="Hors contrat — rien à saisir">—</span>
+                            {% elif peut_modifier %}
                             <a href="{{ url_for('saisie_bp.saisie_heures', date=j.date, user_id=user_id_a_afficher, next='mensuelle') }}"
                                class="btn-icon"
                                title="{% if j.est_saisi %}Modifier{% else %}Saisir{% endif %}">

--- a/templates/vue_mensuelle.html
+++ b/templates/vue_mensuelle.html
@@ -162,7 +162,9 @@
 
                         <div class="month-mobile-day-body">
                             <div class="month-mobile-day-badges">
-                                {% if j.type_saisie == 'ferie' %}
+                                {% if j.hors_contrat %}
+                                    <span class="badge" style="background: #e9ecef; color: #6c757d;">📄 Hors contrat</span>
+                                {% elif j.type_saisie == 'ferie' %}
                                     <span class="badge month-badge-ferie">🎌 Férié</span>
                                 {% elif j.non_declare %}
                                     <span class="badge" style="background: #dc3545; color: white;">⚠️ Non déclaré</span>
@@ -423,7 +425,9 @@
                             {% endif %}
                         </td>
                         <td data-label="Statut">
-                            {% if j.type_saisie == 'ferie' %}
+                            {% if j.hors_contrat %}
+                                <span class="badge" style="background: #e9ecef; color: #6c757d;">📄 Hors contrat</span>
+                            {% elif j.type_saisie == 'ferie' %}
                                 <span class="badge month-badge-ferie">🎌 Férié</span>
                             {% elif j.non_declare %}
                                 <span class="badge" style="background: #dc3545; color: white;">⚠️ Non déclaré</span>
@@ -563,6 +567,7 @@
             <li><strong>🏖️ Récup</strong> : Récupération journée complète</li>
             <li><strong style="background: #8b5cf6; color: white; padding: 2px 6px; border-radius: 3px;">🏥 Absence</strong> : Arrêt maladie, congé ou autre absence saisie</li>
             <li><strong style="background: #dc2626; color: white; padding: 2px 6px; border-radius: 3px;">⚠️ Non déclaré</strong> : Jour passé qui doit être {% if declaration_conforme_active %}saisi ou déclaré{% else %}saisi{% endif %} (empêche la validation)</li>
+            <li><strong style="background: #e9ecef; color: #6c757d; padding: 2px 6px; border-radius: 3px;">📄 Hors contrat</strong> : Jour situé avant l'embauche ou après la fin du contrat — rien n'est dû ni à saisir</li>
             <li><strong style="background: #fff3cd; padding: 2px 6px;">Samedi</strong> : N'apparaît que s'il y a une saisie. 0h théorique = tout en heures supplémentaires</li>
         </ul>
         <p><strong>Solde cumulé :</strong> Inclut les mois précédents ({{ "%.2f"|format(solde_anterieur) }}h) + ce mois ({{ "%.2f"|format(solde_mois) }}h){% if hs_payees_mois %} − heures supp payées sur la paie de ce mois ({{ "%.2f"|format(hs_payees_mois) }}h){% endif %}. Les heures supp déjà payées sont déduites.</p>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,28 @@ def sample_users(app, db):
         }
 
 
+@pytest.fixture
+def sample_contrat(app, db, sample_users):
+    """Contrat sans terme (CDI) pour le salarié de test, depuis toujours.
+
+    La saisie d'heures exige un contrat couvrant la date : tout test qui
+    enregistre des heures doit donc en poser un. Volontairement séparé de
+    `sample_users`, pour ne pas modifier le décompte des contrats des tests
+    d'effectif, de masse salariale ou de documents obligatoires.
+    """
+    with app.app_context():
+        cursor = db.cursor()
+        cursor.execute(
+            """INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin)
+               VALUES (?, 'CDI', '2000-01-01', NULL)""",
+            (sample_users['salarie_id'],)
+        )
+        contrat_id = cursor.lastrowid
+        db.commit()
+
+    return {'contrat_id': contrat_id, 'user_id': sample_users['salarie_id']}
+
+
 def _login(client, login, password):
     """Fonction utilitaire pour se connecter via le formulaire."""
     return client.post('/login', data={

--- a/tests/test_contrats.py
+++ b/tests/test_contrats.py
@@ -70,3 +70,96 @@ class TestPageContrats:
         html = comptable_client.get(f'/contrats?mois={mois}&annee={an}&type=CDD&filtre=en_cours').get_data(as_text=True)
         # Filtré sur CDD → le badge CDI ne doit pas apparaître dans les lignes.
         assert '>CDI</span>' not in html
+
+
+def _couvrir_les_autres(db, uid_exclu):
+    """Donne un CDI à tout l'effectif sauf un : isole le cas testé.
+
+    Sans cela, responsable et comptable — eux aussi sans contrat — peuplent la
+    page et brouillent les assertions.
+    """
+    autres = db.execute(
+        "SELECT id FROM users WHERE actif = 1 "
+        "AND profil NOT IN ('directeur', 'prestataire') AND id != ?",
+        (uid_exclu,)
+    ).fetchall()
+    for row in autres:
+        db.execute(
+            "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+            "VALUES (?, 'CDI', '2000-01-01', NULL)", (row['id'],)
+        )
+    db.commit()
+
+
+class TestSalariesSansContrat:
+    """La liste de ceux qu'aucun contrat ne couvre aujourd'hui.
+
+    Depuis que la saisie des heures exige un contrat, cette page dit
+    exactement qui est bloqué — et pourquoi, les deux causes n'appelant pas le
+    même geste : contrat jamais saisi, ou contrat échu non renouvelé.
+    """
+
+    URL = '/contrats/sans-contrat'
+
+    def test_acces_refuse_salarie(self, app, auth_client):
+        assert auth_client.get(self.URL, follow_redirects=False).status_code == 302
+
+    def test_comptable_autorise(self, app, comptable_client):
+        assert comptable_client.get(self.URL).status_code == 200
+
+    def test_salarie_sans_aucun_contrat_est_liste(self, app, db, comptable_client,
+                                                  sample_users):
+        html = comptable_client.get(self.URL).get_data(as_text=True)
+        assert 'Martin' in html                      # le salarié de test
+        assert 'Aucun contrat au dossier' in html
+
+    def test_salarie_sous_contrat_disparait(self, app, db, comptable_client,
+                                            sample_users, sample_contrat):
+        html = comptable_client.get(self.URL).get_data(as_text=True)
+        assert 'Aucun salarié sans contrat' not in html or 'Martin' not in html
+
+    def test_contrat_echu_est_signale_comme_tel(self, app, db, comptable_client,
+                                                sample_users):
+        an, _, _ = _ctx_mois()
+        with app.app_context():
+            _couvrir_les_autres(db, sample_users['salarie_id'])
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDD', ?, ?)",
+                (sample_users['salarie_id'], f"{an - 2:04d}-01-01", f"{an - 1:04d}-06-30")
+            )
+            db.commit()
+
+        html = comptable_client.get(self.URL).get_data(as_text=True)
+        assert 'Contrat échu' in html
+        assert '30/06/' in html
+        assert 'Aucun contrat au dossier' not in html
+
+    def test_contrat_a_venir_n_est_pas_confondu_avec_un_echu(
+            self, app, db, comptable_client, sample_users):
+        """Embauche signée pour plus tard : le salarié est listé, sans date de fin."""
+        an, _, _ = _ctx_mois()
+        with app.app_context():
+            _couvrir_les_autres(db, sample_users['salarie_id'])
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDI', ?, NULL)",
+                (sample_users['salarie_id'], f"{an + 1:04d}-01-01")
+            )
+            db.commit()
+
+        html = comptable_client.get(self.URL).get_data(as_text=True)
+        assert 'Contrat à venir' in html
+        assert 'Contrat échu' not in html
+
+    def test_le_bouton_figure_sur_la_page_contrats(self, app, comptable_client):
+        html = comptable_client.get('/contrats').get_data(as_text=True)
+        assert '/contrats/sans-contrat' in html
+        assert 'Salariés actifs sans contrat' in html
+
+    def test_la_barre_intelligente_y_mene(self, app, comptable_client):
+        reponse = comptable_client.post('/api/search', json={'query': 'salariés sans contrat'})
+        assert reponse.status_code == 200
+        resultat = reponse.get_json()
+        assert resultat['type'] == 'redirect'
+        assert '/contrats/sans-contrat' in resultat['url']

--- a/tests/test_contrats.py
+++ b/tests/test_contrats.py
@@ -152,6 +152,50 @@ class TestSalariesSansContrat:
         assert 'Contrat à venir' in html
         assert 'Contrat échu' not in html
 
+    def test_cdd_a_venir_n_est_pas_annonce_echu(self, app, db, comptable_client,
+                                                sample_users):
+        """Un CDD futur a une date de fin, futures elles aussi.
+
+        S'en remettre à la seule présence d'une date de fin l'annonçait
+        « échu depuis » une date à venir.
+        """
+        an, _, _ = _ctx_mois()
+        with app.app_context():
+            _couvrir_les_autres(db, sample_users['salarie_id'])
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDD', ?, ?)",
+                (sample_users['salarie_id'], f"{an + 1:04d}-03-01", f"{an + 1:04d}-08-31")
+            )
+            db.commit()
+
+        html = comptable_client.get(self.URL).get_data(as_text=True)
+        assert 'Contrat à venir' in html
+        assert 'Contrat échu' not in html
+        assert f'01/03/{an + 1}' in html
+
+    def test_un_renouvellement_deja_signe_prime_sur_le_contrat_echu(
+            self, app, db, comptable_client, sample_users):
+        """Contrat terminé + reprise programmée : il n'y a rien à régulariser."""
+        an, _, _ = _ctx_mois()
+        with app.app_context():
+            _couvrir_les_autres(db, sample_users['salarie_id'])
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDD', ?, ?)",
+                (sample_users['salarie_id'], f"{an - 2:04d}-01-01", f"{an - 1:04d}-06-30")
+            )
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDI', ?, NULL)",
+                (sample_users['salarie_id'], f"{an + 1:04d}-01-01")
+            )
+            db.commit()
+
+        html = comptable_client.get(self.URL).get_data(as_text=True)
+        assert 'Contrat à venir' in html
+        assert 'Contrat échu' not in html
+
     def test_la_page_reste_hors_du_menu_et_de_la_carte(self, app):
         """Page de réponse : on l'appelle, on ne la parcourt pas.
 

--- a/tests/test_contrats.py
+++ b/tests/test_contrats.py
@@ -152,6 +152,20 @@ class TestSalariesSansContrat:
         assert 'Contrat à venir' in html
         assert 'Contrat échu' not in html
 
+    def test_la_page_reste_hors_du_menu_et_de_la_carte(self, app):
+        """Page de réponse : on l'appelle, on ne la parcourt pas.
+
+        Comme la page Contrats dont elle sort, elle n'encombre pas le menu.
+        On y arrive par son bouton, par la barre intelligente, ou par le
+        bandeau d'alerte quand un salarié n'a aucun contrat.
+        """
+        import navigation
+        endpoints = {p['endpoint']
+                     for g in navigation.ZONES + navigation.ACCES_DIRECTS
+                     for p in g['pages']}
+        assert 'contrats_bp.salaries_sans_contrat' not in endpoints
+        assert 'contrats_bp.liste_contrats' not in endpoints
+
     def test_le_bouton_figure_sur_la_page_contrats(self, app, comptable_client):
         html = comptable_client.get('/contrats').get_data(as_text=True)
         assert '/contrats/sans-contrat' in html

--- a/tests/test_creneau_soir.py
+++ b/tests/test_creneau_soir.py
@@ -78,7 +78,7 @@ class TestMetriquesTempsSoir:
 
 
 class TestSaisieSoir:
-    def test_saisie_enregistre_le_creneau_soir(self, auth_client, app, db, sample_users):
+    def test_saisie_enregistre_le_creneau_soir(self, auth_client, app, db, sample_users, sample_contrat):
         date_test = '2025-01-13'  # lundi
         with app.app_context():
             auth_client.post('/saisie_heures', data={

--- a/tests/test_export_pdf_mensuel.py
+++ b/tests/test_export_pdf_mensuel.py
@@ -1,0 +1,122 @@
+"""
+Cohérence du PDF mensuel avec la fiche qu'il reproduit.
+
+Le PDF n'est délivré qu'une fois la fiche verrouillée : c'est le document
+signé. Il refait pourtant le calcul du mois de son côté, ce qui l'expose à
+diverger de l'écran validé. Ces tests verrouillent l'égalité.
+"""
+import base64
+import re
+import zlib
+
+from blueprints.validation import _get_vue_mensuelle_data_impl
+from database import get_db
+
+
+def _texte_pdf(data):
+    """Texte des flux de contenu d'un PDF reportlab (ASCII85 + Flate)."""
+    morceaux = []
+    for bloc in re.findall(rb'stream\r?\n(.*?)endstream', data, re.S):
+        brut = bloc.strip()
+        for essai in (
+            lambda b: zlib.decompress(base64.a85decode(b, adobe=False)),
+            lambda b: zlib.decompress(base64.a85decode(b.rstrip(b'~>'), adobe=False)),
+            lambda b: zlib.decompress(b),
+            lambda b: b,
+        ):
+            try:
+                morceaux.append(essai(brut))
+                break
+            except Exception:
+                continue
+    return b'\n'.join(morceaux).decode('latin-1')
+
+
+def _cellules(texte):
+    """Chaînes réellement dessinées dans le document, dans l'ordre."""
+    return re.findall(r'\(([^)]*)\) Tj', texte)
+
+
+def _totaux(texte):
+    """(théorique, réel) de la ligne TOTAL du tableau."""
+    cellules = _cellules(texte)
+    i = cellules.index('TOTAL')
+    heures = [float(c[:-1]) for c in cellules[i + 1:i + 3]]
+    return heures[0], heures[1]
+
+
+def _preparer(app, db, uid, contrats=(), verrouiller=(12, 2024)):
+    with app.app_context():
+        for debut, fin in contrats:
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDD', ?, ?)", (uid, debut, fin)
+            )
+        mois, annee = verrouiller
+        db.execute(
+            "INSERT INTO validations (user_id, mois, annee, bloque) VALUES (?, ?, ?, 1)",
+            (uid, mois, annee)
+        )
+        db.commit()
+
+
+def _fiche(app, uid, mois, annee):
+    """Données de la fiche mensuelle, telles que l'écran les montre."""
+    with app.test_request_context(f'/vue_mensuelle?mois={mois}&annee={annee}'):
+        from flask import session
+        session['user_id'] = uid
+        session['profil'] = 'salarie'
+        conn = get_db()
+        try:
+            data, _ = _get_vue_mensuelle_data_impl(
+                conn, mois, annee, None, 'validation_bp.vue_mensuelle')
+        finally:
+            conn.close()
+    return data
+
+
+class TestPdfEtContrat:
+    """CDD du 09 au 20/12/2024 : douze jours ouvrés du mois sont hors contrat."""
+
+    def test_le_pdf_ne_compte_pas_les_jours_hors_contrat(
+            self, app, db, admin_client, sample_users, sample_planning):
+        uid = sample_users['salarie_id']
+        _preparer(app, db, uid, contrats=[('2024-12-09', '2024-12-20')])
+
+        reponse = admin_client.get(
+            f'/export_pdf_mensuel?user_id={uid}&mois=12&annee=2024')
+        assert reponse.headers['Content-Type'] == 'application/pdf'
+        texte = _texte_pdf(reponse.data)
+
+        assert 'Hors contrat' in texte
+        theorique, _ = _totaux(texte)
+        # 10 jours ouvrés couverts à 7h. Le mois entier en compte 22 (154h) :
+        # c'est ce que le PDF affirmait, en « conforme au planning ».
+        assert theorique == 70.0
+
+    def test_le_pdf_dit_la_meme_chose_que_la_fiche(
+            self, app, db, admin_client, sample_users, sample_planning):
+        """L'invariant : le document signé ne peut pas contredire l'écran validé."""
+        uid = sample_users['salarie_id']
+        _preparer(app, db, uid, contrats=[('2024-12-09', '2024-12-20')])
+
+        texte = _texte_pdf(admin_client.get(
+            f'/export_pdf_mensuel?user_id={uid}&mois=12&annee=2024').data)
+        pdf_theorique, pdf_reel = _totaux(texte)
+
+        fiche = _fiche(app, uid, 12, 2024)
+        assert pdf_theorique == fiche['total_heures_theoriques']
+        assert pdf_reel == fiche['total_heures_reelles']
+
+    def test_sans_contrat_au_dossier_le_pdf_ne_change_pas(
+            self, app, db, admin_client, sample_users, sample_planning):
+        """Même garde-fou qu'ailleurs : sans référence, on ne retranche rien."""
+        uid = sample_users['salarie_id']
+        _preparer(app, db, uid)
+
+        texte = _texte_pdf(admin_client.get(
+            f'/export_pdf_mensuel?user_id={uid}&mois=12&annee=2024').data)
+
+        assert 'Hors contrat' not in texte
+        theorique, _ = _totaux(texte)
+        assert theorique == 154.0        # les 22 jours ouvrés de décembre 2024

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -208,6 +208,53 @@ def test_les_subventions_ne_signalent_que_le_retard(admin_client, db):
     assert "étape(s) dont l&#39;échéance est passée" in corps
 
 
+def test_le_manque_de_contrat_s_annonce_sur_la_fiche_salarie(admin_client, db, sample_users):
+    """L'anomalie se signale seule : sa page ne se consulte pas, elle se demande."""
+    corps = admin_client.get('/infos_salaries').get_data(as_text=True)
+    assert 'flx-infos' in corps
+    assert 'sans aucun contrat' in corps
+    assert '/contrats/sans-contrat' in corps
+
+
+def test_aucune_alerte_quand_tout_le_monde_a_un_contrat(admin_client, db, sample_users):
+    with db:
+        salaries = db.execute(
+            "SELECT id FROM users WHERE actif = 1 "
+            "AND profil NOT IN ('directeur', 'prestataire')"
+        ).fetchall()
+        for row in salaries:
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDI', '2000-01-01', NULL)", (row['id'],)
+            )
+
+    corps = admin_client.get('/infos_salaries').get_data(as_text=True)
+    assert 'sans aucun contrat' not in corps
+
+
+def test_un_contrat_echu_ne_declenche_pas_l_alerte(admin_client, db, sample_users):
+    """La fin d'un CDD est normale ; c'est le contrat jamais saisi qui alerte."""
+    with db:
+        salaries = db.execute(
+            "SELECT id FROM users WHERE actif = 1 "
+            "AND profil NOT IN ('directeur', 'prestataire')"
+        ).fetchall()
+        for row in salaries:
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDD', '2000-01-01', '2001-12-31')", (row['id'],)
+            )
+
+    corps = admin_client.get('/infos_salaries').get_data(as_text=True)
+    assert 'sans aucun contrat' not in corps
+
+
+def test_un_responsable_ne_voit_pas_l_alerte_de_contrat(resp_client, db, sample_users):
+    """Il lit la fiche salarié mais ne peut pas y enregistrer un contrat."""
+    corps = resp_client.get('/infos_salaries').get_data(as_text=True)
+    assert 'sans aucun contrat' not in corps
+
+
 def test_bascule_vers_le_menu_classique_et_retour(admin_client):
     reponse = admin_client.post('/api/interface/basculer', json={'actif': False})
     assert reponse.status_code == 200

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -99,7 +99,7 @@ class TestOptionsSaisie:
         assert response.status_code == 200
         assert 'Je certifie avoir travaillé mes heures habituelles ce jour' not in html
 
-    def test_saisie_ignore_declaration_conforme_si_option_desactivee(self, auth_client, app, db, sample_users):
+    def test_saisie_ignore_declaration_conforme_si_option_desactivee(self, auth_client, app, db, sample_users, sample_contrat):
         with app.app_context():
             set_option_bool('saisie_afficher_declaration_conforme', False)
 

--- a/tests/test_pause_remuneree.py
+++ b/tests/test_pause_remuneree.py
@@ -101,7 +101,7 @@ class TestPreventionPauseRemuneree:
 class TestSaisiePauseRemuneree:
     DATE = '2025-06-16'
 
-    def test_saisie_enregistre_la_pause_remuneree(self, auth_client, app, db, sample_users):
+    def test_saisie_enregistre_la_pause_remuneree(self, auth_client, app, db, sample_users, sample_contrat):
         with app.app_context():
             auth_client.post('/saisie_heures', data={
                 'date': self.DATE,
@@ -114,7 +114,7 @@ class TestSaisiePauseRemuneree:
         assert row['pause_remuneree'] == 1
         assert calculer_heures_reelles_jour(row) == 8.0
 
-    def test_saisie_sans_case_reste_a_zero(self, auth_client, app, db, sample_users):
+    def test_saisie_sans_case_reste_a_zero(self, auth_client, app, db, sample_users, sample_contrat):
         with app.app_context():
             auth_client.post('/saisie_heures', data={
                 'date': self.DATE,
@@ -125,7 +125,7 @@ class TestSaisiePauseRemuneree:
                              (sample_users['salarie_id'], self.DATE)).fetchone()
         assert row['pause_remuneree'] == 0
 
-    def test_recup_journee_ignore_la_pause(self, auth_client, app, db, sample_users):
+    def test_recup_journee_ignore_la_pause(self, auth_client, app, db, sample_users, sample_contrat):
         # Une récup journée n'a pas d'heures : le flag est remis à zéro même si envoyé.
         with app.app_context():
             auth_client.post('/saisie_heures', data={

--- a/tests/test_saisie.py
+++ b/tests/test_saisie.py
@@ -26,7 +26,7 @@ class TestSaisieAcces:
 class TestSaisieCreation:
     """Tests de création de saisie d'heures."""
 
-    def test_saisie_heures_standard(self, auth_client, app, db, sample_users):
+    def test_saisie_heures_standard(self, auth_client, app, db, sample_users, sample_contrat):
         """Un salarié peut saisir ses heures pour une journée."""
         # Utiliser une date passée pour éviter les problèmes de validation
         date_test = '2025-01-06'  # Un lundi
@@ -52,7 +52,7 @@ class TestSaisieCreation:
             assert row['heure_fin_matin'] == '12:00'
             assert row['commentaire'] == 'Test automatisé'
 
-    def test_saisie_declaration_conforme(self, auth_client, app, db, sample_users):
+    def test_saisie_declaration_conforme(self, auth_client, app, db, sample_users, sample_contrat):
         """Déclaration conforme : pas d'heures stockées, flag à 1."""
         date_test = '2025-01-07'
 
@@ -71,7 +71,7 @@ class TestSaisieCreation:
             assert row['heure_debut_matin'] is None
             assert row['type_saisie'] == 'declaration_conforme'
 
-    def test_saisie_recup_journee(self, auth_client, app, db, sample_users):
+    def test_saisie_recup_journee(self, auth_client, app, db, sample_users, sample_contrat):
         """Récupération journée : heures vides, type_saisie = recup_journee."""
         date_test = '2025-01-08'
 
@@ -93,7 +93,7 @@ class TestSaisieCreation:
 class TestSaisieHistorique:
     """Tests de traçabilité."""
 
-    def test_historique_creation(self, auth_client, app, db, sample_users):
+    def test_historique_creation(self, auth_client, app, db, sample_users, sample_contrat):
         """La création d'une saisie doit être enregistrée dans l'historique."""
         date_test = '2025-01-09'
 
@@ -117,7 +117,7 @@ class TestSaisieHistorique:
 class TestSaisieAnomalies:
     """Tests de détection d'anomalies à la saisie."""
 
-    def test_creation_declenche_anomalie_si_ecart_superieur_a_3h(self, auth_client, app, db, sample_users, sample_planning):
+    def test_creation_declenche_anomalie_si_ecart_superieur_a_3h(self, auth_client, app, db, sample_users, sample_planning, sample_contrat):
         """Une création avec +4h vs planning théorique doit créer une anomalie."""
         date_test = '2025-01-06'  # Lundi, 7h théoriques via sample_planning
 
@@ -137,6 +137,127 @@ class TestSaisieAnomalies:
                 (sample_users['salarie_id'], date_test, 'gros_changement_heures')
             ).fetchone()
             assert anomalie is not None
+
+
+class TestSaisieExigeUnContrat:
+    """Saisir des heures suppose un contrat couvrant la date.
+
+    Les heures alimentent la paie : elles doivent se rattacher à un contrat.
+    Le planning théorique, lui, n'est pas exigé — il peut arriver plus tard,
+    les heures supplémentaires se recalculent alors d'elles-mêmes.
+    """
+
+    DATE = '2025-01-06'  # un lundi
+
+    def _saisir(self, client, date=None, **extra):
+        donnees = {
+            'date': date or self.DATE,
+            'heure_debut_matin': '08:30',
+            'heure_fin_matin': '12:00',
+            'heure_debut_aprem': '13:30',
+            'heure_fin_aprem': '17:00',
+        }
+        donnees.update(extra)
+        return client.post('/saisie_heures', data=donnees, follow_redirects=True)
+
+    def _saisie_en_base(self, db, user_id, date=None):
+        return db.execute(
+            "SELECT * FROM heures_reelles WHERE user_id = ? AND date = ?",
+            (user_id, date or self.DATE)
+        ).fetchone()
+
+    def test_refus_sans_aucun_contrat(self, auth_client, app, db, sample_users):
+        """Sans contrat au dossier, la saisie est fermée."""
+        with app.app_context():
+            reponse = self._saisir(auth_client)
+            assert reponse.status_code == 200
+            assert 'Aucun contrat enregistré' in reponse.get_data(as_text=True)
+            assert self._saisie_en_base(db, sample_users['salarie_id']) is None
+
+    def test_refus_hors_periode_du_contrat(self, auth_client, app, db, sample_users):
+        """Un CDD ne peut pas saisir avant son début ni après son terme."""
+        with app.app_context():
+            db.execute(
+                """INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin)
+                   VALUES (?, 'CDD', '2025-02-01', '2025-02-28')""",
+                (sample_users['salarie_id'],)
+            )
+            db.commit()
+
+            self._saisir(auth_client)  # janvier : avant le contrat
+            assert self._saisie_en_base(db, sample_users['salarie_id']) is None
+
+            self._saisir(auth_client, date='2025-03-03')  # après le terme
+            assert self._saisie_en_base(db, sample_users['salarie_id'], '2025-03-03') is None
+
+    def test_saisie_acceptee_dans_la_periode(self, auth_client, app, db, sample_users):
+        with app.app_context():
+            db.execute(
+                """INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin)
+                   VALUES (?, 'CDD', '2025-02-01', '2025-02-28')""",
+                (sample_users['salarie_id'],)
+            )
+            db.commit()
+
+            self._saisir(auth_client, date='2025-02-03')
+            assert self._saisie_en_base(db, sample_users['salarie_id'], '2025-02-03') is not None
+
+    def test_le_dernier_jour_du_contrat_est_saisissable(self, auth_client, app, db, sample_users):
+        """`date_fin` est le dernier jour travaillé, pas le premier jour exclu."""
+        with app.app_context():
+            db.execute(
+                """INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin)
+                   VALUES (?, 'CDD', '2025-02-01', '2025-02-28')""",
+                (sample_users['salarie_id'],)
+            )
+            db.commit()
+
+            self._saisir(auth_client, date='2025-02-28')
+            assert self._saisie_en_base(db, sample_users['salarie_id'], '2025-02-28') is not None
+
+    def test_une_saisie_anterieure_reste_modifiable(self, auth_client, app, db, sample_users):
+        """Les heures posées avant la règle ne sont pas figées par elle.
+
+        Leur auteur peut encore les corriger : on refuse la création, pas la
+        rectification de ce qui existe déjà.
+        """
+        with app.app_context():
+            db.execute(
+                """INSERT INTO heures_reelles
+                   (user_id, date, heure_debut_matin, heure_fin_matin,
+                    heure_debut_aprem, heure_fin_aprem, type_saisie, declaration_conforme)
+                   VALUES (?, ?, '09:00', '12:00', '14:00', '17:00',
+                           'heures_modifiees', 0)""",
+                (sample_users['salarie_id'], self.DATE)
+            )
+            db.commit()
+
+            self._saisir(auth_client, heure_debut_matin='08:00')
+            row = self._saisie_en_base(db, sample_users['salarie_id'])
+            assert row['heure_debut_matin'] == '08:00'
+
+    def test_le_planning_n_est_pas_exige(self, auth_client, app, db, sample_users, sample_contrat):
+        """Un contrat suffit : le planning peut arriver plus tard."""
+        with app.app_context():
+            # Volontairement pas de fixture sample_planning.
+            self._saisir(auth_client)
+            assert self._saisie_en_base(db, sample_users['salarie_id']) is not None
+
+    def test_le_formulaire_annonce_le_refus(self, auth_client, app, db, sample_users):
+        """Le bouton est désactivé et la raison affichée, avant tout envoi."""
+        html = auth_client.get(f'/saisie_heures?date={self.DATE}').get_data(as_text=True)
+        assert 'Aucun contrat enregistré' in html
+
+    def test_le_message_dit_quoi_faire_selon_le_lecteur(self, auth_client, resp_client,
+                                                        app, db, sample_users):
+        """Un salarié ne peut pas créer son contrat ; un responsable, si."""
+        pour_soi = auth_client.get(f'/saisie_heures?date={self.DATE}').get_data(as_text=True)
+        assert 'Signalez-le à la direction' in pour_soi
+
+        pour_autrui = resp_client.get(
+            f"/saisie_heures?date={self.DATE}&user_id={sample_users['salarie_id']}"
+        ).get_data(as_text=True)
+        assert 'Infos Salariés' in pour_autrui
 
 
 def _creer_salarie_meme_secteur(db, sample_users, login='collegue_test'):
@@ -264,7 +385,7 @@ class TestSaisieDroits:
             ).fetchone()
             assert row is None    # rien écrit
 
-    def test_responsable_peut_saisir_pour_son_secteur(self, resp_client, app, db, sample_users):
+    def test_responsable_peut_saisir_pour_son_secteur(self, resp_client, app, db, sample_users, sample_contrat):
         """Le responsable peut saisir pour un salarié de son secteur."""
         date_test = '2025-01-10'
 

--- a/tests/test_saisie.py
+++ b/tests/test_saisie.py
@@ -236,6 +236,62 @@ class TestSaisieExigeUnContrat:
             row = self._saisie_en_base(db, sample_users['salarie_id'])
             assert row['heure_debut_matin'] == '08:00'
 
+    def test_une_ligne_d_absence_ne_sert_pas_de_laissez_passer(
+            self, auth_client, app, db, sample_users):
+        """Les circuits absences et récup écrivent librement hors contrat.
+
+        Leur ligne ne doit pas rouvrir la saisie pour autant : sans ce
+        garde-fou, il suffirait d'ouvrir le jour d'une absence pour y
+        substituer des heures travaillées sur une période sans contrat.
+        """
+        with app.app_context():
+            db.execute(
+                """INSERT INTO heures_reelles
+                   (user_id, date, type_saisie, declaration_conforme, commentaire)
+                   VALUES (?, ?, 'absence', 1, 'Arrêt maladie')""",
+                (sample_users['salarie_id'], self.DATE)
+            )
+            db.commit()
+
+            self._saisir(auth_client)
+            row = self._saisie_en_base(db, sample_users['salarie_id'])
+
+        assert row['type_saisie'] == 'absence'          # rien n'a été remplacé
+        assert row['heure_debut_matin'] is None
+
+    def test_une_recup_ne_sert_pas_davantage_de_laissez_passer(
+            self, auth_client, app, db, sample_users):
+        with app.app_context():
+            db.execute(
+                """INSERT INTO heures_reelles
+                   (user_id, date, type_saisie, declaration_conforme, commentaire)
+                   VALUES (?, ?, 'recup_journee', 0, 'Récupération')""",
+                (sample_users['salarie_id'], self.DATE)
+            )
+            db.commit()
+
+            self._saisir(auth_client)
+            row = self._saisie_en_base(db, sample_users['salarie_id'])
+
+        assert row['type_saisie'] == 'recup_journee'
+
+    def test_une_absence_sous_contrat_reste_modifiable(
+            self, auth_client, app, db, sample_users, sample_contrat):
+        """Le garde-fou ne vaut que hors contrat : sous contrat, rien ne change."""
+        with app.app_context():
+            db.execute(
+                """INSERT INTO heures_reelles
+                   (user_id, date, type_saisie, declaration_conforme, commentaire)
+                   VALUES (?, ?, 'absence', 1, 'Arrêt maladie')""",
+                (sample_users['salarie_id'], self.DATE)
+            )
+            db.commit()
+
+            self._saisir(auth_client)
+            row = self._saisie_en_base(db, sample_users['salarie_id'])
+
+        assert row['heure_debut_matin'] == '08:30'
+
     def test_le_planning_n_est_pas_exige(self, auth_client, app, db, sample_users, sample_contrat):
         """Un contrat suffit : le planning peut arriver plus tard."""
         with app.app_context():

--- a/tests/test_search_engine.py
+++ b/tests/test_search_engine.py
@@ -258,6 +258,23 @@ class TestMoteurRH:
         assert v['type'] == 'redirect' and '/contrats' in v['url'] and 'mois=7' in v['url']
         assert 'filtre=echeance' in v['url'] and 'type=CDD' in v['url']
 
+    def test_salaries_sans_contrat(self, app, db, sample_users):
+        """Les formulations du manque mènent à la liste des salariés bloqués."""
+        with app.app_context():
+            _seed(db)
+        for requete in ('salariés sans contrat', 'contrat manquant',
+                        'contrats manquants', 'qui est sans contrat'):
+            v = _analyse(app, db, requete)
+            assert v['type'] == 'redirect', requete
+            assert '/contrats/sans-contrat' in v['url'], requete
+
+    def test_sans_contrat_ne_capture_pas_les_autres_requetes(self, app, db, sample_users):
+        """« contrats avril » ou « contrat Fatou » gardent leur destination."""
+        with app.app_context():
+            _seed(db)
+        assert '/contrats/sans-contrat' not in _analyse(app, db, 'contrats avril')['url']
+        assert '/contrats/sans-contrat' not in _analyse(app, db, 'contrat Fatou')['url']
+
     def test_cdi_en_cours_filtre_type_cdi(self, app, db, sample_users):
         # « cdi » doit ajouter type=CDI (au même titre que « cdd »).
         with app.app_context():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -764,6 +764,50 @@ class TestJoursHorsContrat:
         assert par_date['2024-12-10']['hors_contrat'] is True    # dans le trou
         assert par_date['2024-12-16']['hors_contrat'] is False   # début du second
 
+    def test_le_trou_entre_deux_cdd_n_empeche_pas_la_validation(
+            self, app, db, sample_users, sample_planning):
+        """Cas de référence : CDD du 01 au 10/07, retour du 16 au 31/07.
+
+        Du 11 au 15 il n'y a rien à saisir, donc rien qui doive rougir ni
+        retenir la validation du mois. Le 14 juillet, férié tombé dans le
+        trou, ne compte pas davantage : il n'est pas chômé pour quelqu'un qui
+        n'est pas employé.
+        """
+        from datetime import timedelta
+
+        with app.app_context():
+            _ajouter_jour_ferie(db, '2026-07-14', 'Fête nationale')
+            _creer_contrat(db, sample_users['salarie_id'], '2026-07-01', '2026-07-10')
+            _creer_contrat(db, sample_users['salarie_id'], '2026-07-16', '2026-07-31')
+
+            # Saisir les jours ouvrés des deux périodes, et eux seuls.
+            jour = datetime(2026, 7, 1)
+            while jour <= datetime(2026, 7, 31):
+                dans_contrat = (jour.day <= 10 or jour.day >= 16)
+                if jour.weekday() < 5 and dans_contrat:
+                    db.execute(
+                        """INSERT OR IGNORE INTO heures_reelles
+                           (user_id, date, heure_debut_matin, heure_fin_matin,
+                            heure_debut_aprem, heure_fin_aprem, type_saisie,
+                            declaration_conforme)
+                           VALUES (?, ?, '08:30', '12:00', '13:30', '17:00',
+                                   'heures_modifiees', 0)""",
+                        (sample_users['salarie_id'], jour.strftime('%Y-%m-%d'))
+                    )
+                jour += timedelta(days=1)
+            db.commit()
+
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 7, 2026)
+
+        par_date = {j['date']: j for j in data['journees']}
+        for jour_du_trou in ('2026-07-13', '2026-07-14', '2026-07-15'):
+            assert par_date[jour_du_trou]['hors_contrat'] is True, jour_du_trou
+            assert par_date[jour_du_trou]['non_declare'] is False, jour_du_trou
+            assert par_date[jour_du_trou]['heures_theoriques'] == 0, jour_du_trou
+
+        assert data['nb_jours_non_declares'] == 0
+        assert data['peut_valider_mois'] is True
+
     def test_contrat_sans_terme_ne_retranche_rien(self, app, db, sample_users, sample_planning):
         """Un CDI (date_fin vide) couvre tout ce qui suit son début."""
         with app.app_context():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -61,6 +61,16 @@ def _planning_sans_mercredi(db, planning_id):
     db.commit()
 
 
+def _creer_contrat(db, user_id, date_debut, date_fin, type_contrat='CDD'):
+    """Helper : enregistre un contrat (date_fin à None pour un CDI)."""
+    db.execute(
+        '''INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin)
+           VALUES (?, ?, ?, ?)''',
+        (user_id, type_contrat, date_debut, date_fin)
+    )
+    db.commit()
+
+
 def _charger_vue_mensuelle(app, user_id, mois, annee, profil='salarie'):
     """Helper : charge les données de la fiche mensuelle pour un utilisateur."""
     with app.test_request_context(f'/vue_mensuelle?mois={mois}&annee={annee}'):
@@ -653,6 +663,161 @@ class TestJoursNonTravaillesHabituels:
         assert mercredis  # le mois en compte plusieurs
         assert all(j['est_repos_habituel'] for j in mercredis)
         assert all(not j['non_declare'] for j in mercredis)
+
+
+class TestJoursHorsContrat:
+    """Hors de son contrat, une journée n'est ni due ni à saisir.
+
+    Le planning théorique ne sait pas répondre : il n'a pas de fin de validité
+    (celui d'un CDD reste « valide » après son terme) et n'existe pas avant son
+    premier jour. C'est le contrat qui borne l'emploi.
+
+    Repères de décembre 2024 : le 02 est un lundi, le 13 un vendredi, le 16 le
+    lundi suivant.
+    """
+
+    def test_jours_avant_le_debut_du_cdd_ne_sont_pas_a_saisir(
+            self, app, db, sample_users, sample_planning):
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-09', '2024-12-20')
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        lundi_avant = next(j for j in data['journees'] if j['date'] == '2024-12-02')
+        assert lundi_avant['hors_contrat'] is True
+        assert lundi_avant['non_declare'] is False
+        assert lundi_avant['heures_theoriques'] == 0
+
+    def test_jours_apres_la_fin_du_cdd_ne_sont_pas_a_saisir(
+            self, app, db, sample_users, sample_planning):
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-02', '2024-12-13')
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        lundi_apres = next(j for j in data['journees'] if j['date'] == '2024-12-16')
+        assert lundi_apres['hors_contrat'] is True
+        assert lundi_apres['non_declare'] is False
+        assert lundi_apres['heures_theoriques'] == 0
+
+    def test_le_dernier_jour_du_contrat_reste_du(self, app, db, sample_users, sample_planning):
+        """`date_fin` est le dernier jour travaillé : il est encore à saisir."""
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-02', '2024-12-13')
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        dernier_jour = next(j for j in data['journees'] if j['date'] == '2024-12-13')
+        assert dernier_jour['hors_contrat'] is False
+        assert dernier_jour['non_declare'] is True
+        assert dernier_jour['heures_theoriques'] > 0
+
+    def test_le_cdd_peut_valider_son_mois_partiel(self, app, db, sample_users, sample_planning):
+        """Le blocage à la validation était la vraie conséquence du défaut."""
+        from datetime import timedelta
+
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-09', '2024-12-20')
+
+            # Saisir les seuls jours ouvrés couverts par le contrat.
+            jour = datetime(2024, 12, 9)
+            while jour <= datetime(2024, 12, 20):
+                if jour.weekday() < 5:
+                    db.execute(
+                        """INSERT OR IGNORE INTO heures_reelles
+                           (user_id, date, heure_debut_matin, heure_fin_matin,
+                            heure_debut_aprem, heure_fin_aprem, type_saisie,
+                            declaration_conforme)
+                           VALUES (?, ?, '08:30', '12:00', '13:30', '17:00',
+                                   'heures_modifiees', 0)""",
+                        (sample_users['salarie_id'], jour.strftime('%Y-%m-%d'))
+                    )
+                jour += timedelta(days=1)
+            db.commit()
+
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        assert data['nb_jours_non_declares'] == 0
+        assert data['peut_valider_mois'] is True
+
+    def test_le_total_theorique_se_limite_au_contrat(self, app, db, sample_users, sample_planning):
+        """Sinon la fiche réclame au CDD les heures d'un mois plein."""
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-09', '2024-12-20')
+            partiel = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+            db.execute("DELETE FROM contrats WHERE user_id = ?",
+                       (sample_users['salarie_id'],))
+            db.commit()
+            plein = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        # 10 jours ouvrés couverts, à 7h : le reste du mois ne compte plus.
+        assert partiel['total_heures_theoriques'] == 70
+        assert plein['total_heures_theoriques'] > partiel['total_heures_theoriques']
+
+    def test_trou_entre_deux_contrats(self, app, db, sample_users, sample_planning):
+        """Un CDD renouvelé après une interruption : le trou n'est pas à saisir."""
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-02', '2024-12-06')
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-16', '2024-12-31')
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        par_date = {j['date']: j for j in data['journees']}
+        assert par_date['2024-12-06']['hors_contrat'] is False   # fin du premier
+        assert par_date['2024-12-10']['hors_contrat'] is True    # dans le trou
+        assert par_date['2024-12-16']['hors_contrat'] is False   # début du second
+
+    def test_contrat_sans_terme_ne_retranche_rien(self, app, db, sample_users, sample_planning):
+        """Un CDI (date_fin vide) couvre tout ce qui suit son début."""
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-01-01', None)
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        assert not any(j['hors_contrat'] for j in data['journees'])
+        assert data['nb_jours_non_declares'] > 0
+
+    def test_sans_contrat_au_dossier_rien_ne_change(self, app, db, sample_users, sample_planning):
+        """Un contrat non saisi ne doit pas vider la fiche.
+
+        La table s'est remplie après coup : « aucun contrat » veut dire
+        « on ne sait pas », pas « jamais employé ».
+        """
+        with app.app_context():
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        lundi = next(j for j in data['journees'] if j['date'] == '2024-12-02')
+        assert lundi['hors_contrat'] is False
+        assert lundi['non_declare'] is True
+
+    def test_une_saisie_hors_contrat_reste_visible(self, app, db, sample_users, sample_planning):
+        """Des heures enregistrées se montrent toujours : elles révèlent un
+        contrat oublié au dossier plutôt que de disparaître."""
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-09', '2024-12-20')
+            db.execute(
+                """INSERT INTO heures_reelles
+                   (user_id, date, heure_debut_matin, heure_fin_matin,
+                    heure_debut_aprem, heure_fin_aprem, type_saisie, declaration_conforme)
+                   VALUES (?, '2024-12-02', '08:30', '12:00', '13:30', '17:00',
+                           'heures_modifiees', 0)""",
+                (sample_users['salarie_id'],)
+            )
+            db.commit()
+            data = _charger_vue_mensuelle(app, sample_users['salarie_id'], 12, 2024)
+
+        lundi = next(j for j in data['journees'] if j['date'] == '2024-12-02')
+        assert lundi['est_saisi'] is True
+        assert lundi['hors_contrat'] is False
+        assert lundi['heures_reelles'] > 0
+
+    def test_la_fiche_affiche_hors_contrat(self, auth_client, app, db, sample_users,
+                                           sample_planning):
+        with app.app_context():
+            _creer_contrat(db, sample_users['salarie_id'], '2024-12-09', '2024-12-20')
+
+        html = auth_client.get('/vue_mensuelle?mois=12&annee=2024').get_data(as_text=True)
+        assert 'Hors contrat' in html
+        # Décembre 2024 compte 22 jours ouvrés ; seuls les 10 du contrat
+        # restent à saisir, contre le mois entier auparavant.
+        assert '10 jour(s) non déclaré(s)' in html
+        assert '22 jour(s) non déclaré(s)' not in html
 
 
 class TestPlanningTheoriqueAffichage:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -807,6 +807,22 @@ class TestJoursHorsContrat:
         assert lundi['hors_contrat'] is False
         assert lundi['heures_reelles'] > 0
 
+    def test_la_fiche_explique_l_absence_de_contrat(self, auth_client, app, db,
+                                                    sample_users, sample_planning):
+        """Sans contrat, la fiche réclame des journées que la saisie refuse.
+
+        Le blocage doit être expliqué là où on le rencontre, sinon les jours
+        rouges deviennent une impasse muette.
+        """
+        html = auth_client.get('/vue_mensuelle?mois=12&annee=2024').get_data(as_text=True)
+        assert 'Aucun contrat enregistré' in html
+        assert 'jour(s) non déclaré(s)' in html
+
+    def test_la_fiche_d_un_salarie_sous_contrat_ne_dit_rien(
+            self, auth_client, app, db, sample_users, sample_planning, sample_contrat):
+        html = auth_client.get('/vue_mensuelle?mois=12&annee=2024').get_data(as_text=True)
+        assert 'Aucun contrat enregistré' not in html
+
     def test_la_fiche_affiche_hors_contrat(self, auth_client, app, db, sample_users,
                                            sample_planning):
         with app.app_context():

--- a/utils.py
+++ b/utils.py
@@ -143,21 +143,33 @@ def periodes_contrat(conn, user_id):
             for r in rows]
 
 
-def est_hors_contrat(periodes, date_str):
-    """Ce jour-là, le salarié n'était couvert par aucun de ses contrats.
+def est_couvert_par_contrat(periodes, date_str):
+    """Un contrat enregistré couvre-t-il ce jour ?
 
-    Toujours faux tant qu'aucun contrat n'est enregistré : sans référence, on
-    ne retranche rien plutôt que de vider la fiche d'un salarié dont le
-    contrat n'a pas été saisi.
+    C'est la question de la **saisie** : sans contrat au dossier, la réponse
+    est non, et les heures ne peuvent pas être saisies. Le contrat alimente la
+    paie — le laisser de côté n'est plus une option.
 
     `date_fin` est le dernier jour travaillé : elle est donc incluse. (Le
     prorata de congés, lui, l'exclut délibérément pour solder les compteurs le
     mois de la sortie — même colonne, deux bornes, deux usages.)
     """
+    return any(debut <= date_str and (fin is None or date_str <= fin)
+               for debut, fin in periodes)
+
+
+def est_hors_contrat(periodes, date_str):
+    """Ce jour est-il hors de l'emploi du salarié — donc ni dû ni à réclamer ?
+
+    C'est la question de l'**affichage**, et elle diffère de la précédente sur
+    un point : sans aucun contrat au dossier, on ne conclut rien. La fiche
+    continue alors de réclamer ses journées, le mois reste non validable, et
+    le manque saute aux yeux — au lieu qu'une fiche se vide toute seule parce
+    qu'un contrat n'a pas été saisi.
+    """
     if not periodes:
         return False
-    return not any(debut <= date_str and (fin is None or date_str <= fin)
-                   for debut, fin in periodes)
+    return not est_couvert_par_contrat(periodes, date_str)
 
 
 def validate_password_strength(password):

--- a/utils.py
+++ b/utils.py
@@ -121,6 +121,45 @@ def calcul_etp(type_contrat, temps_hebdo):
     return 1.0
 
 
+def periodes_contrat(conn, user_id):
+    """Périodes d'emploi d'un salarié, d'après ses contrats : [(début, fin|None)].
+
+    `fin` à None = contrat sans terme (CDI, ou CDD dont la fin n'est pas encore
+    saisie). Les dates sont des chaînes ISO, directement comparables.
+
+    Une liste vide signifie « aucun contrat au dossier », pas « jamais
+    employé » : la table s'est remplie après coup pour une partie de
+    l'effectif. L'appelant doit donc s'abstenir de conclure quoi que ce soit
+    d'une liste vide — voir `est_hors_contrat`.
+    """
+    rows = conn.execute(
+        """SELECT date_debut, date_fin FROM contrats
+           WHERE user_id = ? AND date_debut IS NOT NULL AND date_debut != ''
+           ORDER BY date_debut""",
+        (user_id,)
+    ).fetchall()
+    return [(str(r['date_debut'])[:10],
+             str(r['date_fin'])[:10] if r['date_fin'] else None)
+            for r in rows]
+
+
+def est_hors_contrat(periodes, date_str):
+    """Ce jour-là, le salarié n'était couvert par aucun de ses contrats.
+
+    Toujours faux tant qu'aucun contrat n'est enregistré : sans référence, on
+    ne retranche rien plutôt que de vider la fiche d'un salarié dont le
+    contrat n'a pas été saisi.
+
+    `date_fin` est le dernier jour travaillé : elle est donc incluse. (Le
+    prorata de congés, lui, l'exclut délibérément pour solder les compteurs le
+    mois de la sortie — même colonne, deux bornes, deux usages.)
+    """
+    if not periodes:
+        return False
+    return not any(debut <= date_str and (fin is None or date_str <= fin)
+                   for debut, fin in periodes)
+
+
 def validate_password_strength(password):
     """Valide la complexité d'un mot de passe.
 


### PR DESCRIPTION
Six commits, du défaut constaté à sa conséquence outillée : ne plus *réclamer* les jours hors contrat, ne plus *autoriser* la saisie sans contrat, figer le cas de référence, lister les salariés bloqués, faire remonter l'anomalie d'elle-même, puis étendre les bornes au document signé.

## 1. Ne plus réclamer la saisie des jours hors contrat

Tout jour ouvré passé sans saisie était marqué « non déclaré ». Pour un CDD entré ou sorti en cours de mois, cela réclamait des journées où le salarié n'était pas employé — et **bloquait la validation de son mois** (`nb_jours_non_declares > 0` interdit la validation). Les heures théoriques du mois étaient fausses dans la foulée : un CDD de dix jours se voyait attribuer le mois complet.

Le planning théorique ne pouvait pas répondre : `get_planning_valide_a_date` ne connaît qu'une `date_debut_validite`, jamais de fin. **Avant** le premier jour, aucun planning ne s'applique et le code retombait sur le cas « configuration manquante », qui réclame la déclaration exprès. **Après** le terme, le dernier planning reste valide indéfiniment — les journées étaient donc dues *et* comptées.

C'est le contrat qui borne l'emploi, comme le font déjà le prorata de congés (`variables_paie`) et le suivi des documents obligatoires (`dashboard_comptable`). Un jour hors de toute période vaut zéro heure théorique et s'affiche **Hors contrat**, sur la fiche mensuelle comme au calendrier.

## 2. Exiger un contrat pour saisir des heures

Le contrat alimente la paie : il ne peut plus être remis à plus tard. Sans contrat couvrant la date, la saisie est refusée — bouton désactivé et raison affichée avant tout envoi, refus côté POST. **Le refus vaut aussi quand aucun contrat ne figure au dossier**, c'est-à-dire précisément le cas qui poussait à l'oubli.

Le message dit quoi faire selon qui le lit : un salarié est invité à le signaler à la direction, un responsable à l'ajouter depuis *Infos Salariés → Contrats*.

Deux questions distinctes cohabitent, et `utils` les sépare plutôt que de les confondre :

| | question | sans contrat au dossier |
|---|---|---|
| `est_couvert_par_contrat` | la saisie est-elle permise ? | **non** — saisie fermée |
| `est_hors_contrat` | ce jour est-il dû ? | **on ne conclut rien** — la fiche continue de réclamer |

Cette asymétrie est délibérée. Un **trou entre deux contrats** est une information : le salarié n'était pas employé, les jours passent au gris et le mois se valide. **Aucun contrat du tout** n'est pas une information mais une anomalie probable : impossible de distinguer « pas employé » de « contrat non saisi ». Les jours restent donc rouges et bloquants, et un bandeau sur la fiche explique que la saisie est fermée faute de contrat — plutôt qu'une fiche vide et validable qui n'alerterait personne.

## 3. Le cas de référence

CDD du 01 au 10/07, retour du 16 au 31/07 : le trou du 11 au 15 ne rougit pas, ne compte aucune heure théorique et ne retient pas la validation du mois. Le 14 juillet, férié tombé dans le trou, ne compte pas davantage — un jour chômé ne l'est pas pour qui n'est pas employé. Le comportement était déjà celui-là ; le test le nomme et le fige, avec les dates du cas réel.

## 4. La liste des salariés bloqués

La règle pose une question : qui ne peut plus saisir ? Nouvelle page `/contrats/sans-contrat`, qui distingue les situations parce qu'elles n'appellent pas le même geste — **aucun contrat au dossier** (jamais saisi), **contrat à venir** (embauche signée pour plus tard, avec sa date), **contrat échu** (fin sans renouvellement). Cadrage de l'effectif qui saisit ses heures : actifs, hors direction et prestataires.

Côté barre intelligente, la détection passe **avant** l'aiguillage par mot-clé. « Salariés sans contrat » commence par « salarié » : dispatché sur le mot-clé, il partait chercher quelqu'un portant ce nom. Un test vérifie que « contrats avril » et « contrat Fatou » gardent leur destination.

## 5. L'anomalie s'annonce, la page ne s'affiche pas au menu

Cette page ne figure ni au menu ni dans la carte : c'est une **page de réponse**, comme la liste des contrats du mois dont elle sort — on l'appelle, on ne la parcourt pas. L'y inscrire pour que la palette la propose faisait d'ailleurs tomber le test qui aligne carte et menu.

Restait à ne pas la rendre invisible. Un bandeau de `flux_infos.py` compte les salariés actifs **sans aucun contrat** en tête d'*Infos Salariés* et de la page *Contrats*, et mène à la liste ; il disparaît quand les dossiers sont complets. Deux bornes : le manque total seulement (la fin d'un CDD est normale, pas un oubli), direction et comptabilité seulement (un responsable ne peut pas enregistrer un contrat).

La règle générale est écrite dans `docs/interface-sans-menu.md` : une page de réponse ne s'ajoute pas au menu, elle se fait annoncer par un bandeau.

## 6. Le PDF signé, et deux angles morts (revue Codex)

**Le PDF contredisait la fiche.** `export_pdf_mensuel` refait le calcul du mois de son côté et traite toute journée sans saisie comme « ✓ Conforme » au planning. Tant que la fiche comptait elle aussi le mois entier, les deux disaient la même chose ; borner la fiche sans borner l'export les a désaccordés. Mesuré : pour un CDD du 09 au 20/12, le PDF **signé** annonçait 154 h là où la fiche validée en comptait 70 — une attestation de journées travaillées hors emploi. L'export applique désormais les mêmes bornes, et `test_le_pdf_dit_la_meme_chose_que_la_fiche` compare directement les deux totaux : la duplication de calcul demeure, mais elle ne peut plus diverger en silence.

**Une ligne générée servait de laissez-passer.** L'exception qui laisse modifier une saisie existante valait pour toute ligne de `heures_reelles`, y compris celles des circuits absences et récup — qui, eux, restent libres d'écrire hors contrat. Ouvrir le jour d'une absence suffisait donc à y substituer des heures travaillées. L'exception ne couvre plus que les saisies manuelles (`type_saisie` hors `absence` / `recup_*`).

**Un CDD à venir était annoncé « échu ».** Le classement se fiait à la présence d'une date de fin — qu'un contrat futur possède aussi. Le discriminant est maintenant l'existence d'un début futur, et l'embauche à venir prime sur le contrat échu.

## Ce que la règle ne touche pas

- **Les heures déjà enregistrées à la main.** Elles restent visibles et modifiables, y compris hors contrat : la règle refuse une saisie nouvelle, jamais la correction de ce qui existe. Une saisie existante l'emporte aussi sur l'affichage « Hors contrat » — elle révèle un contrat oublié plutôt que de disparaître.
- **Le planning théorique**, qui n'est pas exigé pour saisir : s'il arrive plus tard, les heures supplémentaires se recalculent.
- **Les circuits récup et absences**, qui écrivent aussi dans `heures_reelles` (`recup.py`, `absences.py`). Choix explicite de les laisser libres : **une absence se saisit parfois en retard, y compris après la fin du contrat** — une absence injustifiée régularisée en paie faute d'arrêt maladie fourni, par exemple. Exiger un contrat couvrant la date, ou filtrer la liste déroulante des absences aux seuls salariés sous contrat, bloquerait cette régularisation légitime. La liste reste bornée aux salariés **actifs**, ce qui est le bon cadrage. À revoir si la pratique montre le contraire.

## Portée réelle

Les onze tests de saisie existants échouaient après ce changement, faute de contrat sur le salarié de test : c'est la mesure exacte de ce que la règle bloque. Un fixture `sample_contrat` a été ajouté et posé sur chacun, plutôt que dans `sample_users` — pour ne pas fausser les tests d'effectif, de masse salariale et de documents obligatoires.

**Le jour du déploiement, tout salarié sans contrat enregistré ne pourra plus saisir d'heures.** Un état des lieux avant fusion est prudent — même cadrage que la page :

```sql
SELECT u.id, u.nom, u.prenom FROM users u
WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
  AND NOT EXISTS (SELECT 1 FROM contrats c WHERE c.user_id = u.id);
```

## Limite connue

Les bandeaux du flux d'information ne s'affichent que dans l'interface sans menu. Un utilisateur resté sur le menu classique ne verra pas l'alerte — il garde le bouton de la page Contrats et la barre intelligente.

## Vérification

45 tests ajoutés — 12 sur les bornes de la fiche (`TestJoursHorsContrat`), 11 sur le refus de saisie (`TestSaisieExigeUnContrat`), 11 sur la page et son accès (`TestSalariesSansContrat`, moteur de recherche), 8 sur les bandeaux et l'absence de la page dans la carte, 3 sur la cohérence du PDF signé (`TestPdfEtContrat`).

Les trois correctifs de revue ont été vérifiés en échec avant correction.

Suite complète verte : **1521 tests**.