### PR TITLE
Rendre les rôles lisibles, et faire suivre le cache des statiques

### DIFF
--- a/app.py
+++ b/app.py
@@ -385,6 +385,30 @@ def invalidate_version_cache():
 
 
 @app.context_processor
+def inject_static_version():
+    """Empreinte des fichiers statiques, pour forcer le navigateur à relire.
+
+    La feuille de style et les scripts portaient un numéro écrit à la main
+    (`?v=20`). Personne ne pense à l'incrémenter : une modification de CSS
+    reste alors invisible chez tous ceux qui ont déjà chargé la page, et le
+    défaut se diagnostique mal — le code est juste, le rendu ne bouge pas.
+
+    L'empreinte suit la date de modification du fichier : elle change
+    d'elle-même à chaque livraison, et jamais autrement.
+    """
+    empreintes = {}
+    for nom in ('css/style.css', 'js/flux.js'):
+        chemin = os.path.join(app.static_folder, nom)
+        try:
+            empreintes[nom] = str(int(os.path.getmtime(chemin)))
+        except OSError:
+            # Fichier absent (montage incomplet) : pas de cache-busting plutôt
+            # qu'une page qui ne se rend pas.
+            empreintes[nom] = ''
+    return {'static_version': empreintes}
+
+
+@app.context_processor
 def inject_pending_counts():
     """Injecte le nombre de demandes en attente dans tous les templates."""
     if 'user_id' not in session:

--- a/flux_circuits.py
+++ b/flux_circuits.py
@@ -26,14 +26,20 @@ concernée, pour montrer que l'application relie ces éléments.
 """
 from datetime import date
 
-# Rôle qui traite une étape → (libellé, couleur de pastille). « Application »
-# désigne ce que le logiciel fait seul : rien à attendre de personne.
+# Rôle qui traite une étape → (libellé, couleur). Elle teinte la pastille ET
+# le libellé : c'est ce qui permet de voir qui tient chaque étape sans lire.
+# « Application » désigne ce que le logiciel fait seul, d'où son gris — rien
+# n'est attendu de personne à cette étape.
+#
+# Tons moyens, choisis pour rester lisibles sur le beige clair du thème par
+# défaut comme sur le vert sombre du thème nuit. Un vert profond, par exemple,
+# disparaîtrait sur le second.
 ROLES = {
-    'salarie': ('Salarié', '#4a7dbf'),
-    'responsable': ('Responsable', '#7c5cbf'),
-    'direction': ('Direction', '#c56a2a'),
-    'comptabilite': ('Comptabilité', '#2f7d5d'),
-    'prestataire': ('Prestataire', '#5b6470'),
+    'salarie': ('Salarié', '#3d7fc1'),
+    'responsable': ('Responsable', '#8b5cf6'),
+    'direction': ('Direction', '#d97706'),
+    'comptabilite': ('Comptabilité', '#10a37f'),
+    'prestataire': ('Prestataire', '#6b7f95'),
     'application': ('Application', '#9aa0a6'),
 }
 
@@ -185,14 +191,19 @@ def fiche_heures(profil, today, nom=None, est_cdd=False, solde=None):
     # de la direction, après le passage du responsable.
     courante = 2
 
+    # Ce qu'une fiche non validée bloque réellement — et ce qu'elle ne bloque
+    # pas. Le compteur de récupération, lui, est tenu à jour dès la saisie :
+    # la validation ne le conditionne pas. Ce qu'elle conditionne, c'est le
+    # verrouillage du mois, donc l'existence d'une base arrêtée. Les heures
+    # n'entrent en paie que si elles sont payées — le cas du CDD.
     if est_cdd:
         consequence = ("Non validée, la fiche part sans ses heures : pour un "
                        "CDD elles se paient, et il ne restera qu'un bulletin "
                        "pour régulariser.")
     else:
-        consequence = ("Tant qu'elle n'est pas validée, la préparation de la "
-                       "paie attend, et les heures ne rejoignent pas le "
-                       "compteur de récupération.")
+        consequence = ("Tant qu'elle n'est pas validée, le mois reste ouvert : "
+                       "la fiche peut encore changer, et la préparation de la "
+                       "paie n'a pas de base arrêtée.")
     return _monter('De la fiche d\'heures au bulletin de paie.',
                    etapes, courante, profil, consequence)
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4663,16 +4663,18 @@ body.flx .main-content {
    une étape à venir n'est qu'esquissée. */
 .flx-etape {
     flex: 0 0 208px; padding: 13px 15px; border-radius: 11px;
-    border: 1px solid var(--gray-200); background: transparent;
+    border: 1px solid var(--gray-200); background: var(--gray-50);
     display: flex; flex-direction: column; gap: 5px;
 }
 .flx-etape-fait .flx-etape-titre { color: var(--gray-700); }
+/* Le rôle porte sa couleur sur le libellé, pas seulement sur la pastille :
+   c'est ce qui permet de voir d'un coup qui tient chaque étape. */
 .flx-etape-role {
     display: flex; align-items: center; gap: 6px;
-    font-family: var(--flx-mono); font-size: 0.58rem; letter-spacing: 1.3px;
-    text-transform: uppercase; color: var(--gray-500);
+    font-family: var(--flx-mono); font-size: 0.6rem; letter-spacing: 1.3px;
+    text-transform: uppercase; font-weight: 600;
 }
-.flx-etape-role i { width: 7px; height: 7px; border-radius: 2px; flex: none; }
+.flx-etape-role i { width: 9px; height: 9px; border-radius: 3px; flex: none; }
 .flx-etape-titre {
     font-size: 0.93rem; color: var(--gray-900); line-height: 1.35;
 }

--- a/templates/_flux_circuit.html
+++ b/templates/_flux_circuit.html
@@ -15,7 +15,7 @@
     <div class="flx-circuit-piste">
         {% for etape in circuit.etapes %}
         <div class="flx-etape flx-etape-{{ etape.statut }}">
-            <div class="flx-etape-role">
+            <div class="flx-etape-role" style="color: {{ etape.role_couleur }};">
                 <i style="background: {{ etape.role_couleur }};"></i>{{ etape.role_label }}
             </div>
             <div class="flx-etape-titre">{{ etape.titre }}</div>

--- a/templates/_flux_shell.html
+++ b/templates/_flux_shell.html
@@ -65,4 +65,4 @@
     </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/flux.js') }}?v=2"></script>
+<script src="{{ url_for('static', filename='js/flux.js') }}?v={{ static_version['js/flux.js'] }}"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}CS-PILOT{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v=20">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v={{ static_version['css/style.css'] }}">
     <script>
         (function(){var t=localStorage.getItem('theme');if(t==='dark')document.documentElement.setAttribute('data-theme','dark');})();
     </script>

--- a/tests/test_flux_circuits.py
+++ b/tests/test_flux_circuits.py
@@ -62,8 +62,19 @@ class TestConsequence:
         cdd = flux_circuits.fiche_heures('directeur', date(2026, 8, 3), est_cdd=True)
         cdi = flux_circuits.fiche_heures('directeur', date(2026, 8, 3), est_cdd=False)
         assert 'bulletin' in cdd['consequence']
-        assert 'récupération' in cdi['consequence']
+        assert 'mois reste ouvert' in cdi['consequence']
         assert cdd['consequence'] != cdi['consequence']
+
+    def test_la_consequence_ne_prete_rien_au_compteur_de_recuperation(self):
+        """Il est tenu à jour dès la saisie : la validation ne le conditionne pas.
+
+        Annoncer le contraire ferait valider pour une raison inexistante — et
+        décrédibiliserait les conséquences que le circuit annonce par ailleurs.
+        """
+        for est_cdd in (True, False):
+            circuit = flux_circuits.fiche_heures('directeur', date(2026, 8, 3),
+                                                 est_cdd=est_cdd)
+            assert 'compteur' not in circuit['consequence'], circuit['consequence']
 
     def test_une_echeance_de_facture_depassee_se_compte(self):
         circuit = flux_circuits.facture('en_attente', '2026-07-30', 'directeur',
@@ -111,3 +122,23 @@ class TestFormeDesCircuits:
         for circuit in self._tous():
             for etape in circuit['etapes'][:-1]:
                 assert etape['liaison'], (circuit['intitule'], etape['titre'])
+
+
+class TestCouleursDesRoles:
+    """Le rôle se lit à sa couleur : elle doit rester distincte et lisible."""
+
+    def test_chaque_role_a_une_couleur_distincte(self):
+        couleurs = [couleur for _, couleur in flux_circuits.ROLES.values()]
+        assert len(set(couleurs)) == len(couleurs)
+
+    def test_les_couleurs_tiennent_sur_les_deux_themes(self):
+        """Ni trop sombres ni trop claires : le thème nuit a un fond vert
+        sombre, le thème par défaut un beige clair. Un ton extrême disparaît
+        sur l'un des deux."""
+        for role, (_, couleur) in flux_circuits.ROLES.items():
+            rouge = int(couleur[1:3], 16)
+            vert = int(couleur[3:5], 16)
+            bleu = int(couleur[5:7], 16)
+            # Luminance perçue, formule usuelle.
+            luminance = (0.299 * rouge + 0.587 * vert + 0.114 * bleu) / 255
+            assert 0.28 < luminance < 0.78, (role, couleur, round(luminance, 2))

--- a/tests/test_interface_flux.py
+++ b/tests/test_interface_flux.py
@@ -943,3 +943,20 @@ def test_les_trois_etats_d_etape_portent_leur_classe(admin_client, db, sample_us
     corps = admin_client.get('/accueil').get_data(as_text=True)
     for etat in ('flx-etape-fait', 'flx-etape-courant', 'flx-etape-a_venir'):
         assert etat in corps, etat
+
+
+def test_les_statiques_portent_une_empreinte_qui_change(admin_client, app):
+    """Un numéro écrit à la main ne s'incrémente jamais.
+
+    Le CSS était servi avec `?v=20` figé : toute modification restait
+    invisible chez qui avait déjà chargé la page, et le défaut se
+    diagnostiquait mal — le code est juste, le rendu ne bouge pas.
+    """
+    import os
+
+    corps = admin_client.get('/accueil').get_data(as_text=True)
+    assert 'style.css?v=20"' not in corps
+
+    empreinte = str(int(os.path.getmtime(
+        os.path.join(app.static_folder, 'css/style.css'))))
+    assert f'style.css?v={empreinte}' in corps


### PR DESCRIPTION
Suite de #239, dont la fusion a devancé ces deux commits.

## « Tout est de la même couleur »

Deux causes, pas une.

Les **cartes d'étape étaient devenues transparentes** — j'avais poussé trop loin la correction du fond livrée en #239 — donc elles se confondaient avec le panneau. Elles reprennent un fond distinct.

Et le **rôle ne se signalait que par une pastille de 7 px**, alors qu'il doit dire d'un coup d'œil qui tient l'étape. La couleur passe désormais sur le libellé, et la pastille grossit.

Les six tons ont été repris pour tenir sur les deux thèmes : le vert profond de la comptabilité (`#2f7d5d`) disparaissait sur le fond vert sombre du thème nuit. Toutes les couleurs sont maintenant dans une plage de luminance vérifiée par un test — assez soutenues pour le beige clair, assez claires pour le vert nuit. « Application » reste le plus pâle, c'est voulu : rien n'y est attendu de personne.

## Une conséquence annoncée était fausse

> Tant qu'elle n'est pas validée, la préparation de la paie attend, et les heures ne rejoignent pas le compteur de récupération.

Le compteur est en réalité **tenu à jour dès la saisie** : la validation ne le conditionne pas. Ce qu'elle conditionne, c'est le verrouillage du mois — donc l'existence d'une base arrêtée. Et les heures n'entrent en paie que si elles sont payées, ce qui est le cas du CDD et de lui seul.

Une conséquence fausse est pire qu'une conséquence absente : elle fait valider pour une mauvaise raison, et décrédibilise les autres. Un test interdit désormais toute mention du compteur dans cette phrase.

## Le cache des statiques ne suivait pas

`base.html` servait la feuille avec **`?v=20`, écrit à la main**. Personne n'incrémente ce numéro : toute modification de CSS reste invisible chez qui a déjà chargé la page. Le défaut se diagnostique mal — le code est juste, les tests passent, le rendu ne bouge pas. Les deux corrections visuelles de #239 étaient dans ce cas, et le resteraient après déploiement. Même chose pour `flux.js`, figé à `?v=2`.

L'empreinte suit désormais la date de modification du fichier : elle change d'elle-même à chaque livraison, et jamais autrement. Un fichier absent rend une empreinte vide plutôt qu'une page qui ne se rend pas.

## Vérification

Trois tests ajoutés : les couleurs de rôle sont distinctes deux à deux, elles tiennent dans une plage de luminance lisible sur les deux thèmes, et les statiques ne portent plus de numéro figé.

Suite ciblée verte : 170 tests sur les modules touchés, plus les deux modules de sécurité. La suite complète n'a pas été relancée sur ce lot, à votre demande.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUUpfmfCvHTPtbwCiNhMS9)_