### PR TITLE
Le fil nomme les décisions, et montre le circuit derrière

### DIFF
--- a/blueprints/absences.py
+++ b/blueprints/absences.py
@@ -27,6 +27,22 @@ MOTIFS_ABSENCE = [
     'Autre',
 ]
 
+# Motifs pour lesquels une pièce est réellement attendue au dossier, et dont
+# l'absence se signale avant la paie.
+#
+# Les congés validés ne sont PAS de ceux-là : `_creer_absence_depuis_conge`
+# leur crée une ligne d'absence sans justificatif, par construction — il n'y a
+# rien à fournir pour un congé payé accordé. Les compter ferait crier au loup
+# chaque mois, et un rappel qui se déclenche toujours cesse d'être lu.
+MOTIFS_AVEC_JUSTIFICATIF = (
+    'Arrêt maladie',
+    'Accident du travail',
+    'Jour enfant malade',
+    'Congé parental',
+    'Mi-temps thérapeutique',
+    'Evènement familial',
+)
+
 # Correspondance motif d'absence -> type de journee du calendrier forfait jour
 # (direction). Les motifs non listes retombent sur 'autre' : toute absence
 # retire de toute facon le jour du decompte des jours travailles.

--- a/blueprints/accueil.py
+++ b/blueprints/accueil.py
@@ -23,7 +23,7 @@ from dashboard_actions import construire_actions
 from database import get_db
 from flux_accueil import construire_horizon, separer_actions
 from utils import (aujourd_hui, calculer_solde_recup, get_user_info,
-                   login_required, NOMS_MOIS)
+                   login_required, save_setting, NOMS_MOIS)
 
 logger = logging.getLogger(__name__)
 
@@ -268,6 +268,41 @@ def api_flux_fragment():
     finally:
         conn.close()
     return render_template('_flux_actions.html', actions=separer_actions(actions))
+
+
+@accueil_bp.route('/api/accueil/preparation-paie', methods=['POST'])
+@login_required
+def api_preparation_paie():
+    """Marque comme signalés les cas particuliers de paie d'un mois.
+
+    Déclaratif : le geste attendu — prévenir la comptabilité — se fait hors de
+    l'application, qui ne peut donc que prendre acte. La marque est posée au
+    nom de la personne qui clique, chacune ne répondant que de son périmètre.
+
+    Réservé aux profils qui reçoivent le rappel. Un mois autre que le mois
+    courant ou le précédent est refusé : rien ne justifie de marquer d'avance
+    ou de rouvrir un exercice ancien.
+    """
+    from dashboard_actions import cle_preparation_paie
+
+    profil = session.get('profil')
+    user_id = session.get('user_id')
+    if profil not in ('directeur', 'responsable'):
+        return jsonify({'error': 'Accès non autorisé'}), 403
+
+    donnees = request.get_json(silent=True) or {}
+    mois, annee = donnees.get('mois'), donnees.get('annee')
+    if not isinstance(mois, int) or not isinstance(annee, int):
+        return jsonify({'error': 'Mois ou année manquant'}), 400
+
+    today = aujourd_hui()
+    precedent = (today.month - 1 or 12,
+                 today.year if today.month > 1 else today.year - 1)
+    if (mois, annee) not in ((today.month, today.year), precedent):
+        return jsonify({'error': 'Mois hors de la période courante'}), 400
+
+    save_setting(cle_preparation_paie(mois, annee, user_id), '1')
+    return jsonify({'ok': True})
 
 
 @accueil_bp.route('/api/interface/basculer', methods=['POST'])

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -30,6 +30,7 @@ from flask import url_for
 from blueprints.delegations import (MISSION_SUIVI_COMMANDES_FOURNITURES,
                                     MISSION_SUIVI_VALIDATIONS_RELANCES,
                                     user_has_delegation)
+import flux_circuits
 from utils import (NOMS_MOIS, aujourd_hui, calculer_solde_recup, get_setting,
                    save_setting)
 
@@ -146,6 +147,24 @@ def _solde_du_mois(conn, user_id, mois, annee, planning_cache, periode_cache):
     return round(total, 2)
 
 
+def _est_cdd(conn, user_id, annee, mois):
+    """Le salarié était-il en CDD sur ce mois ?
+
+    Change ce que le circuit annonce : les heures d'un CDD se paient et se
+    régularisent sur un nombre de bulletins compté, celles d'un CDI se
+    récupèrent. La conséquence d'un retard n'est pas la même.
+    """
+    debut = f'{annee:04d}-{mois:02d}-01'
+    fin = (date(annee + (mois == 12), (mois % 12) + 1, 1) - timedelta(days=1)).isoformat()
+    return conn.execute(
+        '''SELECT 1 FROM contrats
+           WHERE user_id = ? AND UPPER(type_contrat) LIKE 'CDD%'
+             AND date_debut <= ? AND (date_fin IS NULL OR date_fin >= ?)
+           LIMIT 1''',
+        (user_id, fin, debut)
+    ).fetchone() is not None
+
+
 def _fiches_a_valider(conn, profil, user_id, secteur_id, today):
     """Fiches d'heures du mois précédent encore non validées.
 
@@ -222,6 +241,9 @@ def _fiches_a_valider(conn, profil, user_id, secteur_id, today):
                             mois=mois, annee=annee),
             'lien_texte': 'Ouvrir la fiche',
             'urgence': urgence,
+            'circuit': flux_circuits.fiche_heures(
+                profil, today, est_cdd=_est_cdd(conn, salarie['id'], annee, mois),
+                solde=arrondi),
         })
 
     reste = len(classees) - len(actions)
@@ -271,6 +293,8 @@ def _factures_a_valider(conn, profil, user_id, secteur_id, today):
             'lien': url_for('factures_bp.detail_facture', facture_id=r['id']),
             'lien_texte': 'Détail',
             'urgence': _urgence_echeance(ech, today),
+            'circuit': flux_circuits.facture('en_attente', r['date_echeance'],
+                                             profil, today),
         })
 
     reste = len(rows) - len(actions)
@@ -417,6 +441,8 @@ def _fournitures_en_attente(conn, profil, user_id, today):
             'lien': url_for('commandes_salaries_bp.commandes_salaries'),
             'lien_texte': 'Traiter',
             'urgence': tons.get(r['urgence'], 'normal'),
+            'circuit': flux_circuits.fourniture(r['date_demande'], profil, today,
+                                                urgence=r['urgence']),
         })
 
     reste = len(rows) - len(actions)
@@ -656,6 +682,8 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
             'lien': url_for('recup_bp.validation_demandes_recup'),
             'lien_texte': 'Valider',
             'urgence': _urgence_depot(depot, today),
+            'circuit': flux_circuits.demande_recup(
+                r['statut'], r['date_demande'], profil, today),
         })
 
     # Congés : dates + solde du compteur concerné APRÈS validation (CP ou
@@ -697,6 +725,9 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
             'detail': ' — '.join(parts),
             'lien': url_for('recup_bp.validation_demandes_recup'),
             'lien_texte': 'Valider',
+            'circuit': flux_circuits.demande_conge(
+                r['statut'], r['date_demande'], profil, today,
+                nb_jours=r['nb_jours']),
             'urgence': _urgence_depot(depot, today),
         })
 
@@ -756,6 +787,8 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
             'lien': lien_sub,
             'lien_texte': 'Voir',
             'urgence': _urgence_echeance(ech, today),
+            'circuit': flux_circuits.subvention(r['date_echeance'], profil, today,
+                                                etape_nom=r['etape']),
         })
 
     # 3. Ce que chaque profil doit trancher, nommé plutôt que compté. Chaque

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -1,24 +1,50 @@
 """
-Construction du panneau « Actions à faire » des tableaux de bord
-(direction / responsable / comptable).
+Construction du fil d'actions — l'accueil sans menu, et les tableaux de bord
+qui le précèdent (direction / responsable / comptable).
 
-Agrège, par profil, les éléments réellement actionnables :
-- les demandes de récupération / congé en attente de validation ;
-- les étapes de subventions à échéance et non terminées.
+**Le fil ne porte aucune donnée informative fixe.** Chaque carte attend une
+décision, signale un risque réel ou annonce une échéance — sinon elle
+disparaît. C'est ce qui le sépare d'un tableau de bord d'indicateurs : un
+compteur qui affiche la même chose tous les jours n'apprend rien et use
+l'attention de son lecteur.
+
+Deux conséquences pratiques, appliquées partout ici :
+
+- **on nomme, on n'agrège pas.** « 30 fiches à valider » n'est pas
+  actionnable — c'est décourageant, et rien n'indique par où commencer. Le fil
+  montre donc une ou deux fiches, désignées par leur salarié et classées par
+  ce qui les rend urgentes, puis une ligne discrète pour le reste. Traiter la
+  première fait remonter la suivante ;
+- **une carte qui n'appelle rien s'efface.** Les compteurs à zéro, les
+  situations normales et les rappels déjà traités ne sont pas construits.
 
 Chaque item porte un libellé, un détail (date), un lien et un niveau d'urgence
 (retard / urgent / normal) pour le code couleur. Le tri place les plus urgents
 en tête.
 """
-from datetime import date
+import logging
+from datetime import date, timedelta
 
 from flask import url_for
 
-from blueprints.delegations import (MISSION_SUIVI_VALIDATIONS_RELANCES,
+from blueprints.delegations import (MISSION_SUIVI_COMMANDES_FOURNITURES,
+                                    MISSION_SUIVI_VALIDATIONS_RELANCES,
                                     user_has_delegation)
-from utils import NOMS_MOIS, aujourd_hui, calculer_solde_recup
+from utils import (NOMS_MOIS, aujourd_hui, calculer_solde_recup, get_setting,
+                   save_setting)
+
+logger = logging.getLogger(__name__)
 
 _ORDRE_URGENCE = {'retard': 0, 'urgent': 1, 'normal': 2}
+
+# Nombre de cartes nominatives par famille avant de basculer sur « et N autres ».
+# Deux : de quoi commencer sans que la famille noie le reste du fil.
+MAX_CARTES_NOMMEES = 2
+
+# Jour du mois où la préparation de paie se rappelle aux responsables et à la
+# direction. Assez tôt pour laisser le temps de régulariser, assez tard pour
+# que le mois soit presque écrit.
+JOUR_RAPPEL_PAIE = 20
 
 
 def _to_date(valeur):
@@ -61,6 +87,26 @@ def _urgence_echeance(d, today):
     return 'normal'
 
 
+def _reste(nb, libelle, lien, lien_texte, cle, icone, categorie):
+    """Carte discrète annonçant la file d'attente derrière les cartes nommées.
+
+    Elle ne demande rien : elle dit seulement que le sujet ne s'arrête pas aux
+    cartes visibles. Son urgence est toujours « normal » — c'est le rappel qui
+    compte, pas l'alarme, et les cartes nommées portent déjà celle-ci.
+    """
+    return {
+        'id': f'reste-{cle}',
+        'categorie': categorie,
+        'type': 'lien',
+        'icone': icone,
+        'titre': f"et {nb} autre{'s' if nb > 1 else ''} {libelle}",
+        'detail': 'traitées ensuite, une fois les premières faites',
+        'lien': lien,
+        'lien_texte': lien_texte,
+        'urgence': 'normal',
+    }
+
+
 def _urgence_depot(d, today):
     if not d:
         return 'normal'
@@ -70,6 +116,458 @@ def _urgence_depot(d, today):
     if jours > 7:
         return 'urgent'
     return 'normal'
+
+
+def _solde_du_mois(conn, user_id, mois, annee, planning_cache, periode_cache):
+    """Écart heures réelles − théoriques d'un salarié sur un mois.
+
+    Sommer les journées saisies suffit : une journée non saisie est réputée
+    conforme au planning et pèse zéro dans l'écart, exactement comme la fiche
+    mensuelle la traite. Une lecture qui échoue vaut zéro plutôt que de faire
+    tomber le fil entier.
+    """
+    from blueprints.worktime_metrics import compute_day_metrics
+
+    dernier = (date(annee + (mois == 12), (mois % 12) + 1, 1) - timedelta(days=1))
+    rows = conn.execute(
+        '''SELECT * FROM heures_reelles
+           WHERE user_id = ? AND date >= ? AND date <= ?''',
+        (user_id, f'{annee:04d}-{mois:02d}-01', dernier.isoformat())
+    ).fetchall()
+
+    total = 0.0
+    for row in rows:
+        try:
+            total += compute_day_metrics(conn, user_id, row,
+                                         planning_cache, periode_cache)['delta']
+        except Exception:
+            logger.warning("Solde du mois : journée ignorée (user %s, %s)",
+                           user_id, row['date'], exc_info=True)
+    return round(total, 2)
+
+
+def _fiches_a_valider(conn, profil, user_id, secteur_id, today):
+    """Fiches d'heures du mois précédent encore non validées.
+
+    Les deux plus lourdes sont nommées, le reste tient en une ligne. Le
+    classement suit le **solde d'heures du mois**, décroissant : une fiche à
+    +20 h engage un compteur de récupération et une paie, une fiche à −5 h
+    attend surtout une explication. À enjeu égal on ne saurait pas par où
+    commencer — c'est ce tri qui rend la carte actionnable.
+
+    Un responsable ne voit que son équipe, comme la vue d'ensemble le fait
+    pour lui ; la direction et la comptabilité voient tout l'effectif.
+    """
+    if profil == 'responsable':
+        scope = 'AND (u.secteur_id = ? OR u.responsable_id = ?)'
+        params = (secteur_id, user_id)
+    elif profil in ('directeur', 'comptable'):
+        scope, params = '', ()
+    else:
+        return []
+
+    mois = today.month - 1 or 12
+    annee = today.year if today.month > 1 else today.year - 1
+
+    salaries = conn.execute(
+        f'''SELECT u.id, u.nom, u.prenom FROM users u
+            WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+              {scope}
+              AND NOT EXISTS (
+                  SELECT 1 FROM validations v
+                  WHERE v.user_id = u.id AND v.mois = ? AND v.annee = ? AND v.bloque = 1
+              )
+            ORDER BY u.nom, u.prenom''',
+        params + (mois, annee)
+    ).fetchall()
+    if not salaries:
+        return []
+
+    planning_cache, periode_cache = {}, {}
+    classees = sorted(
+        ((s, _solde_du_mois(conn, s['id'], mois, annee, planning_cache, periode_cache))
+         for s in salaries),
+        key=lambda couple: -couple[1]
+    )
+
+    # La paie attend ces fiches : passé le 10, le retard est réel.
+    urgence = 'retard' if today.day > 10 else 'urgent'
+    nom_mois = NOMS_MOIS[mois].lower()
+    actions = []
+    for salarie, solde in classees[:MAX_CARTES_NOMMEES]:
+        if solde > 0:
+            detail = f"+{_fr_num(round(solde, 1))} h sur le mois — à trancher avant la paie"
+        elif solde < 0:
+            detail = f"{_fr_num(round(solde, 1))} h sur le mois — écart à expliquer"
+        else:
+            detail = "aucun écart — validation de forme"
+        actions.append({
+            'id': f"fiche-{salarie['id']}-{annee}-{mois:02d}",
+            'categorie': 'validation',
+            'type': 'lien',
+            'icone': '✅',
+            'titre': f"Fiche de {salarie['prenom']} {salarie['nom']} — {nom_mois}",
+            'detail': detail,
+            'lien': url_for('validation_bp.vue_mensuelle', user_id=salarie['id'],
+                            mois=mois, annee=annee),
+            'lien_texte': 'Ouvrir la fiche',
+            'urgence': urgence,
+        })
+
+    reste = len(classees) - len(actions)
+    if reste > 0:
+        actions.append(_reste(
+            reste, f"fiche{'s' if reste > 1 else ''} de {nom_mois}",
+            url_for('validation_bp.vue_ensemble_validation'), 'Vue ensemble',
+            f'fiches-{annee}-{mois:02d}', '✅', 'validation'))
+    return actions
+
+
+def _factures_a_valider(conn, profil, user_id, secteur_id, today):
+    """Factures en attente d'approbation dans le périmètre d'un responsable.
+
+    La direction reçoit déjà ses factures une par une (`_actions_etendues`) :
+    seul le responsable n'avait rien dans son fil, alors que les factures de
+    son secteur l'attendent. Même prédicat que la page d'approbation, pour ne
+    pas annoncer plus que la destination n'affiche.
+    """
+    if profil != 'responsable' or not secteur_id:
+        return []
+
+    rows = conn.execute(
+        '''SELECT f.id, f.numero_facture, f.montant_ttc, f.date_echeance,
+                  fr.nom AS fournisseur_nom
+           FROM factures f
+           LEFT JOIN fournisseurs fr ON f.fournisseur_id = fr.id
+           WHERE f.approbation = 'en_attente' AND f.secteur_id = ?
+           ORDER BY f.date_echeance ASC, f.date_facture ASC''',
+        (secteur_id,)
+    ).fetchall()
+    if not rows:
+        return []
+
+    actions = []
+    for r in rows[:MAX_CARTES_NOMMEES]:
+        ech = _to_date(r['date_echeance'])
+        montant = f"{(r['montant_ttc'] or 0):,.2f}".replace(',', ' ').replace('.', ',')
+        actions.append({
+            'id': f"fact-{r['id']}",
+            'categorie': 'facture',
+            'type': 'facture',
+            'facture_id': r['id'],
+            'icone': '🧾',
+            'titre': f"Facture {r['fournisseur_nom'] or r['numero_facture'] or ''} — {montant} €",
+            'detail': (f"échéance le {_fr(ech)}" if ech else "en attente d'approbation"),
+            'lien': url_for('factures_bp.detail_facture', facture_id=r['id']),
+            'lien_texte': 'Détail',
+            'urgence': _urgence_echeance(ech, today),
+        })
+
+    reste = len(rows) - len(actions)
+    if reste > 0:
+        actions.append(_reste(
+            reste, f"facture{'s' if reste > 1 else ''} du secteur",
+            url_for('factures_bp.approbation_factures'), 'Approbation',
+            'factures-secteur', '🧾', 'facture'))
+    return actions
+
+
+def cle_preparation_paie(mois, annee, user_id):
+    """Clé de mémorisation du rappel de préparation de paie, par personne.
+
+    Le signalement se fait **hors de l'application** — un mail ou un mot à la
+    comptabilité — et chacun ne répond que de son périmètre. Un rappel éteint
+    collectivement laisserait le premier à cliquer effacer celui des autres,
+    qui n'ont rien signalé.
+    """
+    return f'paie_signalee_{annee:04d}_{mois:02d}_u{user_id}'
+
+
+def _preparation_paie(conn, profil, user_id, today):
+    """Rappel daté : les cas particuliers que la paie ne devinera pas.
+
+    Une fiche absente n'est pas toujours un oubli — un salarié mis à pied,
+    licencié en cours de mois ou un CDD jamais saisi n'en produira jamais. La
+    comptabilité doit les traiter à la main, et le seul moment utile pour y
+    penser est avant la clôture, pas après.
+
+    Elle s'adresse aux **responsables et à la direction**, qui signalent ; la
+    comptabilité, elle, reçoit le signalement et a ses propres cartes.
+
+    Deux des quatre cas se calculent (CDD sans fiche, absence sans
+    justificatif) et sont nommés. Les deux autres — mise à pied, licenciement
+    — ne sont modélisés nulle part : `users` ne porte qu'un drapeau `actif`,
+    sans motif de sortie. Aucun calcul ne peut les trouver, et c'est
+    précisément pour cela qu'un humain doit y penser. La carte les rappelle
+    donc en toutes lettres.
+
+    Le geste attendu se fait hors de l'application : prévenir la comptabilité,
+    par mail ou de vive voix. L'application ne peut donc rien constater — d'où
+    le bouton « C'est fait », déclaratif, qui n'éteint le rappel que pour
+    celui qui l'a signalé.
+    """
+    if profil not in ('directeur', 'responsable'):
+        return []
+    if today.day < JOUR_RAPPEL_PAIE:
+        return []
+
+    mois, annee = today.month, today.year
+    if get_setting(cle_preparation_paie(mois, annee, user_id)):
+        return []
+
+    debut = f'{annee:04d}-{mois:02d}-01'
+    fin = (date(annee + (mois == 12), (mois % 12) + 1, 1) - timedelta(days=1)).isoformat()
+
+    # CDD sous contrat sur le mois, sans la moindre saisie : la paie n'a rien.
+    cdd_sans_fiche = conn.execute(
+        '''SELECT COUNT(DISTINCT u.id) AS nb FROM users u
+           JOIN contrats c ON c.user_id = u.id
+           WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+             AND UPPER(c.type_contrat) LIKE 'CDD%'
+             AND c.date_debut <= ? AND (c.date_fin IS NULL OR c.date_fin >= ?)
+             AND NOT EXISTS (
+                 SELECT 1 FROM heures_reelles h
+                 WHERE h.user_id = u.id AND h.date >= ? AND h.date <= ?
+             )''',
+        (fin, debut, debut, fin)
+    ).fetchone()['nb']
+
+    absences_sans_justificatif = conn.execute(
+        '''SELECT COUNT(*) AS nb FROM absences
+           WHERE date_debut <= ? AND date_fin >= ?
+             AND (justificatif_path IS NULL OR justificatif_path = '')''',
+        (fin, debut)
+    ).fetchone()['nb']
+
+    constats = []
+    if cdd_sans_fiche:
+        constats.append(f"{cdd_sans_fiche} CDD sans aucune fiche d'heures")
+    if absences_sans_justificatif:
+        constats.append(f"{absences_sans_justificatif} absence(s) sans justificatif")
+    constats.append('signaler à la comptabilité les mises à pied et licenciements')
+
+    return [{
+        'id': f'paie-{annee}-{mois:02d}',
+        'categorie': 'conges',
+        'type': 'paie',
+        'paie_mois': mois,
+        'paie_annee': annee,
+        'icone': '📆',
+        'titre': f"Signaler à la comptabilité — paie de {NOMS_MOIS[mois].lower()}",
+        'detail': ' · '.join(constats),
+        'lien': url_for('validation_bp.vue_ensemble_validation'),
+        'lien_texte': 'Vue ensemble',
+        'urgence': 'urgent',
+    }]
+
+
+def _fournitures_en_attente(conn, profil, user_id, today):
+    """Demandes de fournitures que personne n'a encore traitées.
+
+    Servies à qui peut les traiter : direction, comptabilité, ou le salarié
+    porteur de la délégation « suivi des commandes ». Classées par urgence
+    déclarée, celle du demandeur — c'est la seule information dont on dispose
+    sur ce qui presse.
+    """
+    peut_suivre = profil in ('directeur', 'comptable') or user_has_delegation(
+        user_id, MISSION_SUIVI_COMMANDES_FOURNITURES)
+    if not peut_suivre:
+        return []
+
+    rows = conn.execute(
+        '''SELECT c.id, c.description, c.quantite, c.urgence, c.date_demande,
+                  u.nom, u.prenom
+           FROM commandes_salaries c
+           JOIN users u ON u.id = c.user_id
+           WHERE c.groupe = 'en_cours'
+           ORDER BY CASE c.urgence WHEN 'urgent' THEN 0 WHEN 'normal' THEN 1
+                                   ELSE 2 END,
+                    c.date_demande ASC'''
+    ).fetchall()
+    if not rows:
+        return []
+
+    # L'urgence déclarée décide de la couleur : « peut attendre » ne doit pas
+    # se présenter comme une décision du jour.
+    tons = {'urgent': 'urgent', 'normal': 'normal', 'peut_attendre': 'normal'}
+    libelles = {'urgent': 'urgent', 'normal': 'normal', 'peut_attendre': 'peut attendre'}
+
+    actions = []
+    for r in rows[:MAX_CARTES_NOMMEES]:
+        depot = _to_date(r['date_demande'])
+        quantite = f"{r['quantite']} × " if (r['quantite'] or 1) > 1 else ''
+        actions.append({
+            'id': f"fourn-{r['id']}",
+            'categorie': 'facture',
+            'type': 'lien',
+            'icone': '📦',
+            'titre': f"{quantite}{r['description']} — {r['prenom']} {r['nom']}",
+            'detail': (f"{libelles.get(r['urgence'], r['urgence'])}"
+                       + (f", demandé le {_fr(depot)}" if depot else '')),
+            'lien': url_for('commandes_salaries_bp.commandes_salaries'),
+            'lien_texte': 'Traiter',
+            'urgence': tons.get(r['urgence'], 'normal'),
+        })
+
+    reste = len(rows) - len(actions)
+    if reste > 0:
+        actions.append(_reste(
+            reste, f"demande{'s' if reste > 1 else ''} de fournitures",
+            url_for('commandes_salaries_bp.commandes_salaries'), 'Fournitures',
+            'fournitures', '📦', 'facture'))
+    return actions
+
+
+def _budgets_depasses(conn, profil, user_id, secteur_id, today):
+    """Secteurs dont les dépenses réelles ont passé le budget prévu.
+
+    Un dépassement est un fait accompli, pas une échéance : il ne se rattrape
+    pas, il se décide (réaffecter, arbitrer, alerter). D'où le ton « retard ».
+    La comparaison est celle de la page budget — poste par poste, un prévu à
+    zéro n'étant jamais « dépassé » puisqu'il n'a rien prévu.
+
+    Un responsable ne voit que son secteur ; direction et comptabilité voient
+    tout.
+    """
+    if profil == 'responsable':
+        if not secteur_id:
+            return []
+        scope, params = 'AND b.secteur_id = ?', (secteur_id,)
+    elif profil in ('directeur', 'comptable'):
+        scope, params = '', ()
+    else:
+        return []
+
+    rows = conn.execute(
+        f'''SELECT s.id AS secteur_id, s.nom AS secteur_nom,
+                   COUNT(*) AS nb_postes,
+                   SUM(r.montant - p.montant) AS depassement
+            FROM budget_lignes p
+            JOIN budget_reel_lignes r
+              ON r.budget_id = p.budget_id
+             AND r.poste_depense_id = p.poste_depense_id
+             AND r.periode = p.periode
+            JOIN budgets b ON b.id = p.budget_id
+            JOIN secteurs s ON s.id = b.secteur_id
+            WHERE b.annee = ? AND p.montant > 0 AND r.montant > p.montant
+              {scope}
+            GROUP BY s.id, s.nom
+            ORDER BY depassement DESC''',
+        (today.year,) + params
+    ).fetchall()
+    if not rows:
+        return []
+
+    actions = []
+    for r in rows[:MAX_CARTES_NOMMEES]:
+        euros = f"{(r['depassement'] or 0):,.0f}".replace(',', ' ')
+        actions.append({
+            'id': f"budget-{r['secteur_id']}-{today.year}",
+            'categorie': 'subvention',
+            'type': 'lien',
+            'icone': '📉',
+            'titre': f"Budget dépassé — {r['secteur_nom']}",
+            'detail': (f"{euros} € au-dessus du prévu sur "
+                       f"{r['nb_postes']} poste{'s' if r['nb_postes'] > 1 else ''}"),
+            'lien': url_for('budget_bp.budget_secteur', secteur_id=r['secteur_id']),
+            'lien_texte': 'Ouvrir le budget',
+            'urgence': 'retard',
+        })
+
+    reste = len(rows) - len(actions)
+    if reste > 0:
+        actions.append(_reste(
+            reste, f"secteur{'s' if reste > 1 else ''} en dépassement",
+            url_for('budget_bp.gestion_budgets'), 'Budgets',
+            'budgets', '📉', 'subvention'))
+    return actions
+
+
+def _taches_du_jour(conn, user_id, today):
+    """Tâches que le planificateur a posées aujourd'hui.
+
+    Volontairement agrégée : le planificateur est déjà l'écran qui détaille
+    et réordonne. Le fil rappelle seulement qu'il y a une journée posée, et y
+    conduit — le détail se lit là-bas, pas ici.
+    """
+    if not user_id:
+        return []
+
+    nb = conn.execute(
+        '''SELECT COUNT(*) AS nb FROM planif_blocs b
+           JOIN planif_taches t ON t.id = b.tache_id
+           WHERE b.user_id = ? AND b.date = ?
+             AND b.statut != 'fait' AND t.statut != 'fait' ''',
+        (user_id, today.isoformat())
+    ).fetchone()['nb']
+    if not nb:
+        return []
+
+    return [{
+        'id': f"planif-{today.isoformat()}",
+        'categorie': 'surcharge',
+        'type': 'lien',
+        'icone': '🗂️',
+        'titre': f"{nb} tâche{'s' if nb > 1 else ''} prévue{'s' if nb > 1 else ''} aujourd'hui",
+        'detail': 'journée posée par le planificateur',
+        'lien': url_for('planificateur_bp.planificateur'),
+        'lien_texte': 'Planificateur',
+        'urgence': 'urgent',
+    }]
+
+
+def _contrats_sans_pdf(conn, profil, today):
+    """Contrats en cours dont le PDF signé manque au dossier.
+
+    La comptabilité est seule concernée : c'est elle qui archive les pièces.
+    Distinct du contrat absent de la base — ici le contrat existe, c'est le
+    document scanné qui manque, et lui seul fait foi en cas de contrôle.
+    """
+    if profil != 'comptable':
+        return []
+
+    jour = today.isoformat()
+    rows = conn.execute(
+        '''WITH derniers AS (
+               SELECT c.user_id, MAX(c.id) AS contrat_id
+               FROM contrats c
+               JOIN users u ON u.id = c.user_id
+               WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+                 AND c.date_debut <= ? AND (c.date_fin IS NULL OR c.date_fin >= ?)
+               GROUP BY c.user_id
+           )
+           SELECT u.id, u.nom, u.prenom, c.type_contrat
+           FROM derniers d
+           JOIN contrats c ON c.id = d.contrat_id
+           JOIN users u ON u.id = d.user_id
+           WHERE c.fichier_path IS NULL OR c.fichier_path = ''
+           ORDER BY u.nom, u.prenom''',
+        (jour, jour)
+    ).fetchall()
+    if not rows:
+        return []
+
+    actions = []
+    for r in rows[:MAX_CARTES_NOMMEES]:
+        actions.append({
+            'id': f"contratpdf-{r['id']}",
+            'categorie': 'conges',
+            'type': 'lien',
+            'icone': '📄',
+            'titre': f"Contrat manquant au dossier — {r['prenom']} {r['nom']}",
+            'detail': f"{r['type_contrat'] or 'Contrat'} en cours, PDF signé non déposé",
+            'lien': url_for('infos_salaries_bp.infos_salaries', user_id=r['id']),
+            'lien_texte': 'Fiche salarié',
+            'urgence': 'normal',
+        })
+
+    reste = len(rows) - len(actions)
+    if reste > 0:
+        actions.append(_reste(
+            reste, f"contrat{'s' if reste > 1 else ''} sans PDF",
+            url_for('infos_salaries_bp.infos_salaries'), 'Infos salariés',
+            'contrats-pdf', '📄', 'conges'))
+    return actions
 
 
 def construire_actions(conn, profil, user_id, secteur_id=None,
@@ -250,6 +748,26 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
             'urgence': _urgence_echeance(ech, today),
         })
 
+    # 3. Ce que chaque profil doit trancher, nommé plutôt que compté. Chaque
+    # constructeur décide seul de son public et ne rend rien quand il n'y a
+    # rien à dire : une famille sans objet ne laisse aucune trace dans le fil.
+    for constructeur, arguments in (
+        (_fiches_a_valider, (profil, user_id, secteur_id, today)),
+        (_factures_a_valider, (profil, user_id, secteur_id, today)),
+        (_preparation_paie, (profil, user_id, today)),
+        (_fournitures_en_attente, (profil, user_id, today)),
+        (_budgets_depasses, (profil, user_id, secteur_id, today)),
+        (_taches_du_jour, (user_id, today)),
+        (_contrats_sans_pdf, (profil, today)),
+    ):
+        try:
+            actions.extend(constructeur(conn, *arguments))
+        except Exception:
+            # Une famille en panne (table absente, base verrouillée) ne doit
+            # pas emporter le fil entier : les autres décisions restent dues.
+            logger.warning("Fil d'actions : %s indisponible", constructeur.__name__,
+                           exc_info=True)
+
     if etendu and profil in ('directeur', 'comptable'):
         actions.extend(_actions_etendues(conn, profil, user_id, today, seuils, surcharges))
 
@@ -302,9 +820,14 @@ def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
             'urgence': _urgence_echeance(ech, today),
         })
 
-    # 4. Fiches du mois précédent non validées : relance des responsables.
+    # 4. Relance des responsables sur les fiches du mois précédent.
+    # Les fiches elles-mêmes sont désormais nommées une à une par
+    # `_fiches_a_valider` : il ne reste ici que le geste collectif — l'envoi
+    # groupé d'un rappel — qui n'a pas d'équivalent carte par carte.
     mois_prec = today.month - 1 or 12
     annee_prec = today.year if today.month > 1 else today.year - 1
+    peut_relancer = (profil == 'directeur'
+                     or user_has_delegation(user_id, MISSION_SUIVI_VALIDATIONS_RELANCES))
     fiches = conn.execute('''
         SELECT COUNT(*) AS nb FROM users u
         WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
@@ -313,29 +836,21 @@ def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
               WHERE v.user_id = u.id AND v.mois = ? AND v.annee = ? AND v.bloque = 1
           )
     ''', (mois_prec, annee_prec)).fetchone()
-    if fiches['nb'] > 0:
-        # L'endpoint de relance est réservé à la direction (ou à un délégué) :
-        # pour les autres (comptable sans délégation), l'item reste informatif
-        # avec un lien vers la vue d'ensemble plutôt qu'un bouton voué au 403.
-        peut_relancer = (profil == 'directeur'
-                         or user_has_delegation(user_id, MISSION_SUIVI_VALIDATIONS_RELANCES))
-        item = {
+    if fiches['nb'] > 0 and peut_relancer:
+        actions.append({
             'id': f"relance-{annee_prec}-{mois_prec:02d}",
             'categorie': 'validation',
-            'type': 'relance' if peut_relancer else 'lien',
-            'icone': '✅',
-            'titre': f"{fiches['nb']} fiche(s) de {NOMS_MOIS[mois_prec].lower()} non validée(s)",
-            'detail': "responsables à relancer par email" if peut_relancer
-                      else "en attente de validation",
+            'type': 'relance',
+            'icone': '📧',
+            'titre': f"Relancer les responsables — {NOMS_MOIS[mois_prec].lower()}",
+            'detail': f"{fiches['nb']} fiche(s) encore non validée(s)",
             'lien': url_for('validation_bp.vue_ensemble_validation'),
             'lien_texte': 'Vue ensemble',
+            'relance_mois': mois_prec,
+            'relance_annee': annee_prec,
             # Urgent passé le 10 du mois (la paie attend les fiches).
             'urgence': 'urgent' if today.day > 10 else 'normal',
-        }
-        if peut_relancer:
-            item['relance_mois'] = mois_prec
-            item['relance_annee'] = annee_prec
-        actions.append(item)
+        })
 
     # 5. Salariés en surcharge (score calculé par l'appelant, déjà filtré par seuil).
     for s in (surcharges or [])[:5]:

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -317,7 +317,7 @@ def cle_preparation_paie(mois, annee, user_id):
     return f'paie_signalee_{annee:04d}_{mois:02d}_u{user_id}'
 
 
-def _preparation_paie(conn, profil, user_id, today):
+def _preparation_paie(conn, profil, user_id, secteur_id, today):
     """Rappel daté : les cas particuliers que la paie ne devinera pas.
 
     Une fiche absente n'est pas toujours un oubli — un salarié mis à pied,
@@ -327,6 +327,11 @@ def _preparation_paie(conn, profil, user_id, today):
 
     Elle s'adresse aux **responsables et à la direction**, qui signalent ; la
     comptabilité, elle, reçoit le signalement et a ses propres cartes.
+
+    Chacun ne compte que son périmètre — un responsable son équipe, la
+    direction tout l'effectif. Sans ce cadrage, un responsable lirait les
+    situations RH des autres équipes, et éteindrait un rappel portant sur des
+    salariés dont il n'a pas à répondre.
 
     Deux des quatre cas se calculent (CDD sans fiche, absence sans
     justificatif) et sont nommés. Les deux autres — mise à pied, licenciement
@@ -349,28 +354,44 @@ def _preparation_paie(conn, profil, user_id, today):
     if get_setting(cle_preparation_paie(mois, annee, user_id)):
         return []
 
+    from blueprints.absences import MOTIFS_AVEC_JUSTIFICATIF
+
     debut = f'{annee:04d}-{mois:02d}-01'
     fin = (date(annee + (mois == 12), (mois % 12) + 1, 1) - timedelta(days=1)).isoformat()
 
+    if profil == 'responsable':
+        scope = 'AND (u.secteur_id = ? OR u.responsable_id = ?)'
+        params = (secteur_id, user_id)
+    else:
+        scope, params = '', ()
+
     # CDD sous contrat sur le mois, sans la moindre saisie : la paie n'a rien.
     cdd_sans_fiche = conn.execute(
-        '''SELECT COUNT(DISTINCT u.id) AS nb FROM users u
-           JOIN contrats c ON c.user_id = u.id
-           WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
-             AND UPPER(c.type_contrat) LIKE 'CDD%'
-             AND c.date_debut <= ? AND (c.date_fin IS NULL OR c.date_fin >= ?)
-             AND NOT EXISTS (
-                 SELECT 1 FROM heures_reelles h
-                 WHERE h.user_id = u.id AND h.date >= ? AND h.date <= ?
-             )''',
-        (fin, debut, debut, fin)
+        f'''SELECT COUNT(DISTINCT u.id) AS nb FROM users u
+            JOIN contrats c ON c.user_id = u.id
+            WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
+              {scope}
+              AND UPPER(c.type_contrat) LIKE 'CDD%'
+              AND c.date_debut <= ? AND (c.date_fin IS NULL OR c.date_fin >= ?)
+              AND NOT EXISTS (
+                  SELECT 1 FROM heures_reelles h
+                  WHERE h.user_id = u.id AND h.date >= ? AND h.date <= ?
+              )''',
+        params + (fin, debut, debut, fin)
     ).fetchone()['nb']
 
+    # Seuls les motifs qui appellent réellement une pièce. Un congé validé
+    # crée une ligne d'absence sans justificatif par construction : le
+    # compter ferait sonner ce rappel tous les mois pour rien.
+    motifs = ','.join('?' for _ in MOTIFS_AVEC_JUSTIFICATIF)
     absences_sans_justificatif = conn.execute(
-        '''SELECT COUNT(*) AS nb FROM absences
-           WHERE date_debut <= ? AND date_fin >= ?
-             AND (justificatif_path IS NULL OR justificatif_path = '')''',
-        (fin, debut)
+        f'''SELECT COUNT(*) AS nb FROM absences a
+            JOIN users u ON u.id = a.user_id
+            WHERE a.date_debut <= ? AND a.date_fin >= ?
+              AND a.motif IN ({motifs})
+              AND (a.justificatif_path IS NULL OR a.justificatif_path = '')
+              {scope}''',
+        (fin, debut) + MOTIFS_AVEC_JUSTIFICATIF + params
     ).fetchone()['nb']
 
     constats = []
@@ -468,24 +489,38 @@ def _budgets_depasses(conn, profil, user_id, secteur_id, today):
     if profil == 'responsable':
         if not secteur_id:
             return []
-        scope, params = 'AND b.secteur_id = ?', (secteur_id,)
+        scope, params = 'AND postes.secteur_id = ?', (secteur_id,)
     elif profil in ('directeur', 'comptable'):
         scope, params = '', ()
     else:
         return []
 
+    # Un poste ALP est réparti sur plusieurs périodes (mercredis, vacances…) ;
+    # la page budget le juge sur leur **total**, pas période par période. Sans
+    # ce regroupement, 150 dépensés sur une période budgétée 100 crieraient au
+    # dépassement alors que le poste, budgété 1000 au total, est largement
+    # sous enveloppe. On agrège donc avant de comparer — un poste annuel n'a
+    # qu'une ligne, l'agrégation le laisse intact.
     rows = conn.execute(
-        f'''SELECT s.id AS secteur_id, s.nom AS secteur_nom,
+        f'''WITH postes AS (
+                SELECT b.secteur_id,
+                       p.poste_depense_id,
+                       SUM(p.montant) AS prevu,
+                       (SELECT COALESCE(SUM(r.montant), 0)
+                        FROM budget_reel_lignes r
+                        WHERE r.budget_id = p.budget_id
+                          AND r.poste_depense_id = p.poste_depense_id) AS reel
+                FROM budget_lignes p
+                JOIN budgets b ON b.id = p.budget_id
+                WHERE b.annee = ?
+                GROUP BY p.budget_id, p.poste_depense_id
+            )
+            SELECT s.id AS secteur_id, s.nom AS secteur_nom,
                    COUNT(*) AS nb_postes,
-                   SUM(r.montant - p.montant) AS depassement
-            FROM budget_lignes p
-            JOIN budget_reel_lignes r
-              ON r.budget_id = p.budget_id
-             AND r.poste_depense_id = p.poste_depense_id
-             AND r.periode = p.periode
-            JOIN budgets b ON b.id = p.budget_id
-            JOIN secteurs s ON s.id = b.secteur_id
-            WHERE b.annee = ? AND p.montant > 0 AND r.montant > p.montant
+                   SUM(postes.reel - postes.prevu) AS depassement
+            FROM postes
+            JOIN secteurs s ON s.id = postes.secteur_id
+            WHERE postes.prevu > 0 AND postes.reel > postes.prevu
               {scope}
             GROUP BY s.id, s.nom
             ORDER BY depassement DESC''',
@@ -797,7 +832,7 @@ def construire_actions(conn, profil, user_id, secteur_id=None,
     for constructeur, arguments in (
         (_fiches_a_valider, (profil, user_id, secteur_id, today)),
         (_factures_a_valider, (profil, user_id, secteur_id, today)),
-        (_preparation_paie, (profil, user_id, today)),
+        (_preparation_paie, (profil, user_id, secteur_id, today)),
         (_fournitures_en_attente, (profil, user_id, today)),
         (_budgets_depasses, (profil, user_id, secteur_id, today)),
         (_taches_du_jour, (user_id, today)),

--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -150,10 +150,16 @@ def _fiches_a_valider(conn, profil, user_id, secteur_id, today):
     """Fiches d'heures du mois précédent encore non validées.
 
     Les deux plus lourdes sont nommées, le reste tient en une ligne. Le
-    classement suit le **solde d'heures du mois**, décroissant : une fiche à
-    +20 h engage un compteur de récupération et une paie, une fiche à −5 h
-    attend surtout une explication. À enjeu égal on ne saurait pas par où
-    commencer — c'est ce tri qui rend la carte actionnable.
+    classement suit le **solde d'heures du mois**, décroissant : plus le solde
+    est élevé, plus il pèse sur le compteur de récupération, et plus la
+    validation tarde à venir. À enjeu égal on ne saurait pas par où commencer
+    — c'est ce tri qui rend la carte actionnable.
+
+    La carte dit **que la fiche attend une validation**, et rien d'autre. Le
+    solde y figure comme un fait, pas comme un verdict : ce n'est pas ici
+    qu'on qualifie un écart, et une fiche chargée n'est pas une anomalie. Les
+    heures supplémentaires se récupèrent — elles ne se paient pas, sauf pour
+    un CDD — donc rien à « trancher avant la paie ».
 
     Un responsable ne voit que son équipe, comme la vue d'ensemble le fait
     pour lui ; la direction et la comptabilité voient tout l'effectif.
@@ -195,18 +201,22 @@ def _fiches_a_valider(conn, profil, user_id, secteur_id, today):
     nom_mois = NOMS_MOIS[mois].lower()
     actions = []
     for salarie, solde in classees[:MAX_CARTES_NOMMEES]:
-        if solde > 0:
-            detail = f"+{_fr_num(round(solde, 1))} h sur le mois — à trancher avant la paie"
-        elif solde < 0:
-            detail = f"{_fr_num(round(solde, 1))} h sur le mois — écart à expliquer"
+        arrondi = round(solde, 1)
+        if arrondi > 0:
+            detail = f"heures supplémentaires sur le mois : +{_fr_num(arrondi)} h"
+        elif arrondi < 0:
+            # « Heures supplémentaires : −3 h » se contredirait : un solde
+            # négatif n'en est pas.
+            detail = f"solde du mois : {_fr_num(arrondi)} h"
         else:
-            detail = "aucun écart — validation de forme"
+            detail = "solde du mois à l'équilibre"
         actions.append({
             'id': f"fiche-{salarie['id']}-{annee}-{mois:02d}",
             'categorie': 'validation',
             'type': 'lien',
             'icone': '✅',
-            'titre': f"Fiche de {salarie['prenom']} {salarie['nom']} — {nom_mois}",
+            'titre': (f"Fiche à valider — {salarie['prenom']} {salarie['nom']}, "
+                      f"{nom_mois}"),
             'detail': detail,
             'lien': url_for('validation_bp.vue_mensuelle', user_id=salarie['id'],
                             mois=mois, annee=annee),

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -63,6 +63,42 @@ Pour la direction et la comptabilité, le fil reprend la file étendue du centre
 de contrôle qu'il remplace : factures assignées à la direction, relance des
 fiches non validées, surcharges, soldes de congés élevés.
 
+### Le « Pourquoi ? » : le circuit derrière une carte
+
+Une carte dit *quoi faire*. Elle ne dit pas *ce qui est arrêté derrière*.
+« Fiche à valider — Marie Dupont » ne laisse pas deviner que la préparation de
+la paie attend, ni qu'un CDD n'aura plus qu'un bulletin pour se régulariser.
+Sous les boutons, un lien **Pourquoi ?** déplie le circuit dans lequel la
+décision s'inscrit, centré sur l'étape en attente.
+
+`flux_circuits.py` décrit six circuits — congé, récupération, fiche d'heures,
+facture, subvention, fourniture. Chaque étape porte le **rôle** qui la traite
+(pastille colorée : salarié, responsable, direction, comptabilité,
+prestataire, ou *application* quand le logiciel agit seul), ce qu'elle fait,
+et son état — faite, en cours, à venir. Les liaisons nomment le geste qui mène
+à la suivante (« soumet », « alimente », « verrouille »).
+
+Trois règles de forme :
+
+- **l'étape courante prend le ton de la carte**, pas la couleur de son rôle.
+  Une décision en retard se signale en rouge jusque dans son circuit ; le rôle
+  reste lisible sur sa pastille ;
+- **la conséquence tient en une phrase**, avec les vraies dates : c'est elle
+  qui répond à « pourquoi c'est important », le schéma seul ne le dit pas.
+  Elle ne paraît que lorsqu'il y a réellement quelque chose à dire — une
+  demande déposée hier ne reproche rien ;
+- **les alimentations annexes se notent sur l'étape concernée.** Les arrêts
+  maladie saisis en comptabilité nourrissent la préparation de paie : le
+  circuit le montre, parce que c'est ce lien entre éléments que l'application
+  fait et que personne ne voit.
+
+Le circuit est rendu **avec la carte, replié** (`hidden`) : pas d'aller-retour
+serveur au clic. À l'ouverture, la piste défile jusqu'à l'étape courante —
+sans ce recentrage, un circuit de six étapes s'ouvre sur ce qui est déjà fait.
+
+Toutes les familles n'en ont pas : la ligne « et N autres » ne désigne aucun
+enregistrement précis, elle n'a donc pas d'étape à mettre en avant.
+
 ### La règle du fil : on nomme, on ne compte pas
 
 **Le fil ne porte aucune donnée informative fixe.** Chaque carte attend une

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -75,12 +75,19 @@ D'où la forme de toutes les familles de `dashboard_actions.py` :
 
 - **au plus deux cartes nommées** (`MAX_CARTES_NOMMEES`), puis une ligne
   discrète « et N autres ». « 30 fiches à valider » décourage et n'indique pas
-  par où commencer ; « Fiche de Marie Dupont — juillet, +12 h sur le mois »
-  se traite. Traiter la première fait remonter la suivante ;
-- **un tri qui dit l'urgence réelle.** Les fiches sont classées par solde
-  d'heures décroissant : une fiche à +20 h engage un compteur de récupération
-  et une paie, une fiche à −5 h attend surtout une explication ;
+  par où commencer ; « Fiche à valider — Marie Dupont, juillet » se traite.
+  Traiter la première fait remonter la suivante ;
+- **un tri qui dit par où commencer.** Les fiches sont classées par solde
+  d'heures décroissant : plus le solde est élevé, plus il pèse sur le compteur
+  de récupération, et plus la validation tarde à venir ;
 - **rien quand il n'y a rien.** Aucune famille ne produit de carte à zéro.
+
+Une carte **dit ce qu'elle attend, elle ne juge pas**. La fiche de Marie
+Dupont attend une validation : c'est tout ce que la carte annonce. Le solde y
+figure comme un fait, jamais comme un verdict — le fil n'est pas un détecteur
+d'anomalies, et une fiche chargée n'en est pas une. (Rappel métier utile ici :
+les heures supplémentaires se **récupèrent**, elles ne se paient pas, sauf
+pour un CDD.)
 
 Chaque constructeur décide seul de son public et s'isole des autres : une
 famille en panne (table absente, base verrouillée) est journalisée et ignorée,

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -63,6 +63,39 @@ Pour la direction et la comptabilité, le fil reprend la file étendue du centre
 de contrôle qu'il remplace : factures assignées à la direction, relance des
 fiches non validées, surcharges, soldes de congés élevés.
 
+### La règle du fil : on nomme, on ne compte pas
+
+**Le fil ne porte aucune donnée informative fixe.** Chaque carte attend une
+décision, signale un risque réel ou annonce une échéance — sinon elle n'est
+pas construite. C'est ce qui le sépare d'un tableau de bord d'indicateurs : un
+compteur qui affiche la même chose tous les jours n'apprend rien et use
+l'attention de son lecteur.
+
+D'où la forme de toutes les familles de `dashboard_actions.py` :
+
+- **au plus deux cartes nommées** (`MAX_CARTES_NOMMEES`), puis une ligne
+  discrète « et N autres ». « 30 fiches à valider » décourage et n'indique pas
+  par où commencer ; « Fiche de Marie Dupont — juillet, +12 h sur le mois »
+  se traite. Traiter la première fait remonter la suivante ;
+- **un tri qui dit l'urgence réelle.** Les fiches sont classées par solde
+  d'heures décroissant : une fiche à +20 h engage un compteur de récupération
+  et une paie, une fiche à −5 h attend surtout une explication ;
+- **rien quand il n'y a rien.** Aucune famille ne produit de carte à zéro.
+
+Chaque constructeur décide seul de son public et s'isole des autres : une
+famille en panne (table absente, base verrouillée) est journalisée et ignorée,
+le reste du fil tient.
+
+Deux exceptions assumées à la règle du nommage. Les **tâches du planificateur**
+restent agrégées (« 3 tâches prévues aujourd'hui ») : le planificateur est
+déjà l'écran qui détaille et réordonne, le fil ne fait qu'y conduire. Le
+**rappel de préparation de paie** est daté plutôt que déclenché par un état :
+il paraît le 20 (`JOUR_RAPPEL_PAIE`) parce que le geste attendu — prévenir la
+comptabilité des mises à pied et licenciements — se fait hors de
+l'application, qui ne peut rien en constater. Son bouton « C'est fait » est
+donc déclaratif, et n'éteint le rappel que pour celui qui l'a signalé :
+chacun ne répond que de son périmètre.
+
 Ce sont les **seuils d'alerte** qui décident de ce qui remonte. Comme ils
 façonnent le fil, ils se règlent là où le fil s'affiche : bouton ⚙ à droite de
 l'en-tête de l'accueil, réservé à la direction et à la comptabilité. La fenêtre

--- a/flux_circuits.py
+++ b/flux_circuits.py
@@ -1,0 +1,281 @@
+"""
+Le « Pourquoi ? » des cartes du fil : le circuit dans lequel s'inscrit une
+décision, centré sur l'étape qui attend.
+
+Une carte dit quoi faire. Elle ne dit pas ce qui est arrêté derrière. « Fiche à
+valider — Marie Dupont » ne laisse pas deviner que la préparation de la paie
+est à l'arrêt tant que ce n'est pas fait, ni qu'un CDD n'aura plus qu'un
+bulletin pour se régulariser. Le circuit répond à cette question-là, et
+seulement quand elle est posée : il est replié par défaut.
+
+Trois principes de lecture :
+
+- **le circuit se lit d'un coup d'œil.** Chaque étape porte le rôle qui la
+  traite (couleur), ce qu'elle fait, et où elle en est — faite, en cours,
+  à venir. Les liaisons nomment le geste qui mène à la suivante ;
+- **l'étape courante prend le ton de la carte**, pas la couleur de son rôle :
+  une décision en retard se signale en rouge jusque dans son circuit. Le rôle
+  reste lisible sur sa pastille ;
+- **la conséquence se dit en une phrase**, avec les vraies dates. C'est elle
+  qui répond à « pourquoi c'est important » — le schéma seul ne le dit pas.
+
+Certains circuits reçoivent une **alimentation annexe** : une étape peut
+dépendre d'informations saisies ailleurs (les arrêts maladie de la
+comptabilité nourrissent la préparation de paie). Elles se notent sur l'étape
+concernée, pour montrer que l'application relie ces éléments.
+"""
+from datetime import date
+
+# Rôle qui traite une étape → (libellé, couleur de pastille). « Application »
+# désigne ce que le logiciel fait seul : rien à attendre de personne.
+ROLES = {
+    'salarie': ('Salarié', '#4a7dbf'),
+    'responsable': ('Responsable', '#7c5cbf'),
+    'direction': ('Direction', '#c56a2a'),
+    'comptabilite': ('Comptabilité', '#2f7d5d'),
+    'prestataire': ('Prestataire', '#5b6470'),
+    'application': ('Application', '#9aa0a6'),
+}
+
+# Profil du lecteur → rôle qu'il tient dans les circuits. Sert à dire « la
+# vôtre » sur l'étape courante quand c'est bien lui qu'on attend.
+_ROLE_DU_PROFIL = {
+    'directeur': 'direction',
+    'comptable': 'comptabilite',
+    'responsable': 'responsable',
+    'salarie': 'salarie',
+    'prestataire': 'prestataire',
+}
+
+
+def _etape(role, titre, *lignes, liaison=None, note=None):
+    """Une étape du circuit. `liaison` nomme le geste vers la suivante."""
+    return {
+        'role': role,
+        'role_label': ROLES[role][0],
+        'role_couleur': ROLES[role][1],
+        'titre': titre,
+        'lignes': [ligne for ligne in lignes if ligne],
+        'liaison': liaison,
+        'note': note,
+    }
+
+
+def _monter(intitule, etapes, courante, profil, consequence=None):
+    """Assemble un circuit : pose les statuts et situe l'étape en attente.
+
+    `courante` est l'index de l'étape qui attend (0-based). Tout ce qui
+    précède est fait, tout ce qui suit est à venir. Un index hors bornes rend
+    un circuit sans étape courante — le circuit se lit encore, il n'attend
+    simplement plus personne.
+    """
+    for rang, etape in enumerate(etapes):
+        if rang < courante:
+            etape['statut'] = 'fait'
+        elif rang == courante:
+            etape['statut'] = 'courant'
+        else:
+            etape['statut'] = 'a_venir'
+
+    a_moi = (0 <= courante < len(etapes)
+             and etapes[courante]['role'] == _ROLE_DU_PROFIL.get(profil))
+    return {
+        'intitule': intitule,
+        'etapes': etapes,
+        'rang': courante + 1,
+        'total': len(etapes),
+        'a_moi': a_moi,
+        'consequence': consequence,
+    }
+
+
+def _jours_depuis(valeur, today):
+    """Nombre de jours écoulés depuis une date ISO, ou None."""
+    if not valeur:
+        return None
+    try:
+        depuis = date.fromisoformat(str(valeur)[:10])
+    except ValueError:
+        return None
+    return (today - depuis).days
+
+
+def _attente(jours):
+    """« Neuf jours sans réponse » — ou rien si l'attente est fraîche."""
+    if not jours or jours < 2:
+        return None
+    return f"{jours} jours sans réponse"
+
+
+# ── Les six circuits ────────────────────────────────────────────────────────
+
+def demande_conge(statut, date_demande, profil, today, nb_jours=None):
+    """De la demande au planning et aux compteurs."""
+    etapes = [
+        _etape('salarie', 'Demande posée',
+               f"{_fr_jours(nb_jours)} ouvré{'s' if (nb_jours or 0) > 1 else ''}"
+               if nb_jours else None,
+               liaison='soumet'),
+        _etape('responsable', 'Validation responsable',
+               'Vérifie la couverture du secteur', liaison='transmet'),
+        _etape('direction', 'Décision',
+               'Approuve ou refuse', liaison='met à jour'),
+        _etape('application', 'Absence au calendrier',
+               'Posée sur le planning de l\'équipe', liaison='alimente'),
+        _etape('comptabilite', 'Compteurs et préparation de paie',
+               'Solde décrémenté, congé visible en paie',
+               note='Aussi alimentée par les arrêts maladie saisis en comptabilité'),
+    ]
+    courante = 1 if statut == 'en_attente_responsable' else 2
+
+    jours = _jours_depuis(date_demande, today)
+    attente = _attente(jours)
+    consequence = None
+    if attente:
+        consequence = (f"{attente} : le salarié ne sait pas s'il part, et le "
+                       "planning de son secteur se construit sur une hypothèse.")
+    return _monter('De la demande au planning et aux compteurs.',
+                   etapes, courante, profil, consequence)
+
+
+def demande_recup(statut, date_demande, profil, today):
+    """De la demande au report sur la fiche d'heures."""
+    etapes = [
+        _etape('salarie', 'Demande posée', liaison='soumet'),
+        _etape('responsable', 'Validation responsable',
+               'Vérifie le solde de récupération', liaison='transmet'),
+        _etape('direction', 'Décision', 'Approuve ou refuse', liaison='reporte'),
+        _etape('application', 'Récupération portée sur la fiche',
+               'Journée posée, compteur décrémenté'),
+    ]
+    courante = 1 if statut == 'en_attente_responsable' else 2
+
+    attente = _attente(_jours_depuis(date_demande, today))
+    consequence = None
+    if attente:
+        consequence = (f"{attente} : la journée n'est ni posée ni décomptée, "
+                       "et la fiche du mois reste incomplète.")
+    return _monter('De la demande au report sur la fiche.',
+                   etapes, courante, profil, consequence)
+
+
+def fiche_heures(profil, today, nom=None, est_cdd=False, solde=None):
+    """De la fiche d'heures au bulletin de paie."""
+    heures = None
+    if solde and solde > 0:
+        heures = f"{solde:g} h au-delà du contrat".replace('.', ',')
+
+    etapes = [
+        _etape('salarie', 'Saisie du mois',
+               'Journées saisies ou déclarées conformes', liaison='alerte'),
+        _etape('responsable', 'Validation responsable',
+               'Confirme ou corrige la fiche', liaison='transmet'),
+        _etape('direction', 'Validation direction',
+               heures or 'Confirme la fiche', liaison='verrouille'),
+        _etape('application', 'Verrouillage',
+               'La fiche devient le document de référence', liaison='alimente'),
+        _etape('comptabilite', 'Préparation de la paie',
+               'Heures à payer pour un CDD, à récupérer sinon',
+               note='Aussi alimentée par les arrêts maladie saisis en comptabilité',
+               liaison='transmet'),
+        _etape('prestataire', 'Transmission au prestataire',
+               'Export des variables de paie'),
+    ]
+    # La fiche n'est pas encore verrouillée : la décision attendue est celle
+    # de la direction, après le passage du responsable.
+    courante = 2
+
+    if est_cdd:
+        consequence = ("Non validée, la fiche part sans ses heures : pour un "
+                       "CDD elles se paient, et il ne restera qu'un bulletin "
+                       "pour régulariser.")
+    else:
+        consequence = ("Tant qu'elle n'est pas validée, la préparation de la "
+                       "paie attend, et les heures ne rejoignent pas le "
+                       "compteur de récupération.")
+    return _monter('De la fiche d\'heures au bulletin de paie.',
+                   etapes, courante, profil, consequence)
+
+
+def facture(approbation, date_echeance, profil, today):
+    """De l'import de la facture à son archivage comptable."""
+    etapes = [
+        _etape('application', 'Import et extraction',
+               'Montants et fournisseur relevés', liaison='oriente'),
+        _etape('comptabilite', 'Assignation',
+               'Rattachée à un secteur ou à la direction', liaison='soumet'),
+        _etape('direction', 'Approbation',
+               'Direction ou responsable du secteur', liaison='génère'),
+        _etape('application', 'Génération des écritures',
+               'Écriture comptable en brouillon', liaison='soumet'),
+        _etape('comptabilite', 'Validation comptable',
+               'Contrôle et validation de l\'écriture', liaison='exporte'),
+        _etape('comptabilite', 'Export Aiga et archivage',
+               'La facture sort de l\'application'),
+    ]
+    courante = 2 if approbation == 'en_attente' else 4
+
+    consequence = None
+    jours = _jours_depuis(date_echeance, today)
+    if jours is not None and jours > 0:
+        consequence = (f"Échéance dépassée de {jours} jour(s) : le fournisseur "
+                       "attend, et l'écriture comptable ne peut pas être générée.")
+    elif jours is not None:
+        consequence = (f"Payable dans {-jours} jour(s) : sans approbation, "
+                       "l'écriture comptable ne part pas.")
+    return _monter('De l\'import de la facture à son archivage.',
+                   etapes, courante, profil, consequence)
+
+
+def subvention(date_echeance, profil, today, etape_nom=None):
+    """Du dossier déposé à la prochaine échéance."""
+    etapes = [
+        _etape('responsable', 'Dossier déposé',
+               'Demande constituée et transmise', liaison='découpe'),
+        _etape('application', 'Étapes datées',
+               'Bilans, justificatifs, versements', liaison='ouvre'),
+        _etape('direction', etape_nom or 'Étape en cours',
+               'À traiter avant son échéance', liaison='appelle'),
+        _etape('application', 'Prochaine échéance',
+               'L\'étape suivante prend le relais'),
+    ]
+    courante = 2
+
+    jours = _jours_depuis(date_echeance, today)
+    consequence = None
+    if jours is not None and jours > 0:
+        consequence = (f"Échéance dépassée de {jours} jour(s) : un bilan remis "
+                       "en retard peut coûter le versement du solde.")
+    return _monter('Du dossier déposé à la prochaine échéance.',
+                   etapes, courante, profil, consequence)
+
+
+def fourniture(date_demande, profil, today, urgence=None):
+    """De la demande déposée à la commande."""
+    etapes = [
+        _etape('salarie', 'Demande déposée',
+               'Description, quantité et urgence', liaison='ouvre'),
+        _etape('comptabilite', 'En cours de traitement',
+               'Arbitrage et recherche du fournisseur', liaison='conclut'),
+        _etape('comptabilite', 'Commandée ou annulée',
+               'La demande sort de la file'),
+    ]
+    courante = 1
+
+    consequence = None
+    attente = _attente(_jours_depuis(date_demande, today))
+    if attente and urgence == 'urgent':
+        consequence = (f"{attente} sur une demande marquée urgente : "
+                       "le salarié n'a pas de quoi travailler.")
+    elif attente:
+        consequence = f"{attente} : le demandeur ne sait pas si sa demande suit."
+    return _monter('De la demande déposée à la commande.',
+                   etapes, courante, profil, consequence)
+
+
+def _fr_jours(nb):
+    """« 5 jours » / « 1 jour », en notation française."""
+    if not nb:
+        return None
+    entier = f"{nb:g}".replace('.', ',')
+    return f"{entier} jour" + ('s' if nb > 1 else '')

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4618,6 +4618,98 @@ body.flx .main-content {
 .flx-btn-plein:hover { background: var(--primary-dark); color: #fff; }
 .flx-btn[disabled] { opacity: 0.55; cursor: default; }
 
+/* ── « Pourquoi ? » : le circuit d'une carte ─────────────────────────── */
+/* La carte passe en deux lignes : l'en-tête habituel, puis le circuit qui
+   s'étend sous les trois colonnes. Replié, il ne coûte rien à la mise en page. */
+.flx-carte:has(> .flx-circuit:not([hidden])) { align-items: start; }
+.flx-circuit { grid-column: 1 / -1; margin-top: 18px; }
+
+.flx-pourquoi {
+    background: none; border: none; padding: 0; margin-top: 2px;
+    font-family: inherit; font-size: 0.78rem; color: var(--gray-500);
+    text-decoration: underline; text-decoration-style: dotted;
+    text-underline-offset: 3px; cursor: pointer; width: 100%; text-align: right;
+}
+.flx-pourquoi:hover { color: var(--gray-700); }
+
+.flx-circuit-entete {
+    display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+    margin-bottom: 14px;
+}
+.flx-circuit-cle {
+    font-family: var(--flx-mono); font-size: 0.62rem; letter-spacing: 1.5px;
+    text-transform: uppercase; color: var(--gray-500);
+}
+.flx-circuit-intitule { font-size: 0.87rem; color: var(--gray-700); }
+.flx-circuit-rang {
+    margin-left: auto; font-size: 0.8rem; color: var(--gray-500);
+}
+
+/* Défilement horizontal : un circuit de six étapes ne tient pas dans la
+   carte, et le tronquer cacherait justement la fin — ce qui est bloqué. */
+.flx-circuit-piste {
+    display: flex; align-items: stretch; gap: 0; overflow-x: auto;
+    padding: 4px 2px 12px; scrollbar-width: thin;
+}
+.flx-etape {
+    flex: 0 0 208px; padding: 13px 15px; border-radius: 11px;
+    border: 1px solid var(--gray-200); background: var(--gray-100);
+    display: flex; flex-direction: column; gap: 5px;
+}
+.flx-etape-role {
+    display: flex; align-items: center; gap: 6px;
+    font-family: var(--flx-mono); font-size: 0.58rem; letter-spacing: 1.3px;
+    text-transform: uppercase; color: var(--gray-500);
+}
+.flx-etape-role i { width: 7px; height: 7px; border-radius: 2px; flex: none; }
+.flx-etape-titre {
+    font-size: 0.93rem; color: var(--gray-900); line-height: 1.35;
+}
+.flx-etape-ligne { font-size: 0.78rem; color: var(--gray-500); line-height: 1.4; }
+.flx-etape-note {
+    margin-top: 4px; padding: 7px 9px; border-radius: 7px;
+    border: 1px solid var(--gray-300); background: var(--white);
+    font-size: 0.74rem; color: var(--gray-600); line-height: 1.4;
+}
+.flx-etape-statut {
+    margin-top: auto; padding-top: 9px;
+    font-family: var(--flx-mono); font-size: 0.58rem; letter-spacing: 1.2px;
+    text-transform: uppercase; color: var(--gray-500);
+}
+.flx-etape-a_venir { background: transparent; border-style: dashed; }
+.flx-etape-a_venir .flx-etape-titre { color: var(--gray-600); }
+
+/* L'étape en attente : fond plein, bordure au ton de la carte. */
+.flx-etape-courant {
+    background: var(--white); border-width: 1.5px;
+    border-color: var(--flx-planifier);
+}
+.flx-etape-courant .flx-etape-statut { color: var(--flx-planifier); }
+.flx-retard .flx-etape-courant { border-color: var(--flx-retard); }
+.flx-retard .flx-etape-courant .flx-etape-statut { color: var(--flx-retard); }
+.flx-urgent .flx-etape-courant { border-color: var(--flx-urgent); }
+.flx-urgent .flx-etape-courant .flx-etape-statut { color: var(--flx-urgent); }
+
+.flx-liaison {
+    flex: 0 0 auto; align-self: center; padding: 0 11px; text-align: center;
+    font-family: var(--flx-mono); font-size: 0.57rem; letter-spacing: 1.1px;
+    text-transform: uppercase; color: var(--gray-500); line-height: 1.6;
+}
+.flx-liaison span { display: block; font-size: 0.8rem; }
+
+/* La conséquence : ce que le schéma ne dit pas — pourquoi ça compte. */
+.flx-circuit-consequence {
+    padding: 11px 14px; border-radius: 9px; font-size: 0.84rem; line-height: 1.5;
+    background: rgba(47,93,80,0.07); color: var(--gray-700);
+}
+.flx-retard .flx-circuit-consequence { background: rgba(191,68,68,0.08); color: #8c3535; }
+.flx-urgent .flx-circuit-consequence { background: rgba(197,106,42,0.09); color: #8a4c1e; }
+
+@media (max-width: 700px) {
+    .flx-etape { flex-basis: 172px; }
+    .flx-circuit-rang { margin-left: 0; width: 100%; }
+}
+
 /* ── Flux vide ───────────────────────────────────────────────────────── */
 .flx-vide {
     text-align: center; padding: 72px 24px; border: 1px dashed var(--gray-300);

--- a/templates/_flux_actions.html
+++ b/templates/_flux_actions.html
@@ -51,7 +51,15 @@
         {% else %}
         <a href="{{ a.lien }}" class="flx-btn">{{ a.lien_texte }} →</a>
         {% endif %}
+        {% if a.circuit %}
+        {# Sous les boutons : la question, pas une action de plus. #}
+        <button type="button" class="flx-pourquoi" data-flx-pourquoi
+                aria-expanded="false">Pourquoi ?</button>
+        {% endif %}
     </div>
+    {% if a.circuit %}
+    {% with circuit = a.circuit %}{% include '_flux_circuit.html' %}{% endwith %}
+    {% endif %}
 </div>
 {% endfor %}
 

--- a/templates/_flux_actions.html
+++ b/templates/_flux_actions.html
@@ -38,6 +38,11 @@
         <button type="button" class="flx-btn flx-btn-plein" data-flx-act="subvention"
                 data-flx-ref="{{ a.id }}" data-se-id="{{ a.se_id }}">✓ C'est fait</button>
         <a href="{{ a.lien }}" class="flx-btn">Ouvrir</a>
+        {% elif a.type == 'paie' %}
+        <button type="button" class="flx-btn flx-btn-plein" data-flx-act="paie"
+                data-flx-ref="{{ a.id }}" data-mois="{{ a.paie_mois }}"
+                data-annee="{{ a.paie_annee }}">✓ C'est fait</button>
+        <a href="{{ a.lien }}" class="flx-btn">{{ a.lien_texte }}</a>
         {% elif a.type == 'relance' %}
         <button type="button" class="flx-btn flx-btn-plein" data-flx-act="relance"
                 data-flx-ref="{{ a.id }}" data-mois="{{ a.relance_mois }}"

--- a/templates/_flux_circuit.html
+++ b/templates/_flux_circuit.html
@@ -1,0 +1,43 @@
+{# Le circuit d'une carte : replié par défaut, déployé par « Pourquoi ? ».
+
+   L'étape courante prend le ton de la carte (retard / urgent / normal) plutôt
+   que la couleur de son rôle : une décision en retard doit se voir comme
+   telle jusque dans son circuit. Le rôle reste lisible sur sa pastille. #}
+<div class="flx-circuit" data-flx-circuit hidden>
+    <div class="flx-circuit-entete">
+        <span class="flx-circuit-cle">Circuit</span>
+        <span class="flx-circuit-intitule">{{ circuit.intitule }}</span>
+        <span class="flx-circuit-rang">
+            Étape {{ circuit.rang }} sur {{ circuit.total }}{% if circuit.a_moi %} — la vôtre{% endif %}.
+        </span>
+    </div>
+
+    <div class="flx-circuit-piste">
+        {% for etape in circuit.etapes %}
+        <div class="flx-etape flx-etape-{{ etape.statut }}">
+            <div class="flx-etape-role">
+                <i style="background: {{ etape.role_couleur }};"></i>{{ etape.role_label }}
+            </div>
+            <div class="flx-etape-titre">{{ etape.titre }}</div>
+            {% for ligne in etape.lignes %}
+            <div class="flx-etape-ligne">{{ ligne }}</div>
+            {% endfor %}
+            {% if etape.note %}
+            <div class="flx-etape-note">{{ etape.note }}</div>
+            {% endif %}
+            <div class="flx-etape-statut">
+                {% if etape.statut == 'fait' %}✓ Fait
+                {% elif etape.statut == 'courant' %}● {% if circuit.a_moi %}Vous, maintenant{% else %}En attente{% endif %}
+                {% else %}○ À venir{% endif %}
+            </div>
+        </div>
+        {% if etape.liaison and not loop.last %}
+        <div class="flx-liaison">{{ etape.liaison }}<span>→</span></div>
+        {% endif %}
+        {% endfor %}
+    </div>
+
+    {% if circuit.consequence %}
+    <div class="flx-circuit-consequence">⚠ {{ circuit.consequence }}</div>
+    {% endif %}
+</div>

--- a/templates/accueil_flux.html
+++ b/templates/accueil_flux.html
@@ -155,6 +155,19 @@
               })
               .catch(function () { btn.disabled = false; echec(); });
 
+        } else if (act === 'paie') {
+            fetch('/api/accueil/preparation-paie', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({mois: Number(btn.getAttribute('data-mois')),
+                                      annee: Number(btn.getAttribute('data-annee'))})
+            }).then(function (r) { return r.json().then(function (d) { return {ok: r.ok, d: d}; }); })
+              .then(function (res) {
+                  if (!res.ok || !res.d.ok) throw 0;
+                  retirer(ref, '📆 Préparation de paie signalée comme faite');
+              })
+              .catch(function () { btn.disabled = false; echec(); });
+
         } else if (act === 'relance') {
             fetch('/api/email/relance_validation', {
                 method: 'POST',

--- a/templates/accueil_flux.html
+++ b/templates/accueil_flux.html
@@ -110,6 +110,30 @@
         if (window.flxToast) window.flxToast(msg || "Erreur — l'action n'a pas pu être traitée");
     }
 
+    // « Pourquoi ? » : déplie le circuit et amène l'étape en attente sous les
+    // yeux. Sans ce recentrage, un circuit de six étapes s'ouvre sur son
+    // début — c'est-à-dire sur ce qui est déjà fait.
+    document.addEventListener('click', function (e) {
+        var lien = e.target.closest('[data-flx-pourquoi]');
+        if (!lien) return;
+        var carte = lien.closest('[data-flx-item]');
+        var circuit = carte && carte.querySelector('[data-flx-circuit]');
+        if (!circuit) return;
+
+        var ouvert = !circuit.hidden;
+        circuit.hidden = ouvert;
+        lien.setAttribute('aria-expanded', String(!ouvert));
+        lien.textContent = ouvert ? 'Pourquoi ?' : 'Masquer le circuit ↑';
+        if (ouvert) return;
+
+        var piste = circuit.querySelector('.flx-circuit-piste');
+        var courante = circuit.querySelector('.flx-etape-courant');
+        if (piste && courante) {
+            piste.scrollLeft = Math.max(
+                0, courante.offsetLeft - (piste.clientWidth - courante.offsetWidth) / 2);
+        }
+    });
+
     document.addEventListener('click', function (e) {
         var btn = e.target.closest('[data-flx-act]');
         if (!btn || btn.disabled) return;

--- a/tests/test_dashboard_actions.py
+++ b/tests/test_dashboard_actions.py
@@ -485,7 +485,7 @@ class TestRappelPreparationPaie:
             db.execute(
                 """INSERT INTO absences (user_id, motif, date_debut, date_fin,
                                          jours_ouvres, saisi_par, justificatif_path)
-                   VALUES (?, 'maladie', '2026-07-06', '2026-07-10', 5, ?, 'abs/arret.pdf')""",
+                   VALUES (?, 'Arrêt maladie', '2026-07-06', '2026-07-10', 5, ?, 'abs/arret.pdf')""",
                 (sample_users['salarie_id'], sample_users['directeur_id']))
             db.commit()
             actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
@@ -502,7 +502,7 @@ class TestRappelPreparationPaie:
             db.execute(
                 """INSERT INTO absences (user_id, motif, date_debut, date_fin,
                                          jours_ouvres, saisi_par)
-                   VALUES (?, 'maladie', '2026-07-06', '2026-07-10', 5, ?)""",
+                   VALUES (?, 'Arrêt maladie', '2026-07-06', '2026-07-10', 5, ?)""",
                 (sample_users['salarie_id'], sample_users['directeur_id']))
             db.commit()
             actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
@@ -528,3 +528,125 @@ class TestRappelPreparationPaie:
 
         assert not [a for a in vu_directeur if a['type'] == 'paie']
         assert [a for a in vu_responsable if a['type'] == 'paie']
+
+
+class TestPerimetreEtAgregation:
+    """Trois angles morts relevés en revue : périmètre, motifs, agrégation."""
+
+    def _le_20(self, monkeypatch):
+        import dashboard_actions
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: date(2026, 7, 20))
+
+    def test_un_responsable_ne_compte_que_son_equipe(self, app, db, sample_users,
+                                                     monkeypatch):
+        """Sinon il lit les situations RH des autres équipes."""
+        self._le_20(monkeypatch)
+        with app.app_context():
+            # Un CDD sans fiche, hors du secteur du responsable.
+            cur = db.execute(
+                "INSERT INTO users (nom, prenom, login, password, profil) "
+                "VALUES ('Ailleurs', 'Luc', 'ailleurs', 'x', 'salarie')")
+            etranger = cur.lastrowid
+            db.execute(
+                "INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin) "
+                "VALUES (?, 'CDD', '2026-07-01', '2026-07-31')", (etranger,))
+            db.commit()
+
+            vu_responsable = construire_actions(
+                db, 'responsable', sample_users['responsable_id'],
+                secteur_id=sample_users['secteur_id'])
+            vu_direction = construire_actions(db, 'directeur',
+                                              sample_users['directeur_id'])
+
+        paie_resp = [a for a in vu_responsable if a['type'] == 'paie']
+        paie_dir = next(a for a in vu_direction if a['type'] == 'paie')
+        assert 'CDD' in paie_dir['detail']              # la direction le voit
+        assert not paie_resp or 'CDD' not in paie_resp[0]['detail']
+
+    def test_un_conge_valide_ne_compte_pas_comme_absence_injustifiee(
+            self, app, db, sample_users, monkeypatch):
+        """Un congé validé crée une absence sans pièce, par construction.
+
+        La compter ferait sonner le rappel tous les mois, et un rappel qui
+        se déclenche toujours cesse d'être lu.
+        """
+        self._le_20(monkeypatch)
+        with app.app_context():
+            db.execute(
+                """INSERT INTO absences (user_id, motif, date_debut, date_fin,
+                                         jours_ouvres, saisi_par, commentaire)
+                   VALUES (?, 'Congé payé', '2026-07-06', '2026-07-10', 5, ?,
+                           'Congé validé - Demande #1')""",
+                (sample_users['salarie_id'], sample_users['directeur_id']))
+            db.commit()
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        paie = next(a for a in actions if a['type'] == 'paie')
+        assert 'sans justificatif' not in paie['detail']
+
+    def test_un_arret_maladie_sans_piece_compte_toujours(self, app, db, sample_users,
+                                                         monkeypatch):
+        self._le_20(monkeypatch)
+        with app.app_context():
+            db.execute(
+                """INSERT INTO absences (user_id, motif, date_debut, date_fin,
+                                         jours_ouvres, saisi_par)
+                   VALUES (?, 'Arrêt maladie', '2026-07-06', '2026-07-10', 5, ?)""",
+                (sample_users['salarie_id'], sample_users['directeur_id']))
+            db.commit()
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        paie = next(a for a in actions if a['type'] == 'paie')
+        assert '1 absence(s) sans justificatif' in paie['detail']
+
+    def test_un_poste_alp_se_juge_sur_le_total_de_ses_periodes(self, app, db,
+                                                               sample_users):
+        """150 dépensés sur une période budgétée 100 ne sont pas un dépassement
+        si le poste, budgété 1000 au total, reste sous enveloppe."""
+        from utils import aujourd_hui
+        annee = aujourd_hui().year
+        with app.app_context():
+            cur = db.execute(
+                "INSERT INTO budgets (secteur_id, annee, montant_global) VALUES (?, ?, 2000)",
+                (sample_users['secteur_id'], annee))
+            budget_id = cur.lastrowid
+            cur = db.execute("INSERT INTO postes_depense (nom) VALUES ('Sorties ALP')")
+            poste_id = cur.lastrowid
+            for periode, prevu, reel in (('mercredis', 100, 150), ('ete', 900, 0)):
+                db.execute("INSERT INTO budget_lignes (budget_id, poste_depense_id, "
+                           "periode, montant) VALUES (?, ?, ?, ?)",
+                           (budget_id, poste_id, periode, prevu))
+                db.execute("INSERT INTO budget_reel_lignes (budget_id, poste_depense_id, "
+                           "periode, montant) VALUES (?, ?, ?, ?)",
+                           (budget_id, poste_id, periode, reel))
+            db.commit()
+
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        assert not [a for a in actions if a['id'].startswith('budget-')]
+
+    def test_un_poste_alp_reellement_depasse_remonte(self, app, db, sample_users):
+        from utils import aujourd_hui
+        annee = aujourd_hui().year
+        with app.app_context():
+            cur = db.execute(
+                "INSERT INTO budgets (secteur_id, annee, montant_global) VALUES (?, ?, 2000)",
+                (sample_users['secteur_id'], annee))
+            budget_id = cur.lastrowid
+            cur = db.execute("INSERT INTO postes_depense (nom) VALUES ('Sorties ALP')")
+            poste_id = cur.lastrowid
+            for periode, prevu, reel in (('mercredis', 100, 150), ('ete', 900, 1000)):
+                db.execute("INSERT INTO budget_lignes (budget_id, poste_depense_id, "
+                           "periode, montant) VALUES (?, ?, ?, ?)",
+                           (budget_id, poste_id, periode, prevu))
+                db.execute("INSERT INTO budget_reel_lignes (budget_id, poste_depense_id, "
+                           "periode, montant) VALUES (?, ?, ?, ?)",
+                           (budget_id, poste_id, periode, reel))
+            db.commit()
+
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        budgets = [a for a in actions if a['id'].startswith('budget-')]
+        assert len(budgets) == 1
+        assert '150' in budgets[0]['detail']      # 1150 réels − 1000 prévus

--- a/tests/test_dashboard_actions.py
+++ b/tests/test_dashboard_actions.py
@@ -163,3 +163,342 @@ def test_lien_action_cible_l_annee_de_la_subvention(app, db, sample_users):
     assert f'annee={n}' in lien_de('AnCourante')
     assert 'annee=toutes' in lien_de('SansAnnee')
     assert 'annee=toutes' in lien_de('Vieille')
+
+
+# ── Le fil nomme au lieu de compter ─────────────────────────────────────────
+
+def _valider_tout_le_monde(db, mois, annee, sauf=()):
+    """Verrouille les fiches du mois pour tous, sauf les IDs indiqués."""
+    ids = [r['id'] for r in db.execute(
+        "SELECT id FROM users WHERE actif = 1 "
+        "AND profil NOT IN ('directeur', 'prestataire')"
+    ).fetchall() if r['id'] not in sauf]
+    for uid in ids:
+        db.execute(
+            "INSERT OR REPLACE INTO validations (user_id, mois, annee, bloque) "
+            "VALUES (?, ?, ?, 1)", (uid, mois, annee)
+        )
+    db.commit()
+
+
+def _saisir_journee(db, user_id, jour, debut='08:30', fin='18:00'):
+    """Une journée saisie, volontairement longue pour créer des heures supp."""
+    db.execute(
+        """INSERT OR REPLACE INTO heures_reelles
+           (user_id, date, heure_debut_matin, heure_fin_matin,
+            heure_debut_aprem, heure_fin_aprem, type_saisie, declaration_conforme)
+           VALUES (?, ?, ?, '12:00', '13:30', ?, 'heures_modifiees', 0)""",
+        (user_id, jour, debut, fin)
+    )
+    db.commit()
+
+
+def _mois_precedent(today):
+    return (today.month - 1 or 12,
+            today.year if today.month > 1 else today.year - 1)
+
+
+class TestFichesNommees:
+    """« 30 fiches à valider » n'est pas actionnable : le fil en nomme deux.
+
+    Le classement suit le solde d'heures du mois — celui qui a accumulé des
+    heures supplémentaires passe devant celui qui est à l'équilibre.
+    """
+
+    def test_deux_fiches_nommees_et_le_reste_en_une_ligne(self, app, db, sample_users):
+        from utils import aujourd_hui
+        mois, annee = _mois_precedent(aujourd_hui())
+
+        with app.app_context():
+            titres = [a['titre'] for a in construire_actions(
+                db, 'directeur', sample_users['directeur_id'])]
+
+        nommees = [t for t in titres if t.startswith('Fiche de')]
+        assert len(nommees) == 2, titres
+        # sample_users crée trois salariés non validés : un doit rester en file.
+        assert any(t.startswith('et 1 autre') for t in titres), titres
+
+    def test_le_solde_le_plus_lourd_passe_devant(self, app, db, sample_users,
+                                                 sample_planning):
+        """Le salarié à +heures supp passe devant celui qui n'a rien saisi."""
+        from utils import aujourd_hui
+        mois, annee = _mois_precedent(aujourd_hui())
+        salarie = sample_users['salarie_id']
+
+        with app.app_context():
+            # Ne laisser que deux fiches ouvertes, dont une chargée d'heures.
+            _valider_tout_le_monde(db, mois, annee,
+                                   sauf=(salarie, sample_users['responsable_id']))
+            jour = date(annee, mois, 1)
+            while jour.weekday() >= 5:
+                jour += timedelta(days=1)
+            _saisir_journee(db, salarie, jour.isoformat())
+
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        fiches = [a for a in actions if a['titre'].startswith('Fiche de')]
+        assert len(fiches) == 2
+        assert 'Martin' in fiches[0]['titre'], [f['titre'] for f in fiches]
+        assert '+' in fiches[0]['detail'] and 'h sur le mois' in fiches[0]['detail']
+
+    def test_aucune_carte_quand_tout_est_valide(self, app, db, sample_users):
+        from utils import aujourd_hui
+        mois, annee = _mois_precedent(aujourd_hui())
+
+        with app.app_context():
+            _valider_tout_le_monde(db, mois, annee)
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        assert not [a for a in actions if a['titre'].startswith('Fiche de')]
+        assert not [a for a in actions if a['id'].startswith('reste-fiches')]
+
+    def test_un_responsable_ne_voit_que_son_equipe(self, app, db, sample_users):
+        with app.app_context():
+            actions = construire_actions(db, 'responsable',
+                                         sample_users['responsable_id'],
+                                         secteur_id=sample_users['secteur_id'])
+
+        titres = [a['titre'] for a in actions if a['titre'].startswith('Fiche de')]
+        # Le comptable est hors secteur : il ne doit pas apparaître.
+        assert titres and not any('Durand' in t for t in titres), titres
+
+
+class TestCartesDuFil:
+    """Chaque famille se tait quand elle n'a rien à dire."""
+
+    def test_budget_depasse_remonte_dans_le_fil(self, app, db, sample_users):
+        from utils import aujourd_hui
+        annee = aujourd_hui().year
+        with app.app_context():
+            cur = db.execute(
+                "INSERT INTO budgets (secteur_id, annee, montant_global) VALUES (?, ?, 1000)",
+                (sample_users['secteur_id'], annee))
+            budget_id = cur.lastrowid
+            cur = db.execute(
+                "INSERT INTO postes_depense (nom) VALUES ('Fournitures')")
+            poste_id = cur.lastrowid
+            db.execute("INSERT INTO budget_lignes (budget_id, poste_depense_id, periode, montant) "
+                       "VALUES (?, ?, 'annuel', 500)", (budget_id, poste_id))
+            db.execute("INSERT INTO budget_reel_lignes (budget_id, poste_depense_id, periode, montant) "
+                       "VALUES (?, ?, 'annuel', 800)", (budget_id, poste_id))
+            db.commit()
+
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        budgets = [a for a in actions if a['id'].startswith('budget-')]
+        assert len(budgets) == 1
+        assert 'Budget dépassé' in budgets[0]['titre']
+        assert '300' in budgets[0]['detail']
+        assert budgets[0]['urgence'] == 'retard'
+
+    def test_pas_de_carte_budget_sans_depassement(self, app, db, sample_users):
+        from utils import aujourd_hui
+        annee = aujourd_hui().year
+        with app.app_context():
+            cur = db.execute(
+                "INSERT INTO budgets (secteur_id, annee, montant_global) VALUES (?, ?, 1000)",
+                (sample_users['secteur_id'], annee))
+            budget_id = cur.lastrowid
+            cur = db.execute("INSERT INTO postes_depense (nom) VALUES ('Fournitures')")
+            poste_id = cur.lastrowid
+            db.execute("INSERT INTO budget_lignes (budget_id, poste_depense_id, periode, montant) "
+                       "VALUES (?, ?, 'annuel', 500)", (budget_id, poste_id))
+            db.execute("INSERT INTO budget_reel_lignes (budget_id, poste_depense_id, periode, montant) "
+                       "VALUES (?, ?, 'annuel', 400)", (budget_id, poste_id))
+            db.commit()
+
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        assert not [a for a in actions if a['id'].startswith('budget-')]
+
+    def test_fournitures_en_attente_classees_par_urgence(self, app, db, sample_users):
+        with app.app_context():
+            for description, urgence in (('Ramettes A4', 'peut_attendre'),
+                                         ('Cartouches encre', 'urgent')):
+                db.execute(
+                    """INSERT INTO commandes_salaries
+                       (user_id, date_demande, description, quantite, urgence, groupe)
+                       VALUES (?, '2026-07-01', ?, 1, ?, 'en_cours')""",
+                    (sample_users['salarie_id'], description, urgence))
+            db.commit()
+
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        fournitures = [a for a in actions if a['id'].startswith('fourn-')]
+        assert len(fournitures) == 2
+        assert 'Cartouches' in fournitures[0]['titre']       # urgent d'abord
+        assert fournitures[0]['urgence'] == 'urgent'
+        assert fournitures[1]['urgence'] == 'normal'          # « peut attendre »
+
+    def test_un_salarie_sans_delegation_ne_voit_pas_les_fournitures(
+            self, app, db, sample_users):
+        with app.app_context():
+            db.execute(
+                """INSERT INTO commandes_salaries
+                   (user_id, date_demande, description, quantite, urgence, groupe)
+                   VALUES (?, '2026-07-01', 'Ramettes', 1, 'urgent', 'en_cours')""",
+                (sample_users['salarie_id'],))
+            db.commit()
+
+            actions = construire_actions(db, 'salarie', sample_users['salarie_id'])
+
+        assert not [a for a in actions if a['id'].startswith('fourn-')]
+
+    def test_taches_du_jour_renvoient_au_planificateur(self, app, db, sample_users):
+        from utils import aujourd_hui
+        today = aujourd_hui()
+        with app.app_context():
+            cur = db.execute(
+                "INSERT INTO planif_taches (user_id, titre, statut) VALUES (?, 'Bilan', 'a_faire')",
+                (sample_users['directeur_id'],))
+            tache_id = cur.lastrowid
+            db.execute(
+                """INSERT INTO planif_blocs (tache_id, user_id, date, heure_debut,
+                                             heure_fin, duree_min, statut)
+                   VALUES (?, ?, ?, '09:00', '10:00', 60, 'planifie')""",
+                (tache_id, sample_users['directeur_id'], today.isoformat()))
+            db.commit()
+
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        planif = [a for a in actions if a['id'].startswith('planif-')]
+        assert len(planif) == 1
+        assert '1 tâche prévue' in planif[0]['titre']
+        assert '/planificateur' in planif[0]['lien']
+
+    def test_contrat_sans_pdf_pour_le_comptable_seul(self, app, db, sample_users):
+        with app.app_context():
+            db.execute(
+                """INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin)
+                   VALUES (?, 'CDI', '2000-01-01', NULL)""",
+                (sample_users['salarie_id'],))
+            db.commit()
+
+            vus_comptable = construire_actions(db, 'comptable', sample_users['comptable_id'])
+            vus_directeur = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        assert [a for a in vus_comptable if a['id'].startswith('contratpdf-')]
+        assert not [a for a in vus_directeur if a['id'].startswith('contratpdf-')]
+
+    def test_contrat_avec_pdf_ne_remonte_pas(self, app, db, sample_users):
+        with app.app_context():
+            db.execute(
+                """INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin,
+                                         fichier_path)
+                   VALUES (?, 'CDI', '2000-01-01', NULL, 'contrats/cdi.pdf')""",
+                (sample_users['salarie_id'],))
+            db.commit()
+
+            actions = construire_actions(db, 'comptable', sample_users['comptable_id'])
+
+        assert not [a for a in actions if a['id'].startswith('contratpdf-')]
+
+
+class TestRappelPreparationPaie:
+    """Le 20, un rappel daté ; avant, rien.
+
+    Le geste attendu se fait hors de l'application — prévenir la comptabilité
+    — d'où un bouton déclaratif, et une marque posée au nom de celui qui
+    clique : chacun ne répond que de son périmètre.
+    """
+
+    def _le(self, jour, mois=7, annee=2026):
+        return date(annee, mois, jour)
+
+    def test_rien_avant_le_20(self, app, db, sample_users, monkeypatch):
+        import dashboard_actions
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: self._le(19))
+        with app.app_context():
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+        assert not [a for a in actions if a['type'] == 'paie']
+
+    def test_le_rappel_parait_le_20(self, app, db, sample_users, monkeypatch):
+        import dashboard_actions
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: self._le(20))
+        with app.app_context():
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        paie = [a for a in actions if a['type'] == 'paie']
+        assert len(paie) == 1
+        assert 'Signaler à la comptabilité' in paie[0]['titre']
+        # Ce que l'application ne sait pas déduire, elle le rappelle en toutes
+        # lettres : ni la mise à pied ni le licenciement ne sont modélisés.
+        assert 'mises à pied et licenciements' in paie[0]['detail']
+
+    def test_le_comptable_ne_recoit_pas_le_rappel(self, app, db, sample_users, monkeypatch):
+        """Il reçoit le signalement ; il n'a pas à se le faire à lui-même."""
+        import dashboard_actions
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: self._le(20))
+        with app.app_context():
+            actions = construire_actions(db, 'comptable', sample_users['comptable_id'])
+        assert not [a for a in actions if a['type'] == 'paie']
+
+    def test_les_cdd_sans_fiche_sont_nommes(self, app, db, sample_users, monkeypatch):
+        import dashboard_actions
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: self._le(20))
+        with app.app_context():
+            db.execute(
+                """INSERT INTO contrats (user_id, type_contrat, date_debut, date_fin)
+                   VALUES (?, 'CDD', '2026-07-01', '2026-07-31')""",
+                (sample_users['salarie_id'],))
+            db.commit()
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        paie = next(a for a in actions if a['type'] == 'paie')
+        assert "1 CDD sans aucune fiche d'heures" in paie['detail']
+
+    def test_une_absence_justifiee_ne_compte_pas(self, app, db, sample_users, monkeypatch):
+        import dashboard_actions
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: self._le(20))
+        with app.app_context():
+            db.execute(
+                """INSERT INTO absences (user_id, motif, date_debut, date_fin,
+                                         jours_ouvres, saisi_par, justificatif_path)
+                   VALUES (?, 'maladie', '2026-07-06', '2026-07-10', 5, ?, 'abs/arret.pdf')""",
+                (sample_users['salarie_id'], sample_users['directeur_id']))
+            db.commit()
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        paie = next(a for a in actions if a['type'] == 'paie')
+        assert 'sans justificatif' not in paie['detail']
+
+    def test_une_absence_sans_justificatif_est_signalee(self, app, db, sample_users,
+                                                        monkeypatch):
+        import dashboard_actions
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: self._le(20))
+        with app.app_context():
+            db.execute(
+                """INSERT INTO absences (user_id, motif, date_debut, date_fin,
+                                         jours_ouvres, saisi_par)
+                   VALUES (?, 'maladie', '2026-07-06', '2026-07-10', 5, ?)""",
+                (sample_users['salarie_id'], sample_users['directeur_id']))
+            db.commit()
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        paie = next(a for a in actions if a['type'] == 'paie')
+        assert '1 absence(s) sans justificatif' in paie['detail']
+
+    def test_c_est_fait_n_eteint_que_le_sien(self, app, db, sample_users, monkeypatch):
+        """Chacun signale pour son périmètre : un clic ne vaut pas pour tous."""
+        import dashboard_actions
+        from utils import save_setting
+        monkeypatch.setattr(dashboard_actions, 'aujourd_hui',
+                            lambda: self._le(20))
+
+        with app.app_context():
+            save_setting(dashboard_actions.cle_preparation_paie(
+                7, 2026, sample_users['directeur_id']), '1')
+
+            vu_directeur = construire_actions(db, 'directeur', sample_users['directeur_id'])
+            vu_responsable = construire_actions(
+                db, 'responsable', sample_users['responsable_id'],
+                secteur_id=sample_users['secteur_id'])
+
+        assert not [a for a in vu_directeur if a['type'] == 'paie']
+        assert [a for a in vu_responsable if a['type'] == 'paie']

--- a/tests/test_dashboard_actions.py
+++ b/tests/test_dashboard_actions.py
@@ -213,7 +213,7 @@ class TestFichesNommees:
             titres = [a['titre'] for a in construire_actions(
                 db, 'directeur', sample_users['directeur_id'])]
 
-        nommees = [t for t in titres if t.startswith('Fiche de')]
+        nommees = [t for t in titres if t.startswith('Fiche à valider')]
         assert len(nommees) == 2, titres
         # sample_users crée trois salariés non validés : un doit rester en file.
         assert any(t.startswith('et 1 autre') for t in titres), titres
@@ -236,10 +236,36 @@ class TestFichesNommees:
 
             actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
 
-        fiches = [a for a in actions if a['titre'].startswith('Fiche de')]
+        fiches = [a for a in actions if a['titre'].startswith('Fiche à valider')]
         assert len(fiches) == 2
         assert 'Martin' in fiches[0]['titre'], [f['titre'] for f in fiches]
-        assert '+' in fiches[0]['detail'] and 'h sur le mois' in fiches[0]['detail']
+        assert fiches[0]['detail'] == 'heures supplémentaires sur le mois : +1 h'
+
+    def test_la_carte_annonce_une_validation_pas_une_anomalie(
+            self, app, db, sample_users, sample_planning):
+        """Le fil signale qu'une fiche attend, il ne qualifie pas les écarts.
+
+        Le solde y figure comme un fait. Les heures supplémentaires se
+        récupèrent — elles ne se paient pas, sauf pour un CDD — donc rien n'y
+        est « à trancher avant la paie ».
+        """
+        from utils import aujourd_hui
+        mois, annee = _mois_precedent(aujourd_hui())
+        salarie = sample_users['salarie_id']
+
+        with app.app_context():
+            jour = date(annee, mois, 1)
+            while jour.weekday() >= 5:
+                jour += timedelta(days=1)
+            _saisir_journee(db, salarie, jour.isoformat())
+            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+
+        fiches = [a for a in actions if a['titre'].startswith('Fiche à valider')]
+        assert fiches
+        for fiche in fiches:
+            assert 'sur le mois' in fiche['detail'] or 'équilibre' in fiche['detail']
+            for verdict in ('trancher', 'paie', 'expliquer', 'anomalie', 'écart à'):
+                assert verdict not in fiche['detail'], fiche['detail']
 
     def test_aucune_carte_quand_tout_est_valide(self, app, db, sample_users):
         from utils import aujourd_hui
@@ -249,7 +275,7 @@ class TestFichesNommees:
             _valider_tout_le_monde(db, mois, annee)
             actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
 
-        assert not [a for a in actions if a['titre'].startswith('Fiche de')]
+        assert not [a for a in actions if a['titre'].startswith('Fiche à valider')]
         assert not [a for a in actions if a['id'].startswith('reste-fiches')]
 
     def test_un_responsable_ne_voit_que_son_equipe(self, app, db, sample_users):
@@ -258,7 +284,7 @@ class TestFichesNommees:
                                          sample_users['responsable_id'],
                                          secteur_id=sample_users['secteur_id'])
 
-        titres = [a['titre'] for a in actions if a['titre'].startswith('Fiche de')]
+        titres = [a['titre'] for a in actions if a['titre'].startswith('Fiche à valider')]
         # Le comptable est hors secteur : il ne doit pas apparaître.
         assert titres and not any('Durand' in t for t in titres), titres
 

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -137,7 +137,7 @@ def test_relance_sans_bouton_pour_comptable_sans_delegation(comptable_client, db
     informatif « N fiches non validées ».
     """
     html = comptable_client.get('/dashboard_direction').get_data(as_text=True)
-    assert 'Fiche de' in html                # l'information reste visible
+    assert 'Fiche à valider' in html                # l'information reste visible
     # … mais pas de bouton un clic (data-mois n'est rendu qu'avec le bouton ;
     # la chaîne data-cc-act="relance" existe aussi dans le JS statique).
     assert 'data-mois=' not in html

--- a/tests/test_dashboard_direction.py
+++ b/tests/test_dashboard_direction.py
@@ -129,11 +129,15 @@ def test_facture_hors_circuit_sans_bouton(admin_client, db, sample_users):
 
 
 def test_relance_sans_bouton_pour_comptable_sans_delegation(comptable_client, db, sample_users):
-    """L'endpoint de relance refuse un comptable sans délégation : l'item des
-    fiches non validées reste informatif (lien) au lieu d'un bouton voué au
-    403 — revue Codex."""
+    """L'endpoint de relance refuse un comptable sans délégation : pas de
+    bouton voué au 403 — revue Codex.
+
+    L'information lui parvient désormais par les fiches nommées, qui disent
+    *qui* attend plutôt que *combien* : c'est ce qui remplace l'ancien item
+    informatif « N fiches non validées ».
+    """
     html = comptable_client.get('/dashboard_direction').get_data(as_text=True)
-    assert 'non validée(s)' in html          # l'information reste visible
+    assert 'Fiche de' in html                # l'information reste visible
     # … mais pas de bouton un clic (data-mois n'est rendu qu'avec le bouton ;
     # la chaîne data-cc-act="relance" existe aussi dans le JS statique).
     assert 'data-mois=' not in html

--- a/tests/test_flux_circuits.py
+++ b/tests/test_flux_circuits.py
@@ -1,0 +1,113 @@
+"""
+Le « Pourquoi ? » des cartes du fil (flux_circuits.py).
+
+Vérifient ce qui fait la valeur du circuit, et qui se casse sans bruit :
+l'étape mise en avant est bien celle qui attend, elle est reconnue comme
+« la vôtre » pour le bon profil, et la conséquence dit ce qui est arrêté.
+"""
+from datetime import date
+
+import flux_circuits
+
+
+def _courante(circuit):
+    return next(e for e in circuit['etapes'] if e['statut'] == 'courant')
+
+
+class TestPositionDeLEtape:
+    """Le circuit s'ouvre sur ce qui attend, pas sur ce qui est fait."""
+
+    def test_conge_en_attente_responsable(self):
+        circuit = flux_circuits.demande_conge(
+            'en_attente_responsable', '2026-07-25', 'responsable', date(2026, 8, 3))
+        assert circuit['rang'] == 2
+        assert _courante(circuit)['role'] == 'responsable'
+        assert circuit['a_moi'] is True
+
+    def test_conge_en_attente_direction(self):
+        circuit = flux_circuits.demande_conge(
+            'en_attente_direction', '2026-07-25', 'directeur', date(2026, 8, 3))
+        assert circuit['rang'] == 3
+        assert _courante(circuit)['role'] == 'direction'
+        assert circuit['a_moi'] is True
+
+    def test_la_vôtre_ne_se_dit_qu_au_bon_profil(self):
+        """Un comptable qui lit une décision de direction n'est pas concerné."""
+        circuit = flux_circuits.demande_conge(
+            'en_attente_direction', '2026-07-25', 'comptable', date(2026, 8, 3))
+        assert circuit['a_moi'] is False
+
+    def test_les_etapes_precedentes_sont_faites_et_les_suivantes_a_venir(self):
+        circuit = flux_circuits.demande_conge(
+            'en_attente_direction', '2026-07-25', 'directeur', date(2026, 8, 3))
+        statuts = [e['statut'] for e in circuit['etapes']]
+        assert statuts == ['fait', 'fait', 'courant', 'a_venir', 'a_venir']
+
+
+class TestConsequence:
+    """Le schéma seul ne dit pas pourquoi ça compte : la phrase du bas, si."""
+
+    def test_une_attente_longue_est_chiffree(self):
+        circuit = flux_circuits.demande_conge(
+            'en_attente_direction', '2026-07-25', 'directeur', date(2026, 8, 3))
+        assert '9 jours sans réponse' in circuit['consequence']
+
+    def test_une_demande_fraiche_ne_reproche_rien(self):
+        circuit = flux_circuits.demande_conge(
+            'en_attente_direction', '2026-08-03', 'directeur', date(2026, 8, 3))
+        assert circuit['consequence'] is None
+
+    def test_le_cdd_a_sa_propre_consequence(self):
+        """Ses heures se paient et il ne reste qu'un nombre fini de bulletins."""
+        cdd = flux_circuits.fiche_heures('directeur', date(2026, 8, 3), est_cdd=True)
+        cdi = flux_circuits.fiche_heures('directeur', date(2026, 8, 3), est_cdd=False)
+        assert 'bulletin' in cdd['consequence']
+        assert 'récupération' in cdi['consequence']
+        assert cdd['consequence'] != cdi['consequence']
+
+    def test_une_echeance_de_facture_depassee_se_compte(self):
+        circuit = flux_circuits.facture('en_attente', '2026-07-30', 'directeur',
+                                        date(2026, 8, 3))
+        assert 'dépassée de 4 jour(s)' in circuit['consequence']
+
+
+class TestAlimentationsAnnexes:
+    """Le circuit montre que l'application relie les éléments entre eux."""
+
+    def test_la_paie_est_aussi_alimentee_par_les_arrets_maladie(self):
+        circuit = flux_circuits.fiche_heures('directeur', date(2026, 8, 3))
+        notes = [e['note'] for e in circuit['etapes'] if e['note']]
+        assert any('arrêts maladie' in n for n in notes)
+
+
+class TestFormeDesCircuits:
+    """Chaque circuit reste lisible : rôle connu, liaisons nommées."""
+
+    def _tous(self):
+        aujourdhui = date(2026, 8, 3)
+        return [
+            flux_circuits.demande_conge('en_attente_direction', '2026-07-25',
+                                        'directeur', aujourdhui, nb_jours=5),
+            flux_circuits.demande_recup('en_attente_direction', '2026-07-25',
+                                        'directeur', aujourdhui),
+            flux_circuits.fiche_heures('directeur', aujourdhui, solde=7),
+            flux_circuits.facture('en_attente', '2026-08-10', 'directeur', aujourdhui),
+            flux_circuits.subvention('2026-08-10', 'directeur', aujourdhui),
+            flux_circuits.fourniture('2026-07-25', 'directeur', aujourdhui),
+        ]
+
+    def test_chaque_etape_porte_un_role_connu(self):
+        for circuit in self._tous():
+            for etape in circuit['etapes']:
+                assert etape['role'] in flux_circuits.ROLES
+                assert etape['role_couleur'].startswith('#')
+
+    def test_chaque_circuit_a_exactement_une_etape_courante(self):
+        for circuit in self._tous():
+            courantes = [e for e in circuit['etapes'] if e['statut'] == 'courant']
+            assert len(courantes) == 1, circuit['intitule']
+
+    def test_toutes_les_etapes_sauf_la_derniere_nomment_leur_liaison(self):
+        for circuit in self._tous():
+            for etape in circuit['etapes'][:-1]:
+                assert etape['liaison'], (circuit['intitule'], etape['titre'])

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -883,3 +883,44 @@ def test_le_rappel_de_paie_est_ferme_au_salarie(auth_client, sample_users):
     reponse = auth_client.post('/api/accueil/preparation-paie',
                                json={'mois': today.month, 'annee': today.year})
     assert reponse.status_code == 403
+
+
+# ── Le « Pourquoi ? » sur les cartes du fil ─────────────────────────────────
+
+def test_le_circuit_est_replie_mais_present(admin_client, db, sample_users):
+    """Rendu avec la carte, caché : pas d'aller-retour au clic."""
+    with db:
+        db.execute(
+            "INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, "
+            "nb_jours, statut, date_demande) VALUES (?, 'Congé payé', '2026-08-12', "
+            "'2026-08-19', 5, 'en_attente_direction', '2026-07-25')",
+            (sample_users['salarie_id'],))
+
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'flx-pourquoi' in corps
+    assert 'data-flx-circuit' in corps
+    assert 'hidden' in corps.split('data-flx-circuit')[1][:20]
+    assert 'De la demande au planning et aux compteurs' in corps
+
+
+def test_le_circuit_situe_l_etape_en_attente(admin_client, db, sample_users):
+    with db:
+        db.execute(
+            "INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, "
+            "nb_jours, statut, date_demande) VALUES (?, 'Congé payé', '2026-08-12', "
+            "'2026-08-19', 5, 'en_attente_direction', '2026-07-25')",
+            (sample_users['salarie_id'],))
+
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'Étape 3 sur 5' in corps
+    assert 'la vôtre' in corps
+    assert 'flx-etape-courant' in corps
+
+
+def test_une_carte_sans_circuit_n_affiche_pas_pourquoi(admin_client, db, sample_users):
+    """Toutes les familles n'ont pas de circuit : la question ne se pose pas."""
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    # Les fiches à valider en ont un, la ligne « et N autres » non.
+    assert 'reste-fiches' in corps
+    bloc_reste = corps.split('data-flx-id="reste-fiches')[1][:900]
+    assert 'flx-pourquoi' not in bloc_reste

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -852,3 +852,34 @@ def test_le_meme_compte_suit_l_appareil(client, sample_users):
                            headers={'User-Agent': UA_IPHONE}).get_data(as_text=True)
     assert 'flx-entete' in bureau and 'class="sidebar"' not in bureau
     assert 'class="sidebar"' in telephone and 'flx-entete' not in telephone
+
+
+def test_le_bouton_c_est_fait_eteint_le_rappel_de_paie(admin_client, db, sample_users):
+    """L'API prend acte d'un signalement fait hors de l'application."""
+    from utils import aujourd_hui
+    today = aujourd_hui()
+
+    reponse = admin_client.post('/api/accueil/preparation-paie',
+                                json={'mois': today.month, 'annee': today.year})
+    assert reponse.status_code == 200
+    assert reponse.get_json()['ok'] is True
+
+    # Rejoué : idempotent, la marque est déjà posée.
+    assert admin_client.post('/api/accueil/preparation-paie',
+                             json={'mois': today.month,
+                                   'annee': today.year}).status_code == 200
+
+
+def test_le_rappel_de_paie_refuse_un_mois_lointain(admin_client, sample_users):
+    """Ni marquage d'avance, ni réouverture d'un exercice ancien."""
+    reponse = admin_client.post('/api/accueil/preparation-paie',
+                                json={'mois': 1, 'annee': 2001})
+    assert reponse.status_code == 400
+
+
+def test_le_rappel_de_paie_est_ferme_au_salarie(auth_client, sample_users):
+    from utils import aujourd_hui
+    today = aujourd_hui()
+    reponse = auth_client.post('/api/accueil/preparation-paie',
+                               json={'mois': today.month, 'annee': today.year})
+    assert reponse.status_code == 403


### PR DESCRIPTION
Deux étapes du chantier flux. **Étape 1** : plus aucune donnée informative fixe — chaque carte attend une décision, signale un risque réel ou annonce une échéance, sinon elle n'est pas construite. **Étape 2** : chaque carte peut expliquer le circuit dans lequel sa décision s'inscrit.

---

# Étape 1 — on nomme, on ne compte pas

« 30 fiches à valider » n'est pas une action. C'est un chiffre qui décourage, et qui n'indique pas par où commencer. Le fil montre désormais **deux fiches nommées**, puis une ligne discrète pour le reste :

> ✅ **Fiche à valider — Marie Dupont, juillet** · heures supplémentaires sur le mois : +12 h
> ✅ **Fiche à valider — Sophie Durand, juillet** · solde du mois : −3 h
> ✅ et 22 autres fiches de juillet · traitées ensuite, une fois les premières faites

Le classement suit le **solde d'heures du mois**, décroissant : plus le solde est élevé, plus il pèse sur le compteur de récupération. Sans ce tri, deux cartes prises au hasard ne valent pas mieux qu'un total. Traiter la première fait remonter la suivante.

La carte **dit ce qu'elle attend, elle ne juge pas** : le solde y figure comme un fait, jamais comme un verdict. Le fil n'est pas un détecteur d'anomalies, et une fiche chargée n'en est pas une. (Les heures supplémentaires se **récupèrent** — elles ne se paient pas, sauf pour un CDD.)

## Les familles ajoutées

Toutes suivent la même forme, et toutes se taisent quand elles n'ont rien à dire.

| Famille | Public | Note |
|---|---|---|
| Factures du secteur | responsable | Il n'avait rien dans son fil ; la direction recevait déjà les siennes |
| Demandes de fournitures | direction, comptabilité, délégué | Classées par l'urgence déclarée par le demandeur |
| Dépassements de budget | direction, comptabilité, responsable du secteur | Ton « retard » : un dépassement est un fait accompli, il s'arbitre |
| Contrats sans PDF | comptabilité | Distinct du contrat absent de la base — ici c'est la pièce signée qui manque |
| Tâches du jour | tout porteur du planificateur | Volontairement agrégée, voir plus bas |

## Le rappel du 20

Pour les responsables et la direction. Il nomme ce qui se calcule — **CDD sans aucune fiche d'heures**, **absences sans justificatif** — et rappelle en toutes lettres ce qui ne se calcule pas : les **mises à pied et licenciements** ne sont modélisés nulle part, `users` ne portant qu'un drapeau `actif` sans motif de sortie. Aucune requête ne peut les trouver, et c'est précisément pourquoi un humain doit y penser.

Le geste attendu se fait **hors de l'application** — prévenir la comptabilité par mail ou de vive voix. Son bouton « C'est fait » est donc déclaratif, et n'éteint le rappel **que pour celui qui l'a signalé** : chacun ne répond que de son périmètre, et un rappel éteint collectivement laisserait le premier à cliquer effacer celui des autres.

La comptabilité ne le reçoit pas : elle est destinataire du signalement, pas émettrice.

## Deux exceptions assumées

- **Les tâches du planificateur** restent agrégées (« 3 tâches prévues aujourd'hui »). Le planificateur est déjà l'écran qui détaille et réordonne ; le fil ne fait qu'y conduire.
- **Le rappel de paie** est déclenché par une date, pas par un état — son objet n'est pas observable depuis la base.

Documentées comme telles, pour qu'on ne les prenne pas pour des oublis.

---

# Étape 2 — le « Pourquoi ? »

Une carte dit *quoi faire*. Elle ne dit pas *ce qui est arrêté derrière*. « Fiche à valider — Marie Dupont » ne laisse pas deviner que la préparation de la paie attend, ni qu'un CDD n'aura plus qu'un bulletin pour se régulariser. C'est la différence entre une tâche administrative subie et une décision comprise.

Sous les boutons, un lien **Pourquoi ?** déplie le circuit, centré sur l'étape en attente :

> **CIRCUIT** De la demande au planning et aux compteurs. *Étape 3 sur 5 — la vôtre.*
> `SALARIÉ` Demande posée · ✓ Fait → **soumet** → `RESPONSABLE` Validation responsable · ✓ Fait → **transmet** → `DIRECTION` **Décision** · ● Vous, maintenant → **met à jour** → `APPLICATION` Absence au calendrier…
> ⚠ 9 jours sans réponse : le salarié ne sait pas s'il part, et le planning de son secteur se construit sur une hypothèse.

`flux_circuits.py` décrit six circuits — congé, récupération, fiche d'heures, facture, subvention, fourniture. Chaque étape porte le **rôle** qui la traite (pastille colorée : salarié, responsable, direction, comptabilité, prestataire, ou *application* quand le logiciel agit seul), ce qu'elle fait, et son état.

Trois choix de forme :

- **l'étape courante prend le ton de la carte**, pas la couleur de son rôle. Une décision en retard se signale en rouge jusque dans son circuit ; le rôle reste lisible sur sa pastille ;
- **la conséquence tient en une phrase**, avec les vraies dates. C'est elle qui répond à la question posée — le schéma seul ne le dit pas. Elle ne paraît que s'il y a quelque chose à dire : une demande déposée hier ne reproche rien, et un CDD n'a pas la même conséquence qu'un CDI ;
- **les alimentations annexes se notent sur l'étape concernée.** « Aussi alimentée par les arrêts maladie saisis en comptabilité » : c'est ce lien entre éléments que l'application fait et que personne ne voit.

Le circuit est rendu **avec la carte, replié** — pas d'aller-retour serveur au clic. À l'ouverture, la piste défile jusqu'à l'étape courante : sans ce recentrage, un circuit de six étapes s'ouvre sur ce qui est déjà fait.

La ligne « et N autres » n'en reçoit pas : elle ne désigne aucun enregistrement précis, donc aucune étape à mettre en avant.

---

## Corrections de revue

Trois angles morts relevés par Codex, tous réels, corrigés en `0d07361` :

- **le rappel du 20 ignorait le périmètre du responsable** — il lisait les situations RH des autres équipes, et éteignait un rappel portant sur des salariés dont il n'a pas à répondre, alors que la marque est justement posée par personne ;
- **un congé validé comptait comme absence sans justificatif.** `_creer_absence_depuis_conge` crée une ligne sans pièce par construction : le rappel aurait sonné tous les mois pour des dossiers en règle, et un rappel qui sonne toujours cesse d'être lu. Le décompte se limite aux motifs qui appellent réellement une pièce ;
- **un budget ALP se jugeait période par période**, là où la page conclut sur le total des périodes d'un poste. La requête agrège avant de comparer — un poste annuel n'ayant qu'une ligne, l'agrégation le laisse intact.

## Effets de bord

L'ancien compteur agrégé disparaît. La carte de relance ne garde que ce qui n'a pas d'équivalent nommé : l'envoi groupé d'un rappel par e-mail. Un comptable sans délégation ne voit donc plus « N fiches non validées » mais les fiches elles-mêmes — même information, meilleure forme ; le test qui protégeait ce cas a été mis à jour, pas supprimé.

Chaque constructeur s'isole des autres : une famille en panne (table absente, base verrouillée) est journalisée et ignorée, le reste du fil tient.

## Vérification

41 tests ajoutés — classement et troncature des fiches, périmètre par profil, chaque famille présente et absente, seuils du rappel du 20, isolation du « C'est fait », l'API ; pour les circuits : position de l'étape courante, « la vôtre » réservée au bon profil, conséquence chiffrée ou muette, distinction CDD/CDI, alimentations annexes, forme des six circuits ; et les trois cas de revue, chacun vérifié en échec avant correctif.

Le rendu visuel a été vérifié sur le HTML produit, pas dans un navigateur — c'est le point qui mérite un œil humain.

Suite complète verte : **1563 tests**.