### PR TITLE
Fond du circuit, recentrage, et deux périmètres de cartes

### DIFF
--- a/dashboard_actions.py
+++ b/dashboard_actions.py
@@ -419,14 +419,17 @@ def _preparation_paie(conn, profil, user_id, secteur_id, today):
 def _fournitures_en_attente(conn, profil, user_id, today):
     """Demandes de fournitures que personne n'a encore traitées.
 
-    Servies à qui peut les traiter : direction, comptabilité, ou le salarié
-    porteur de la délégation « suivi des commandes ». Classées par urgence
-    déclarée, celle du demandeur — c'est la seule information dont on dispose
-    sur ce qui presse.
+    Réservées au **seul porteur de la délégation** « suivi des commandes ».
+    C'est une mission confiée à quelqu'un : la servir aussi à la direction et
+    à la comptabilité doublerait le travail et diluerait la responsabilité —
+    chacun supposant que l'autre s'en charge. Sans délégué désigné, ces cartes
+    n'apparaissent à personne, et c'est le comportement voulu : la file se
+    consulte alors sur sa page, elle ne réclame personne en particulier.
+
+    Classées par urgence déclarée, celle du demandeur — c'est la seule
+    information dont on dispose sur ce qui presse.
     """
-    peut_suivre = profil in ('directeur', 'comptable') or user_has_delegation(
-        user_id, MISSION_SUIVI_COMMANDES_FOURNITURES)
-    if not peut_suivre:
+    if not user_has_delegation(user_id, MISSION_SUIVI_COMMANDES_FOURNITURES):
         return []
 
     rows = conn.execute(
@@ -946,6 +949,9 @@ def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
         })
 
     # 6. Soldes de congés conventionnels au-dessus du seuil : à planifier.
+    # Même forme que les autres familles — les deux plus lourds nommés, le
+    # reste en une ligne. Cinq cartes de congés d'affilée noyaient les
+    # décisions du jour pour un sujet qui, lui, se planifie.
     seuil_conges = seuils.get('conges')
     if seuil_conges is not None:
         rows = conn.execute('''
@@ -954,11 +960,12 @@ def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
             WHERE u.actif = 1 AND u.profil NOT IN ('directeur', 'prestataire')
               AND COALESCE(u.cc_solde, 0) >= ?
             ORDER BY u.cc_solde DESC
-            LIMIT 5
         ''', (seuil_conges,)).fetchall()
-        for r in rows:
+
+        nommes = []
+        for r in rows[:MAX_CARTES_NOMMEES]:
             solde = f"{r['cc_solde']:g}".replace('.', ',')
-            actions.append({
+            nommes.append({
                 'id': f"conge-{r['id']}",
                 'categorie': 'conges',
                 'type': 'lien',
@@ -969,5 +976,13 @@ def _actions_etendues(conn, profil, user_id, today, seuils, surcharges):
                 'lien_texte': 'Planifier',
                 'urgence': 'normal',
             })
+        actions.extend(nommes)
+
+        reste = len(rows) - len(nommes)
+        if reste > 0:
+            actions.append(_reste(
+                reste, f"solde{'s' if reste > 1 else ''} au-dessus du seuil",
+                url_for('infos_salaries_bp.soldes_conges'), 'Soldes de congés',
+                'conges-eleves', '🏖️', 'conges'))
 
     return actions

--- a/docs/interface-sans-menu.md
+++ b/docs/interface-sans-menu.md
@@ -116,7 +116,14 @@ D'où la forme de toutes les familles de `dashboard_actions.py` :
 - **un tri qui dit par où commencer.** Les fiches sont classées par solde
   d'heures décroissant : plus le solde est élevé, plus il pèse sur le compteur
   de récupération, et plus la validation tarde à venir ;
-- **rien quand il n'y a rien.** Aucune famille ne produit de carte à zéro.
+- **rien quand il n'y a rien.** Aucune famille ne produit de carte à zéro ;
+- **une mission déléguée ne se sert qu'à son porteur.** Les demandes de
+  fournitures ne paraissent que dans le fil du salarié qui tient la
+  délégation « suivi des commandes ». Les servir aussi à la direction et à la
+  comptabilité doublerait le travail et diluerait la responsabilité — chacun
+  supposant que l'autre s'en charge. Sans délégué désigné, ces cartes
+  n'apparaissent à personne, et c'est voulu : la file se consulte alors sur
+  sa page, elle ne réclame personne en particulier.
 
 Une carte **dit ce qu'elle attend, elle ne juge pas**. La fiche de Marie
 Dupont attend une validation : c'est tout ce que la carte annonce. Le solde y

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4622,7 +4622,14 @@ body.flx .main-content {
 /* La carte passe en deux lignes : l'en-tête habituel, puis le circuit qui
    s'étend sous les trois colonnes. Replié, il ne coûte rien à la mise en page. */
 .flx-carte:has(> .flx-circuit:not([hidden])) { align-items: start; }
-.flx-circuit { grid-column: 1 / -1; margin-top: 18px; }
+/* Panneau teinté : il détache le circuit du corps de la carte, et sert de
+   fond sur lequel l'étape en attente ressort en blanc. Sans lui, tout est
+   blanc sur blanc et le regard n'a plus de point d'accroche. */
+.flx-circuit {
+    grid-column: 1 / -1; margin-top: 18px;
+    padding: 16px 18px 14px; border-radius: 14px;
+    background: var(--gray-100); border: 1px solid var(--gray-200);
+}
 
 .flx-pourquoi {
     background: none; border: none; padding: 0; margin-top: 2px;
@@ -4651,11 +4658,15 @@ body.flx .main-content {
     display: flex; align-items: stretch; gap: 0; overflow-x: auto;
     padding: 4px 2px 12px; scrollbar-width: thin;
 }
+/* Trois états, trois poids visuels sur le panneau teinté : une étape faite
+   s'efface (fond à peine détaché), l'étape en attente ressort en blanc plein,
+   une étape à venir n'est qu'esquissée. */
 .flx-etape {
     flex: 0 0 208px; padding: 13px 15px; border-radius: 11px;
-    border: 1px solid var(--gray-200); background: var(--gray-100);
+    border: 1px solid var(--gray-200); background: transparent;
     display: flex; flex-direction: column; gap: 5px;
 }
+.flx-etape-fait .flx-etape-titre { color: var(--gray-700); }
 .flx-etape-role {
     display: flex; align-items: center; gap: 6px;
     font-family: var(--flx-mono); font-size: 0.58rem; letter-spacing: 1.3px;
@@ -4669,7 +4680,7 @@ body.flx .main-content {
 .flx-etape-note {
     margin-top: 4px; padding: 7px 9px; border-radius: 7px;
     border: 1px solid var(--gray-300); background: var(--white);
-    font-size: 0.74rem; color: var(--gray-600); line-height: 1.4;
+    font-size: 0.74rem; color: var(--gray-700); line-height: 1.4;
 }
 .flx-etape-statut {
     margin-top: auto; padding-top: 9px;
@@ -4677,13 +4688,16 @@ body.flx .main-content {
     text-transform: uppercase; color: var(--gray-500);
 }
 .flx-etape-a_venir { background: transparent; border-style: dashed; }
-.flx-etape-a_venir .flx-etape-titre { color: var(--gray-600); }
+.flx-etape-a_venir .flx-etape-titre { color: var(--gray-500); }
 
-/* L'étape en attente : fond plein, bordure au ton de la carte. */
+/* L'étape en attente : fond blanc plein, bordure au ton de la carte, et une
+   ombre douce qui la décolle du panneau — c'est elle qu'on doit voir en
+   premier à l'ouverture. */
 .flx-etape-courant {
     background: var(--white); border-width: 1.5px;
-    border-color: var(--flx-planifier);
+    border-color: var(--flx-planifier); box-shadow: var(--shadow-sm);
 }
+.flx-etape-courant .flx-etape-titre { color: var(--gray-900); font-weight: 500; }
 .flx-etape-courant .flx-etape-statut { color: var(--flx-planifier); }
 .flx-retard .flx-etape-courant { border-color: var(--flx-retard); }
 .flx-retard .flx-etape-courant .flx-etape-statut { color: var(--flx-retard); }

--- a/templates/accueil_flux.html
+++ b/templates/accueil_flux.html
@@ -129,8 +129,14 @@
         var piste = circuit.querySelector('.flx-circuit-piste');
         var courante = circuit.querySelector('.flx-etape-courant');
         if (piste && courante) {
-            piste.scrollLeft = Math.max(
-                0, courante.offsetLeft - (piste.clientWidth - courante.offsetWidth) / 2);
+            // Positions mesurées à l'écran plutôt que via offsetLeft : celui-ci
+            // se compte depuis le premier ancêtre positionné, qui n'est pas la
+            // piste — la valeur incluait le décalage de la carte dans la page
+            // et saturait le défilement tout à droite.
+            var cadre = piste.getBoundingClientRect();
+            var etape = courante.getBoundingClientRect();
+            piste.scrollLeft += (etape.left - cadre.left)
+                              - (piste.clientWidth - etape.width) / 2;
         }
     });
 

--- a/tests/test_dashboard_actions.py
+++ b/tests/test_dashboard_actions.py
@@ -337,18 +337,29 @@ class TestCartesDuFil:
 
         assert not [a for a in actions if a['id'].startswith('budget-')]
 
+    def _deleguer_les_fournitures(self, db, sample_users, user_id):
+        from blueprints.delegations import (MISSION_SUIVI_COMMANDES_FOURNITURES,
+                                            save_delegation)
+        save_delegation(MISSION_SUIVI_COMMANDES_FOURNITURES, user_id,
+                        sample_users['directeur_id'])
+
+    def _deux_demandes(self, db, sample_users):
+        for description, urgence in (('Ramettes A4', 'peut_attendre'),
+                                     ('Cartouches encre', 'urgent')):
+            db.execute(
+                """INSERT INTO commandes_salaries
+                   (user_id, date_demande, description, quantite, urgence, groupe)
+                   VALUES (?, '2026-07-01', ?, 1, ?, 'en_cours')""",
+                (sample_users['salarie_id'], description, urgence))
+        db.commit()
+
     def test_fournitures_en_attente_classees_par_urgence(self, app, db, sample_users):
         with app.app_context():
-            for description, urgence in (('Ramettes A4', 'peut_attendre'),
-                                         ('Cartouches encre', 'urgent')):
-                db.execute(
-                    """INSERT INTO commandes_salaries
-                       (user_id, date_demande, description, quantite, urgence, groupe)
-                       VALUES (?, '2026-07-01', ?, 1, ?, 'en_cours')""",
-                    (sample_users['salarie_id'], description, urgence))
-            db.commit()
+            self._deux_demandes(db, sample_users)
+            self._deleguer_les_fournitures(db, sample_users,
+                                           sample_users['salarie_id'])
 
-            actions = construire_actions(db, 'directeur', sample_users['directeur_id'])
+            actions = construire_actions(db, 'salarie', sample_users['salarie_id'])
 
         fournitures = [a for a in actions if a['id'].startswith('fourn-')]
         assert len(fournitures) == 2
@@ -359,16 +370,40 @@ class TestCartesDuFil:
     def test_un_salarie_sans_delegation_ne_voit_pas_les_fournitures(
             self, app, db, sample_users):
         with app.app_context():
-            db.execute(
-                """INSERT INTO commandes_salaries
-                   (user_id, date_demande, description, quantite, urgence, groupe)
-                   VALUES (?, '2026-07-01', 'Ramettes', 1, 'urgent', 'en_cours')""",
-                (sample_users['salarie_id'],))
-            db.commit()
+            self._deux_demandes(db, sample_users)
 
             actions = construire_actions(db, 'salarie', sample_users['salarie_id'])
 
         assert not [a for a in actions if a['id'].startswith('fourn-')]
+
+    def test_la_direction_ne_recoit_pas_les_fournitures(self, app, db, sample_users):
+        """La mission est confiée à quelqu'un : la doubler diluerait la
+        responsabilité, chacun supposant que l'autre s'en charge."""
+        with app.app_context():
+            self._deux_demandes(db, sample_users)
+            self._deleguer_les_fournitures(db, sample_users,
+                                           sample_users['salarie_id'])
+
+            vus_direction = construire_actions(db, 'directeur',
+                                               sample_users['directeur_id'])
+            vus_comptable = construire_actions(db, 'comptable',
+                                               sample_users['comptable_id'])
+
+        assert not [a for a in vus_direction if a['id'].startswith('fourn-')]
+        assert not [a for a in vus_comptable if a['id'].startswith('fourn-')]
+
+    def test_sans_delegue_personne_ne_recoit_les_fournitures(self, app, db,
+                                                             sample_users):
+        """La file se consulte alors sur sa page ; elle ne réclame personne."""
+        with app.app_context():
+            self._deux_demandes(db, sample_users)
+
+            for profil, uid in (('directeur', sample_users['directeur_id']),
+                                ('comptable', sample_users['comptable_id']),
+                                ('responsable', sample_users['responsable_id'])):
+                actions = construire_actions(db, profil, uid,
+                                             secteur_id=sample_users['secteur_id'])
+                assert not [a for a in actions if a['id'].startswith('fourn-')], profil
 
     def test_taches_du_jour_renvoient_au_planificateur(self, app, db, sample_users):
         from utils import aujourd_hui
@@ -650,3 +685,48 @@ class TestPerimetreEtAgregation:
         budgets = [a for a in actions if a['id'].startswith('budget-')]
         assert len(budgets) == 1
         assert '150' in budgets[0]['detail']      # 1150 réels − 1000 prévus
+
+
+class TestSoldesDeCongesEleves:
+    """Même forme que les autres familles : deux nommés, puis le total."""
+
+    def _salaries_au_dessus_du_seuil(self, db, combien, solde=12):
+        for rang in range(combien):
+            db.execute(
+                "INSERT INTO users (nom, prenom, login, password, profil, cc_solde) "
+                "VALUES (?, 'Test', ?, 'x', 'salarie', ?)",
+                (f'Solde{rang}', f'solde{rang}', solde + rang))
+        db.commit()
+
+    def _cartes(self, db, sample_users):
+        from blueprints.dashboard_direction import _lire_seuils
+        return construire_actions(db, 'directeur', sample_users['directeur_id'],
+                                  etendu=True, seuils=_lire_seuils(), surcharges=[])
+
+    def test_deux_nommes_puis_une_ligne_pour_le_reste(self, app, db, sample_users):
+        with app.app_context():
+            self._salaries_au_dessus_du_seuil(db, 5)
+            actions = self._cartes(db, sample_users)
+
+        nommes = [a for a in actions if a['id'].startswith('conge-')]
+        assert len(nommes) == 2
+        reste = [a for a in actions if a['id'] == 'reste-conges-eleves']
+        assert len(reste) == 1
+        assert 'et 3 autres' in reste[0]['titre']
+
+    def test_les_soldes_les_plus_eleves_passent_devant(self, app, db, sample_users):
+        with app.app_context():
+            self._salaries_au_dessus_du_seuil(db, 4)
+            actions = self._cartes(db, sample_users)
+
+        nommes = [a for a in actions if a['id'].startswith('conge-')]
+        assert 'Solde3' in nommes[0]['titre']      # 15 j, le plus haut
+        assert 'Solde2' in nommes[1]['titre']      # 14 j
+
+    def test_pas_de_ligne_de_reste_quand_deux_suffisent(self, app, db, sample_users):
+        with app.app_context():
+            self._salaries_au_dessus_du_seuil(db, 2)
+            actions = self._cartes(db, sample_users)
+
+        assert len([a for a in actions if a['id'].startswith('conge-')]) == 2
+        assert not [a for a in actions if a['id'] == 'reste-conges-eleves']

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -924,3 +924,22 @@ def test_une_carte_sans_circuit_n_affiche_pas_pourquoi(admin_client, db, sample_
     assert 'reste-fiches' in corps
     bloc_reste = corps.split('data-flx-id="reste-fiches')[1][:900]
     assert 'flx-pourquoi' not in bloc_reste
+
+
+def test_les_trois_etats_d_etape_portent_leur_classe(admin_client, db, sample_users):
+    """La feuille de style cible `flx-etape-fait|courant|a_venir`.
+
+    Un statut renommé côté modèle passerait inaperçu : les étapes perdraient
+    leur poids visuel sans qu'aucun test ne tombe, et le circuit deviendrait
+    un aplat gris où l'étape en attente ne ressort plus.
+    """
+    with db:
+        db.execute(
+            "INSERT INTO demandes_conges (user_id, type_conge, date_debut, date_fin, "
+            "nb_jours, statut, date_demande) VALUES (?, 'Congé payé', '2026-08-12', "
+            "'2026-08-19', 5, 'en_attente_direction', '2026-07-25')",
+            (sample_users['salarie_id'],))
+
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    for etat in ('flx-etape-fait', 'flx-etape-courant', 'flx-etape-a_venir'):
+        assert etat in corps, etat


### PR DESCRIPTION
Retours d'usage sur le fil, après la mise en service de #238.

## Le circuit n'avait pas de fond

Il se posait à même la carte, blanc sur blanc, sans le panneau teinté du modèle. Ce panneau ne décore pas : c'est le fond sur lequel l'étape en attente ressort. Sans lui, les six étapes forment un aplat uniforme où le regard n'a aucun point d'accroche.

Le panneau prend `--gray-100` et une bordure, et les trois états d'étape reçoivent trois poids : une étape **faite** se fond dans le panneau, une étape **à venir** n'est qu'esquissée en pointillé, l'étape **en attente** ressort en blanc plein, bordure au ton de la carte et ombre douce qui la décolle.

## Le défilement s'arrêtait toujours à droite

Sur la dernière étape, jamais sur celle en cours. `offsetLeft` se compte depuis le premier ancêtre positionné — la piste ne l'étant pas, la valeur incluait le décalage de la carte dans la page et saturait `scrollLeft`. Les positions se mesurent désormais à l'écran, par `getBoundingClientRect`, indépendamment du positionnement des ancêtres.

Deux corrections trouvées en chemin : le fond des étapes s'écrivait en `rgba(255,255,255,…)`, qui aurait viré au gris clair sur le **thème sombre**, et `--gray-600` n'existe pas dans la palette. Les deux passent par des jetons définis dans les deux thèmes.

## Les fournitures ne concernent que leur délégué

Je les servais aussi à la direction et à la comptabilité. C'était doubler le travail et diluer la responsabilité — chacun pouvant supposer que l'autre s'en charge. Une mission confiée à quelqu'un se sert à ce quelqu'un.

**Sans délégué désigné, ces cartes n'apparaissent à personne**, et c'est voulu : la file se consulte alors sur sa page, elle ne réclame personne en particulier.

## Les soldes de congés élevés suivent enfin la règle

Deux nommés, puis une ligne pour le reste. Ils étaient restés à cinq cartes d'affilée, héritage du centre de contrôle — de quoi noyer les décisions du jour pour un sujet qui, lui, se planifie.

## Vérification

Six tests ajoutés : les trois classes d'état du circuit (un statut renommé côté modèle passerait sinon inaperçu — les étapes perdraient leur poids visuel sans qu'aucun test ne tombe), le périmètre des fournitures dans ses trois cas (délégué, non-délégué, aucun délégué), et la troncature des soldes de congés.

Le recentrage lui-même n'est pas couvert : le dépôt n'a pas de runner JavaScript. **C'est le point à revérifier dans un navigateur**, avec le fond.

Suite complète verte : **1569 tests**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUUpfmfCvHTPtbwCiNhMS9)_